### PR TITLE
Add new python bindings

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -161,6 +161,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void print_to_DOT(ostream)
         WordSet get_shortest_words()
         TransitionList get_transitions_from_state(State)
+        void trim()
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -119,6 +119,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         # Public Attributes
         StateSet initialstates
         StateSet finalstates
+        TransitionRelation transitionrelation
 
         # Constructor
         CNfa() except +
@@ -162,6 +163,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         WordSet get_shortest_words()
         TransitionList get_transitions_from_state(State)
         void trim()
+        CNfa get_digraph()
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -162,11 +162,15 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void print_to_DOT(ostream)
         WordSet get_shortest_words()
         TransitionList get_transitions_from_state(State)
-        void trim()
-        CNfa get_digraph()
         vector[CTrans] get_transitions_to_state(State)
         vector[CTrans] get_trans_as_sequence()
         vector[CTrans] get_trans_from_state_as_sequence(State)
+        void trim()
+        CNfa get_digraph()
+        StateSet get_useful_states()
+        StateSet get_reachable_states()
+        StateSet get_terminating_states()
+
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -134,6 +134,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void remove_final(State)
         void add_trans(CTrans) except +
         void add_trans(State, Symbol, State) except +
+        void remove_trans(CTrans) except +
+        void remove_trans(State, Symbol, State) except +
         bool has_trans(CTrans)
         bool has_trans(State, Symbol, State)
         bool trans_empty()

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -170,6 +170,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         StateSet get_useful_states()
         StateSet get_reachable_states()
         StateSet get_terminating_states()
