### PR TITLE
renaming add initial and final to make initial & final

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -80,11 +80,11 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         CNfa(unsigned long) except +
 
         # Public Functions
-        void add_initial(State)
-        void add_initial(vector[State])
+        void make_initial(State)
+        void make_initial(vector[State])
         bool has_initial(State)
         void remove_initial(State)
-        void add_final(State)
+        void make_final(State)
         bool has_final(State)
         void remove_final(State)
         void add_trans(CTrans) except +

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -95,14 +95,14 @@ cdef class Nfa:
 
         :param State st: added initial state
         """
-        self.thisptr.add_initial(st)
+        self.thisptr.make_initial(st)
 
     def add_initial_states(self, vector[State] states):
         """Adds list of initial state to automaton
 
         :param list states: list of initial states
         """
-        self.thisptr.add_initial(states)
+        self.thisptr.make_initial(states)
 
     def has_initial_state(self, State st):
         """Tests if automaton contains given state
@@ -117,7 +117,7 @@ cdef class Nfa:
 
         :param State st: added final state
         """
-        self.thisptr.add_final(st)
+        self.thisptr.make_final(st)
 
     def has_final_state(self, State st):
         """Tests if automaton contains given state

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -9,7 +9,7 @@ __author__ = 'Tomas Fiedor'
 
 def test_adding_states():
     """Test nfa"""
-    lhs = mata.Nfa()
+    lhs = mata.Nfa(5)
 
     # Test adding states
     assert not lhs.has_initial_state(0)

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -274,8 +274,7 @@ public:
      */
     Nfa(unsigned long num_of_states) : transitionrelation(num_of_states), initialstates(), finalstates() {}
 
-    auto get_num_of_states() const { return std::max(
-            {transitionrelation.size(), initialstates.size(), finalstates.size()}); }
+    auto get_num_of_states() const { return transitionrelation.size(); }
 
     void increase_size(size_t size)
     {
@@ -283,11 +282,16 @@ public:
         transitionrelation.resize(size);
     }
 
-    // TODO: exceptions if states do not exist
-    void add_initial(State state) { this->initialstates.insert(state); }
-    void add_initial(const std::vector<State>& vec)
+    void make_initial(State state) {
+        if (this->get_num_of_states() <= state) {
+            throw std::runtime_error("Cannot make state initial because it is not in automaton");
+        }
+
+        this->initialstates.insert(state);
+    }
+    void make_initial(const std::vector<State>& vec)
     { // {{{
-        for (const State& st : vec) { this->add_initial(st); }
+        for (const State& st : vec) { this->make_initial(st); }
     } // }}}
     bool has_initial(const State &state_to_check) const {return initialstates.count(state_to_check);}
     void remove_initial(State state)
@@ -296,10 +300,16 @@ public:
         this->initialstates.remove(state);
     }
 
