### PR TITLE
Implement noodlification

### DIFF
--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1100,7 +1100,6 @@ private:
     void handle_epsilon_transitions(const StateDepthPair& state_depth_pair, const TransSymbolStates& state_transitions,
                                     std::deque<StateDepthPair>& worklist);
 }; // Segmentation
-
 } // SegNfa
 
 /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -275,8 +275,6 @@ struct Nfa
     StateSet initialstates = {};
     StateSet finalstates = {};
 
-    //TODO we probably need the number of states, int, as a member, for when we want to remove states
-    // alphabet?
 public:
     Nfa() : transitionrelation(), initialstates(), finalstates() {}
 
@@ -482,8 +480,6 @@ public:
 
     /**
      * @brief Adds a transition from stateFrom trough symbol to stateTo.
-     *
-     * TODO: If stateFrom or stateTo are not in the set of states of this automaton, there should probably be exception.
      */
     void add_trans(State src, Symbol symb, State tgt);
 
@@ -626,7 +622,6 @@ public:
 
         std::pair<Symbol, const StateSet> next();
     };
-
 
     struct const_iterator
     { // {{{

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1119,14 +1119,21 @@ public:
         insert_initial_lengths();
 
         compute();
-   }
+    }
 
     /**
      * Gets shortest words for the given @p states.
      * @param[in] states States to map shortest words for.
      * @return Set of shortest words.
      */
-    WordSet get_shortest_words_for_states(const StateSet& states) const;
+    WordSet get_shortest_words_for(const StateSet& states) const;
+
+    /**
+     * Gets shortest words for the given @p state.
+     * @param[in] state State to map shortest words for.
+     * @return Set of shortest words.
+     */
+    WordSet get_shortest_words_for(State state) const;
 
 private:
     using WordLength = int; ///< A length of a word.

--- a/include/mata/noodlify.hh
+++ b/include/mata/noodlify.hh
@@ -1,0 +1,47 @@
+/* noodlify.hh -- Noodlification of NFAs
+ *
+ * Copyright (c) 2018 Ondrej Lengal <ondra.lengal@gmail.com>
+ *
+ * This file is a part of libmata.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _MATA_NOODLIFY_HH
+#define _MATA_NOODLIFY_HH
+
+#include <mata/nfa.hh>
+
+namespace Mata
+{
+namespace Nfa
+{
+namespace SegNfa
+{
+
+/**
+ * @brief Create noodles from segment @p automaton.
+ *
+ * Segment automaton is a chain of finite automata connected via ε-transitions.
+ * A noodle is a copy of the segment automaton with exactly 1 ε-transition between each two consecutive segments.
+ *
+ * @param[in] automaton Segment automaton to noodlify.
+ * @param[in] epsilon Epsilon symbol to noodlify for.
+ * @param[in] include_empty Whether to also include empty noodles.
+ * @return A list of all (non-empty) noodles.
+ */
+AutSequence noodlify(SegNfa& aut, Symbol epsilon, bool include_empty = false);
+
+} // SegNfa
+} // Nfa
+} // Mata
+
+#endif // _MATA_NOODLIFY_HH

--- a/include/mata/noodlify.hh
+++ b/include/mata/noodlify.hh
@@ -28,17 +28,17 @@ namespace SegNfa
 {
 
 /**
- * @brief Create noodles from segment @p automaton.
+ * @brief Create noodles from segment automaton @p aut.
  *
- * Segment automaton is a chain of finite automata connected via ε-transitions.
- * A noodle is a copy of the segment automaton with exactly 1 ε-transition between each two consecutive segments.
+ * Segment automaton is a chain of finite automata (segments) connected via ε-transitions.
+ * A noodle is a copy of the segment automaton with exactly one ε-transition between each two consecutive segments.
  *
  * @param[in] automaton Segment automaton to noodlify.
  * @param[in] epsilon Epsilon symbol to noodlify for.
  * @param[in] include_empty Whether to also include empty noodles.
  * @return A list of all (non-empty) noodles.
  */
-AutSequence noodlify(SegNfa& aut, Symbol epsilon, bool include_empty = false);
+AutSequence noodlify(const SegNfa& aut, Symbol epsilon, bool include_empty = false);
 
 } // SegNfa
 } // Nfa

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(libmata STATIC
 	nfa/nfa-complement.cc
 	nfa/nfa-intersection.cc
 	nfa/nfa-concatenation.cc
+	nfa/noodlify.cc
 	rra/rrt.cc
 )
 
