### PR TITLE
Implement functions for segmentation

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -139,7 +139,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         bool trans_empty()
         bool nothing_in_trans()
         bool is_state(State)
-        size_t trans_size()
+        size_t get_num_of_trans()
         StateSet post(StateSet&, Symbol)
         CNfa.const_iterator begin()
         CNfa.const_iterator end()

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -251,12 +251,12 @@ cdef class Nfa:
         """
         return self.thisptr.nothing_in_trans()
 
-    def trans_size(self):
+    def get_num_of_trans(self):
         """Returns number of transitions in automaton
 
         :return: number of transitions in automaton
         """
-        return self.thisptr.trans_size()
+        return self.thisptr.get_num_of_trans()
 
     def resize(self, size):
         """Increases the size of the automaton to size

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -65,7 +65,7 @@ def test_transitions():
 
     # Test adding transition
     assert lhs.trans_empty()
-    assert lhs.trans_size() == 3
+    assert lhs.get_num_of_trans() == 0
     lhs.add_trans(t1)
     assert not lhs.trans_empty()
     assert lhs.has_trans(t1)
@@ -301,6 +301,7 @@ def test_revert():
     assert not mata.Nfa.is_in_lang(rhs, [0, 1])
     assert mata.Nfa.is_in_lang(rhs, [1, 0])
 
+
 def test_removing_epsilon():
     lhs = mata.Nfa(3)
     lhs.add_initial_state(0)
@@ -319,11 +320,11 @@ def test_minimize(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
     minimized = mata.Nfa.minimize(fa_one_divisible_by_two)
-    assert minimized.trans_size() <= fa_one_divisible_by_two.trans_size()
+    assert minimized.get_num_of_trans() <= fa_one_divisible_by_two.get_num_of_trans()
     minimized = mata.Nfa.minimize(fa_one_divisible_by_four)
-    assert minimized.trans_size() <= fa_one_divisible_by_four.trans_size()
+    assert minimized.get_num_of_trans() <= fa_one_divisible_by_four.get_num_of_trans()
     minimized = mata.Nfa.minimize(fa_one_divisible_by_eight)
-    assert minimized.trans_size() <= fa_one_divisible_by_eight.trans_size()
+    assert minimized.get_num_of_trans() <= fa_one_divisible_by_eight.get_num_of_trans()
 
     lhs = mata.Nfa(11)
     lhs.add_initial_state(0)
@@ -332,10 +333,11 @@ def test_minimize(
         lhs.add_final_state(i)
     lhs.add_trans_raw(10, 0, 10)
     lhs.add_final_state(10)
-    assert lhs.trans_size() == 11
+    assert lhs.get_num_of_trans() == 11
 
     minimized = mata.Nfa.minimize(lhs)
-    assert minimized.trans_size() == 1
+    assert minimized.get_num_of_trans() == 1
+
 
 def test_to_dot():
     lhs = mata.Nfa()

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -279,12 +279,19 @@ struct Nfa
     //TODO we probably need the number of states, int, as a member, for when we want to remove states
     // alphabet?
 public:
-    Nfa () : transitionrelation(), initialstates(), finalstates() {}
+    Nfa() : transitionrelation(), initialstates(), finalstates() {}
 
     /**
-     * @brief Construct a new explicit NFA with num_of_states states.
+     * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
      */
-    explicit Nfa(const unsigned long num_of_states) : transitionrelation(num_of_states), initialstates(), finalstates() {}
+    explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{}, const StateSet& final_states = StateSet{})
+        : transitionrelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
+
+    /**
+     * @brief Construct a new explicit NFA with already filled transition relation and optionally set initial and final states.
+     */
+    explicit Nfa(const TransitionRelation& transition_relation, const StateSet& initial_states = StateSet{}, const StateSet& final_states = StateSet{})
+            : transitionrelation(transition_relation), initialstates(initial_states), finalstates(final_states) {}
 
     auto get_num_of_states() const { return transitionrelation.size(); }
 
@@ -518,6 +525,12 @@ public:
      * @return Sequence of transitions as @c Trans.
      */
     TransSequence get_trans_as_sequence();
+
+    /**
+     * Unify transitions to create a directed graph with at most a single transition between two states.
+     * @return An automaton representing a directed graph.
+     */
+    Nfa get_digraph();
 
     void print_to_DOT(std::ostream &outputStream) const;
     static Nfa read_from_our_format(std::istream &inputStream);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -403,8 +403,8 @@ public:
         return this->has_trans({src, symb, tgt});
     } // }}}
 