+        void remove_epsilon(Symbol) except +
 
 
     # Automata tests

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -187,6 +187,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void determinize(CNfa*, CNfa&, SubsetMap*)
     cdef void uni(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
+    cdef void intersection(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
+    cdef void concatenate(CNfa*, CNfa&, CNfa&)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +
     cdef void revert(CNfa*, CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -145,6 +145,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         CNfa.const_iterator end()
         size_t get_num_of_states()
         void increase_size(size_t)
+        void increase_size_for_state(State)
         State add_new_state()
         void print_to_DOT(ostream)
         WordSet get_shortest_words()

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -226,8 +226,14 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         Symbol translate_symb(string)
         clist[Symbol] get_symbols()
 
+
+cdef extern from "mata/noodlify.hh" namespace "Mata::Nfa::SegNfa":
+    cdef vector[CNfa] noodlify(CNfa&, Symbol, bool)
+
+
 cdef extern from "mata/re2parser.hh" namespace "Mata::RE2Parser":
     cdef void create_nfa(CNfa*, string)
+
 
 cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void compute_fw_direct_simulation(const CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -91,6 +91,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         bool operator==(CTrans)
         bool operator!=(CTrans)
 
+    ctypedef vector[CTrans] TransitionSequence
+
     cdef cppclass CTransSymbolStates "Mata::Nfa::TransSymbolStates":
         # Public Attributes
         Symbol symbol
@@ -228,6 +230,15 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         COnTheFlyAlphabet(StringToSymbolMap*, Symbol) except +
         Symbol translate_symb(string)
         clist[Symbol] get_symbols()
+
+    cdef cppclass CSegmentation "Mata::Nfa::SegNfa::Segmentation":
+        CSegmentation(CNfa&, Symbol) except +
+
+        ctypedef unsigned EpsilonDepth
+        ctypedef umap[EpsilonDepth, TransitionSequence] EpsilonDepthTransitions
+
+        EpsilonDepthTransitions get_epsilon_depths()
+        vector[CNfa] get_segments()
 
 
 cdef extern from "mata/noodlify.hh" namespace "Mata::Nfa::SegNfa":

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -129,10 +129,18 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void make_initial(vector[State])
         bool has_initial(State)
         void remove_initial(State)
+        void remove_initial(vector[State])
+        void reset_initial(State)
+        void reset_initial(vector[State])
+        void clear_initial()
         void make_final(State)
         void make_final(vector[State])
         bool has_final(State)
         void remove_final(State)
+        void remove_final(vector[State])
+        void reset_final(State)
+        void reset_final(vector[State])
+        void clear_final()
         void add_trans(CTrans) except +
         void add_trans(State, Symbol, State) except +
         void remove_trans(CTrans) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -165,6 +165,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void trim()
         CNfa get_digraph()
         vector[CTrans] get_transitions_to_state(State)
+        vector[CTrans] get_trans_as_sequence()
+        vector[CTrans] get_trans_from_state_as_sequence(State)
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -164,6 +164,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         TransitionList get_transitions_from_state(State)
         void trim()
         CNfa get_digraph()
+        vector[CTrans] get_transitions_to_state(State)
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -180,6 +180,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef bool is_universal(CNfa&, CAlphabet&, StringDict&) except +
     cdef bool is_incl(CNfa&, CNfa&, CAlphabet&, StringDict&)
     cdef bool is_incl(CNfa&, CNfa&, CAlphabet&, Word*, StringDict&) except +
+    cdef bool equivalence_check(CNfa&, CNfa&, CAlphabet&, StringDict&)
+    cdef bool equivalence_check(CNfa&, CNfa&, StringDict&)
     cdef bool is_complete(CNfa&, CAlphabet&) except +
     cdef bool is_in_lang(CNfa&, Word&)
     cdef bool is_prfx_in_lang(CNfa&, Word&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -130,6 +130,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         bool has_initial(State)
         void remove_initial(State)
         void make_final(State)
+        void make_final(vector[State])
         bool has_final(State)
         void remove_final(State)
         void add_trans(CTrans) except +

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -152,22 +152,22 @@ cdef class Nfa:
         del self.thisptr
 
     @property
-    def initialstates(self):
+    def initial_states(self):
         cdef vector[State] initial_states = self.thisptr.initialstates.ToVector()
         return [initial_state for initial_state in initial_states]
 
-    @initialstates.setter
-    def initialstates(self, value):
+    @initial_states.setter
+    def initial_states(self, value):
         cdef StateSet initial_states = StateSet(value)
         self.thisptr.initialstates = initial_states
 
     @property
-    def finalstates(self):
+    def final_states(self):
         cdef vector[State] final_states = self.thisptr.finalstates.ToVector()
         return [final_state for final_state in final_states]
 
-    @finalstates.setter
-    def finalstates(self, value):
+    @final_states.setter
+    def final_states(self, value):
         cdef StateSet final_states = StateSet(value)
         self.thisptr.finalstates = final_states
 
@@ -464,29 +464,26 @@ cdef class Nfa:
 
     def get_useful_states(self):
         """
-        Get useful states (states which are reachable and terminating at the same time.)
-        :return: List of useful states.
+        Get useful states (states which are reachable and terminating at the same time).
+        :return: A set of useful states.
         """
-        cdef vector[State] return_value
-        return_value = self.thisptr.get_useful_states().ToVector()
+        cdef vector[State] return_value = self.thisptr.get_useful_states().ToVector()
         return {state for state in return_value}
 
     def get_reachable_states(self):
         """
         Get reachable states.
-        :return: List of reachable states.
+        :return: A set of reachable states.
         """
-        cdef vector[State] return_value
-        return_value = self.thisptr.get_reachable_states().ToVector()
+        cdef vector[State] return_value = self.thisptr.get_reachable_states().ToVector()
         return {state for state in return_value}
 
     def get_terminating_states(self):
         """
-        Get terminating states.
-        :return: List of terminating states.
+        Get terminating states (states with a path from them leading to any final state).
+        :return: A set of terminating states.
         """
-        cdef vector[State] return_value
-        return_value = self.thisptr.get_terminating_states().ToVector()
+        cdef vector[State] return_value = self.thisptr.get_terminating_states().ToVector()
         return {state for state in return_value}
 
     def trim(self):
@@ -665,9 +662,9 @@ cdef class Nfa:
         return result, {tuple(k): v for k, v in product_map}
 
     @classmethod
-    def intersection_epsilon_preserving(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
+    def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
         """
-        Performs intersection of lhs and rhs preserving epsilon transitions
+        Performs intersection of lhs and rhs preserving epsilon transitions.
 
         Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -719,7 +716,6 @@ cdef class Nfa:
             noodle.thisptr.initialstates = c_noodle.initialstates
             noodle.thisptr.finalstates = c_noodle.finalstates
             noodle.thisptr.transitionrelation = c_noodle.transitionrelation
-
             noodles.append(noodle)
 
         return noodles

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -427,6 +427,39 @@ cdef class Nfa:
             transsymbols.append(t)
         return transsymbols
 
+    def get_transitions_to_state(self, State state_to):
+        """
+        Get transitions leading to state_to (state_to is their target state).
+
+        :return: List mata.CTrans: List of transitions leading to state_to.
+        """
+        cdef vector[CTrans] c_transitions = self.thisptr.get_transitions_to_state(state_to)
+        trans = []
+        for c_transition in c_transitions:
+            trans.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+        return trans
+
+    def get_trans_as_sequence(self):
+        """
+        Get automaton transitions as a sequence.
+        :return: List of automaton transitions.
+        """
+        cdef vector[CTrans] c_transitions = self.thisptr.get_trans_as_sequence()
+        transitions = []
+        for c_transition in c_transitions:
+            transitions.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+        return transitions
+
+    def get_trans_from_state_as_sequence(self, State state_from):
+        """
+        Get automaton transitions from state_from as a sequence.
+        :return: List of automaton transitions.
+        """
+        cdef vector[CTrans] c_transitions = self.thisptr.get_trans_from_state_as_sequence(state_from)
+        transitions = []
+        for c_transition in c_transitions:
+            transitions.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+        return transitions
 
     def trim(self):
         """
@@ -451,19 +484,6 @@ cdef class Nfa:
         digraph.thisptr.finalstates = c_digraph.finalstates
         digraph.thisptr.transitionrelation = c_digraph.transitionrelation
         return digraph
-
-    def get_transitions_to_state(self, State state_to):
-        """
-        Get transitions leading to state_to (state_to is their target state).
-
-        :return: List mata.CTrans: List of transitions leading to state_to.
-        """
-        cdef vector[CTrans] c_transitions = self.thisptr.get_transitions_to_state(state_to)
-        trans = []
-        for c_transition in c_transitions:
-            trans.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
-
-        return trans
 
     def __str__(self):
         """String representation of the automaton displays states, and transitions

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -912,6 +912,40 @@ cdef class Nfa:
         return result, word
 
     @classmethod
+    def equivalence_check(cls, Nfa lhs, Nfa rhs, Alphabet alphabet = None, params = None) -> bool:
+        """
+        Test equivalence of two automata.
+
+        :param Nfa lhs: Smaller automaton.
+        :param Nfa rhs: Bigger automaton.
+        :param Alphabet alphabet: Alphabet shared by two automata.
+        :param dict params: Additional params.
+        :return: True if lhs is equivalent to rhs, False otherwise.
+        """
+        params = params or {'algo': 'antichains'}
+        if alphabet:
+            return mata.equivalence_check(
+                dereference(lhs.thisptr),
+                dereference(rhs.thisptr),
+                <CAlphabet&>dereference(alphabet.as_base()),
+                {
+                    k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
+                    for k, v in params.items()
+                }
+            )
+        else:
+            return mata.equivalence_check(
+                dereference(lhs.thisptr),
+                dereference(rhs.thisptr),
+                {
+                    k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
+                    for k, v in params.items()
+                }
+            )
+
+
+
+    @classmethod
     def is_complete(cls, Nfa lhs, Alphabet alphabet):
         """Test if automaton is complete
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -226,6 +226,24 @@ cdef class Nfa:
         """
         self.thisptr.add_trans(src, symb, tgt)
 
+    def remove_trans(self, Trans tr):
+        """
+        Removes transition from the automaton.
+
+        :param Trans tr: Transition to be removed.
+        """
+        self.thisptr.remove_trans(dereference(tr.thisptr))
+
+    def remove_trans_raw(self, State src, Symbol symb, State tgt):
+        """
+        Constructs transition and removes it from the automaton.
+
+        :param State src: Source state of the transition to be removed.
+        :param Symbol symb: Symbol of the transition to be removed.
+        :param State tgt: Target state of the transition to be removed.
+        """
+        self.thisptr.remove_trans(src, symb, tgt)
+
     def has_trans(self, Trans tr):
         """Tests if automaton contains transition
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -699,6 +699,31 @@ cdef class Nfa:
         return result
 
     @classmethod
+    def noodlify(cls, Nfa aut, Symbol symbol, include_empty = False):
+        """
+        Create noodles from segment automaton.
+
+        Segment automaton is a chain of finite automata (segments) connected via ε-transitions.
+        A noodle is a copy of the segment automaton with exactly one ε-transition between each two consecutive segments.
+
+        :param: Nfa aut: Segment automaton to noodlify.
+        :param: Symbol epsilon: Epsilon symbol to noodlify for.
+        :param: bool include_empty: Whether to also include empty noodles.
+        :return: List of automata: A list of all (non-empty) noodles.
+        """
+        noodles = []
+        cdef vector[CNfa] c_noodles = mata.noodlify(dereference(aut.thisptr), symbol, include_empty)
+        for c_noodle in c_noodles:
+            noodle = Nfa(c_noodle.get_num_of_states())
+            noodle.thisptr.initialstates = c_noodle.initialstates
+            noodle.thisptr.finalstates = c_noodle.finalstates
+            noodle.thisptr.transitionrelation = c_noodle.transitionrelation
+
+            noodles.append(noodle)
+
+        return noodles
+
+    @classmethod
     def complement(cls, Nfa lhs, Alphabet alphabet, params = None):
         """Performs complement of lhs
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -452,6 +452,19 @@ cdef class Nfa:
         digraph.thisptr.transitionrelation = c_digraph.transitionrelation
         return digraph
 
+    def get_transitions_to_state(self, State state_to):
+        """
+        Get transitions leading to state_to (state_to is their target state).
+
+        :return: List mata.CTrans: List of transitions leading to state_to.
+        """
+        cdef vector[CTrans] c_transitions = self.thisptr.get_transitions_to_state(state_to)
+        trans = []
+        for c_transition in c_transitions:
+            trans.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+
+        return trans
+
     def __str__(self):
         """String representation of the automaton displays states, and transitions
 
@@ -471,7 +484,7 @@ cdef class Nfa:
     def to_dot_file(self, output_file='aut.dot', output_format='pdf'):
         """Transforms the automaton to dot format.
 
-        By default the result is saved to `aut.dot`, and further to `aut.dot.pdf`.
+        By default, the result is saved to `aut.dot`, and further to `aut.dot.pdf`.
 
         One can choose other format that is supported by graphviz format (e.g. pdf or png).
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -772,7 +772,7 @@ cdef class Nfa:
 
     @classmethod
     def remove_epsilon(cls, Nfa lhs, Symbol epsilon):
-        """Removes transitions that contains epsilon symbol
+        """Removes transitions that contain epsilon symbol
 
         TODO: Possibly there may be issue with setting the size of the automaton beforehand?
 
@@ -783,6 +783,16 @@ cdef class Nfa:
         result = Nfa()
         mata.remove_epsilon(result.thisptr, dereference(lhs.thisptr), epsilon)
         return result
+
+    def remove_epsilon(self, Symbol epsilon):
+        """
+        Removes transitions which contain epsilon symbol.
+
+        TODO: Possibly there may be issue with setting the size of the automaton beforehand?
+
+        :param Symbol epsilon: Symbol representing the epsilon symbol.
+        """
+        self.thisptr.remove_epsilon(epsilon)
 
     @classmethod
     def minimize(cls, Nfa lhs):

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -166,17 +166,19 @@ cdef class Nfa:
         """
         return self.thisptr.add_new_state()
 
-    def add_initial_state(self, State st):
-        """Adds initial state to automaton
-
-        :param State st: added initial state
+    def make_initial_state(self, State state):
         """
-        self.thisptr.make_initial(st)
+        Makes specified state from the automaton initial.
 
-    def add_initial_states(self, vector[State] states):
-        """Adds list of initial state to automaton
+        :param State state: State to be made initial.
+        """
+        self.thisptr.make_initial(state)
 
-        :param list states: list of initial states
+    def make_initial_states(self, vector[State] states):
+        """
+        Makes specified states from the automaton initial.
+
+        :param list states: List of states to be made initial.
         """
         self.thisptr.make_initial(states)
 
@@ -188,12 +190,21 @@ cdef class Nfa:
         """
         return self.thisptr.has_initial(st)
 
-    def add_final_state(self, State st):
-        """Adds final state to automaton
-
-        :param State st: added final state
+    def make_final_state(self, State state):
         """
-        self.thisptr.make_final(st)
+        Makes specified state from the automaton final.
+
+        :param State state: State to be made final.
+        """
+        self.thisptr.make_final(state)
+
+    def make_final_states(self, vector[State] states):
+        """
+        Makes specified states from the automaton final.
+
+        :param vector[State] states: List of states to be made final.
+        """
+        self.thisptr.make_final(states)
 
     def has_final_state(self, State st):
         """Tests if automaton contains given state
@@ -1107,13 +1118,13 @@ def divisible_by(k: int):
     """
     assert k > 1
     lhs = Nfa(k+1)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     for i in range(1, k + 1):
         lhs.add_trans_raw(i - 1, 1, i)
         lhs.add_trans_raw(i, 0, i)
     lhs.add_trans_raw(k, 1, 1)
-    lhs.add_final_state(k)
+    lhs.make_final_state(k)
     return lhs
 
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -438,6 +438,19 @@ cdef class Nfa:
         """
         self.thisptr.trim()
 
+    def get_digraph(self) -> Nfa:
+        """
+        Unify transitions to create a directed graph with at most a single transition between two states.
+
+        :return: mata.Nfa: An automaton representing a directed graph.
+        """
+        cdef mata.CNfa c_digraph = self.thisptr.get_digraph()
+
+        digraph  = Nfa(c_digraph.get_num_of_states())
+        digraph.thisptr.initialstates = c_digraph.initialstates
+        digraph.thisptr.finalstates = c_digraph.finalstates
+        digraph.thisptr.transitionrelation = c_digraph.transitionrelation
+        return digraph
 
     def __str__(self):
         """String representation of the automaton displays states, and transitions

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -265,6 +265,14 @@ cdef class Nfa:
         """
         self.thisptr.increase_size(size)
 
+    def resize_for_state(self, State state):
+        """
+        Increases the size of the automaton to include state.
+
+        :param State state: State to resize for.
+        """
+        self.thisptr.increase_size_for_state(state)
+
     def iterate(self):
         """Iterates over all transitions
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -428,6 +428,16 @@ cdef class Nfa:
         return transsymbols
 
 
+    def trim(self):
+        """
+        Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
+
+        Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
+         starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
+         the starting point of a path ending in a final state).
+        """
+        self.thisptr.trim()
+
 
     def __str__(self):
         """String representation of the automaton displays states, and transitions

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -461,6 +461,33 @@ cdef class Nfa:
             transitions.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
         return transitions
 
+    def get_useful_states(self):
+        """
+        Get useful states (states which are reachable and terminating at the same time.)
+        :return: List of useful states.
+        """
+        cdef vector[State] return_value
+        return_value = self.thisptr.get_useful_states().ToVector()
+        return {state for state in return_value}
+
+    def get_reachable_states(self):
+        """
+        Get reachable states.
+        :return: List of reachable states.
+        """
+        cdef vector[State] return_value
+        return_value = self.thisptr.get_reachable_states().ToVector()
+        return {state for state in return_value}
+
+    def get_terminating_states(self):
+        """
+        Get terminating states.
+        :return: List of terminating states.
+        """
+        cdef vector[State] return_value
+        return_value = self.thisptr.get_terminating_states().ToVector()
+        return {state for state in return_value}
+
     def trim(self):
         """
         Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -661,7 +661,42 @@ cdef class Nfa:
         mata.intersection(
             result.thisptr, dereference(lhs.thisptr), dereference(rhs.thisptr), &product_map
         )
-        return result, {tuple(sorted(k)): v for k, v in product_map}
+        return result, {tuple(k): v for k, v in product_map}
+
+    @classmethod
+    def intersection_epsilon_preserving(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
+        """
+        Performs intersection of lhs and rhs preserving epsilon transitions
+
+        Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
+         of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
+         an ε-transition `(s,a)-ε->(p,a)` is created. Furthermore, for each ε-transition `s-ε->p` and `a-ε->b`,
+         a product state `(s,a)-ε->(p,b)` is created.
+
+        Automata must share alphabets.
+
+        :param: Nfa lhs: First automaton with possible epsilon symbols.
+        :param: Nfa rhs: Second automaton with possible epsilon symbols.
+        :param: Symbol epsilon: Symbol to handle as an epsilon symbol.
+        :return: Intersection of lhs and rhs with epsilon transitions preserved, product map of the results.
+        """
+        result = Nfa()
+        cdef ProductMap product_map
+        mata.intersection(result.thisptr, dereference(lhs.thisptr), dereference(rhs.thisptr), epsilon, &product_map)
+        return result, {tuple(k): v for k, v in product_map}
+
+    @classmethod
+    def concatenate(cls, Nfa lhs, Nfa rhs):
+        """
+        Concatenate two NFAs.
+
+        :param Nfa lhs: First automaton to concatenate.
+        :param Nfa rhs: Second automaton to concatenate.
+        :return: Nfa: Concatenated automaton.
+        """
+        result = Nfa()
+        mata.concatenate(result.thisptr, dereference(lhs.thisptr), dereference(rhs.thisptr))
+        return result
 
     @classmethod
     def complement(cls, Nfa lhs, Alphabet alphabet, params = None):
@@ -720,10 +755,8 @@ cdef class Nfa:
         :param Symbol epsilon: symbol representing the epsilon
         :return: automaton, with epsilon transitions removed
         """
-        result = Nfa(lhs.get_num_of_states())
-        mata.remove_epsilon(
-            result.thisptr, dereference(lhs.thisptr), epsilon
-        )
+        result = Nfa()
+        mata.remove_epsilon(result.thisptr, dereference(lhs.thisptr), epsilon)
         return result
 
     @classmethod

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -90,7 +90,6 @@ cdef class TransSymbolStates:
 
     @property
     def states_to(self):
-        states = []
         cdef vector[State] states_as_vector = self.thisptr.states_to.ToVector()
         return [s for s in states_as_vector]
 
@@ -151,6 +150,26 @@ cdef class Nfa:
     def __dealloc__(self):
         del self.thisptr
 
+    @property
+    def initialstates(self):
+        cdef vector[State] initial_states = self.thisptr.initialstates.ToVector()
+        return [initial_state for initial_state in initial_states]
+
+    @initialstates.setter
+    def initialstates(self, value):
+        cdef StateSet initial_states = StateSet(value)
+        self.thisptr.initialstates = initial_states
+
+    @property
+    def finalstates(self):
+        cdef vector[State] final_states = self.thisptr.finalstates.ToVector()
+        return [final_state for final_state in final_states]
+
+    @finalstates.setter
+    def finalstates(self, value):
+        cdef StateSet final_states = StateSet(value)
+        self.thisptr.finalstates = final_states
+
     def is_state(self, state):
         """Tests if state is in the automaton
 
@@ -190,6 +209,42 @@ cdef class Nfa:
         """
         return self.thisptr.has_initial(st)
 
+    def remove_initial_state(self, State state):
+        """
+        Removes state from initial state set of the automaton.
+
+        :param State state: State to be removed from initial states.
+        """
+        self.thisptr.remove_initial(state)
+
+    def remove_initial_states(self, vector[State] states):
+        """
+        Removes states from initial state set of the automaton.
+
+        :param list State states: States to be removed from initial states.
+        """
+        self.thisptr.remove_initial(states)
+
+    def reset_initial_state(self, State state):
+        """
+        Resets initial state set of the automaton to the specified state.
+
+        :param State state: State to be made initial.
+        """
+        self.thisptr.reset_initial(state)
+
+    def reset_initial_states(self, vector[State] states):
+        """
+        Resets initial state set of the automaton to the specified states.
+
+        :param list states: List of states to be made initial.
+        """
+        self.thisptr.reset_initial(states)
+
+    def clear_initial(self):
+        """Clears initial state set of the automaton."""
+        self.thisptr.clear_initial()
+
     def make_final_state(self, State state):
         """
         Makes specified state from the automaton final.
@@ -213,6 +268,42 @@ cdef class Nfa:
         :return: true if automaton contains given state
         """
         return self.thisptr.has_final(st)
+
+    def remove_final_state(self, State state):
+        """
+        Removes state from final state set of the automaton.
+
+        :param State state: State to be removed from final states.
+        """
+        self.thisptr.remove_final(state)
+
+    def remove_final_states(self, vector[State] states):
+        """
+        Removes states from final state set of the automaton.
+
+        :param list State states: States to be removed from final states.
+        """
+        self.thisptr.remove_final(states)
+
+    def reset_final_state(self, State state):
+        """
+        Resets final state set of the automaton to the specified state.
+
+        :param State state: State to be made final.
+        """
+        self.thisptr.reset_final(state)
+
+    def reset_final_states(self, vector[State] states):
+        """
+        Resets final state set of the automaton to the specified states.
+
+        :param list states: List of states to be made final.
+        """
+        self.thisptr.reset_final(states)
+
+    def clear_final(self):
+        """Clears final state set of the automaton."""
+        self.thisptr.clear_final()
 
     def state_size(self):
         """Returns number of states in automaton

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -138,11 +138,11 @@ cdef class Nfa:
     cdef mata.CNfa *thisptr
     cdef alphabet
 
-    def __cinit__(self, state_number = 0, alphabet=None):
+    def __cinit__(self, state_number = 0, alphabet = None):
         """Constructor of the NFA
 
         :param int state_number: number of states in automaton
-        :param Alpabet alphabet: alphabet corresponding to the automaton
+        :param Alphabet alphabet: alphabet corresponding to the automaton
         """
         self.thisptr = new mata.CNfa(state_number)
         self.alphabet = alphabet
@@ -305,7 +305,7 @@ cdef class Nfa:
         """Clears final state set of the automaton."""
         self.thisptr.clear_final()
 
-    def state_size(self):
+    def get_num_of_states(self):
         """Returns number of states in automaton
 
         :return: number of states in automaton
@@ -623,7 +623,7 @@ cdef class Nfa:
         :param OnTheFlyAlphabet alphabet: alphabet of the
         """
         if not lhs.thisptr.is_state(sink_state):
-            lhs.thisptr.increase_size(lhs.state_size() + 1)
+            lhs.thisptr.increase_size(lhs.get_num_of_states() + 1)
         mata.make_complete(lhs.thisptr, <CAlphabet&>dereference(alphabet.as_base()), sink_state)
 
     @classmethod
@@ -647,7 +647,7 @@ cdef class Nfa:
         :param Symbol epsilon: symbol representing the epsilon
         :return: automaton, with epsilon transitions removed
         """
-        result = Nfa(lhs.state_size())
+        result = Nfa(lhs.get_num_of_states())
         mata.remove_epsilon(
             result.thisptr, dereference(lhs.thisptr), epsilon
         )

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -133,3 +133,24 @@ def fill_with_automaton_a(nfa):
     nfa.add_trans_raw(7, ord('a'), 5)
     nfa.add_trans_raw(5, ord('a'), 5)
     nfa.add_trans_raw(5, ord('c'), 9)
+
+def fill_with_automaton_b(nfa):
+    """
+    Fill nfa with automaton B.
+
+    :param: mata.Nfa nfa: Automaton to be filled with automaton B.
+    """
+    nfa.make_initial_states([4])
+    nfa.make_final_states([2, 12])
+    nfa.add_trans_raw(4, ord('c'), 8)
+    nfa.add_trans_raw(4, ord('a'), 8)
+    nfa.add_trans_raw(8, ord('b'), 4)
+    nfa.add_trans_raw(4, ord('a'), 6)
+    nfa.add_trans_raw(4, ord('b'), 6)
+    nfa.add_trans_raw(6, ord('a'), 2)
+    nfa.add_trans_raw(2, ord('b'), 2)
+    nfa.add_trans_raw(2, ord('a'), 0)
+    nfa.add_trans_raw(0, ord('a'), 2)
+    nfa.add_trans_raw(2, ord('c'), 12)
+    nfa.add_trans_raw(12, ord('a'), 14)
+    nfa.add_trans_raw(14, ord('b'), 12)

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -108,3 +108,28 @@ def binary_alphabet():
     alph.translate_symbol("0")
     alph.translate_symbol("1")
     yield alph
+
+
+def fill_with_automaton_a(nfa):
+    """
+    Fill nfa with automaton A.
+
+    :param: mata.Nfa nfa: Automaton to be filled with automaton A.
+    """
+    nfa.make_initial_states([1, 3])
+    nfa.make_final_state(5)
+    nfa.add_trans_raw(1, ord('a'), 3)
+    nfa.add_trans_raw(1, ord('a'), 10)
+    nfa.add_trans_raw(1, ord('b'), 7)
+    nfa.add_trans_raw(3, ord('a'), 7)
+    nfa.add_trans_raw(3, ord('b'), 9)
+    nfa.add_trans_raw(9, ord('a'), 9)
+    nfa.add_trans_raw(7, ord('b'), 1)
+    nfa.add_trans_raw(7, ord('a'), 3)
+    nfa.add_trans_raw(7, ord('c'), 3)
+    nfa.add_trans_raw(10, ord('a'), 7)
+    nfa.add_trans_raw(10, ord('b'), 7)
+    nfa.add_trans_raw(10, ord('c'), 7)
+    nfa.add_trans_raw(7, ord('a'), 5)
+    nfa.add_trans_raw(5, ord('a'), 5)
+    nfa.add_trans_raw(5, ord('c'), 9)

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -110,7 +110,7 @@ def binary_alphabet():
     yield alph
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def prepare_automaton_a():
     """
     Prepare Nfa as automaton A.
@@ -140,7 +140,7 @@ def prepare_automaton_a():
     return _prepare_automaton_a
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def prepare_automaton_b():
     """
     Prepare Nfa as automaton B.

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -20,17 +20,17 @@ def cleandir():
 @pytest.fixture(scope="function")
 def dfa_one_state_uni():
     lhs = mata.Nfa(1)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 0)
-    lhs.add_final_state(0)
+    lhs.make_final_state(0)
     yield lhs
 
 
 @pytest.fixture(scope="function")
 def dfa_one_state_empty():
     lhs = mata.Nfa(1)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 0)
     yield lhs
@@ -39,13 +39,13 @@ def dfa_one_state_empty():
 @pytest.fixture(scope="function")
 def nfa_two_states_uni():
     lhs = mata.Nfa(2)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 0)
     lhs.add_trans_raw(0, 0, 1)
     lhs.add_trans_raw(1, 0, 1)
     lhs.add_trans_raw(1, 1, 1)
-    lhs.add_final_state(1)
+    lhs.make_final_state(1)
     yield lhs
 
 
@@ -55,13 +55,13 @@ def divisible_by(k: int):
     """
     assert k > 1
     lhs = mata.Nfa(k+1)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     for i in range(1, k + 1):
         lhs.add_trans_raw(i - 1, 1, i)
         lhs.add_trans_raw(i, 0, i)
     lhs.add_trans_raw(k, 1, 1)
-    lhs.add_final_state(k)
+    lhs.make_final_state(k)
     return lhs
 
 
@@ -83,23 +83,23 @@ def fa_one_divisible_by_eight():
 @pytest.fixture(scope="function")
 def fa_odd_ones():
     lhs = mata.Nfa(2)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 1)
     lhs.add_trans_raw(1, 1, 0)
     lhs.add_trans_raw(1, 0, 1)
-    lhs.add_final_state(1)
+    lhs.make_final_state(1)
 
 
 @pytest.fixture(scope="function")
 def fa_even_ones():
     lhs = mata.Nfa(2)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 1)
     lhs.add_trans_raw(1, 1, 0)
     lhs.add_trans_raw(1, 0, 1)
-    lhs.add_final_state(0)
+    lhs.make_final_state(0)
 
 
 @pytest.fixture(scope="function")

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -110,47 +110,58 @@ def binary_alphabet():
     yield alph
 
 
-def fill_with_automaton_a(nfa):
+@pytest.fixture(scope="function")
+def prepare_automaton_a():
     """
-    Fill nfa with automaton A.
+    Prepare Nfa as automaton A.
+    """
 
-    :param: mata.Nfa nfa: Automaton to be filled with automaton A.
-    """
-    nfa.make_initial_states([1, 3])
-    nfa.make_final_state(5)
-    nfa.add_trans_raw(1, ord('a'), 3)
-    nfa.add_trans_raw(1, ord('a'), 10)
-    nfa.add_trans_raw(1, ord('b'), 7)
-    nfa.add_trans_raw(3, ord('a'), 7)
-    nfa.add_trans_raw(3, ord('b'), 9)
-    nfa.add_trans_raw(9, ord('a'), 9)
-    nfa.add_trans_raw(7, ord('b'), 1)
-    nfa.add_trans_raw(7, ord('a'), 3)
-    nfa.add_trans_raw(7, ord('c'), 3)
-    nfa.add_trans_raw(10, ord('a'), 7)
-    nfa.add_trans_raw(10, ord('b'), 7)
-    nfa.add_trans_raw(10, ord('c'), 7)
-    nfa.add_trans_raw(7, ord('a'), 5)
-    nfa.add_trans_raw(5, ord('a'), 5)
-    nfa.add_trans_raw(5, ord('c'), 9)
+    def _prepare_automaton_a():
+        nfa = mata.Nfa(100)
+        nfa.make_initial_states([1, 3])
+        nfa.make_final_state(5)
+        nfa.add_trans_raw(1, ord('a'), 3)
+        nfa.add_trans_raw(1, ord('a'), 10)
+        nfa.add_trans_raw(1, ord('b'), 7)
+        nfa.add_trans_raw(3, ord('a'), 7)
+        nfa.add_trans_raw(3, ord('b'), 9)
+        nfa.add_trans_raw(9, ord('a'), 9)
+        nfa.add_trans_raw(7, ord('b'), 1)
+        nfa.add_trans_raw(7, ord('a'), 3)
+        nfa.add_trans_raw(7, ord('c'), 3)
+        nfa.add_trans_raw(10, ord('a'), 7)
+        nfa.add_trans_raw(10, ord('b'), 7)
+        nfa.add_trans_raw(10, ord('c'), 7)
+        nfa.add_trans_raw(7, ord('a'), 5)
+        nfa.add_trans_raw(5, ord('a'), 5)
+        nfa.add_trans_raw(5, ord('c'), 9)
+        return nfa
 
-def fill_with_automaton_b(nfa):
-    """
-    Fill nfa with automaton B.
+    return _prepare_automaton_a
 
-    :param: mata.Nfa nfa: Automaton to be filled with automaton B.
+
+@pytest.fixture(scope="function")
+def prepare_automaton_b():
     """
-    nfa.make_initial_states([4])
-    nfa.make_final_states([2, 12])
-    nfa.add_trans_raw(4, ord('c'), 8)
-    nfa.add_trans_raw(4, ord('a'), 8)
-    nfa.add_trans_raw(8, ord('b'), 4)
-    nfa.add_trans_raw(4, ord('a'), 6)
-    nfa.add_trans_raw(4, ord('b'), 6)
-    nfa.add_trans_raw(6, ord('a'), 2)
-    nfa.add_trans_raw(2, ord('b'), 2)
-    nfa.add_trans_raw(2, ord('a'), 0)
-    nfa.add_trans_raw(0, ord('a'), 2)
-    nfa.add_trans_raw(2, ord('c'), 12)
-    nfa.add_trans_raw(12, ord('a'), 14)
-    nfa.add_trans_raw(14, ord('b'), 12)
+    Prepare Nfa as automaton B.
+    """
+
+    def _prepare_automaton_b():
+        nfa = mata.Nfa(100)
+        nfa.make_initial_states([4])
+        nfa.make_final_states([2, 12])
+        nfa.add_trans_raw(4, ord('c'), 8)
+        nfa.add_trans_raw(4, ord('a'), 8)
+        nfa.add_trans_raw(8, ord('b'), 4)
+        nfa.add_trans_raw(4, ord('a'), 6)
+        nfa.add_trans_raw(4, ord('b'), 6)
+        nfa.add_trans_raw(6, ord('a'), 2)
+        nfa.add_trans_raw(2, ord('b'), 2)
+        nfa.add_trans_raw(2, ord('a'), 0)
+        nfa.add_trans_raw(0, ord('a'), 2)
+        nfa.add_trans_raw(2, ord('c'), 12)
+        nfa.add_trans_raw(12, ord('a'), 14)
+        nfa.add_trans_raw(14, ord('b'), 12)
+        return nfa
+
+    return _prepare_automaton_b

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -4,32 +4,10 @@ import pytest
 import mata
 import os
 
+from conftest import fill_with_automaton_a
+
 __author__ = 'Tomas Fiedor'
 
-
-def fill_with_automaton_a(nfa):
-    """
-    Fill nfa with automaton A.
-
-    :param: mata.Nfa nfa: Automaton to be filled with automaton A.
-    """
-    nfa.make_initial_states([1, 3])
-    nfa.make_final_state(5)
-    nfa.add_trans_raw(1, ord('a'), 3)
-    nfa.add_trans_raw(1, ord('a'), 10)
-    nfa.add_trans_raw(1, ord('b'), 7)
-    nfa.add_trans_raw(3, ord('a'), 7)
-    nfa.add_trans_raw(3, ord('b'), 9)
-    nfa.add_trans_raw(9, ord('a'), 9)
-    nfa.add_trans_raw(7, ord('b'), 1)
-    nfa.add_trans_raw(7, ord('a'), 3)
-    nfa.add_trans_raw(7, ord('c'), 3)
-    nfa.add_trans_raw(10, ord('a'), 7)
-    nfa.add_trans_raw(10, ord('b'), 7)
-    nfa.add_trans_raw(10, ord('c'), 7)
-    nfa.add_trans_raw(7, ord('a'), 5)
-    nfa.add_trans_raw(5, ord('a'), 5)
-    nfa.add_trans_raw(5, ord('c'), 9)
 
 def test_adding_states():
     """Test nfa"""

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -7,6 +7,30 @@ import os
 __author__ = 'Tomas Fiedor'
 
 
+def fill_with_automaton_a(nfa):
+    """
+    Fill nfa with automaton A.
+
+    :param: mata.Nfa nfa: Automaton to be filled with automaton A.
+    """
+    nfa.make_initial_states([1, 3])
+    nfa.make_final_state(5)
+    nfa.add_trans_raw(1, ord('a'), 3)
+    nfa.add_trans_raw(1, ord('a'), 10)
+    nfa.add_trans_raw(1, ord('b'), 7)
+    nfa.add_trans_raw(3, ord('a'), 7)
+    nfa.add_trans_raw(3, ord('b'), 9)
+    nfa.add_trans_raw(9, ord('a'), 9)
+    nfa.add_trans_raw(7, ord('b'), 1)
+    nfa.add_trans_raw(7, ord('a'), 3)
+    nfa.add_trans_raw(7, ord('c'), 3)
+    nfa.add_trans_raw(10, ord('a'), 7)
+    nfa.add_trans_raw(10, ord('b'), 7)
+    nfa.add_trans_raw(10, ord('c'), 7)
+    nfa.add_trans_raw(7, ord('a'), 5)
+    nfa.add_trans_raw(5, ord('a'), 5)
+    nfa.add_trans_raw(5, ord('c'), 9)
+
 def test_adding_states():
     """Test nfa"""
     lhs = mata.Nfa(5)
@@ -499,6 +523,25 @@ def test_get_trans(fa_one_divisible_by_two):
     assert sorted(t) == sorted([mata.TransSymbolStates(0, [0]), mata.TransSymbolStates(1, [1])])
     tt = lhs.get_transitions_from_state(1)
     assert sorted(tt) == sorted([mata.TransSymbolStates(0, [1]), mata.TransSymbolStates(1, [2])])
+
+
+def test_trim():
+    """Test trimming the automaton."""
+    nfa = mata.Nfa(20)
+    fill_with_automaton_a(nfa)
+    nfa.remove_trans_raw(1, ord('a'), 10)
+
+    old_nfa = mata.Nfa(20)
+    fill_with_automaton_a(old_nfa)
+    old_nfa.remove_trans_raw(1, ord('a'), 10)
+
+    nfa.trim()
+
+    assert len(nfa.initialstates) == len(old_nfa.initialstates)
+    assert len(nfa.finalstates) == len(old_nfa.finalstates)
+
+    for word in old_nfa.get_shortest_words():
+        assert mata.Nfa.is_in_lang(nfa, word)
 
 
 def test_simulation(fa_one_divisible_by_four):

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -57,21 +57,21 @@ def test_adding_states():
     assert lhs.has_final_state(0)
 
     rhs = mata.Nfa()
-    assert rhs.state_size() == 0
+    assert rhs.get_num_of_states() == 0
     state = rhs.add_new_state()
     assert state == 0
-    assert rhs.state_size() == 1
+    assert rhs.get_num_of_states() == 1
     state = rhs.add_new_state()
     assert state == 1
-    assert rhs.state_size() == 2
+    assert rhs.get_num_of_states() == 2
 
     rhs.resize(10)
-    assert rhs.state_size() == 10
+    assert rhs.get_num_of_states() == 10
     for i in range(0, 10):
         assert rhs.is_state(i)
 
     rhs.resize(1)
-    assert rhs.state_size() == 1
+    assert rhs.get_num_of_states() == 1
     assert rhs.is_state(0)
     assert not rhs.is_state(1)
 
@@ -79,7 +79,7 @@ def test_adding_states():
         rhs.resize(-10)
 
     rhs.resize_for_state(11)
-    assert rhs.state_size() == 12
+    assert rhs.get_num_of_states() == 12
     assert rhs.is_state(11)
     assert not rhs.is_state(12)
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -318,6 +318,49 @@ def test_inclusion(
     assert not mata.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight, alph)[0]
     assert not mata.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight, alph)[0]
 
+    # Test equivalence of two NFAs.
+    smaller = mata.Nfa(10)
+    bigger = mata.Nfa(16)
+    alph = ["a", "b"]
+    smaller.make_initial_state(1)
+    smaller.make_final_state(1)
+    smaller.add_trans_raw(1, ord('a'), 1)
+    smaller.add_trans_raw(1, ord('b'), 1)
+
+    bigger.make_initial_state(11)
+    bigger.make_final_states([11, 12, 13, 14, 15])
+
+    bigger.add_trans_raw(11, ord('a'), 12)
+    bigger.add_trans_raw(11, ord('b'), 12)
+    bigger.add_trans_raw(12, ord('a'), 13)
+    bigger.add_trans_raw(12, ord('b'), 13)
+
+    bigger.add_trans_raw(13, ord('a'), 14)
+    bigger.add_trans_raw(14, ord('a'), 14)
+
+    bigger.add_trans_raw(13, ord('b'), 15)
+    bigger.add_trans_raw(15, ord('b'), 15)
+
+    assert not mata.Nfa.equivalence_check(smaller, bigger, mata.EnumAlphabet(alph))
+    assert not mata.Nfa.equivalence_check(smaller, bigger)
+    assert not mata.Nfa.equivalence_check(bigger, smaller, mata.EnumAlphabet(alph))
+    assert not mata.Nfa.equivalence_check(bigger, smaller)
+
+    smaller = mata.Nfa(10)
+    bigger = mata.Nfa(16)
+    alph = []
+    smaller.initialstates = [1]
+    smaller.finalstates = [1]
+    bigger.initialstates = [11]
+    bigger.finalstates = [11]
+
+    assert mata.Nfa.equivalence_check(smaller, bigger, mata.EnumAlphabet(alph))
+    assert mata.Nfa.equivalence_check(smaller, bigger)
+    assert mata.Nfa.equivalence_check(bigger, smaller, mata.EnumAlphabet(alph))
+    assert mata.Nfa.equivalence_check(bigger, smaller)
+
+
+def test_concatenate():
     lhs = mata.Nfa(2)
     lhs.make_initial_state(0)
     lhs.make_final_state(1)
@@ -339,6 +382,7 @@ def test_inclusion(
     shortest_words = result.get_shortest_words()
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
+
 
 def test_completeness(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -544,6 +544,26 @@ def test_trim():
         assert mata.Nfa.is_in_lang(nfa, word)
 
 
+def test_get_digraph():
+    """Test creating digraph from an automaton."""
+    nfa = mata.Nfa(100)
+    abstract_symbol = ord('x')
+    fill_with_automaton_a(nfa)
+
+    old_nfa = mata.Nfa(20)
+    fill_with_automaton_a(old_nfa)
+
+    digraph = nfa.get_digraph()
+
+    assert digraph.get_num_of_states() == nfa.get_num_of_states()
+    assert digraph.get_num_of_trans() == 12
+    assert digraph.has_trans_raw(1, abstract_symbol, 10)
+    assert digraph.has_trans_raw(10, abstract_symbol, 7)
+    assert not digraph.has_trans_raw(10, ord('a'), 7)
+    assert not digraph.has_trans_raw(10, ord('b'), 7)
+    assert not digraph.has_trans_raw(10, ord('c'), 7)
+
+
 def test_simulation(fa_one_divisible_by_four):
     lhs = fa_one_divisible_by_four
     rel = mata.Nfa.compute_relation(lhs)

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -881,3 +881,41 @@ def test_get_states():
     assert len(useful) == 1
     assert 4 in useful
     
+    
+def test_segmentation():
+    nfa = mata.Nfa(ord('q') + 1)
+    epsilon = ord('c')
+
+    fill_with_automaton_a(nfa)
+    segmentation = mata.Segmentation(nfa, epsilon)
+    epsilon_depths = segmentation.get_epsilon_depths()
+    assert len(epsilon_depths) == 1
+    assert 0 in epsilon_depths
+    assert len(epsilon_depths[0]) == 3
+    assert mata.Trans(10, epsilon, 7) in epsilon_depths[0]
+    assert mata.Trans(7, epsilon, 3) in epsilon_depths[0]
+    assert mata.Trans(5, epsilon, 9) in epsilon_depths[0]
+
+    nfa = mata.Nfa(ord('q') + 1)
+    nfa.make_initial_state(1)
+    nfa.make_final_state(8)
+    nfa.add_trans_raw(1, epsilon, 2)
+    nfa.add_trans_raw(2, ord('a'), 3)
+    nfa.add_trans_raw(2, ord('b'), 4)
+    nfa.add_trans_raw(3, ord('b'), 6)
+    nfa.add_trans_raw(4, ord('a'), 6)
+    nfa.add_trans_raw(6, epsilon, 7)
+    nfa.add_trans_raw(7, epsilon, 8)
+
+    segmentation = mata.Segmentation(nfa, epsilon)
+    epsilon_depths = segmentation.get_epsilon_depths()
+    assert len(epsilon_depths) == 3
+    assert 0 in epsilon_depths
+    assert 1 in epsilon_depths
+    assert 2 in epsilon_depths
+    assert len(epsilon_depths[0]) == 1
+    assert len(epsilon_depths[1]) == 1
+    assert len(epsilon_depths[2]) == 1
+    assert mata.Trans(1, epsilon, 2) in epsilon_depths[0]
+    assert mata.Trans(6, epsilon, 7) in epsilon_depths[1]
+    assert mata.Trans(7, epsilon, 8) in epsilon_depths[2]

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -54,6 +54,13 @@ def test_adding_states():
     with pytest.raises(OverflowError):
         rhs.resize(-10)
 
+    rhs.resize_for_state(11)
+    assert rhs.state_size() == 12
+    assert rhs.is_state(11)
+    assert not rhs.is_state(12)
+
+    with pytest.raises(OverflowError):
+        rhs.resize_for_state(-10)
 
 def test_transitions():
     """Test adding transitions to automaton"""

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -14,7 +14,7 @@ def test_adding_states():
     # Test adding states
     assert not lhs.has_initial_state(0)
     assert not lhs.has_final_state(0)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     assert lhs.has_initial_state(0)
     assert not lhs.has_final_state(0)
 
@@ -23,13 +23,13 @@ def test_adding_states():
         assert not lhs.has_initial_state(i)
         assert not lhs.has_final_state(i)
 
-    lhs.add_initial_states([1, 2, 3, 4])
+    lhs.make_initial_states([1, 2, 3, 4])
     for i in range(0, 5):
         assert lhs.has_initial_state(i)
         assert not lhs.has_final_state(i)
 
     # Test adding final states
-    lhs.add_final_state(0)
+    lhs.make_final_state(0)
     assert lhs.has_final_state(0)
 
     rhs = mata.Nfa()
@@ -61,6 +61,87 @@ def test_adding_states():
 
     with pytest.raises(OverflowError):
         rhs.resize_for_state(-10)
+
+
+def making_initial_and_final_states():
+    """Test making states in the automaton initial and final."""
+    nfa = mata.Nfa(10)
+    assert len(nfa.initalstates) == 0
+    assert len(nfa.finalstates) == 0
+
+    nfa.make_initial_state(0)
+    assert len(nfa.initalstates) == 1
+    assert nfa.has_initial(0)
+    assert len(nfa.finalstates) == 0
+
+    nfa.make_final_state(0)
+    assert len(nfa.initalstates) == 1
+    assert nfa.has_initial(0)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final(1)
+
+    nfa.make_initial_states(1, 2, 3)
+    assert len(nfa.initalstates) == 4
+    assert nfa.has_initial(0)
+    assert nfa.has_initial(1)
+    assert nfa.has_initial(2)
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final(1)
+
+    nfa.make_final_states(1, 2, 3)
+    assert len(nfa.initalstates) == 4
+    assert nfa.has_initial(0)
+    assert nfa.has_initial(1)
+    assert nfa.has_initial(2)
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 4
+    assert nfa.has_final(0)
+    assert nfa.has_final(1)
+    assert nfa.has_final(2)
+    assert nfa.has_final(3)
+
+    nfa.remove_initial_state(0)
+    assert len(nfa.initalstates) == 3
+    assert not nfa.has_initial(0)
+    assert nfa.has_initial(1)
+    assert nfa.has_initial(2)
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 4
+    assert nfa.has_final(0)
+    assert nfa.has_final(1)
+    assert nfa.has_final(2)
+    assert nfa.has_final(3)
+
+    nfa.remove_final_states(0)
+    assert len(nfa.initalstates) == 3
+    assert not nfa.has_initial(0)
+    assert nfa.has_initial(1)
+    assert nfa.has_initial(2)
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 3
+    assert not nfa.has_final(0)
+    assert nfa.has_final(1)
+    assert nfa.has_final(2)
+    assert nfa.has_final(3)
+
+    nfa.remove_initial_states(1, 2)
+    assert len(nfa.initalstates) == 1
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 3
+    assert not nfa.has_final(0)
+    assert nfa.has_final(1)
+    assert nfa.has_final(2)
+    assert nfa.has_final(3)
+
+    nfa.remove_final_states(1, 2)
+    assert len(nfa.initalstates) == 1
+    assert nfa.has_initial(3)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final(3)
+    assert len(nfa.initalstates) == 0
+    assert len(nfa.finalstates) == 0
+
 
 def test_transitions():
     """Test adding transitions to automaton"""
@@ -98,14 +179,14 @@ def test_post(binary_alphabet):
     :return:
     """
     lhs = mata.Nfa(3)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 1)
     lhs.add_trans_raw(1, 1, 2)
     lhs.add_trans_raw(0, 1, 2)
     lhs.add_trans_raw(1, 0, 0)
     lhs.add_trans_raw(2, 1, 2)
     lhs.add_trans_raw(2, 0, 2)
-    lhs.add_final_state(2)
+    lhs.make_final_state(2)
 
     assert lhs.post_of({0}, 0) == {1}
     assert lhs.post_of({0, 1}, 0) == {0, 1}
@@ -162,7 +243,7 @@ def test_language_emptiness(fa_one_divisible_by_two):
     assert mata.Nfa.is_lang_empty_word_counterexample(fa_one_divisible_by_two) == (False, [1, 1])
 
     lhs = mata.Nfa(4)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 1)
     lhs.add_trans_raw(1, 0, 2)
     lhs.add_trans_raw(2, 0, 3)
@@ -176,11 +257,12 @@ def test_universality(fa_one_divisible_by_two):
     assert mata.Nfa.is_universal(fa_one_divisible_by_two, alph) == False
 
     l = mata.Nfa(1)
-    l.add_initial_state(0)
+    l.make_initial_state(0)
     l.add_trans_raw(0, 0, 0)
     l.add_trans_raw(0, 1, 0)
-    l.add_final_state(0)
+    l.make_final_state(0)
     assert mata.Nfa.is_universal(l, alph) == True
+
 
 def test_inclusion(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
@@ -213,14 +295,14 @@ def test_completeness(
     assert mata.Nfa.is_complete(fa_one_divisible_by_eight, alph)
 
     l = mata.Nfa(1)
-    l.add_initial_state(0)
+    l.make_initial_state(0)
     l.add_trans_raw(0,0,0)
     assert not mata.Nfa.is_complete(l, alph)
     l.add_trans_raw(0,1,0)
     assert mata.Nfa.is_complete(l, alph)
 
     r = mata.Nfa(1)
-    r.add_initial_state(0)
+    r.make_initial_state(0)
     r.add_trans_raw(0,0,0)
     assert not mata.Nfa.is_complete(r, alph)
     mata.Nfa.make_complete(r, 1, alph)
@@ -238,14 +320,15 @@ def test_in_language(
     assert not mata.Nfa.accepts_epsilon(fa_one_divisible_by_four)
 
     lhs = mata.Nfa(2)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 1)
     assert not mata.Nfa.accepts_epsilon(lhs)
-    lhs.add_final_state(1)
+    lhs.make_final_state(1)
     assert not mata.Nfa.accepts_epsilon(lhs)
-    lhs.add_final_state(0)
+    lhs.make_final_state(0)
     assert mata.Nfa.accepts_epsilon(lhs)
+
 
 def test_union(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
@@ -264,6 +347,7 @@ def test_union(
     assert mata.Nfa.is_included(fa_one_divisible_by_two, uni, alph)[0]
     assert mata.Nfa.is_included(fa_one_divisible_by_four, uni, alph)[0]
 
+
 def test_intersection(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
@@ -281,6 +365,7 @@ def test_intersection(
     assert mata.Nfa.is_included(inter, fa_one_divisible_by_four, alph)[0]
     assert map == {(0,0): 0, (1,1): 1, (1,3): 3, (2,2): 2, (2, 4): 4}
 
+
 def test_complement(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
@@ -297,10 +382,10 @@ def test_complement(
 
 def test_revert():
     lhs = mata.Nfa(3)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 1)
     lhs.add_trans_raw(1, 1, 2)
-    lhs.add_final_state(2)
+    lhs.make_final_state(2)
     assert mata.Nfa.is_in_lang(lhs, [0, 1])
     assert not mata.Nfa.is_in_lang(lhs, [1, 0])
 
@@ -311,11 +396,11 @@ def test_revert():
 
 def test_removing_epsilon():
     lhs = mata.Nfa(3)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     lhs.add_trans_raw(0, 0, 1)
     lhs.add_trans_raw(1, 1, 2)
     lhs.add_trans_raw(0, 2, 2)
-    lhs.add_final_state(2)
+    lhs.make_final_state(2)
 
     rhs = mata.Nfa.remove_epsilon(lhs, 2)
     assert rhs.has_trans_raw(0, 0, 1)
@@ -334,12 +419,12 @@ def test_minimize(
     assert minimized.get_num_of_trans() <= fa_one_divisible_by_eight.get_num_of_trans()
 
     lhs = mata.Nfa(11)
-    lhs.add_initial_state(0)
+    lhs.make_initial_state(0)
     for i in range(0, 10):
         lhs.add_trans_raw(i, 0, i+1)
-        lhs.add_final_state(i)
+        lhs.make_final_state(i)
     lhs.add_trans_raw(10, 0, 10)
-    lhs.add_final_state(10)
+    lhs.make_final_state(10)
     assert lhs.get_num_of_trans() == 11
 
     minimized = mata.Nfa.minimize(lhs)
@@ -358,19 +443,22 @@ def test_to_dot():
         lines = test_handle.read()
     assert lines == expected
 
+
 def test_to_str():
     lhs = mata.Nfa(2)
-    lhs.add_initial_state(0)
-    lhs.add_final_state(1)
+    lhs.make_initial_state(0)
+    lhs.make_final_state(1)
     lhs.add_trans_raw(0, 0, 0)
     lhs.add_trans_raw(0, 1, 1)
     expected = "initial_states: [0]\nfinal_states: [1]\ntransitions:\n0-[0]→0\n0-[1]→1\n"
     assert str(lhs) == expected
 
+
 def test_shortest(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
     shortest = lhs.get_shortest_words()
     assert shortest == [[1, 1]]
+
 
 def test_get_trans(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
@@ -378,6 +466,7 @@ def test_get_trans(fa_one_divisible_by_two):
     assert sorted(t) == sorted([mata.TransSymbolStates(0, [0]), mata.TransSymbolStates(1, [1])])
     tt = lhs.get_transitions_from_state(1)
     assert sorted(tt) == sorted([mata.TransSymbolStates(0, [1]), mata.TransSymbolStates(1, [2])])
+
 
 def test_simulation(fa_one_divisible_by_four):
     lhs = fa_one_divisible_by_four
@@ -409,6 +498,7 @@ def test_simulation(fa_one_divisible_by_four):
         [True for _ in range(0, 5)],
         [True for _ in range(0, 5)],
     ]
+
 
 def test_simulation_other_features(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
@@ -464,6 +554,7 @@ def test_simulation_equivalence():
     classes, heads = r.build_equivalence_classes()
     assert classes == [0, 1, 2]
     assert heads == [0, 1, 2]
+
 
 def test_simulation_indexes(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -4,7 +4,6 @@ import pytest
 import mata
 import os
 
-from conftest import fill_with_automaton_a, fill_with_automaton_b
 
 __author__ = 'Tomas Fiedor'
 
@@ -68,114 +67,114 @@ def test_adding_states():
 def test_making_initial_and_final_states():
     """Test making states in the automaton initial and final."""
     nfa = mata.Nfa(10)
-    assert len(nfa.initialstates) == 0
-    assert len(nfa.finalstates) == 0
+    assert len(nfa.initial_states) == 0
+    assert len(nfa.final_states) == 0
 
     nfa.make_initial_state(0)
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(0)
-    assert len(nfa.finalstates) == 0
+    assert len(nfa.final_states) == 0
 
     nfa.make_final_state(0)
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(0)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(0)
 
     nfa.make_initial_states([1, 2, 3])
-    assert len(nfa.initialstates) == 4
+    assert len(nfa.initial_states) == 4
     assert nfa.has_initial_state(0)
     assert nfa.has_initial_state(1)
     assert nfa.has_initial_state(2)
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(0)
 
     nfa.make_final_states([1, 2, 3])
-    assert len(nfa.initialstates) == 4
+    assert len(nfa.initial_states) == 4
     assert nfa.has_initial_state(0)
     assert nfa.has_initial_state(1)
     assert nfa.has_initial_state(2)
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 4
+    assert len(nfa.final_states) == 4
     assert nfa.has_final_state(0)
     assert nfa.has_final_state(1)
     assert nfa.has_final_state(2)
     assert nfa.has_final_state(3)
 
     nfa.remove_initial_state(0)
-    assert len(nfa.initialstates) == 3
+    assert len(nfa.initial_states) == 3
     assert not nfa.has_initial_state(0)
     assert nfa.has_initial_state(1)
     assert nfa.has_initial_state(2)
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 4
+    assert len(nfa.final_states) == 4
     assert nfa.has_final_state(0)
     assert nfa.has_final_state(1)
     assert nfa.has_final_state(2)
     assert nfa.has_final_state(3)
 
     nfa.remove_final_state(0)
-    assert len(nfa.initialstates) == 3
+    assert len(nfa.initial_states) == 3
     assert not nfa.has_initial_state(0)
     assert nfa.has_initial_state(1)
     assert nfa.has_initial_state(2)
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 3
+    assert len(nfa.final_states) == 3
     assert not nfa.has_final_state(0)
     assert nfa.has_final_state(1)
     assert nfa.has_final_state(2)
     assert nfa.has_final_state(3)
 
     nfa.remove_initial_states([1, 2])
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 3
+    assert len(nfa.final_states) == 3
     assert not nfa.has_final_state(0)
     assert nfa.has_final_state(1)
     assert nfa.has_final_state(2)
     assert nfa.has_final_state(3)
 
     nfa.remove_final_states([1, 2])
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(3)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(3)
 
     nfa.reset_initial_state(4)
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(4)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(3)
 
     nfa.reset_final_state(4)
-    assert len(nfa.initialstates) == 1
+    assert len(nfa.initial_states) == 1
     assert nfa.has_initial_state(4)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(4)
 
     nfa.reset_initial_states([5, 6])
-    assert len(nfa.initialstates) == 2
+    assert len(nfa.initial_states) == 2
     assert nfa.has_initial_state(5)
     assert nfa.has_initial_state(6)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(4)
 
     nfa.reset_initial_states([5, 6])
-    assert len(nfa.initialstates) == 2
+    assert len(nfa.initial_states) == 2
     assert nfa.has_initial_state(5)
     assert nfa.has_initial_state(6)
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(4)
 
     nfa.clear_initial()
-    assert len(nfa.initialstates) == 0
-    assert len(nfa.finalstates) == 1
+    assert len(nfa.initial_states) == 0
+    assert len(nfa.final_states) == 1
     assert nfa.has_final_state(4)
 
     nfa.clear_final()
-    assert len(nfa.initialstates) == 0
-    assert len(nfa.finalstates) == 0
+    assert len(nfa.initial_states) == 0
+    assert len(nfa.final_states) == 0
 
 
 def test_transitions():
@@ -349,10 +348,10 @@ def test_inclusion(
     smaller = mata.Nfa(10)
     bigger = mata.Nfa(16)
     alph = []
-    smaller.initialstates = [1]
-    smaller.finalstates = [1]
-    bigger.initialstates = [11]
-    bigger.finalstates = [11]
+    smaller.initial_states = [1]
+    smaller.final_states = [1]
+    bigger.initial_states = [11]
+    bigger.final_states = [11]
 
     assert mata.Nfa.equivalence_check(smaller, bigger, mata.EnumAlphabet(alph))
     assert mata.Nfa.equivalence_check(smaller, bigger)
@@ -466,7 +465,7 @@ def test_intersection(
     assert map == {(0,0): 0, (1,1): 1, (1,3): 3, (2,2): 2, (2, 4): 4}
 
 
-def test_intersection_epsilon_preserving():
+def test_intersection_preserving_epsilon_transitions():
     epsilon = ord('e')
     a = mata.Nfa(6)
     a.make_initial_state(0)
@@ -493,12 +492,9 @@ def test_intersection_epsilon_preserving():
     b.add_trans_raw(6, ord('a'), 9)
     b.add_trans_raw(6, ord('b'), 7)
 
-    result, prod_map = mata.Nfa.intersection_epsilon_preserving(a, b, epsilon)
+    result, prod_map = mata.Nfa.intersection_preserving_epsilon_transitions(a, b, epsilon)
 
     # Check states.
-    for i, m in prod_map.items():
-        print(f"{i}: {m}")
-
     assert result.get_num_of_states() == 13
     assert result.is_state(prod_map[(0, 0)])
     assert result.is_state(prod_map[(1, 0)])
@@ -515,12 +511,12 @@ def test_intersection_epsilon_preserving():
     assert result.is_state(prod_map[(5, 8)])
 
     assert result.has_initial_state(prod_map[(0, 0)])
-    assert len(result.initialstates) == 1
+    assert len(result.initial_states) == 1
     assert result.has_final_state(prod_map[(1, 2)])
     assert result.has_final_state(prod_map[(1, 4)])
     assert result.has_final_state(prod_map[(4, 7)])
     assert result.has_final_state(prod_map[(5, 8)])
-    assert len(result.finalstates) == 4
+    assert len(result.final_states) == 4
 
     # Check transitions.
     assert result.get_num_of_trans() == 15
@@ -669,20 +665,18 @@ def test_get_trans(fa_one_divisible_by_two):
     assert sorted(tt) == sorted([mata.TransSymbolStates(0, [1]), mata.TransSymbolStates(1, [2])])
 
 
-def test_trim():
+def test_trim(prepare_automaton_a):
     """Test trimming the automaton."""
-    nfa = mata.Nfa(20)
-    fill_with_automaton_a(nfa)
+    nfa = prepare_automaton_a()
     nfa.remove_trans_raw(1, ord('a'), 10)
 
-    old_nfa = mata.Nfa(20)
-    fill_with_automaton_a(old_nfa)
+    old_nfa = prepare_automaton_a()
     old_nfa.remove_trans_raw(1, ord('a'), 10)
 
     nfa.trim()
 
-    assert len(nfa.initialstates) == len(old_nfa.initialstates)
-    assert len(nfa.finalstates) == len(old_nfa.finalstates)
+    assert len(nfa.initial_states) == len(old_nfa.initial_states)
+    assert len(nfa.final_states) == len(old_nfa.final_states)
 
     for word in old_nfa.get_shortest_words():
         assert mata.Nfa.is_in_lang(nfa, word)
@@ -693,14 +687,11 @@ def test_trim():
     assert nfa.get_num_of_states() == 0
 
 
-def test_get_digraph():
+def test_get_digraph(prepare_automaton_a):
     """Test creating digraph from an automaton."""
-    nfa = mata.Nfa(100)
     abstract_symbol = ord('x')
-    fill_with_automaton_a(nfa)
-
-    old_nfa = mata.Nfa(20)
-    fill_with_automaton_a(old_nfa)
+    nfa = prepare_automaton_a()
+    old_nfa = prepare_automaton_a()
 
     digraph = nfa.get_digraph()
 
@@ -813,9 +804,8 @@ def test_simulation_indexes(fa_one_divisible_by_two):
     assert sorted(inv_index) == [[0], [0, 2], [1]]
 
 
-def test_get_states():
-    nfa = mata.Nfa(20)
-    fill_with_automaton_a(nfa)
+def test_get_states(prepare_automaton_a, prepare_automaton_b):
+    nfa = prepare_automaton_a()
 
     nfa.remove_trans_raw(3, ord('b'), 9)
     nfa.remove_trans_raw(5, ord('c'), 9)
@@ -841,8 +831,7 @@ def test_get_states():
     reachable = nfa.get_reachable_states()
     assert len(reachable) == 0
 
-    nfa = mata.Nfa(20)
-    fill_with_automaton_b(nfa)
+    nfa = prepare_automaton_b()
 
     nfa.remove_trans_raw(2, ord('c'), 12)
     nfa.remove_trans_raw(4, ord('c'), 8)
@@ -882,11 +871,10 @@ def test_get_states():
     assert 4 in useful
     
     
-def test_segmentation():
-    nfa = mata.Nfa(ord('q') + 1)
+def test_segmentation(prepare_automaton_a):
+    nfa = prepare_automaton_a()
     epsilon = ord('c')
 
-    fill_with_automaton_a(nfa)
     segmentation = mata.Segmentation(nfa, epsilon)
     epsilon_depths = segmentation.get_epsilon_depths()
     assert len(epsilon_depths) == 1

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -63,83 +63,116 @@ def test_adding_states():
         rhs.resize_for_state(-10)
 
 
-def making_initial_and_final_states():
+def test_making_initial_and_final_states():
     """Test making states in the automaton initial and final."""
     nfa = mata.Nfa(10)
-    assert len(nfa.initalstates) == 0
+    assert len(nfa.initialstates) == 0
     assert len(nfa.finalstates) == 0
 
     nfa.make_initial_state(0)
-    assert len(nfa.initalstates) == 1
-    assert nfa.has_initial(0)
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(0)
     assert len(nfa.finalstates) == 0
 
     nfa.make_final_state(0)
-    assert len(nfa.initalstates) == 1
-    assert nfa.has_initial(0)
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(0)
     assert len(nfa.finalstates) == 1
-    assert nfa.has_final(1)
+    assert nfa.has_final_state(0)
 
-    nfa.make_initial_states(1, 2, 3)
-    assert len(nfa.initalstates) == 4
-    assert nfa.has_initial(0)
-    assert nfa.has_initial(1)
-    assert nfa.has_initial(2)
-    assert nfa.has_initial(3)
+    nfa.make_initial_states([1, 2, 3])
+    assert len(nfa.initialstates) == 4
+    assert nfa.has_initial_state(0)
+    assert nfa.has_initial_state(1)
+    assert nfa.has_initial_state(2)
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 1
-    assert nfa.has_final(1)
+    assert nfa.has_final_state(0)
 
-    nfa.make_final_states(1, 2, 3)
-    assert len(nfa.initalstates) == 4
-    assert nfa.has_initial(0)
-    assert nfa.has_initial(1)
-    assert nfa.has_initial(2)
-    assert nfa.has_initial(3)
+    nfa.make_final_states([1, 2, 3])
+    assert len(nfa.initialstates) == 4
+    assert nfa.has_initial_state(0)
+    assert nfa.has_initial_state(1)
+    assert nfa.has_initial_state(2)
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 4
-    assert nfa.has_final(0)
-    assert nfa.has_final(1)
-    assert nfa.has_final(2)
-    assert nfa.has_final(3)
+    assert nfa.has_final_state(0)
+    assert nfa.has_final_state(1)
+    assert nfa.has_final_state(2)
+    assert nfa.has_final_state(3)
 
     nfa.remove_initial_state(0)
-    assert len(nfa.initalstates) == 3
-    assert not nfa.has_initial(0)
-    assert nfa.has_initial(1)
-    assert nfa.has_initial(2)
-    assert nfa.has_initial(3)
+    assert len(nfa.initialstates) == 3
+    assert not nfa.has_initial_state(0)
+    assert nfa.has_initial_state(1)
+    assert nfa.has_initial_state(2)
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 4
-    assert nfa.has_final(0)
-    assert nfa.has_final(1)
-    assert nfa.has_final(2)
-    assert nfa.has_final(3)
+    assert nfa.has_final_state(0)
+    assert nfa.has_final_state(1)
+    assert nfa.has_final_state(2)
+    assert nfa.has_final_state(3)
 
-    nfa.remove_final_states(0)
-    assert len(nfa.initalstates) == 3
-    assert not nfa.has_initial(0)
-    assert nfa.has_initial(1)
-    assert nfa.has_initial(2)
-    assert nfa.has_initial(3)
+    nfa.remove_final_state(0)
+    assert len(nfa.initialstates) == 3
+    assert not nfa.has_initial_state(0)
+    assert nfa.has_initial_state(1)
+    assert nfa.has_initial_state(2)
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 3
-    assert not nfa.has_final(0)
-    assert nfa.has_final(1)
-    assert nfa.has_final(2)
-    assert nfa.has_final(3)
+    assert not nfa.has_final_state(0)
+    assert nfa.has_final_state(1)
+    assert nfa.has_final_state(2)
+    assert nfa.has_final_state(3)
 
-    nfa.remove_initial_states(1, 2)
-    assert len(nfa.initalstates) == 1
-    assert nfa.has_initial(3)
+    nfa.remove_initial_states([1, 2])
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 3
-    assert not nfa.has_final(0)
-    assert nfa.has_final(1)
-    assert nfa.has_final(2)
-    assert nfa.has_final(3)
+    assert not nfa.has_final_state(0)
+    assert nfa.has_final_state(1)
+    assert nfa.has_final_state(2)
+    assert nfa.has_final_state(3)
 
-    nfa.remove_final_states(1, 2)
-    assert len(nfa.initalstates) == 1
-    assert nfa.has_initial(3)
+    nfa.remove_final_states([1, 2])
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(3)
     assert len(nfa.finalstates) == 1
-    assert nfa.has_final(3)
-    assert len(nfa.initalstates) == 0
+    assert nfa.has_final_state(3)
+
+    nfa.reset_initial_state(4)
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(4)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final_state(3)
+
+    nfa.reset_final_state(4)
+    assert len(nfa.initialstates) == 1
+    assert nfa.has_initial_state(4)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final_state(4)
+
+    nfa.reset_initial_states([5, 6])
+    assert len(nfa.initialstates) == 2
+    assert nfa.has_initial_state(5)
+    assert nfa.has_initial_state(6)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final_state(4)
+
+    nfa.reset_initial_states([5, 6])
+    assert len(nfa.initialstates) == 2
+    assert nfa.has_initial_state(5)
+    assert nfa.has_initial_state(6)
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final_state(4)
+
+    nfa.clear_initial()
+    assert len(nfa.initialstates) == 0
+    assert len(nfa.finalstates) == 1
+    assert nfa.has_final_state(4)
+
+    nfa.clear_final()
+    assert len(nfa.initialstates) == 0
     assert len(nfa.finalstates) == 0
 
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -4,7 +4,7 @@ import pytest
 import mata
 import os
 
-from conftest import fill_with_automaton_a
+from conftest import fill_with_automaton_a, fill_with_automaton_b
 
 __author__ = 'Tomas Fiedor'
 
@@ -521,6 +521,11 @@ def test_trim():
     for word in old_nfa.get_shortest_words():
         assert mata.Nfa.is_in_lang(nfa, word)
 
+    nfa.remove_final_state(2)  # '2' is the new final state in the earlier trimmed automaton.
+    nfa.trim()
+    assert nfa.trans_empty()
+    assert nfa.get_num_of_states() == 0
+
 
 def test_get_digraph():
     """Test creating digraph from an automaton."""
@@ -640,3 +645,72 @@ def test_simulation_indexes(fa_one_divisible_by_two):
     index, inv_index = rel.build_indexes()
     assert sorted(index) == [[0, 2], [1], [2]]
     assert sorted(inv_index) == [[0], [0, 2], [1]]
+
+
+def test_get_states():
+    nfa = mata.Nfa(20)
+    fill_with_automaton_a(nfa)
+
+    nfa.remove_trans_raw(3, ord('b'), 9)
+    nfa.remove_trans_raw(5, ord('c'), 9)
+    nfa.remove_trans_raw(1, ord('a'), 10)
+
+    reachable = nfa.get_reachable_states()
+
+    assert 0 not in reachable
+    assert 1 in reachable
+    assert 2 not in reachable
+    assert 3 in reachable
+    assert 4 not in reachable
+    assert 5 in reachable
+    assert 6 not in reachable
+    assert 7 in reachable
+    assert 8 not in reachable
+    assert 9 not in reachable
+    assert 10 not in reachable
+
+    nfa.remove_initial_state(1)
+    nfa.remove_initial_state(3)
+
+    reachable = nfa.get_reachable_states()
+    assert len(reachable) == 0
+
+    nfa = mata.Nfa(20)
+    fill_with_automaton_b(nfa)
+
+    nfa.remove_trans_raw(2, ord('c'), 12)
+    nfa.remove_trans_raw(4, ord('c'), 8)
+    nfa.remove_trans_raw(4, ord('a'), 8)
+
+    reachable = nfa.get_reachable_states()
+    assert 0 in reachable
+    assert 1 not in reachable
+    assert 2 in reachable
+    assert 3 not in reachable
+    assert 4 in reachable
+    assert 5 not in reachable
+    assert 6 in reachable
+    assert 7 not in reachable
+    assert 8 not in reachable
+    assert 9 not in reachable
+    assert 10 not in reachable
+    assert 11 not in reachable
+    assert 12 not in reachable
+    assert 13 not in reachable
+    assert 14 not in reachable
+
+    nfa.remove_final_state(2)
+    reachable = nfa.get_reachable_states()
+    assert len(reachable) == 4
+    assert 0 in reachable
+    assert 2 in reachable
+    assert 4 in reachable
+    assert 6 in reachable
+
+    useful = nfa.get_useful_states()
+    assert len(useful) == 0
+
+    nfa.make_final_state(4)
+    useful = nfa.get_useful_states()
+    assert len(useful) == 1
+    assert 4 in useful

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -3,7 +3,6 @@
 import pytest
 import mata
 
-from conftest import fill_with_automaton_a
 
 __author__ = 'Tomas Fiedor'
 
@@ -42,7 +41,7 @@ def test_transsymbstates():
     assert not b < d
 
 
-def test_transition_operations():
+def test_transition_operations(prepare_automaton_a):
     nfa = mata.Nfa(10)
     nfa.add_trans_raw(3, ord('c'), 4)
     assert nfa.has_trans_raw(3, ord('c'), 4)
@@ -55,8 +54,7 @@ def test_transition_operations():
     nfa.remove_trans(trans)
     assert not nfa.has_trans(trans)
 
-    nfa = mata.Nfa(20)
-    fill_with_automaton_a(nfa)
+    nfa = prepare_automaton_a()
 
     expected_trans = [mata.Trans(3, ord('b'), 9), mata.Trans(5, ord('c'), 9), mata.Trans(9, ord('a'), 9)]
 
@@ -90,5 +88,3 @@ def test_transition_operations():
         mata.Trans(1, ord('b'), 7),
     ]
     assert trans == expected_trans
-
-

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -3,6 +3,8 @@
 import pytest
 import mata
 
+from conftest import fill_with_automaton_a
+
 __author__ = 'Tomas Fiedor'
 
 
@@ -52,4 +54,14 @@ def test_transition_operations():
     assert not nfa.has_trans_raw(3, ord('c'), 4)
     nfa.remove_trans(trans)
     assert not nfa.has_trans(trans)
+
+    nfa = mata.Nfa(20)
+    fill_with_automaton_a(nfa)
+
+    expected_trans = [mata.Trans(3, ord('b'), 9), mata.Trans(5, ord('c'), 9), mata.Trans(9, ord('a'), 9)]
+
+    trans = nfa.get_transitions_to_state(9)
+    assert trans == expected_trans
+
+
 

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -39,3 +39,17 @@ def test_transsymbstates():
     assert not d < b
     assert not b < d
 
+
+def test_transition_operations():
+    nfa = mata.Nfa(10)
+    nfa.add_trans_raw(3, ord('c'), 4)
+    assert nfa.has_trans_raw(3, ord('c'), 4)
+    trans = mata.Trans(4, ord('c'), 5)
+    nfa.add_trans(trans)
+    assert nfa.has_trans(trans)
+
+    nfa.remove_trans_raw(3, ord('c'), 4)
+    assert not nfa.has_trans_raw(3, ord('c'), 4)
+    nfa.remove_trans(trans)
+    assert not nfa.has_trans(trans)
+

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -63,5 +63,32 @@ def test_transition_operations():
     trans = nfa.get_transitions_to_state(9)
     assert trans == expected_trans
 
+    trans = nfa.get_trans_as_sequence()
+    expected_trans = [
+        mata.Trans(1, ord('a'), 3),
+        mata.Trans(1, ord('a'), 10),
+        mata.Trans(1, ord('b'), 7),
+        mata.Trans(3, ord('a'), 7),
+        mata.Trans(3, ord('b'), 9),
+        mata.Trans(5, ord('a'), 5),
+        mata.Trans(5, ord('c'), 9),
+        mata.Trans(7, ord('a'), 3),
+        mata.Trans(7, ord('a'), 5),
+        mata.Trans(7, ord('b'), 1),
+        mata.Trans(7, ord('c'), 3),
+        mata.Trans(9, ord('a'), 9),
+        mata.Trans(10, ord('a'), 7),
+        mata.Trans(10, ord('b'), 7),
+        mata.Trans(10, ord('c'), 7),
+    ]
+    assert trans == expected_trans
+
+    trans = nfa.get_trans_from_state_as_sequence(1)
+    expected_trans = [
+        mata.Trans(1, ord('a'), 3),
+        mata.Trans(1, ord('a'), 10),
+        mata.Trans(1, ord('b'), 7),
+    ]
+    assert trans == expected_trans
 
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -362,10 +362,23 @@ public:
 
     bool has_initial(const State &state_to_check) const {return initialstates.count(state_to_check);}
 
+    /**
+     * Remove @p state from initial states.
+     * @param state[in] State to be removed from initial states.
+     */
     void remove_initial(State state)
     {
         assert(has_initial(state));
         this->initialstates.remove(state);
+    }
+
+    /**
+     * Remove @p vec of states from initial states.
+     * @param vec[in] Vector of states to be removed from initial states.
+     */
+    void remove_initial(const std::vector<State>& vec)
+    {
+        for (const State& st : vec) { this->remove_initial(st); }
     }
 
     /**
@@ -423,10 +436,23 @@ public:
 
     bool has_final(const State &state_to_check) const { return finalstates.count(state_to_check); }
 
+    /**
+     * Remove @p state from final states.
+     * @param state[in] State to be removed from final states.
+     */
     void remove_final(State state)
     {
         assert(has_final(state));
         this->finalstates.remove(state);
+    }
+
+    /**
+     * Remove @p vec of states from final states.
+     * @param vec[in] Vector of states to be removed from final states.
+     */
+    void remove_final(const std::vector<State>& vec)
+    {
+        for (const State& st : vec) { this->remove_final(st); }
     }
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -943,8 +943,6 @@ bool equivalence_check(const Nfa& lhs, const Nfa& rhs, const Alphabet& alphabet,
  */
 bool equivalence_check(const Nfa& lhs, const Nfa& rhs, const StringDict& params = {{ "algo", "antichains"}});
 
-//bool operator==(Nfa& lhs, Nfa& rhs) { return equivalence_check(lhs, rhs); }
-
 /// Reverting the automaton
 void revert(Nfa* result, const Nfa& aut);
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -762,6 +762,24 @@ inline Nfa uni(const Nfa &lhs, const Nfa &rhs)
 Nfa intersection(const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map = nullptr);
 
 /**
+ * @brief Compute intersection of two NFAs preserving epsilon transitions.
+ *
+ * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
+ * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
+ * an ε-transition `(s, a) -ε-> (p, a)` is created. Furthermore, for each ε-transition `s -ε-> p` and `a -ε-> b`,
+ * a product state `(s, a) -ε-> (p, b)` is created.
+ *
+ * Automata must share alphabets.
+ *
+ * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs with ε-transitions preserved.
+ * @param[in] lhs First NFA with possible epsilon symbols @p epsilon.
+ * @param[in] rhs Second NFA with possible epsilon symbols @p epsilon.
+ * @param[in] epsilon Symbol to handle as an epsilon symbol.
+ * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
+ */
+void intersection(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map = nullptr);
+
+/**
  * @brief Compute intersection of two NFAs.
  *
  * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs.
@@ -782,8 +800,16 @@ Nfa intersection(const Nfa &lhs, const Nfa &rhs);
 
 /**
  * Concatenate two NFAs.
- * @param lhs[in] First automaton to concatenate.
- * @param rhs[in] Second automaton to concatenate.
+ * @param[out] res Concatenated automaton as a result of the concatenation of @p lhs and @p rhs.
+ * @param[in] lhs First automaton to concatenate.
+ * @param[in] rhs Second automaton to concatenate.
+ */
+void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs);
+
+/**
+ * Concatenate two NFAs.
+ * @param[in] lhs First automaton to concatenate.
+ * @param[in] rhs Second automaton to concatenate.
  * @return Concatenated automaton.
  */
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs);

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -236,6 +236,11 @@ private:
     }
 }; // Concatenation
 
+void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs)
+{
+    *res = Concatenation(lhs, rhs).get_result();
+}
+
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs)
 {
     return Concatenation(lhs, rhs).get_result();

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -372,6 +372,16 @@ void intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMap*  prod_ma
     *res = intersection.get_product();
 }
 
+void intersection(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
+{
+    Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
+    if (prod_map != nullptr)
+    {
+        *prod_map = intersection.get_product_map();
+    }
+    *res = intersection.get_product();
+}
+
 Nfa intersection(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon, ProductMap*  prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };


### PR DESCRIPTION
This PR extends Python bindings for Mata with bindings for functions from #42.

Each function from #42 has a corresponding binding in Python and at least one test to ensure that the binding works.

I ask for a review from @tfiedor for this draft PR. It would help me if you could go through the code and look for any obvious bugs. I plan to improve documentation in a few places. However, the code should be complete (all tests pass) as it is now. There still might be some implementation changes before opening this PR, but I do not plan anything major, mainly refactorization I hope.

Furthermore, I might add bindings for new `Mata::Nfa::Nfa()` constructors, as discussed in #42.

This PR resolves #42.