### PR TITLE
Add Python binding for simulation minimization

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -72,6 +72,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     ctypedef umap[string, State] StringToStateMap
     ctypedef umap[string, Symbol] StringToSymbolMap
     ctypedef umap[State, string] StateToStringMap
+    ctypedef umap[State, State] StateToStateMap
     ctypedef umap[Symbol, string] SymbolToStringMap
     ctypedef umap[string, string] StringDict
     ctypedef COrdVector[CTransSymbolStates] TransitionList
@@ -199,6 +200,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void revert(CNfa*, CNfa&)
     cdef void remove_epsilon(CNfa*, CNfa&, Symbol) except +
     cdef void minimize(CNfa*, CNfa&)
+    cdef void reduce(CNfa*, CNfa&, StateToStateMap*, StringDict&)
     cdef CBinaryRelation& compute_relation(CNfa&, StringDict&)
 
     # Helper functions

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -802,6 +802,26 @@ cdef class Nfa:
         mata.minimize(result.thisptr, dereference(lhs.thisptr))
         return result
 
+    @classmethod
+    def reduce(cls, Nfa aut, params = None):
+        """
+        Reduce the automaton.
+
+        :param Nfa aut: Original automaton to reduce.
+        :param Dict params: Additional parameters for the reduction algorithm:
+            - "algorithm": "simulation"
+        :return: (Reduced automaton, state map of original to new states)
+        """
+        params = params or {"algorithm": "simulation"}
+        cdef StateToStateMap state_map
+        result = Nfa()
+        mata.reduce(result.thisptr, dereference(aut.thisptr), &state_map,
+                    {
+                        k.encode('utf-8'): v.encode('utf-8') for k, v in params.items()
+                    }
+        )
+
+        return result, {k: v for k, v in state_map}
 
     @classmethod
     def compute_relation(cls, Nfa lhs, params = None):
@@ -891,7 +911,7 @@ cdef class Nfa:
         :param Nfa lhs: smaller automaton
         :param Nfa rhs: bigger automaton
         :param Alphabet alphabet: alpabet shared by two automata
-        :param dict params: adtitional params
+        :param dict params: additional params
         :return: true if lhs is included by rhs, counter example word if not
         """
         cdef Word word
@@ -916,7 +936,8 @@ cdef class Nfa:
         :param Nfa lhs: Smaller automaton.
         :param Nfa rhs: Bigger automaton.
         :param Alphabet alphabet: Alphabet shared by two automata.
-        :param dict params: Additional params.
+        :param dict params: Additional params:
+            - "algo": "antichains"
         :return: True if lhs is equivalent to rhs, False otherwise.
         """
         params = params or {'algo': 'antichains'}

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -907,3 +907,61 @@ def test_segmentation(prepare_automaton_a):
     assert mata.Trans(1, epsilon, 2) in epsilon_depths[0]
     assert mata.Trans(6, epsilon, 7) in epsilon_depths[1]
     assert mata.Trans(7, epsilon, 8) in epsilon_depths[2]