-    bool trans_empty() const { return this->transitionrelation.empty();} /// no transitions
-    size_t trans_size() const {return transitionrelation.size();} /// number of transitions; has linear time complexity
+    bool trans_empty() const { return this->transitionrelation.empty();} ///< No transitions.
+    size_t get_num_of_trans() const; ///< Number of transitions; has linear time complexity.
     bool nothing_in_trans() const
     {
         return std::all_of(this->transitionrelation.begin(), this->transitionrelation.end(),

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -996,7 +996,7 @@ private:
     /// Map mapping states to the shortest words accepted by the automaton from the mapped state.
     StateMap<LengthWordsPair> shortest_words_map{};
     std::set<State> processed{}; ///< Set of already processed states.
-    std::deque<State> lifo_queue{}; ///< LIFO queue for states to process.
+    std::deque<State> fifo_queue{}; ///< FIFO queue for states to process.
     const Nfa reversed_automaton{}; ///< Reversed input automaton.
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -69,7 +69,7 @@ static const struct Limits {
     Symbol minSymbol = 0;
 } limits;
 
-/// A transition
+/// A transition.
 struct Trans
 {
 	State src;
@@ -85,6 +85,8 @@ struct Trans
 	} // operator== }}}
 	bool operator!=(const Trans& rhs) const { return !this->operator==(rhs); }
 };
+
+using TransSequence = std::vector<Trans>; ///< Set of transitions.
 
 // ALPHABET {{{
 class Alphabet
@@ -257,7 +259,7 @@ struct Nfa
     /**
      * @brief For state q, transitionrelation[q] keeps the list of transitions ordered by symbols.
      *
-     * The set of states of this automaton are the numbers from 0 to
+     * The set of states of this automaton are the numbers from 0 to the number of states minus one.
      *
      * @todo maybe have this as its own class
      */
@@ -269,10 +271,11 @@ struct Nfa
     // alphabet?
 public:
     Nfa () : transitionrelation(), initialstates(), finalstates() {}
+
     /**
-     * @brief Construct a new Explicit NFA with num_of_states states
+     * @brief Construct a new explicit NFA with num_of_states states.
      */
-    Nfa(unsigned long num_of_states) : transitionrelation(num_of_states), initialstates(), finalstates() {}
+    explicit Nfa(const unsigned long num_of_states) : transitionrelation(num_of_states), initialstates(), finalstates() {}
 
     auto get_num_of_states() const { return transitionrelation.size(); }
 
@@ -328,7 +331,8 @@ public:
     }
 
     /**
-     * @brief Returns a newly created state.
+     * Add a new state to the automaton.
+     * @return The newly created state.
      */
     State add_new_state();
     bool is_state(const State &state_to_check) const { return state_to_check < transitionrelation.size(); }
@@ -339,7 +343,7 @@ public:
         return transitionrelation[state_from];
     }
 
-    /* Lukas: the above is nice. The good thing is that acces to [q] is constant,
+    /* Lukas: the above is nice. The good thing is that access to [q] is constant,
      * so one can iterate over all states for instance using this, and it is fast.
      * But I don't know how to do a similar thing inside TransitionList.
      * Returning a transition of q with the symbol a means to search for it in the list,
@@ -406,6 +410,12 @@ public:
         return std::all_of(this->transitionrelation.begin(), this->transitionrelation.end(),
                     [](const auto& trans) {return trans.size() == 0;});
     }
+
+    /**
+     * Get transitions as a sequence of @c Trans.
+     * @return Sequence of transitions as @c Trans.
+     */
+    TransSequence get_trans_as_sequence();
 
     void print_to_DOT(std::ostream &outputStream) const;
     static Nfa read_from_our_format(std::istream &inputStream);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -294,36 +294,122 @@ public:
         increase_size(state + 1);
     }
 