@@ -74,6 +75,7 @@ add_executable(tests
 	tests-ord-vector.cc
 	afa/tests-afa.cc
 	nfa/tests-nfa.cc
+	nfa/tests-noodlify.cc
 	rra/tests-rrt.cc
 )
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -46,7 +46,7 @@ namespace {
         return any_of(states.begin(), states.end(), [&isFinal](State s) { return isFinal[s]; });
     }
 
-    void uniont_to_left(StateSet &receivingSet, const StateSet &addedSet) {
+    void union_to_left(StateSet &receivingSet, const StateSet &addedSet) {
         receivingSet.insert(addedSet);
     }
 
@@ -342,7 +342,7 @@ void Nfa::add_trimmed_transitions(const StateMap<State>& original_to_new_states_
     }
 }
 
-/// General methods for NFA
+// General methods for NFA.
 
 bool Mata::Nfa::are_state_disjoint(const Nfa& lhs, const Nfa& rhs)
 { // {{{
@@ -1395,7 +1395,7 @@ Nfa::const_iterator& Nfa::const_iterator::operator++()
     for (size_t i=0; i < size;) {
         Symbol transitionSymbol = transition_iterators[i]->symbol;
         if (transitionSymbol == min_symbol) {
-            uniont_to_left(post, transition_iterators[i]->states_to);
+            union_to_left(post, transition_iterators[i]->states_to);
             transition_iterators[i]++;
             if (transition_iterators[i] != automaton.transitionrelation[state_vector[i]].end()) {
                 Symbol nextTransitionSymbol = transition_iterators[i]->symbol;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -645,7 +645,7 @@ WordSet Mata::Nfa::Nfa::get_shortest_words() const
     ShortestWordsMap shortest_words_map{ *this };
 
     // Get the shortest words for all initial states accepted by the whole automaton (not just a part of the automaton).
-    return shortest_words_map.get_shortest_words_for_states(this->initialstates);
+    return shortest_words_map.get_shortest_words_for(this->initialstates);
 }
 
 /// serializes Nfa into a ParsedSection
@@ -1434,7 +1434,7 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Nfa::NfaWrapper& nfa
 	return os;
 } // operator<<(NfaWrapper) }}}
 
-WordSet ShortestWordsMap::get_shortest_words_for_states(const StateSet& states) const
+WordSet ShortestWordsMap::get_shortest_words_for(const StateSet& states) const
 {
     std::set <Word> result{};
 
@@ -1466,6 +1466,11 @@ WordSet ShortestWordsMap::get_shortest_words_for_states(const StateSet& states) 
     }
 
     return result;
+}
+
+WordSet ShortestWordsMap::get_shortest_words_for(State state) const
+{
+     return get_shortest_words_for(StateSet{ state });
 }
 
 void Mata::Nfa::ShortestWordsMap::insert_initial_lengths()

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -185,7 +185,7 @@ std::list<Symbol> EnumAlphabet::get_complement(
 ///// Nfa structure related methods
 
 void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {
-    // TODO: define own exceptions
+    // TODO: Define own exception.
     if (!is_state(stateFrom) || !is_state(stateTo)) {
         throw std::out_of_range(std::to_string(stateFrom) + " or " + std::to_string(stateTo) + " is not a state.");
     }

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -20,32 +20,49 @@
 
 using namespace Mata::Nfa;
 
-AutSequence SegNfa::noodlify(SegNfa& aut, const Symbol epsilon, bool include_empty)
+namespace
 {
-    AutSequence noodles{}; // Store the generated noodles.
 
-    // For each depth, get a list of epsilon transitions.
-    Segmentation segmentation{ aut, epsilon };
-    const auto& epsilon_depths{ segmentation.get_epsilon_depths() };
-
-    Nfa noodle{}; // Noodle created for each combination of epsilon transitions.
-
-    // Compute number of all combinations of ε-transitions with one ε-transitions from each depth.
+/**
+ * Get a number of permutations for computed epsilon depths.
+ * @param[in] epsilon_depths Computed list of epsilon transitions for each depth.
+ * @return Number of permutations.
+ */
+size_t get_num_of_permutations(const SegNfa::Segmentation::EpsilonDepthTransitions& epsilon_depths)
+{
     size_t num_of_permutations{ 1 };
     for (const auto& segment: epsilon_depths)
     {
         num_of_permutations *= segment.second.size();
     }
+    return num_of_permutations;
+}
 
+/**
+ * Create noodles for computed epsilon depths.
+ * @param[in] aut Segment automaton to create noodles for.
+ * @param[in] include_empty Whether to also include empty noodles.
+ * @param[in] epsilon_depths Computed list of epsilon transitions for each depth.
+ * @return A Sequence of noodles (noodle automata).
+ */
+AutSequence create_noodles(const SegNfa::SegNfa& aut, bool include_empty,
+                           const SegNfa::Segmentation::EpsilonDepthTransitions& epsilon_depths)
+{
+    // Compute number of all combinations of ε-transitions with one ε-transitions from each depth.
+    size_t num_of_permutations{ get_num_of_permutations(epsilon_depths) };
+    int epsilon_depths_size{ static_cast<int>(epsilon_depths.size()) };
+    int maximal_depth{ epsilon_depths_size - 1 };
+    AutSequence noodles{}; // Store the generated noodles.
+    Nfa noodle{}; // Noodle created for each combination of epsilon transitions.
     // Indices of a transition in each depth to compute the noodle for.
-    std::vector<size_t> transition_indices(epsilon_depths.size(), 0);
-
+    std::vector<size_t> transition_indices(epsilon_depths_size, 0);
     // For each combination of ε-transitions, create the automaton.
-    for (size_t index{ 0 }; index < num_of_permutations; ++index) {
-        for (int depth{ static_cast<int>(epsilon_depths.size()) - 1 }; depth >= 0; --depth)
+    for (size_t index{ 0 }; index < num_of_permutations; ++index)
+    {
+        for (int depth{ maximal_depth }; depth >= 0; --depth)
         {
             size_t computed_index{ index };
-            for (int previous_depth{0}; previous_depth < depth; ++previous_depth)
+            for (int previous_depth{ 0 }; previous_depth < depth; ++previous_depth)
             {
                 computed_index /= epsilon_depths.at(previous_depth).size();
             }
@@ -54,8 +71,7 @@ AutSequence SegNfa::noodlify(SegNfa& aut, const Symbol epsilon, bool include_emp
         }
 
         noodle = aut;
-
-        for (int depth{ 0 }; depth < static_cast<int>(epsilon_depths.size()); ++depth)
+        for (int depth{ 0 }; depth < epsilon_depths_size; ++depth)
         {
             for (const auto& transition: epsilon_depths.at(depth))
             {
@@ -66,14 +82,21 @@ AutSequence SegNfa::noodlify(SegNfa& aut, const Symbol epsilon, bool include_emp
                 }
             }
         }
-
         noodle.trim();
-
-        if (include_empty || noodle.get_num_of_states() > 0)
-        {
-            noodles.push_back(noodle);
-        }
+        if (include_empty || noodle.get_num_of_states() > 0) { noodles.push_back(noodle); }
     }
-
     return noodles;
 }
+
+} // namespace
+
+AutSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon, bool include_empty)
+{
+    // For each depth, get a list of epsilon transitions.
+    Segmentation segmentation{ aut, epsilon };
+    const auto& epsilon_depths{ segmentation.get_epsilon_depths() };
+
+    // Create noodles for computed epsilon depths.
+    return create_noodles(aut, include_empty, epsilon_depths);
+}
+

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -1,0 +1,79 @@
+/* noodlify.cc -- Noodlification of NFAs
+ *
+ * Copyright (c) 2018 Ondrej Lengal <ondra.lengal@gmail.com>
+ *
+ * This file is a part of libmata.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+#include <mata/nfa.hh>
+#include <mata/noodlify.hh>
+
+using namespace Mata::Nfa;
+
+AutSequence SegNfa::noodlify(SegNfa& aut, const Symbol epsilon, bool include_empty)
+{
+    AutSequence noodles{}; // Store the generated noodles.
+
+    // For each depth, get a list of epsilon transitions.
+    Segmentation segmentation{ aut, epsilon };
+    const auto& epsilon_depths{ segmentation.get_epsilon_depths() };
+
+    Nfa noodle{}; // Noodle created for each combination of epsilon transitions.
+
+    // Compute number of all combinations of ε-transitions with one ε-transitions from each depth.
+    size_t num_of_permutations{ 1 };
+    for (const auto& segment: epsilon_depths)
+    {
+        num_of_permutations *= segment.second.size();
+    }
+
+    // Indices of a transition in each depth to compute the noodle for.
+    std::vector<size_t> transition_indices(epsilon_depths.size(), 0);
+
+    // For each combination of ε-transitions, create the automaton.
+    for (size_t index{ 0 }; index < num_of_permutations; ++index) {
+        for (int depth{ static_cast<int>(epsilon_depths.size()) - 1 }; depth >= 0; --depth)
+        {
+            size_t computed_index{ index };
+            for (int previous_depth{0}; previous_depth < depth; ++previous_depth)
+            {
+                computed_index /= epsilon_depths.at(previous_depth).size();
+            }
+
+            transition_indices.at(depth) = computed_index % epsilon_depths.at(depth).size();
+        }
+
+        noodle = aut;
+
+        for (int depth{ 0 }; depth < static_cast<int>(epsilon_depths.size()); ++depth)
+        {
+            for (const auto& transition: epsilon_depths.at(depth))
+            {
+                // Remove all ε-transitions of depth 'i' except for 'noodle_trans[i]'.
+                if (epsilon_depths.at(depth).at(transition_indices.at(depth)) != transition)
+                {
+                    noodle.remove_trans(transition);
+                }
+            }
+        }
+
+        noodle.trim();
+
+        if (include_empty || noodle.get_num_of_states() > 0)
+        {
+            noodles.push_back(noodle);
+        }
+    }
+
+    return noodles;
+}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2503,23 +2503,71 @@ TEST_CASE("Mata::Nfa::get_digraph()")
 TEST_CASE("Mata::Nfa::get_reachable_states()")
 {
     Nfa aut{20};
-    FILL_WITH_AUT_A(aut);
-    aut.remove_trans(3, 'b', 9);
-    aut.remove_trans(5, 'c', 9);
-    aut.remove_trans(1, 'a', 10);
 
-    auto reachable{aut.get_reachable_states()};
-    CHECK(reachable.find(0) == reachable.end());
-    CHECK(reachable.find(1) != reachable.end());
-    CHECK(reachable.find(2) == reachable.end());
-    CHECK(reachable.find(3) != reachable.end());
-    CHECK(reachable.find(4) == reachable.end());
-    CHECK(reachable.find(5) != reachable.end());
-    CHECK(reachable.find(6) == reachable.end());
-    CHECK(reachable.find(7) != reachable.end());
-    CHECK(reachable.find(8) == reachable.end());
-    CHECK(reachable.find(9) == reachable.end());
-    CHECK(reachable.find(10) == reachable.end());
+    SECTION("Automaton A")
+    {
+        FILL_WITH_AUT_A(aut);
+        aut.remove_trans(3, 'b', 9);
+        aut.remove_trans(5, 'c', 9);
+        aut.remove_trans(1, 'a', 10);
+
+        auto reachable{aut.get_reachable_states()};
+        CHECK(reachable.find(0) == reachable.end());
+        CHECK(reachable.find(1) != reachable.end());
+        CHECK(reachable.find(2) == reachable.end());
+        CHECK(reachable.find(3) != reachable.end());
+        CHECK(reachable.find(4) == reachable.end());
+        CHECK(reachable.find(5) != reachable.end());
+        CHECK(reachable.find(6) == reachable.end());
+        CHECK(reachable.find(7) != reachable.end());
+        CHECK(reachable.find(8) == reachable.end());
+        CHECK(reachable.find(9) == reachable.end());
+        CHECK(reachable.find(10) == reachable.end());
+
+        aut.remove_initial(1);
+        aut.remove_initial(3);
+
+        reachable = aut.get_reachable_states();
+        CHECK(reachable.empty());
+    }
+
+    SECTION("Automaton B")
+    {
+        FILL_WITH_AUT_B(aut);
+        aut.remove_trans(2, 'c', 12);
+        aut.remove_trans(4, 'c', 8);
+        aut.remove_trans(4, 'a', 8);
+
+        auto reachable{aut.get_reachable_states()};
+        CHECK(reachable.find(0) != reachable.end());
+        CHECK(reachable.find(1) == reachable.end());
+        CHECK(reachable.find(2) != reachable.end());
+        CHECK(reachable.find(3) == reachable.end());
+        CHECK(reachable.find(4) != reachable.end());
+        CHECK(reachable.find(5) == reachable.end());
+        CHECK(reachable.find(6) != reachable.end());
+        CHECK(reachable.find(7) == reachable.end());
+        CHECK(reachable.find(8) == reachable.end());
+        CHECK(reachable.find(9) == reachable.end());
+        CHECK(reachable.find(10) == reachable.end());
+        CHECK(reachable.find(11) == reachable.end());
+        CHECK(reachable.find(12) == reachable.end());
+        CHECK(reachable.find(13) == reachable.end());
+        CHECK(reachable.find(14) == reachable.end());
+
+        aut.remove_final(2);
+        reachable = aut.get_reachable_states();
+        CHECK(reachable.size() == 4);
+        CHECK(reachable.find(0) != reachable.end());
+        CHECK(reachable.find(2) != reachable.end());
+        CHECK(reachable.find(4) != reachable.end());
+        CHECK(reachable.find(6) != reachable.end());
+        CHECK(aut.get_useful_states().empty());
+
+        aut.make_final(4);
+        reachable = aut.get_reachable_states();
+        CHECK(reachable.find(4) != reachable.end());
+    }
 }
 
 TEST_CASE("Mata::Nfa::trim()")
@@ -2531,12 +2579,18 @@ TEST_CASE("Mata::Nfa::trim()")
     Nfa old_aut{aut};
 
     aut.trim();
-    REQUIRE(aut.initialstates.size() == old_aut.initialstates.size());
-    REQUIRE(aut.finalstates.size() == old_aut.finalstates.size());
+    CHECK(aut.initialstates.size() == old_aut.initialstates.size());
+    CHECK(aut.finalstates.size() == old_aut.finalstates.size());
+    CHECK(aut.get_num_of_states() == 4);
     for (const Word& word: old_aut.get_shortest_words())
     {
-        REQUIRE(is_in_lang(aut, word));
+        CHECK(is_in_lang(aut, word));
     }
+
+    aut.remove_final(2); // '2' is the new final state in the earlier trimmed automaton.
+    aut.trim();
+    CHECK(aut.trans_empty());
+    CHECK(aut.get_num_of_states() == 0);
 }
 
 TEST_CASE("Mata::Nfa::Nfa::trans_empty()")

--- a/src/nfa/tests-noodlify.cc
+++ b/src/nfa/tests-noodlify.cc
@@ -1,0 +1,131 @@
+// TODO: some header
+
+#include <unordered_set>
+
+#include "../3rdparty/catch.hpp"
+
+#include <mata/nfa.hh>
+#include <mata/noodlify.hh>
+
+using namespace Mata::Nfa;
+using namespace Mata::util;
+using namespace Mata::Parser;
+
+// Some common automata {{{
+
+// Automaton A
+#define FILL_WITH_AUT_A(x) \
+	x.initialstates = {1, 3}; \
+	x.finalstates = {5}; \
+	x.add_trans(1, 'a', 3); \
+	x.add_trans(1, 'a', 10); \
+	x.add_trans(1, 'b', 7); \
+	x.add_trans(3, 'a', 7); \
+	x.add_trans(3, 'b', 9); \
+	x.add_trans(9, 'a', 9); \
+	x.add_trans(7, 'b', 1); \
+	x.add_trans(7, 'a', 3); \
+	x.add_trans(7, 'c', 3); \
+	x.add_trans(10, 'a', 7); \
+	x.add_trans(10, 'b', 7); \
+	x.add_trans(10, 'c', 7); \
+	x.add_trans(7, 'a', 5); \
+	x.add_trans(5, 'a', 5); \
+	x.add_trans(5, 'c', 9); \
+
+
+// Automaton B
+#define FILL_WITH_AUT_B(x) \
+	x.initialstates = {4}; \
+	x.finalstates = {2, 12}; \
+	x.add_trans(4, 'c', 8); \
+	x.add_trans(4, 'a', 8); \
+	x.add_trans(8, 'b', 4); \
+	x.add_trans(4, 'a', 6); \
+	x.add_trans(4, 'b', 6); \
+	x.add_trans(6, 'a', 2); \
+	x.add_trans(2, 'b', 2); \
+	x.add_trans(2, 'a', 0); \
+	x.add_trans(0, 'a', 2); \
+	x.add_trans(2, 'c', 12); \
+	x.add_trans(12, 'a', 14); \
+	x.add_trans(14, 'b', 12); \
+
+// }}}
+
+template<class T> void unused(const T &) {}
+
+TEST_CASE("Mata::Nfa::SegNfa::noodlify()")
+{
+    Nfa aut{20};
+
+    SECTION("1-2-3 epsilon transitions")
+    {
+        aut.make_initial(0);
+        aut.make_final({ 4, 5, 6, 7 });
+        aut.add_trans(0, 'e', 1);
+        aut.add_trans(1, 'e', 2);
+        aut.add_trans(1, 'e', 3);
+        aut.add_trans(2, 'e', 4);
+        aut.add_trans(2, 'e', 5);
+        aut.add_trans(2, 'e', 6);
+        aut.add_trans(3, 'e', 7);
+
+        auto noodles{ SegNfa::noodlify(aut, 'e') };
+
+        CHECK(noodles.size() == 4);
+    }
+
+    SECTION("6-5-6 epsilon transitions")
+    {
+        aut.make_initial({ 0, 1, 2 });
+        aut.make_final({ 11, 12, 13, 14, 15, 16 });
+        aut.add_trans(0, 'e', 3);
+        aut.add_trans(0, 'e', 4);
+        aut.add_trans(0, 'e', 5);
+        aut.add_trans(1, 'e', 3);
+        aut.add_trans(1, 'e', 4);
+        aut.add_trans(2, 'e', 5);
+
+        aut.add_trans(3, 'e', 6);
+        aut.add_trans(3, 'e', 7);
+        aut.add_trans(4, 'e', 8);
+        aut.add_trans(4, 'e', 9);
+        aut.add_trans(5, 'e', 10);
+
+        aut.add_trans(6, 'e', 11);
+        aut.add_trans(7, 'e', 12);
+        aut.add_trans(8, 'e', 13);
+        aut.add_trans(8, 'e', 14);
+        aut.add_trans(9, 'e', 15);
+        aut.add_trans(10, 'e', 16);
+
+        auto noodles{ SegNfa::noodlify(aut, 'e') };
+
+        CHECK(noodles.size() == 12);
+    }
+
+    SECTION("1-2-3-3 epsilon transitions")
+    {
+        aut.make_initial(0);
+        aut.make_final(7);
+        aut.add_trans(0, 'e', 1);
+
+        aut.add_trans(1, 'e', 2);
+        aut.add_trans(1, 'e', 3);
+
+        aut.add_trans(2, 'e', 4);
+        aut.add_trans(3, 'e', 5);
+        aut.add_trans(3, 'e', 6);
+
+        aut.add_trans(4, 'e', 7);
+        aut.add_trans(5, 'e', 7);
+        aut.add_trans(6, 'e', 7);
+
+        auto noodles{ SegNfa::noodlify(aut, 'e') };
+
+        CHECK(noodles.size() == 3);
+    }
+}
+
+


### PR DESCRIPTION
This PR implements function `noodlify` for noodlification of NFA.

As agreed upon, we implement a naive noodlification method creating all noodles: all permutations of epsilon transitions, one from each depth. In the following PR, we will improve the current implementation with a new algorithm, creating only actually possible noodles which have a path in the original automaton. 

The code has been tested with some tests.