+
+
+def test_reduce():
+    """Test reducing the automaton."""
+    nfa = mata.Nfa()
+
+    # Test the reduction of an empty automaton.
+    result, state_map = mata.Nfa.reduce(nfa)
+    assert result.trans_empty()
+    assert len(result.initial_states) == 0
+    assert len(result.final_states) == 0
+
+    # Test the reduction of a simple automaton.
+    nfa.resize(3)
+    nfa.make_initial_state(1)
+    nfa.make_final_state(2)
+    result, state_map = mata.Nfa.reduce(nfa)
+    assert result.trans_empty()
+    assert result.get_num_of_states() == 2
+    assert result.has_initial_state(state_map[1])
+    assert result.has_final_state(state_map[2])
+    assert state_map[1] == state_map[0]
+    assert state_map[2] != state_map[0]
+
+    # Test the reduction of a bigger automaton.
+    nfa.resize(10)
+    nfa.initial_states = {1, 2}
+    nfa.final_states = {3, 9}
+    nfa.add_trans_raw(1, ord('a'), 2)
+    nfa.add_trans_raw(1, ord('a'), 3)
+    nfa.add_trans_raw(1, ord('b'), 4)
+    nfa.add_trans_raw(2, ord('a'), 2)
+    nfa.add_trans_raw(2, ord('b'), 2)
+    nfa.add_trans_raw(2, ord('a'), 3)
+    nfa.add_trans_raw(2, ord('b'), 4)
+    nfa.add_trans_raw(3, ord('b'), 4)
+    nfa.add_trans_raw(3, ord('c'), 7)
+    nfa.add_trans_raw(3, ord('b'), 2)
+    nfa.add_trans_raw(5, ord('c'), 3)
+    nfa.add_trans_raw(7, ord('a'), 8)
+    nfa.add_trans_raw(9, ord('b'), 2)
+    nfa.add_trans_raw(9, ord('c'), 0)
+    nfa.add_trans_raw(0, ord('a'), 4)
+
+    result, state_map = mata.Nfa.reduce(nfa)
+    assert result.get_num_of_states() == 6
+    assert result.has_initial_state(state_map[1])
+    assert result.has_initial_state(state_map[2])
+    assert result.has_final_state(state_map[9])
+    assert result.has_final_state(state_map[3])
+    assert result.has_trans_raw(state_map[9], ord('c'), state_map[0])
+    assert result.has_trans_raw(state_map[9], ord('c'), state_map[7])
+    assert result.has_trans_raw(state_map[3], ord('c'), state_map[0])
+    assert result.has_trans_raw(state_map[0], ord('a'), state_map[8])
+    assert result.has_trans_raw(state_map[7], ord('a'), state_map[4])
+    assert result.has_trans_raw(state_map[1], ord('a'), state_map[3])
+    assert not result.has_trans_raw(state_map[3], ord('b'), state_map[4])
+    assert result.has_trans_raw(state_map[2], ord('a'), state_map[2])

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -62,6 +62,8 @@ using StateMap = std::unordered_map<State, Target>;
 
 using StateToStringMap = StateMap<std::string>;
 using StateToPostMap = StateMap<PostSymb>; ///< Transitions.
+/// Mapping of states to states, used, for example, to map original states to reindexed states of new automaton, etc.
+using StateToStateMap = StateMap<State>;
 
 using SymbolToStringMap = std::unordered_map<Symbol, std::string>;
 
@@ -703,14 +705,14 @@ private:
      * @param original_to_new_states_map Map of old states to new trimmed automaton states.
      * @param trimmed_aut The new trimmed automaton.
      */
-    void add_trimmed_transitions(const StateMap<State>& original_to_new_states_map, Nfa& trimmed_aut);
+    void add_trimmed_transitions(const StateToStateMap& original_to_new_states_map, Nfa& trimmed_aut);
 
     /**
      * Get a new trimmed automaton.
      * @param original_to_new_states_map Map of old states to new trimmed automaton states.
      * @return Newly created trimmed automaton.
      */
-    Nfa create_trimmed_aut(const StateMap<State>& original_to_new_states_map);
+    Nfa create_trimmed_aut(const StateToStateMap& original_to_new_states_map);
 }; // Nfa
 
 /// a wrapper encapsulating @p Nfa for higher-level use