-    void make_initial(State state) {
+    /**
+     * Clear initial states set.
+     */
+    void clear_initial() { initialstates.clear(); }
+
+    /**
+     * Make @p state initial.
+     * @param state State to be added to initial states.
+     */
+    void make_initial(State state)
+    {
         if (this->get_num_of_states() <= state) {
             throw std::runtime_error("Cannot make state initial because it is not in automaton");
         }
 
         this->initialstates.insert(state);
     }
+
+    /**
+     * @brief Set initial states set with @p state.
+     *
+     * Overwrite the previous initial states set.
+     *
+     * @param state State to be set as the new initial state.
+     */
+    void set_initial(State state)
+    {
+        clear_initial();
+        make_initial(state);
+    }
+
+    /**
+     * Make @p vec of states initial states.
+     * @param vec Vector of states to be added to initial states.
+     */
     void make_initial(const std::vector<State>& vec)
-    { // {{{
+    {
         for (const State& st : vec) { this->make_initial(st); }
-    } // }}}
+    }
+
+    /**
+     * @brief Set initial states set with @p state.
+     *
+     * Overwrite the previous initial states set.
+     *
+     * @param vec Vector of states to be set as new initial states.
+     */
+    void set_initial(const std::vector<State>& vec)
+    {
+        clear_initial();
+        for (const State& st: vec) { this->make_initial(st); }
+    }
+
     bool has_initial(const State &state_to_check) const {return initialstates.count(state_to_check);}
+
     void remove_initial(State state)
     {
         assert(has_initial(state));
         this->initialstates.remove(state);
     }
 
-    void make_final(State state) {
+    /**
+     * Clear final states set.
+     */
+    void clear_final() { finalstates.clear(); }
+
+    /**
+     * Make @p state final.
+     * @param state[in] State to be added to final states.
+     */
+    void make_final(const State state)
+    {
         if (this->get_num_of_states() <= state) {
             throw std::runtime_error("Cannot make state final because it is not in automaton");
         }
 
         this->finalstates.insert(state);
     }
+
+    /**
+     * @brief Set final states set with @p state.
+     *
+     * Overwrite the previous final states set.
+     *
+     * @param state[in] State to be set as the new final state.
+     */
+    void set_final(const State state)
+    {
+        clear_final();
+        make_final(state);
+    }
+
+    /**
+     * Make @p vec of states final states.
+     * @param vec[in] Vector of states to be added to final states.
+     */
     void make_final(const std::vector<State>& vec)
-    { // {{{
+    {
         for (const State& st : vec) { this->make_final(st); }
-    } // }}}
+    }
+
+    /**
+     * @brief Set final states set with @p state.
+     *
+     * Overwrite the previous final states set.
+     *
+     * @param vec[in] Vector of states to be set as new final states.
+     */
+    void set_final(const std::vector<State>& vec)
+    {
+        clear_final();
+        for (const State& st: vec) { this->make_final(st); }
+    }
+
     bool has_final(const State &state_to_check) const { return finalstates.count(state_to_check); }
+
     void remove_final(State state)
     {
         assert(has_final(state));
@@ -335,6 +421,7 @@ public:
      * @return The newly created state.
      */
     State add_new_state();
+
     bool is_state(const State &state_to_check) const { return state_to_check < transitionrelation.size(); }
 
     const TransitionList& get_transitions_from_state(State state_from) const
@@ -357,6 +444,7 @@ public:
      * TODO: If stateFrom or stateTo are not in the set of states of this automaton, there should probably be exception.
      */
     void add_trans(State src, Symbol symb, State tgt);
+
     void add_trans(const Trans& trans)
     {
         add_trans(trans.src, trans.symb, trans.tgt);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -329,13 +329,13 @@ public:
     }
 
     /**
-     * @brief Set initial states set with @p state.
+     * @brief Reset initial states set to contain only @p state.
      *
      * Overwrite the previous initial states set.
      *
      * @param state State to be set as the new initial state.
      */
-    void set_initial(State state)
+    void reset_initial(State state)
     {
         clear_initial();
         make_initial(state);
@@ -351,13 +351,13 @@ public:
     }
 
     /**
-     * @brief Set initial states set with @p state.
+     * @brief Reset initial states set to contain only @p state.
      *
      * Overwrite the previous initial states set.
      *
      * @param vec Vector of states to be set as new initial states.
      */
-    void set_initial(const std::vector<State>& vec)
+    void reset_initial(const std::vector<State>& vec)
     {
         clear_initial();
         for (const State& st: vec) { this->make_initial(st); }
@@ -390,13 +390,13 @@ public:
     }
 
     /**
-     * @brief Set final states set with @p state.
+     * @brief Reset final states set to contain only @p state.
      *
      * Overwrite the previous final states set.
      *
      * @param state[in] State to be set as the new final state.
      */
-    void set_final(const State state)
+    void reset_final(const State state)
     {
         clear_final();
         make_final(state);
@@ -412,13 +412,13 @@ public:
     }
 
     /**
-     * @brief Set final states set with @p state.
+     * @brief Reset final states set to contain only @p state.
      *
      * Overwrite the previous final states set.
      *
      * @param vec[in] Vector of states to be set as new final states.
      */
-    void set_final(const std::vector<State>& vec)
+    void reset_final(const std::vector<State>& vec)
     {
         clear_final();
         for (const State& st: vec) { this->make_final(st); }
@@ -663,11 +663,11 @@ private:
     void add_trimmed_transitions(const StateMap<State>& original_to_new_states_map, Nfa& trimmed_aut);
 
     /**
-     * Get new trimmed automaton.
+     * Get a new trimmed automaton.
      * @param original_to_new_states_map Map of old states to new trimmed automaton states.
-     * @return Newly initialized trimmed automaton.
+     * @return Newly created trimmed automaton.
      */
-    Nfa initialize_trimmed_aut(const StateMap<State>& original_to_new_states_map);
+    Nfa create_trimmed_aut(const StateMap<State>& original_to_new_states_map);
 }; // Nfa
 
 /// a wrapper encapsulating @p Nfa for higher-level use

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -237,11 +237,11 @@ struct TransSymbolStates {
     StateSet states_to;
 
     TransSymbolStates() = delete;
-    TransSymbolStates(Symbol symbolOnTransition) : symbol(symbolOnTransition) {}
+    explicit TransSymbolStates(Symbol symbolOnTransition) : symbol(symbolOnTransition), states_to() {}
     TransSymbolStates(Symbol symbolOnTransition, State states_to) :
             symbol(symbolOnTransition), states_to{states_to} {}
-    TransSymbolStates(Symbol symbolOnTransition, StateSet states_to) :
-            symbol(symbolOnTransition), states_to(std::move(states_to)) {}
+    TransSymbolStates(Symbol symbolOnTransition, const StateSet& states_to) :
+            symbol(symbolOnTransition), states_to(states_to) {}
 
     inline bool operator<(const TransSymbolStates& rhs) const { return symbol < rhs.symbol; }
     inline bool operator<=(const TransSymbolStates& rhs) const { return symbol <= rhs.symbol; }
@@ -280,6 +280,15 @@ public:
     {
         assert(get_num_of_states() <= size);
         transitionrelation.resize(size);
+    }
+
+    /**
+     * Increase size to include @p state.
+     * @param state[in] The new state to be included.
+     */
+    void increase_size_for_state(const State state)
+    {
+        increase_size(state + 1);
     }
 
     void make_initial(State state) {
@@ -347,6 +356,23 @@ public:
     void add_trans(const Trans& trans)
     {
         add_trans(trans.src, trans.symb, trans.tgt);
+    }
+
+    /**
+     * Remove transition.
+     * @param src Source state of the transition to be removed.
+     * @param symb Transition symbol of the transition to be removed.
+     * @param tgt Target state of the transition to be removed.
+     */
+    void remove_trans(State src, Symbol symb, State tgt);
+
+    /**
+     * Remove transition.
+     * @param trans Transition to be removed.
+     */
+    void remove_trans(const Trans& trans)
+    {
+        remove_trans(trans.src, trans.symb, trans.tgt);
     }
 
     bool has_trans(Trans trans) const

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -435,7 +435,7 @@ public:
 
     const TransitionList& get_transitions_from_state(State state_from) const
     {
-        assert(!transitionrelation.empty());
+        assert(transitionrelation.size() >= state_from + 1);
         return transitionrelation[state_from];
     }
 
@@ -475,6 +475,11 @@ public:
     {
         remove_trans(trans.src, trans.symb, trans.tgt);
     }
+
+    /**
+     * Remove epsilon transitions from the automaton.
+     */
+    void remove_epsilon(Symbol epsilon);
 
     bool has_trans(Trans trans) const
     {
@@ -751,7 +756,7 @@ void remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon);
 
 inline Nfa remove_epsilon(const Nfa& aut, Symbol epsilon)
 { // {{{
-    Nfa result;
+    Nfa result{};
     remove_epsilon(&result, aut, epsilon);
     return result;
 } // }}}

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -131,7 +131,7 @@ private:
 
 public:
 
-	OnTheFlyAlphabet(StringToSymbolMap* str_sym_map, Symbol init_symbol = 0) :
+	explicit OnTheFlyAlphabet(StringToSymbolMap* str_sym_map, Symbol init_symbol = 0) :
 		symbol_map(str_sym_map), cnt_symbol(init_symbol)
 	{
 		assert(nullptr != symbol_map);
@@ -165,7 +165,7 @@ public:
 			((str[0] == '\'' && str[2] == '\'') ||
 			(str[0] == '\"' && str[2] == '\"')
 			 ))
-		{ // direct occurence of a character
+		{ // direct occurrence of a character
 			return str[1];
 		}
 
@@ -440,6 +440,22 @@ public:
 
     bool is_state(const State &state_to_check) const { return state_to_check < transitionrelation.size(); }
 
+    /**
+     * @brief Get set of reachable states.
+     *
+     * Reachable states are states accessible from any initial state.
+     * @return Set of reachable states.
+     */
+    StateSet get_reachable_states() const;
+
+    /**
+     * @brief Get set of terminating states.
+     *
+     * Terminating states are states leading to any final state.
+     * @return Set of terminating states.
+     */
+    StateSet get_terminating_states() const;
+
     const TransitionList& get_transitions_from_state(State state_from) const
     {
         assert(transitionrelation.size() >= state_from + 1);
@@ -612,7 +628,16 @@ public:
 
         return transitionrelation[state];
     } // operator[] }}}
-};
+
+private:
+    using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
+
+    /**
+     * Compute reachability of states.
+     * @return Bool array for reachable states (from initial states): true for reachable, false for unreachable states.
+     */
+    StateBoolArray compute_reachability() const;
+}; // Nfa
 
 /// a wrapper encapsulating @p Nfa for higher-level use
 struct NfaWrapper
@@ -825,7 +850,7 @@ inline Word encode_word(
 	const std::vector<std::string>&  input)
 { // {{{
 	Word result;
-	for (auto str : input) { result.push_back(symbol_map.at(str)); }
+	for (const auto& str : input) { result.push_back(symbol_map.at(str)); }
 	return result;
 } // encode_word }}}
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -456,6 +456,23 @@ public:
      */
     StateSet get_terminating_states() const;
 
+    /**
+     * @brief Get a set of useful states.
+     *
+     * Useful states are reachable and terminating states.
+     * @return Set of useful states.
+     */
+    StateSet get_useful_states();
+
+    /**
+     * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
+     *
+     * Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
+     * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
+     * the starting point of a path ending in a final state).
+     */
+    void trim();
+
     const TransitionList& get_transitions_from_state(State state_from) const
     {
         assert(transitionrelation.size() >= state_from + 1);
@@ -637,6 +654,20 @@ private:
      * @return Bool array for reachable states (from initial states): true for reachable, false for unreachable states.
      */
     StateBoolArray compute_reachability() const;
+
+    /**
+     * Add transitions to the trimmed automaton.
+     * @param original_to_new_states_map Map of old states to new trimmed automaton states.
+     * @param trimmed_aut The new trimmed automaton.
+     */
+    void add_trimmed_transitions(const StateMap<State>& original_to_new_states_map, Nfa& trimmed_aut);
+
+    /**
+     * Get new trimmed automaton.
+     * @param original_to_new_states_map Map of old states to new trimmed automaton states.
+     * @return Newly initialized trimmed automaton.
+     */
+    Nfa initialize_trimmed_aut(const StateMap<State>& original_to_new_states_map);
 }; // Nfa
 
 /// a wrapper encapsulating @p Nfa for higher-level use

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -134,7 +134,8 @@ public:   // Public methods
 		assert(vectorIsSorted());
 	}
 
-    OrdVector(const OrdVector& rhs)
+    OrdVector(const OrdVector& rhs) :
+        vec_()
     {
         // Assertions
         assert(rhs.vectorIsSorted());
@@ -293,6 +294,44 @@ public:   // Public methods
         }
 
         return 0;
+    }
+
+    OrdVector intersection(const OrdVector& rhs) const
+    {
+        // Assertions
+        assert(vectorIsSorted());
+        assert(rhs.vectorIsSorted());
+
+        VectorType newVector{};
+
+        auto lhsIt = vec_.begin();
+        auto rhsIt = rhs.vec_.begin();
+
+        while ((lhsIt != vec_.end()) && (rhsIt != rhs.vec_.end()))
+        {	// until we get to the end of both vectors
+            if (*lhsIt == *rhsIt)
+            {
+                newVector.push_back(*lhsIt);
+
+                ++lhsIt;
+                ++rhsIt;
+            }
+            else if (*lhsIt < *rhsIt)
+            {
+                ++lhsIt;
+            }
+            else if (*rhsIt < *lhsIt)
+            {
+                ++rhsIt;
+            }
+        }
+
+        OrdVector result(newVector);
+
+        // Assertions
+        assert(result.vectorIsSorted());
+
+        return result;
     }
 
 	OrdVector Union(const OrdVector& rhs) const
@@ -515,7 +554,7 @@ public:   // Public methods
 		const_iterator itLhs = begin();
 		const_iterator itRhs = rhs.begin();
 
-		while ((itLhs != end()) || (itRhs != rhs.end()))
+		while ((itLhs != end()) && (itRhs != rhs.end()))
 		{	// until we drop out of the array (or find a common element)
 			if (*itLhs == *itRhs)
 			{	// in case there exists a common element

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -257,7 +257,7 @@ public:   // Public methods
 
     void push_back(const Key& k)
     {
-        assert(vec_.size() == 0 || vec_.at(vec_.size()-1) < k);
+        assert(vec_.empty() || vec_.at(vec_.size()-1) < k);
 
         vec_.push_back(k);
     }

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -379,7 +379,7 @@ public:   // Public methods
     inline void remove(Key k)
     {
         assert(vectorIsSorted());
-        std::remove(this->vec_.begin(), this->vec_.end(),k);
+        vec_.erase(std::remove(vec_.begin(), vec_.end(), k), vec_.end());
         assert(vectorIsSorted());
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(tests
 	tests-main.cc
 	tests-parser.cc
 	tests-re2parser.cc
+	tests-ord-vector.cc
 	afa/tests-afa.cc
 	nfa/tests-nfa.cc
 	rra/tests-rrt.cc

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -276,7 +276,7 @@ void Nfa::trim()
         ++new_state_num;
     }
 
-    Nfa trimmed_aut{ initialize_trimmed_aut(original_to_new_states_map) };
+    Nfa trimmed_aut{ create_trimmed_aut(original_to_new_states_map) };
 
     add_trimmed_transitions(original_to_new_states_map, trimmed_aut);
 
@@ -301,7 +301,7 @@ StateSet Nfa::get_useful_states()
     return useful_states;
 }
 
-Nfa Nfa::initialize_trimmed_aut(const StateMap<State>& original_to_new_states_map)
+Nfa Nfa::create_trimmed_aut(const StateMap<State>& original_to_new_states_map)
 {
     Nfa trimmed_aut{ original_to_new_states_map.size() };
 
@@ -1691,7 +1691,7 @@ void SegNfa::Segmentation::update_current_segment(const size_t current_depth, co
     assert(transition.symb == epsilon);
     assert(segments[current_depth].has_trans(transition));
 
-    segments[current_depth].set_final(transition.src);
+    segments[current_depth].reset_final(transition.src);
     segments[current_depth].remove_trans(transition);
 }
 
@@ -1703,7 +1703,7 @@ void SegNfa::Segmentation::propagate_to_other_segments(const size_t current_dept
          ++other_segment_depth)
     {
         segments[other_segment_depth].remove_trans(transition);
-        segments[other_segment_depth].set_initial(transition.tgt);
+        segments[other_segment_depth].reset_initial(transition.tgt);
     }
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -193,6 +193,7 @@ void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {
     auto transitionFromStateIter = transitionrelation[stateFrom].begin();
     for (; transitionFromStateIter != transitionrelation[stateFrom].end(); ++transitionFromStateIter) {
         if (transitionFromStateIter->symbol == symbolOnTransition) {
+            // Add transition with symbolOnTransition already used on transitions from stateFrom.
             transitionFromStateIter->states_to.insert(stateTo);
             return;
         } else if (transitionFromStateIter->symbol > symbolOnTransition) {
@@ -200,6 +201,7 @@ void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {
         }
     }
 
+    // Add transition to a new TransSymbolStates struct with symbolOnTransition yet unused on transitions from stateFrom.
     transitionrelation[stateFrom].insert(transitionFromStateIter, TransSymbolStates(symbolOnTransition, stateTo));
 }
 
@@ -825,6 +827,28 @@ size_t Nfa::get_num_of_trans() const
     }
 
     return num_of_transitions;
+}
+
+Nfa Nfa::get_digraph()
+{
+    Nfa digraph{ get_num_of_states(), initialstates, finalstates};
+    Symbol abstract_symbol{ 'x' };
+
+    for (State src_state{ 0 }; src_state < get_num_of_states(); ++src_state)
+    {
+        for (const auto &symbol_transitions: this->transitionrelation[src_state])
+        {
+            for (State tgt_state: symbol_transitions.states_to)
+            {
+                if (!digraph.has_trans(src_state, abstract_symbol, tgt_state))
+                {
+                    digraph.add_trans(src_state, abstract_symbol, tgt_state);
+                }
+            }
+        }
+    }
+
+    return digraph;
 }
 
 void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -783,6 +783,24 @@ Nfa Nfa::read_from_our_format(std::istream &inputStream) {
     return newNFA;
 }
 
+TransSequence Nfa::get_trans_as_sequence()
+{
+    TransSequence trans_sequence{};
+
+    for (State state_from{ 0 }; state_from < transitionrelation.size(); ++state_from)
+    {
+        for (const auto& transition_from_state: transitionrelation[state_from])
+        {
+            for (State state_to: transition_from_state.states_to)
+            {
+                trans_sequence.push_back(Trans{ state_from, transition_from_state.symbol, state_to });
+            }
+        }
+    }
+
+    return trans_sequence;
+}
+
 void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {
     *unionAutomaton = rhs;
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -327,7 +327,7 @@ void Mata::Nfa::remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
 
     // TODO: grossly inefficient
     // first we compute the epsilon closure
-    for (size_t i=0; i < aut.trans_size(); ++i)
+    for (size_t i=0; i < aut.get_num_of_states(); ++i)
     {
         for (const auto& trans: aut[i])
         { // initialize
@@ -343,7 +343,7 @@ void Mata::Nfa::remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
     bool changed = true;
     while (changed) { // compute the fixpoint
         changed = false;
-        for (size_t i=0; i < aut.trans_size(); ++i)
+        for (size_t i=0; i < aut.get_num_of_states(); ++i)
         {
             for (auto const &trans: aut[i])
             {
@@ -388,12 +388,12 @@ void Mata::Nfa::revert(Nfa* result, const Nfa& aut)
 {
     assert(nullptr != result);
 
-    if (aut.trans_size() > result->trans_size()) { result->increase_size(aut.trans_size()); }
+    if (aut.get_num_of_states() > result->get_num_of_states()) { result->increase_size(aut.get_num_of_states()); }
 
     result->initialstates = aut.finalstates;
     result->finalstates = aut.initialstates;
 
-    for (size_t i = 0; i < aut.trans_size(); ++i)
+    for (size_t i = 0; i < aut.get_num_of_states(); ++i)
     {
         for (const auto& symStates : aut[i])
             for (const State tgt : symStates.states_to)
@@ -407,7 +407,7 @@ bool Mata::Nfa::is_deterministic(const Nfa& aut)
 
     if (aut.trans_empty()) { return true; }
 
-    for (size_t i = 0; i < aut.trans_size(); ++i)
+    for (size_t i = 0; i < aut.get_num_of_states(); ++i)
     {
         for (const auto& symStates : aut[i])
         {
@@ -799,6 +799,21 @@ TransSequence Nfa::get_trans_as_sequence()
     }
 
     return trans_sequence;
+}
+
+size_t Nfa::get_num_of_trans() const
+{
+    size_t num_of_transitions{};
+
+    for (const auto& state_transitions: transitionrelation)
+    {
+        for (const auto& symbol_transitions: state_transitions)
+        {
+            num_of_transitions += symbol_transitions.states_to.size();
+        }
+    }
+
+    return num_of_transitions;
 }
 
 void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -203,6 +203,33 @@ void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {
     transitionrelation[stateFrom].insert(transitionFromStateIter, TransSymbolStates(symbolOnTransition, stateTo));
 }
 
+void Nfa::remove_trans(State src, Symbol symb, State tgt)
+{
+    if (!has_trans(src, symb, tgt))
+    {
+        throw std::invalid_argument(
+                "Transition [" + std::to_string(src) + ", " + std::to_string(symb) + ", " +
+                std::to_string(tgt) + "] does not exist.");
+    }
+
+    auto transitionFromStateIter{ transitionrelation[src].begin() };
+    for (; transitionFromStateIter != transitionrelation[src].end(); ++transitionFromStateIter)
+    {
+        if (transitionFromStateIter->symbol == symb)
+        {
+            transitionFromStateIter->states_to.remove(tgt);
+            if (transitionFromStateIter->states_to.empty())
+            {
+                transitionrelation[src].remove(*transitionFromStateIter);
+            }
+
+            return;
+        }
+
+        ++transitionFromStateIter;
+    }
+}
+
 State Nfa::add_new_state() {
     transitionrelation.emplace_back();
     return transitionrelation.size() - 1;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1397,7 +1397,7 @@ void Mata::Nfa::ShortestWordsMap::insert_initial_lengths()
         }
 
         processed.insert(reversed_automaton.initialstates.begin(), reversed_automaton.initialstates.end());
-        lifo_queue.insert(lifo_queue.end(), reversed_automaton.initialstates.begin(),
+        fifo_queue.insert(fifo_queue.end(), reversed_automaton.initialstates.begin(),
                           reversed_automaton.initialstates.end());
     }
 }
@@ -1405,10 +1405,10 @@ void Mata::Nfa::ShortestWordsMap::insert_initial_lengths()
 void ShortestWordsMap::compute()
 {
     State state{};
-    while (!lifo_queue.empty())
+    while (!fifo_queue.empty())
     {
-        state = lifo_queue.front();
-        lifo_queue.pop_front();
+        state = fifo_queue.front();
+        fifo_queue.pop_front();
 
         // Compute the shortest words for the current state.
         compute_for_state(state);
@@ -1448,7 +1448,7 @@ void ShortestWordsMap::compute_for_state(const State state)
             if (processed.find(state_to) == processed.end())
             {
                 processed.insert(state_to);
-                lifo_queue.push_back(state_to);
+                fifo_queue.push_back(state_to);
             }
         }
     }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1498,7 +1498,7 @@ TEST_CASE("Mata::Nfa::revert()")
 		REQUIRE(result.has_initial(2));
 		REQUIRE(result.has_final(1));
 		REQUIRE(result.has_trans(2, 'a', 1));
-		REQUIRE(result.trans_size() == aut.trans_size());
+		REQUIRE(result.get_num_of_states() == aut.get_num_of_states());
 	}
 
 	SECTION("bigger automaton")

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1933,6 +1933,25 @@ TEST_CASE("Mata::Nfa::get_shortest_words()")
 
         REQUIRE(aut.get_shortest_words() == std::set<Word>{Word{}});
     }
+
+    SECTION("Require FIFO queue")
+    {
+        aut.initialstates = { 1 };
+        aut.finalstates = { 4 };
+        aut.add_trans(1, 'a', 5);
+        aut.add_trans(5, 'c', 4);
+        aut.add_trans(1, 'a', 2);
+        aut.add_trans(2, 'b', 3);
+        aut.add_trans(3, 'b', 4);
+
+        Word word{};
+        word.push_back('a');
+        word.push_back('c');
+        std::set<Word> expected{word};
+
+        // LIFO queue would return as shortest words string "abb", which would be incorrect.
+        REQUIRE(aut.get_shortest_words() == expected);
+    }
 }
 
 TEST_CASE("Mata::Nfa::remove_final()")

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1924,3 +1924,18 @@ TEST_CASE("Mata::Nfa::get_shortest_words()")
         REQUIRE(aut.get_shortest_words() == std::set<Word>{Word{}});
     }
 }
+
+TEST_CASE("Mata::Nfa::remove_final()")
+{
+    Nfa aut('q' + 1);
+
+    SECTION("Automaton B")
+    {
+        FILL_WITH_AUT_B(aut);
+        REQUIRE(aut.has_final(2));
+        REQUIRE(aut.has_final(12));
+        aut.remove_final(12);
+        REQUIRE(aut.has_final(2));
+        REQUIRE(!aut.has_final(12));
+    }
+}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1854,7 +1854,7 @@ TEST_CASE("Mata::Nfa::get_shortest_words()")
         Word word{};
         word.push_back('b');
         word.push_back('a');
-        std::set<Word> expected{word};
+        WordSet expected{word};
         Word word2{};
         word2.push_back('a');
         word2.push_back('a');
@@ -1876,7 +1876,7 @@ TEST_CASE("Mata::Nfa::get_shortest_words()")
             word.push_back('b');
             word.push_back('b');
             word.push_back('a');
-            expected = std::set<Word>{word};
+            expected = WordSet{word};
             word2.clear();
             word2.push_back('b');
             word2.push_back('a');
@@ -1937,5 +1937,59 @@ TEST_CASE("Mata::Nfa::remove_final()")
         aut.remove_final(12);
         REQUIRE(aut.has_final(2));
         REQUIRE(!aut.has_final(12));
+    }
+}
+
+TEST_CASE("Mata::Nfa::remove_trans()")
+{
+    Nfa aut('q' + 1);
+
+    SECTION("Automaton B")
+    {
+        FILL_WITH_AUT_B(aut);
+        aut.add_trans(1, 3, 4);
+        aut.add_trans(1, 3, 5);
+
+        SECTION("Simple remove")
+        {
+            REQUIRE(aut.has_trans(1, 3, 4));
+            REQUIRE(aut.has_trans(1, 3, 5));
+            aut.remove_trans(1, 3, 5);
+            REQUIRE(aut.has_trans(1, 3, 4));
+            REQUIRE(!aut.has_trans(1, 3, 5));
+        }
+
+        SECTION("Remove missing transition")
+        {
+            REQUIRE_THROWS_AS(aut.remove_trans(1, 1, 5), std::invalid_argument);
+        }
+
+        SECTION("Remove the last state_to from states_to")
+        {
+            REQUIRE(aut.has_trans(6, 'a', 2));
+            aut.remove_trans(6, 'a', 2);
+            REQUIRE(!aut.has_trans(6, 'a', 2));
+            REQUIRE(aut.transitionrelation[6].empty());
+
+            REQUIRE(aut.has_trans(4, 'a', 8));
+            REQUIRE(aut.has_trans(4, 'c', 8));
+            REQUIRE(aut.has_trans(4, 'a', 6));
+            REQUIRE(aut.has_trans(4, 'b', 6));
+            REQUIRE(aut.transitionrelation[4].size() == 3);
+            aut.remove_trans(4, 'a', 6);
+            REQUIRE(!aut.has_trans(4, 'a', 6));
+            REQUIRE(aut.has_trans(4, 'b', 6));
+            REQUIRE(aut.transitionrelation[4].size() == 3);
+
+            aut.remove_trans(4, 'a', 8);
+            REQUIRE(!aut.has_trans(4, 'a', 8));
+            REQUIRE(aut.has_trans(4, 'c', 8));
+            REQUIRE(aut.transitionrelation[4].size() == 2);
+
+            aut.remove_trans(4, 'c', 8);
+            REQUIRE(!aut.has_trans(4, 'a', 8));
+            REQUIRE(!aut.has_trans(4, 'c', 8));
+            REQUIRE(aut.transitionrelation[4].size() == 1);
+        }
     }
 }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1993,3 +1993,20 @@ TEST_CASE("Mata::Nfa::remove_trans()")
         }
     }
 }
+
+TEST_CASE("Mata::Nfa::get_trans_as_sequence(}")
+{
+    Nfa aut('q' + 1);
+    TransSequence expected{};
+
+    aut.add_trans(1, 2, 3);
+    expected.push_back(Trans{1, 2, 3});
+    aut.add_trans(1, 3, 4);
+    expected.push_back(Trans{1, 3, 4});
+    aut.add_trans(2, 3, 4);
+    expected.push_back(Trans{2, 3, 4});
+
+
+    REQUIRE(aut.get_trans_as_sequence() == expected);
+}
+

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2236,3 +2236,20 @@ TEST_CASE("Mata::Nfa::get_reachable_states()")
     CHECK(reachable.find(10) == reachable.end());
 }
 