-    void add_final(State state) { this->finalstates.insert(state); }
-    void add_final(const std::vector<State>& vec)
+    void make_final(State state) {
+        if (this->get_num_of_states() <= state) {
+            throw std::runtime_error("Cannot make state final because it is not in automaton");
+        }
+
+        this->finalstates.insert(state);
+    }
+    void make_final(const std::vector<State>& vec)
     { // {{{
-        for (const State& st : vec) { this->add_final(st); }
+        for (const State& st : vec) { this->make_final(st); }
     } // }}}
     bool has_final(const State &state_to_check) const { return finalstates.count(state_to_check); }
     void remove_final(State state)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -344,7 +344,7 @@ void Mata::Nfa::remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
     for (auto state_closure_pair : eps_closure) { // for every state
         State src_state = state_closure_pair.first;
         for (State eps_cl_state : state_closure_pair.second) { // for every state in its eps cl
-            if (aut.has_final(eps_cl_state)) result->add_final(src_state);
+            if (aut.has_final(eps_cl_state)) result->make_final(src_state);
             for (auto symb_set : aut[eps_cl_state]) {
                 if (symb_set.symbol == epsilon) continue;
 
@@ -722,9 +722,9 @@ Nfa Nfa::read_from_our_format(std::istream &inputStream) {
                 // TODO if (stateName[0] != 's') { error }
                 State stateToAdd = getStateFromName(stateName.substr(1));
                 if (identificator == "kInitialFormula") {
-                    newNFA.add_initial(stateToAdd);
+                    newNFA.make_initial(stateToAdd);
                 } else if (identificator == "kFinalFormula") {
-                    newNFA.add_final(stateToAdd);
+                    newNFA.make_final(stateToAdd);
                 } else {
                     // TODO: define own exception for parsing
                     throw std::runtime_error(std::string("Keywords are kInitialFormula and kFinalFormula but there is ") + identificator);
@@ -765,11 +765,11 @@ void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {
     }
 
     for (State thisInitialState : lhs.initialstates) {
-        unionAutomaton->add_initial(thisStateToUnionState[thisInitialState]);
+        unionAutomaton->make_initial(thisStateToUnionState[thisInitialState]);
     }
 
     for (State thisFinalState : lhs.finalstates) {
-        unionAutomaton->add_final(thisStateToUnionState[thisFinalState]);
+        unionAutomaton->make_final(thisStateToUnionState[thisFinalState]);
     }
 
     for (State thisState = 0; thisState < lhs.transitionrelation.size(); ++thisState) {
@@ -816,11 +816,11 @@ void Mata::Nfa::intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMa
             (*prod_map)[thisAndOtherInitialStatePair] = newIntersectState;
             pairsToProcess.push_back(thisAndOtherInitialStatePair);
 
-            res->add_initial(newIntersectState);
+            res->make_initial(newIntersectState);
             if (lhs.has_final(thisInitialState) && rhs.has_final(otherInitialState))
-                res->add_initial(newIntersectState);
+                res->make_initial(newIntersectState);
             if (lhs.has_final(thisInitialState) && rhs.has_final(otherInitialState)) {
-                res->add_final(newIntersectState);
+                res->make_final(newIntersectState);
             }
         }
     }
@@ -877,7 +877,7 @@ void Mata::Nfa::intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMa
                             pairsToProcess.push_back(intersectStatePairTo);
 
                             if (lhs.has_final(thisStateTo) && rhs.has_final(otherStateTo)) {
-                                res->add_final(intersectStateTo);
+                                res->make_final(intersectStateTo);
                             }
                         } else {
                             intersectStateTo = (*prod_map)[intersectStatePairTo];
@@ -931,13 +931,13 @@ void Mata::Nfa::determinize(
     }
     StateSet S0 =  Mata::Util::OrdVector<State>(aut.initialstates.ToVector());
     State S0id = result->add_new_state();
-    result->add_initial(S0id);
+    result->make_initial(S0id);
     std::vector<bool> isFinal(aut.get_num_of_states(), false);//for fast detection of a final state in a set
     for (const auto &q: aut.finalstates) {
         isFinal[q] = true;
     }
     if (contains_final(S0, isFinal)) {
-        result->add_final(S0id);
+        result->make_final(S0id);
     }
     worklist.emplace_back(std::make_pair(S0id, S0));
 
@@ -968,7 +968,7 @@ void Mata::Nfa::determinize(
                 Tid = result->add_new_state();
                 (*subset_map)[Mata::Util::OrdVector<State>(T)] = Tid;
                 if (contains_final(T, isFinal)) {
-                    result->add_final(Tid);
+                    result->make_final(Tid);
                 }
                 worklist.emplace_back(std::make_pair(Tid, T));
             }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1472,11 +1472,11 @@ TEST_CASE("Mata::Nfa::revert()")
 
 	SECTION("no-transition automaton")
 	{
-		aut.add_initial(1);
-		aut.add_initial(3);
+		aut.make_initial(1);
+		aut.make_initial(3);
 
-		aut.add_final(2);
-		aut.add_final(5);
+		aut.make_final(2);
+		aut.make_final(5);
 
 		Nfa result = revert(aut);
 
@@ -1489,8 +1489,8 @@ TEST_CASE("Mata::Nfa::revert()")
 
 	SECTION("one-transition automaton")
 	{
-		aut.add_initial(1);
-		aut.add_final(2);
+		aut.make_initial(1);
+		aut.make_final(2);
 		aut.add_trans(1, 'a', 2);
 
 		Nfa result = revert(aut);
@@ -1542,25 +1542,25 @@ TEST_CASE("Mata::Nfa::is_deterministic()")
 		REQUIRE(!is_deterministic(aut));
 
 		// add an initial state
-		aut.add_initial('q');
+		aut.make_initial('q');
 		REQUIRE(is_deterministic(aut));
 
 		// add the same initial state
-		aut.add_initial('q');
+		aut.make_initial('q');
 		REQUIRE(is_deterministic(aut));
 
 		// add another initial state
-		aut.add_initial('r');
+		aut.make_initial('r');
 		REQUIRE(!is_deterministic(aut));
 
 		// add a final state
-		aut.add_final('q');
+		aut.make_final('q');
 		REQUIRE(!is_deterministic(aut));
 	}
 
 	SECTION("trivial automata")
 	{
-		aut.add_initial('q');
+		aut.make_initial('q');
 		aut.add_trans('q', 'a', 'r');
 		REQUIRE(is_deterministic(aut));
 
@@ -1618,7 +1618,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 		StringToSymbolMap ssmap;
 		OnTheFlyAlphabet alph(&ssmap);
 
-		aut.add_initial(4);
+		aut.make_initial(4);
 		aut.add_trans(4, alph["a"], 8);
 		aut.add_trans(4, alph["c"], 8);
 		aut.add_trans(4, alph["a"], 6);
@@ -1631,7 +1631,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 		aut.add_trans(0, alph["a"], 2);
 		aut.add_trans(12, alph["a"], 14);
 		aut.add_trans(14, alph["b"], 12);
-		aut.add_final({2, 12});
+		aut.make_final({2, 12});
 
 		REQUIRE(!is_complete(aut, alph));
 
@@ -1644,7 +1644,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 		StringToSymbolMap ssmap;
 		OnTheFlyAlphabet alph(&ssmap);
 
-		aut.add_initial(4);
+		aut.make_initial(4);
 		aut.add_trans(4, alph["a"], 8);
 		aut.add_trans(4, alph["c"], 8);
 		aut.add_trans(4, alph["a"], 6);
@@ -1659,7 +1659,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 	{
 		CharAlphabet alph;
 
-		aut.add_initial(4);
+        aut.make_initial(4);
 		aut.add_trans(4, 'a', 8);
 		aut.add_trans(4, 'c', 8);
 		aut.add_trans(4, 'a', 6);
@@ -1672,7 +1672,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 		aut.add_trans(0, 'a', 2);
 		aut.add_trans(12, 'a', 14);
 		aut.add_trans(14, 'b', 12);
-		aut.add_final({2, 12});
+		aut.make_final({2, 12});
 
 		REQUIRE(!is_complete(aut, alph));
 
@@ -1697,8 +1697,8 @@ TEST_CASE("Mata::Nfa::is_prfx_in_lang()")
 
 	SECTION("automaton accepting only epsilon")
 	{
-		aut.add_initial('q');
-		aut.add_final('q');
+		aut.make_initial('q');
+		aut.make_final('q');
 
 		Word w;
 		w = { };
@@ -1753,11 +1753,11 @@ TEST_CASE("Mata::Nfa::fw-direct-simulation()")
     aut.increase_size(9);
     SECTION("no-transition automaton")
     {
-        aut.add_initial(1);
-        aut.add_initial(3);
+        aut.make_initial(1);
+        aut.make_initial(3);
 
-        aut.add_final(2);
-        aut.add_final(5);
+        aut.make_final(2);
+        aut.make_final(5);
 
         Mata::Util::BinaryRelation result = compute_relation(aut);
         REQUIRE(result.get(1,3));
@@ -1768,8 +1768,8 @@ TEST_CASE("Mata::Nfa::fw-direct-simulation()")
 
     SECTION("small automaton")
     {
-        aut.add_initial(1);
-        aut.add_final(2);
+        aut.make_initial(1);
+        aut.make_final(2);
         aut.add_trans(1, 'a', 4);
         aut.add_trans(4, 'b', 5);
         aut.add_trans(2, 'b', 5);
@@ -1823,16 +1823,16 @@ TEST_CASE("Mata::Nfa::union_norename()") {
     Word zero{0};
 
     Nfa lhs(2);
-    lhs.add_initial(0);
+    lhs.make_initial(0);
     lhs.add_trans(0, 0, 1);
-    lhs.add_final(1);
+    lhs.make_final(1);
     REQUIRE(!is_in_lang(lhs, one));
     REQUIRE(is_in_lang(lhs, zero));
 
     Nfa rhs(2);
-    rhs.add_initial(0);
+    rhs.make_initial(0);
     rhs.add_trans(0, 1, 1);
-    rhs.add_final(1);
+    rhs.make_final(1);
     REQUIRE(is_in_lang(rhs, one));
     REQUIRE(!is_in_lang(rhs, zero));
 

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -99,7 +99,7 @@ namespace {
             // Vectors are saved in this->state_cache after this
             this->create_state_cache(prog);
 
-            explicit_nfa.add_initial(this->state_cache.state_mapping[start_state][0]);
+            explicit_nfa.make_initial(this->state_cache.state_mapping[start_state][0]);
             this->state_cache.has_state_incoming_edge[this->state_cache.state_mapping[start_state][0]] = true;
 
             // We traverse all the states and create corresponding states and edges in mata::Nfa::Nfa
@@ -455,7 +455,7 @@ namespace {
                 if (!this->state_cache.has_state_incoming_edge[target_state]) {
                     continue;
                 }
-                nfa.add_final(target_state);
+                nfa.make_final(target_state);
             }
         }
 
@@ -485,7 +485,7 @@ namespace {
                 if (static_cast<int>(renumbered_states[state]) == -1) {
                     renumbered_states[state] = renumbered_explicit_nfa.add_new_state();
                 }
-                renumbered_explicit_nfa.add_final(renumbered_states[state]);
+                renumbered_explicit_nfa.make_final(renumbered_states[state]);
             }
 
             for (int state = 0; state < program_size; state++) {
@@ -499,7 +499,7 @@ namespace {
             }
 
             for (auto state: input_nfa.initialstates) {
-                renumbered_explicit_nfa.add_initial(renumbered_states[state]);
+                renumbered_explicit_nfa.make_initial(renumbered_states[state]);
             }
 
             return renumbered_explicit_nfa;


### PR DESCRIPTION
Renaming of functions for making states initial and finals + function throw exception when a state is not presented in automaton already. The changes are based on our discussion at yesterday meeting.