@@ -883,12 +885,12 @@ Simlib::Util::BinaryRelation compute_relation(
 void reduce(
         Nfa* result,
         const Nfa &aut,
-        StateMap<State> *state_map = nullptr,
+        StateToStateMap *state_map = nullptr,
         const StringDict&  params = {{"algorithm", "simulation"}});
 
 inline Nfa reduce(
         const Nfa &aut,
-        StateMap<State> *state_map = nullptr,
+        StateToStateMap *state_map = nullptr,
         const StringDict&  params = {{"algorithm", "simulation"}})
 {
     Nfa reduced;

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -54,13 +54,13 @@ public:
      * Get @c lhs to @c result states map.
      * @return @c lhs to @c result states map.
      */
-    StateMap<State>& get_lhs_result_states_map() { return lhs_result_states_map; }
+    StateToStateMap& get_lhs_result_states_map() { return lhs_result_states_map; }
 
     /**
      * Get @c rhs to @c result states map.
      * @return @c rhs to @c result states map.
      */
-    StateMap<State>& get_rhs_result_states_map() { return rhs_result_states_map; }
+    StateToStateMap& get_rhs_result_states_map() { return rhs_result_states_map; }
 
 private:
     const Nfa& lhs{}; ///< First automaton to concatenate.
@@ -68,8 +68,8 @@ private:
     const unsigned long lhs_states_num{}; ///< Number of states in @c lhs.
     const unsigned long rhs_states_num{}; ///< Number of states in @c rhs.
     Nfa result{}; ///< Concatenated automaton.
-    StateMap<State> lhs_result_states_map{}; ///< Map mapping @c lhs states to @c result states.
-    StateMap<State> rhs_result_states_map{}; ///< Map mapping @c rhs states to @c result states.
+    StateToStateMap lhs_result_states_map{}; ///< Map mapping @c lhs states to @c result states.
+    StateToStateMap rhs_result_states_map{}; ///< Map mapping @c rhs states to @c result states.
 
     /**
      * Compute concatenation of given automata.

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -75,7 +75,7 @@ namespace {
         return LTSforSimulation.compute_simulation();
     }
 
-	void reduce_size_by_simulation(Nfa* result, const Nfa& aut, StateMap<State> &state_map) {
+	void reduce_size_by_simulation(Nfa* result, const Nfa& aut, StateToStateMap &state_map) {
         auto sim_relation = compute_relation(aut, StringDict{{"relation", "simulation"}, {"direction","forward"}});
 
         auto sim_relation_symmetric = sim_relation;
@@ -334,7 +334,7 @@ void Nfa::trim()
 {
     StateSet original_useful_states{ get_useful_states() };
 
-    StateMap<State> original_to_new_states_map{ original_useful_states.size() };
+    StateToStateMap original_to_new_states_map{ original_useful_states.size() };
     size_t new_state_num{ 0 };
     for (const State original_state: original_useful_states)
     {
@@ -367,7 +367,7 @@ StateSet Nfa::get_useful_states()
     return useful_states;
 }
 
-Nfa Nfa::create_trimmed_aut(const StateMap<State>& original_to_new_states_map)
+Nfa Nfa::create_trimmed_aut(const StateToStateMap& original_to_new_states_map)
 {
     Nfa trimmed_aut{ original_to_new_states_map.size() };
 
@@ -389,7 +389,7 @@ Nfa Nfa::create_trimmed_aut(const StateMap<State>& original_to_new_states_map)
     return trimmed_aut;
 }
 
-void Nfa::add_trimmed_transitions(const StateMap<State>& original_to_new_states_map, Nfa& trimmed_aut)
+void Nfa::add_trimmed_transitions(const StateToStateMap& original_to_new_states_map, Nfa& trimmed_aut)
 {
     for (const auto& original_state_mapping: original_to_new_states_map)
     {
@@ -1108,7 +1108,7 @@ TransSequence Nfa::get_transitions_to_state(const State state_to) const
 void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {
     *unionAutomaton = rhs;
 
-    StateMap<State> thisStateToUnionState;
+    StateToStateMap thisStateToUnionState;
     for (State thisState = 0; thisState < lhs.transitionrelation.size(); ++thisState) {
         thisStateToUnionState[thisState] = unionAutomaton->add_new_state();
     }
@@ -1159,7 +1159,7 @@ Simlib::Util::BinaryRelation Mata::Nfa::compute_relation(const Nfa& aut, const S
     }
 }
 
-void Mata::Nfa::reduce(Nfa* result, const Nfa &aut, StateMap<State> *state_map, const StringDict& params) {
+void Mata::Nfa::reduce(Nfa* result, const Nfa &aut, StateToStateMap *state_map, const StringDict& params) {
     if (!haskey(params, "algorithm")) {
         throw std::runtime_error(std::to_string(__func__) +
                                  " requires setting the \"algorithm\" key in the \"params\" argument; "

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2108,7 +2108,7 @@ TEST_CASE("Mata::Nfa::fw-direct-simulation()")
 TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 {
 	Nfa aut;
-	StateMap<State> state_map;
+	StateToStateMap state_map;
 
 	SECTION("empty automaton")
 	{


### PR DESCRIPTION
This PR implements Python binding for simulation minimization from #43.

Seeing as `StateMap<State>` finds plenty of uses, I have introduced a new type in `Mata::Nfa`:
```cpp
using StateToStateMp = StateMap<State>
```

Thanks to this, I can simplify Python binding for a template type `StateMap<State>` to a simple type binding `StateToStateMap`.

I include some tests confirming the binding works as intended.