+TEST_CASE("Mata::Nfa::trim()")
+{
+    Nfa aut{20};
+    FILL_WITH_AUT_A(aut);
+    aut.remove_trans(1, 'a', 10);
+
+    Nfa old_aut{aut};
+
+    aut.trim();
+    REQUIRE(aut.initialstates.size() == old_aut.initialstates.size());
+    REQUIRE(aut.finalstates.size() == old_aut.finalstates.size());
+    for (const Word& word: old_aut.get_shortest_words())
+    {
+        REQUIRE(is_in_lang(aut, word));
+    }
+}
+

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -349,8 +349,8 @@ TEST_CASE("Mata::Nfa::intersection()")
 		REQUIRE(res.has_initial(prod_map[{3, 4}]));
 		REQUIRE(res.has_final(prod_map[{5, 2}]));
 
-        for (const auto& c : prod_map) std::cout << c.first.first << "," << c.first.second << " -> " << c.second << "\n";
-        std::cout << prod_map[{7, 2}] << " " <<  prod_map[{1, 2}] << '\n';
+        //for (const auto& c : prod_map) std::cout << c.first.first << "," << c.first.second << " -> " << c.second << "\n";
+        //std::cout << prod_map[{7, 2}] << " " <<  prod_map[{1, 2}] << '\n';
 		REQUIRE(res.has_trans(prod_map[{1, 4}], 'a', prod_map[{3, 6}]));
 		REQUIRE(res.has_trans(prod_map[{1, 4}], 'a', prod_map[{10, 8}]));
 		REQUIRE(res.has_trans(prod_map[{1, 4}], 'a', prod_map[{10, 6}]));

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1892,6 +1892,16 @@ TEST_CASE("Mata::Nfa::get_shortest_words()")
         REQUIRE(aut.get_shortest_words().empty());
     }
 
+    SECTION("One-state automaton accepting an empty language")
+    {
+        aut.make_initial(0);
+        REQUIRE(aut.get_shortest_words().empty());
+        aut.make_final(1);
+        REQUIRE(aut.get_shortest_words().empty());
+        aut.make_final(0);
+        REQUIRE(aut.get_shortest_words() == WordSet{Word{}});
+    }
+
     SECTION("Automaton A")
     {
         FILL_WITH_AUT_A(aut);

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2059,6 +2059,31 @@ TEST_CASE("Mata::Nfa::Segmentation::get_epsilon_depths()")
 
 }
 
+TEST_CASE("Mata::Nfa::remove_epsilon()")
+{
+    Nfa aut{20};
+    FILL_WITH_AUT_A(aut);
+    aut.remove_epsilon('c');
+    REQUIRE(aut.has_trans(10, 'a', 7));
+    REQUIRE(aut.has_trans(10, 'b', 7));
+    REQUIRE(!aut.has_trans(10, 'c', 7));
+    REQUIRE(aut.has_trans(7, 'a', 5));
+    REQUIRE(aut.has_trans(7, 'a', 3));
+    REQUIRE(!aut.has_trans(7, 'c', 3));
+    REQUIRE(aut.has_trans(7, 'b', 9));
+    REQUIRE(aut.has_trans(7, 'a', 7));
+    REQUIRE(aut.has_trans(5, 'a', 5));
+    REQUIRE(!aut.has_trans(5, 'c', 9));
+    REQUIRE(aut.has_trans(5, 'a', 9));
+}
+
+TEST_CASE("Mata::Nfa::get_num_of_trans()")
+{
+    Nfa aut{20};
+    FILL_WITH_AUT_A(aut);
+    REQUIRE(aut.get_num_of_trans() == 15);
+}
+
 TEST_CASE("Mata::Nfa::Segmentation::split_segment_automaton()")
 {
     Nfa aut(100);

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2130,3 +2130,21 @@ TEST_CASE("Mata::Nfa::Segmentation::split_segment_automaton()")
     REQUIRE(segments[3].has_final(1));
     REQUIRE(segments[3].has_trans(0, 'b', 1));
 }
+
+TEST_CASE("Mata::Nfa::get_digraph()")
+{
+    Nfa aut(100);
+    Symbol abstract_symbol{'x'};
+    FILL_WITH_AUT_A(aut);
+
+    Nfa digraph{ aut.get_digraph() };
+
+    REQUIRE(digraph.get_num_of_states() == aut.get_num_of_states());
+    REQUIRE(digraph.get_num_of_trans() == 12);
+    REQUIRE(digraph.has_trans(1, abstract_symbol, 10));
+    REQUIRE(digraph.has_trans(10, abstract_symbol, 7));
+    REQUIRE(!digraph.has_trans(10, 'a', 7));
+    REQUIRE(!digraph.has_trans(10, 'b', 7));
+    REQUIRE(!digraph.has_trans(10, 'c', 7));
+}
+

--- a/src/tests-ord-vector.cc
+++ b/src/tests-ord-vector.cc
@@ -1,0 +1,60 @@
+/* tests-ord-vector.cc -- tests of OrdVector
+ *
+ * Copyright (c) 2018 Ondrej Lengal <ondra.lengal@gmail.com>
+ *
+ * This file is a part of libmata.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../3rdparty/catch.hpp"
+
+#include <mata/util.hh>
+#include <mata/ord_vector.hh>
+
+using namespace Mata::util;
+using namespace Mata::Util;
+
+TEST_CASE("Mata::Util::OrdVector::intersection(}")
+{
+    using OrdVectorT = OrdVector<int>;
+    OrdVectorT set1{};
+    OrdVectorT set2{};
+
+    SECTION("Empty sets")
+    {
+        REQUIRE(set1.intersection(set2).empty());
+    }
+
+    SECTION("Sets of same lengths")
+    {
+        set1 = {1, 3, 5, 7};
+        set2 = {1, 2, 5, 6};
+
+        REQUIRE(set1.intersection(set2) == OrdVectorT{1, 5});
+    }
+
+    SECTION("Sets of different lengths")
+    {
+        set1 = {1, 3, 5, 7};
+        set2 = {1, 2, 5, 7, 8};
+
+        REQUIRE(set1.intersection(set2) == OrdVectorT{1, 5, 7});
+    }
+
+    SECTION("Empty intersection of non-empty sets")
+    {
+        set1 = {0, 3, 6};
+        set2 = {1, 2, 5, 7, 8};
+
+        REQUIRE(set1.intersection(set2).empty());
+    }
+}


### PR DESCRIPTION
This PR implements functions used in segmentation algorithms. Furthermore, this PR contains implementation of helper functions and generally useful member functions on class (struct) `Mata::Nfa::Nfa`.

All implemented helper functions are required by segmentation algorithms, but are useful for operations on NFAs.

This PR:
1. Fixes `OrdVector` implementation
   - Fixes a bug with remove method of `OrdVector`
   - Implements intersection method on `OrdVectors`
3. Creates test file for `OrdVector` implementation
7. Reflects changes to methods to make states initial and final
   - Accordingly modifies `trans_size()` method
8. Reflects bug fix from Noodler implementation of method to get the shortest words in its Mata implementation 
9. Adds methods to
   - Trim redundant states (one of the requested functions in #25)
   - Compute reachability of states (both forward and backward reachability)
   - Execute segmentation by a given symbol
   - Get directed graph from an NFA
   - Remove transitions from `Nfa`
   - Get sequence of transitions from `Nfa`

A new namespace inside `Mata::Nfa` named `Mata::Nfa::SegNfa` is introduced, which includes methods applicable only on segment automata, NFAs whose state space can be split into several segments connected by ε-transitions in a chain. No other ε-transitions are allowed. As a consequence, no ε-transitions can appear in a cycle.

The original method `Mata::Nfa::Nfa::trans_size()` returned a number of states instead of the number of transitions. The method was fixed to truly return the number of transitions in an automaton. Furthermore, the method was renamed to `get_num_of_trans()` to follow the naming structure of an already existing method `get_num_of_states()` and not introduce a new structure for similar methods. For that reason, Python binding for the original `trans_size()` was updated as well to call the new `get_num_of_trans()` method instead. 

All introduced methods are documented and there are basic tests written for all of them.