### PR TITLE
Make alphabet parameter optional for inclusion and equivalence checks

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -181,9 +181,9 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef bool is_lang_empty(CNfa&, Path*)
     cdef bool is_lang_empty_cex(CNfa&, Word*)
     cdef bool is_universal(CNfa&, CAlphabet&, StringDict&) except +
-    cdef bool is_incl(CNfa&, CNfa&, CAlphabet&, StringDict&)
-    cdef bool is_incl(CNfa&, CNfa&, CAlphabet&, Word*, StringDict&) except +
-    cdef bool equivalence_check(CNfa&, CNfa&, CAlphabet&, StringDict&)
+    cdef bool is_incl(CNfa&, CNfa&, CAlphabet*, StringDict&)
+    cdef bool is_incl(CNfa&, CNfa&, Word*, CAlphabet*, StringDict&) except +
+    cdef bool equivalence_check(CNfa&, CNfa&, CAlphabet*, StringDict&)
     cdef bool equivalence_check(CNfa&, CNfa&, StringDict&)
     cdef bool is_complete(CNfa&, CAlphabet&) except +
     cdef bool is_in_lang(CNfa&, Word&)

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -904,7 +904,7 @@ cdef class Nfa:
 
     @classmethod
     def is_included(
-            cls, Nfa lhs, Nfa rhs, Alphabet alphabet, params = None
+            cls, Nfa lhs, Nfa rhs, Alphabet alphabet = None, params = None
     ):
         """Test inclusion between two automata
 
@@ -915,12 +915,15 @@ cdef class Nfa:
         :return: true if lhs is included by rhs, counter example word if not
         """
         cdef Word word
+        cdef CAlphabet* c_alphabet = NULL
+        if alphabet:
+            c_alphabet = alphabet.as_base()
         params = params or {'algo': 'antichains'}
         result = mata.is_incl(
             dereference(lhs.thisptr),
             dereference(rhs.thisptr),
-            <CAlphabet&>dereference(alphabet.as_base()),
             &word,
+            c_alphabet,
             {
                 k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
                 for k, v in params.items()
@@ -941,11 +944,13 @@ cdef class Nfa:
         :return: True if lhs is equivalent to rhs, False otherwise.
         """
         params = params or {'algo': 'antichains'}
+        cdef CAlphabet * c_alphabet = NULL
         if alphabet:
+            c_alphabet = alphabet.as_base()
             return mata.equivalence_check(
                 dereference(lhs.thisptr),
                 dereference(rhs.thisptr),
-                <CAlphabet&>dereference(alphabet.as_base()),
+                c_alphabet,
                 {
                     k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
                     for k, v in params.items()

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -307,8 +307,14 @@ def test_inclusion(
     result, cex = mata.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_four, alph)
     assert not result
     assert cex == [1, 1]
+    result, cex = mata.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_four)
+    assert not result
+    assert cex == [1, 1]
 
     result, cex = mata.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_two, alph)
+    assert result
+    assert cex == []
+    result, cex = mata.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_two)
     assert result
     assert cex == []
 
@@ -316,6 +322,10 @@ def test_inclusion(
     assert mata.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four, alph)[0]
     assert not mata.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight, alph)[0]
     assert not mata.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight, alph)[0]
+    assert mata.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_two)[0]
+    assert mata.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four)[0]
+    assert not mata.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight)[0]
+    assert not mata.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight)[0]
 
     # Test equivalence of two NFAs.
     smaller = mata.Nfa(10)
@@ -446,6 +456,9 @@ def test_union(
     assert mata.Nfa.is_included(fa_one_divisible_by_two, uni, alph)[0]
     assert mata.Nfa.is_included(fa_one_divisible_by_four, uni, alph)[0]
 
+    assert mata.Nfa.is_included(fa_one_divisible_by_two, uni)[0]
+    assert mata.Nfa.is_included(fa_one_divisible_by_four, uni)[0]
+
 
 def test_intersection(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
@@ -462,6 +475,8 @@ def test_intersection(
     assert mata.Nfa.is_in_lang(inter, [1, 1, 1, 1, 1, 1, 1, 1,])
     assert mata.Nfa.is_included(inter, fa_one_divisible_by_two, alph)[0]
     assert mata.Nfa.is_included(inter, fa_one_divisible_by_four, alph)[0]
+    assert mata.Nfa.is_included(inter, fa_one_divisible_by_two)[0]
+    assert mata.Nfa.is_included(inter, fa_one_divisible_by_four)[0]
     assert map == {(0,0): 0, (1,1): 1, (1,3): 3, (2,2): 2, (2, 4): 4}
 
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -918,17 +918,17 @@ inline bool is_universal(
 bool is_incl(
         const Nfa&         smaller,
         const Nfa&         bigger,
-        const Alphabet&    alphabet,
-        Word*              cex = nullptr,
+        Word*              cex,
+        const Alphabet*    alphabet = nullptr,
         const StringDict&  params = {{"algo", "antichains"}});
 
 inline bool is_incl(
-        const Nfa&         smaller,
-        const Nfa&         bigger,
-        const Alphabet&    alphabet,
-        const StringDict&  params)
+        const Nfa&             smaller,
+        const Nfa&             bigger,
+        const Alphabet* const  alphabet = nullptr,
+        const StringDict&      params = {{"algo", "antichains"}})
 { // {{{
-    return is_incl(smaller, bigger, alphabet, nullptr, params);
+    return is_incl(smaller, bigger, nullptr, alphabet, params);
 } // }}}
 
 /**
@@ -941,7 +941,7 @@ inline bool is_incl(
  * - "algo": "naive", "antichains" (Default: "antichains")
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
-bool equivalence_check(const Nfa& lhs, const Nfa& rhs, const Alphabet& alphabet,
+bool equivalence_check(const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet,
                        const StringDict& params = {{"algo", "antichains"}});
 
 /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -97,6 +97,8 @@ struct Trans
 
 using TransSequence = std::vector<Trans>; ///< Set of transitions.
 
+struct Nfa; ///< A non-deterministic finite automaton.
+
 // ALPHABET {{{
 class Alphabet
 {
@@ -187,13 +189,13 @@ class EnumAlphabet : public Alphabet
 private:
 	StringToSymbolMap symbol_map;
 
-private:
-	EnumAlphabet(const EnumAlphabet& rhs);
-	EnumAlphabet& operator=(const EnumAlphabet& rhs);
+    EnumAlphabet& operator=(const EnumAlphabet& rhs);
 
 public:
 
 	EnumAlphabet() : symbol_map() { }
+
+    EnumAlphabet(const EnumAlphabet& rhs) : symbol_map(rhs.symbol_map) {}
 
 	template <class InputIt>
 	EnumAlphabet(InputIt first, InputIt last) : EnumAlphabet()
@@ -227,11 +229,10 @@ public:
 
 	std::list<Symbol> get_symbols() const override;
 	std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
-};
-// }}}
 
+    explicit EnumAlphabet(const Nfa& aut);
 
-struct Nfa; ///< A non-deterministic finite automaton.
+}; // }}}
 
 using AutSequence = std::vector<Nfa>; ///< A sequence of non-deterministic finite automata.
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -184,55 +184,6 @@ public:
 		const std::set<Symbol>& syms) const override;
 };
 
-class EnumAlphabet : public Alphabet
-{
-private:
-	StringToSymbolMap symbol_map;
-
-    EnumAlphabet& operator=(const EnumAlphabet& rhs);
-
-public:
-
-	EnumAlphabet() : symbol_map() { }
-
-    EnumAlphabet(const EnumAlphabet& rhs) : symbol_map(rhs.symbol_map) {}
-
-	template <class InputIt>
-	EnumAlphabet(InputIt first, InputIt last) : EnumAlphabet()
-	{ // {{{
-		size_t cnt = 0;
-		for (; first != last; ++first)
-		{
-			bool inserted;
-			std::tie(std::ignore, inserted) = symbol_map.insert({*first, cnt++});
-			if (!inserted)
-			{
-				throw std::runtime_error("multiple occurrence of the same symbol");
-			}
-		}
-	} // }}}
-
-	EnumAlphabet(std::initializer_list<std::string> l) :
-		EnumAlphabet(l.begin(), l.end())
-	{ }
-
-	Symbol translate_symb(const std::string& str) override
-	{
-		auto it = symbol_map.find(str);
-		if (symbol_map.end() == it)
-		{
-			throw std::runtime_error("unknown symbol \'" + str + "\'");
-		}
-
-		return it->second;
-	}
-
-	std::list<Symbol> get_symbols() const override;
-	std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
-
-    explicit EnumAlphabet(const Nfa& aut);
-
-}; // }}}
 
 using AutSequence = std::vector<Nfa>; ///< A sequence of non-deterministic finite automata.
 
@@ -1250,6 +1201,96 @@ private:
      */
     static void update_current_words(LengthWordsPair& act, const LengthWordsPair& dst, Symbol symbol);
 }; // ShortestWordsMap
+
+class EnumAlphabet : public Alphabet
+{
+private:
+    StringToSymbolMap symbol_map;
+
+    EnumAlphabet& operator=(const EnumAlphabet& rhs);
+
+    // Adapted from: https://stackoverflow.com/a/41623721.
+    template <typename TF, typename... Ts>
+    static void for_each_argument(TF&& f, Ts&&... xs)
+    {
+        std::initializer_list<const Nfa>{(f(std::forward<Ts>(xs)), Nfa{})... };
+    }
+
+    // Adapted from: https://www.fluentcpp.com/2019/01/25/variadic-number-function-parameters-type/.
+    template<bool...> struct bool_pack{};
+    /// Checks for all types in the pack.
+    template<typename... Ts>
+    using conjunction = std::is_same<bool_pack<true,Ts::value...>, bool_pack<Ts::value..., true>>;
+    /// Checks whether all types are 'Nfa'.
+    template<typename... Ts>
+    using AreAllNfas = typename conjunction<std::is_same<Ts, const Nfa&>...>::type;
+
+public:
+
+    EnumAlphabet() : symbol_map() { }
+
+    EnumAlphabet(const EnumAlphabet& rhs) : symbol_map(rhs.symbol_map) {}
+
+    /**
+     * Create alphabet from variable number of NFAs.
+     * @tparam Nfas Type Nfa.
+     * @param nfas NFAs to create alphabet from.
+     * @return Alphabet.
+     */
+    template<typename... Nfas, typename = AreAllNfas<Nfas...>>
+    static EnumAlphabet from_nfas(const Nfas&... nfas) {
+        EnumAlphabet alphabet{};
+        for_each_argument([&alphabet](const Nfa& aut) {
+            size_t aut_num_of_states{ aut.get_num_of_states() };
+            for (State state{ 0 }; state < aut_num_of_states; ++state) {
+                for (const auto& state_transitions: aut.transitionrelation[state]) {
+                    alphabet.add_symbol(std::to_string(state_transitions.symbol), state_transitions.symbol);
+                }
+            }
+        }, nfas...);
+        return alphabet;
+    }
+
+    template <class InputIt>
+    EnumAlphabet(InputIt first, InputIt last) : EnumAlphabet()
+    { // {{{
+        size_t cnt = 0;
+        for (; first != last; ++first)
+        {
+            bool inserted;
+            std::tie(std::ignore, inserted) = symbol_map.insert({*first, cnt++});
+            if (!inserted)
+            {
+                throw std::runtime_error("multiple occurrence of the same symbol");
+            }
+        }
+    } // }}}
+
+    EnumAlphabet(std::initializer_list<std::string> l) :
+            EnumAlphabet(l.begin(), l.end())
+    { }
+
+    Symbol translate_symb(const std::string& str) override
+    {
+        auto it = symbol_map.find(str);
+        if (symbol_map.end() == it)
+        {
+            throw std::runtime_error("unknown symbol \'" + str + "\'");
+        }
+
+        return it->second;
+    }
+
+    std::list<Symbol> get_symbols() const override;
+    std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
+
+    /**
+     * Add new symbol to the alphabet.
+     * @param key User-space representation of the symbol.
+     * @param value Number of the symbol to be used on transitions.
+     */
+    void add_symbol(const std::string& key, Symbol value) { symbol_map.insert({key, value}); }
+}; // class EnumAlphabet.
 
 // CLOSING NAMESPACES AND GUARDS
 } /* Nfa */

--- a/src/nfa/nfa-incl.cc
+++ b/src/nfa/nfa-incl.cc
@@ -33,7 +33,7 @@ bool is_incl_naive(
 { // {{{
     Nfa bigger_cmpl;
     if (alphabet == nullptr) {
-        bigger_cmpl = complement(bigger, EnumAlphabet(smaller));
+        bigger_cmpl = complement(bigger, EnumAlphabet::from_nfas(smaller, bigger));
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
@@ -235,7 +235,7 @@ bool Mata::Nfa::equivalence_check(const Nfa& lhs, const Nfa& rhs, const StringDi
 {
     if (haskey(params, "algo")) {
         if (params.at("algo") == "naive") {
-            auto alphabet{ EnumAlphabet{ lhs } };
+            auto alphabet{ EnumAlphabet::from_nfas(lhs, rhs) };
             return equivalence_check(lhs, rhs, &alphabet, params);
         }
     }

--- a/src/nfa/nfa-incl.cc
+++ b/src/nfa/nfa-incl.cc
@@ -186,6 +186,42 @@ bool is_incl_antichains(
 	return true;
 } // }}}
 
+
+using AlgoType = decltype(is_incl_naive)*;
+
+bool compute_equivalence(const Nfa& lhs, const Nfa& rhs, const Alphabet* const alphabet, const StringDict& params, const AlgoType& algo) {
+    if (algo(lhs, rhs, alphabet, nullptr, params))
+    {
+        if (algo(rhs, lhs, alphabet, nullptr, params))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+AlgoType set_algorithm(const std::string& function_name, const StringDict& params) {
+    if (!haskey(params, "algo")) {
+        throw std::runtime_error(function_name +
+                                 " requires setting the \"algo\" key in the \"params\" argument; "
+                                 "received: " + std::to_string(params));
+    }
+
+    decltype(is_incl_naive)* algo;
+    const std::string& str_algo = params.at("algo");
+    if ("naive" == str_algo) {
+        algo = is_incl_naive;
+    } else if ("antichains" == str_algo) {
+        algo = is_incl_antichains;
+    } else {
+        throw std::runtime_error(std::to_string(__func__) +
+                                 " received an unknown value of the \"algo\" key: " + str_algo);
+    }
+
+    return algo;
+}
+
 } // namespace
 
 
@@ -197,48 +233,24 @@ bool Mata::Nfa::is_incl(
 	const Alphabet* const  alphabet,
 	const StringDict&      params)
 { // {{{
-
-	// setting the default algorithm
-	decltype(is_incl_naive)* algo = is_incl_naive;
-	if (!haskey(params, "algo")) {
-		throw std::runtime_error(std::to_string(__func__) +
-			" requires setting the \"algo\" key in the \"params\" argument; "
-			"received: " + std::to_string(params));
-	}
-
-	const std::string& str_algo = params.at("algo");
-	if ("naive" == str_algo) { }
-	else if ("antichains" == str_algo) {
-		algo = is_incl_antichains;
-	} else {
-		throw std::runtime_error(std::to_string(__func__) +
-			" received an unknown value of the \"algo\" key: " + str_algo);
-	}
-
+    AlgoType algo{ set_algorithm(std::to_string(__func__), params) };
 	return algo(smaller, bigger, alphabet, cex, params);
 } // is_incl }}}
 
 bool Mata::Nfa::equivalence_check(const Nfa& lhs, const Nfa& rhs, const Alphabet* const alphabet, const StringDict& params)
 {
-    if (is_incl(lhs, rhs, alphabet, params))
-    {
-        if (is_incl(rhs, lhs, alphabet, params))
-        {
-            return true;
+    AlgoType algo{ set_algorithm(std::to_string(__func__), params) };
+
+    if (params.at("algo") == "naive") {
+        if (alphabet == nullptr) {
+            auto compute_alphabet{ EnumAlphabet::from_nfas(lhs, rhs) };
+            return compute_equivalence(lhs, rhs, alphabet, params, algo);
         }
     }
 
-    return false;
+    return compute_equivalence(lhs, rhs, alphabet, params, algo);
 }
 
-bool Mata::Nfa::equivalence_check(const Nfa& lhs, const Nfa& rhs, const StringDict& params)
-{
-    if (haskey(params, "algo")) {
-        if (params.at("algo") == "naive") {
-            auto alphabet{ EnumAlphabet::from_nfas(lhs, rhs) };
-            return equivalence_check(lhs, rhs, &alphabet, params);
-        }
-    }
-
+bool Mata::Nfa::equivalence_check(const Nfa& lhs, const Nfa& rhs, const StringDict& params) {
     return equivalence_check(lhs, rhs, nullptr, params);
 }

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -34,7 +34,7 @@ public:
     /**
      * Compute classic intersection of NFAs @p lhs and @p rhs.
      * @param lhs First NFA to compute intersection for.
-     * @param rhs Second NFA to compute intersecion for.
+     * @param rhs Second NFA to compute intersection for.
      */
     Intersection(const Nfa& lhs, const Nfa& rhs) : lhs(lhs), rhs(rhs)
     {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -248,15 +248,6 @@ std::list<Symbol> EnumAlphabet::get_complement(
     return result;
 } // EnumAlphabet::get_complement }}}
 
-EnumAlphabet::EnumAlphabet(const Nfa& aut) : symbol_map() {
-    const size_t aut_num_of_states{ aut.get_num_of_states() };
-    for (State state{ 0 }; state < aut_num_of_states; ++state) {
-        for (const auto& state_transitions: aut.transitionrelation[state]) {
-            symbol_map.insert({std::to_string(state_transitions.symbol), state_transitions.symbol});
-        }
-    }
-}
-
 ///// Nfa structure related methods
 
 void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -248,6 +248,15 @@ std::list<Symbol> EnumAlphabet::get_complement(
     return result;
 } // EnumAlphabet::get_complement }}}
 
+EnumAlphabet::EnumAlphabet(const Nfa& aut) : symbol_map() {
+    const size_t aut_num_of_states{ aut.get_num_of_states() };
+    for (State state{ 0 }; state < aut_num_of_states; ++state) {
+        for (const auto& state_transitions: aut.transitionrelation[state]) {
+            symbol_map.insert({std::to_string(state_transitions.symbol), state_transitions.symbol});
+        }
+    }
+}
+
 ///// Nfa structure related methods
 
 void Nfa::add_trans(State stateFrom, Symbol symbolOnTransition, State stateTo) {

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -261,8 +261,8 @@ TEST_CASE("Mata::Nfa::union_norename()")
 		StringDict params;
 		params["algo"] = "antichains";
 
-		REQUIRE(is_incl(a, res, alph, params));
-		REQUIRE(is_incl(b, res, alph, params));
+		REQUIRE(is_incl(a, res, &alph, params));
+		REQUIRE(is_incl(b, res, &alph, params));
 	}
 
 	SECTION("Union of automata with some transitions but without a final state")
@@ -277,8 +277,8 @@ TEST_CASE("Mata::Nfa::union_norename()")
 		StringDict params;
 		params["algo"] = "antichains";
 
-		REQUIRE(is_incl(a, res, alph, params));
-		REQUIRE(is_incl(res, a, alph, params));
+		REQUIRE(is_incl(a, res, &alph, params));
+		REQUIRE(is_incl(res, a, &alph, params));
 
 		WARN_PRINT("Insufficient testing of Mata::Nfa::union_norename()");
 	}
@@ -1409,10 +1409,10 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, params);
+			bool is_included = is_incl(smaller, bigger, &alph, params);
 			CHECK(is_included);
 
-            is_included = is_incl(bigger, smaller, alph, params);
+            is_included = is_incl(bigger, smaller, &alph, params);
             CHECK(is_included);
 		}
 	}
@@ -1425,10 +1425,10 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, &cex, params);
+			bool is_included = is_incl(smaller, bigger, &cex, &alph, params);
             CHECK(is_included);
 
-            is_included = is_incl(bigger, smaller, alph, &cex, params);
+            is_included = is_incl(bigger, smaller, &cex, &alph, params);
             CHECK(!is_included);
 		}
 	}
@@ -1443,10 +1443,10 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, &cex, params);
+			bool is_included = is_incl(smaller, bigger, &cex, &alph, params);
             CHECK(is_included);
 
-            is_included = is_incl(bigger, smaller, alph, &cex, params);
+            is_included = is_incl(bigger, smaller, &cex, &alph, params);
             CHECK(is_included);
 		}
 	}
@@ -1459,12 +1459,12 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, &cex, params);
+			bool is_included = is_incl(smaller, bigger, &cex, &alph, params);
 
 			REQUIRE(!is_included);
 			REQUIRE(cex == Word{});
 
-            is_included = is_incl(bigger, smaller, alph, &cex, params);
+            is_included = is_incl(bigger, smaller, &cex, &alph, params);
             REQUIRE(cex == Word{});
             REQUIRE(is_included);
 		}
@@ -1485,10 +1485,10 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, params);
+			bool is_included = is_incl(smaller, bigger, &alph, params);
 			REQUIRE(is_included);
 
-            is_included = is_incl(bigger, smaller, alph, params);
+            is_included = is_incl(bigger, smaller, &alph, params);
             REQUIRE(!is_included);
 		}
 	}
@@ -1509,14 +1509,14 @@ TEST_CASE("Mata::Nfa::is_incl()")
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
 
-			bool is_included = is_incl(smaller, bigger, alph, &cex, params);
+			bool is_included = is_incl(smaller, bigger, &cex, &alph, params);
 
 			REQUIRE(!is_included);
 			REQUIRE((
 				cex == Word{alph["a"], alph["b"]} ||
 				cex == Word{alph["b"], alph["a"]}));
 
-            is_included = is_incl(bigger, smaller, alph, &cex, params);
+            is_included = is_incl(bigger, smaller, &cex, &alph, params);
             REQUIRE(is_included);
             REQUIRE((
                 cex == Word{alph["a"], alph["b"]} ||
@@ -1548,7 +1548,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
-			bool is_included = is_incl(smaller, bigger, alph, &cex, params);
+			bool is_included = is_incl(smaller, bigger, &cex, &alph, params);
 			REQUIRE(!is_included);
 
 			REQUIRE(cex.size() == 4);
@@ -1558,7 +1558,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 			REQUIRE((cex[3] == alph["a"] || cex[3] == alph["b"]));
 			REQUIRE(cex[2] != cex[3]);
 
-            is_included = is_incl(bigger, smaller, alph, &cex, params);
+            is_included = is_incl(bigger, smaller, &cex, &alph, params);
             REQUIRE(is_included);
 
             REQUIRE(cex.size() == 4);
@@ -1574,9 +1574,9 @@ TEST_CASE("Mata::Nfa::is_incl()")
 	{
 		EnumAlphabet alph = { };
 
-		CHECK_THROWS_WITH(is_incl(smaller, bigger, alph, params),
+		CHECK_THROWS_WITH(is_incl(smaller, bigger, &alph, params),
 			Catch::Contains("requires setting the \"algo\" key"));
-        CHECK_NOTHROW(is_incl(smaller, bigger, alph));
+        CHECK_NOTHROW(is_incl(smaller, bigger, &alph));
 	}
 
 	SECTION("wrong parameters 2")
@@ -1584,9 +1584,9 @@ TEST_CASE("Mata::Nfa::is_incl()")
 		EnumAlphabet alph = { };
 		params["algo"] = "foo";
 
-		CHECK_THROWS_WITH(is_incl(smaller, bigger, alph, params),
+		CHECK_THROWS_WITH(is_incl(smaller, bigger, &alph, params),
 			Catch::Contains("received an unknown value"));
-        CHECK_NOTHROW(is_incl(smaller, bigger, alph));
+        CHECK_NOTHROW(is_incl(smaller, bigger, &alph));
 	}
 } // }}}
 
@@ -1609,11 +1609,11 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
 
-            CHECK(equivalence_check(smaller, bigger, alph, params));
+            CHECK(equivalence_check(smaller, bigger, &alph, params));
             CHECK(equivalence_check(smaller, bigger, params));
             CHECK(equivalence_check(smaller, bigger));
 
-            CHECK(equivalence_check(bigger, smaller , alph, params));
+            CHECK(equivalence_check(bigger, smaller , &alph, params));
             CHECK(equivalence_check(bigger, smaller, params));
             CHECK(equivalence_check(bigger, smaller));
         }
@@ -1628,11 +1628,11 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
 
-            CHECK(!equivalence_check(smaller, bigger, alph, params));
+            CHECK(!equivalence_check(smaller, bigger, &alph, params));
             CHECK(!equivalence_check(smaller, bigger, params));
             CHECK(!equivalence_check(smaller, bigger));
 
-            CHECK(!equivalence_check(bigger, smaller , alph, params));
+            CHECK(!equivalence_check(bigger, smaller , &alph, params));
             CHECK(!equivalence_check(bigger, smaller, params));
             CHECK(!equivalence_check(bigger, smaller));
         }
@@ -1649,11 +1649,11 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
 
-            CHECK(equivalence_check(smaller, bigger, alph, params));
+            CHECK(equivalence_check(smaller, bigger, &alph, params));
             CHECK(equivalence_check(smaller, bigger, params));
             CHECK(equivalence_check(smaller, bigger));
 
-            CHECK(equivalence_check(bigger, smaller , alph, params));
+            CHECK(equivalence_check(bigger, smaller , &alph, params));
             CHECK(equivalence_check(bigger, smaller, params));
             CHECK(equivalence_check(bigger, smaller));
         }
@@ -1675,11 +1675,11 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
 
-            CHECK(!equivalence_check(smaller, bigger, alph, params));
+            CHECK(!equivalence_check(smaller, bigger, &alph, params));
             CHECK(!equivalence_check(smaller, bigger, params));
             CHECK(!equivalence_check(smaller, bigger));
 
-            CHECK(!equivalence_check(bigger, smaller , alph, params));
+            CHECK(!equivalence_check(bigger, smaller , &alph, params));
             CHECK(!equivalence_check(bigger, smaller, params));
             CHECK(!equivalence_check(bigger, smaller));
         }
@@ -1710,11 +1710,11 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
 
-            CHECK(!equivalence_check(smaller, bigger, alph, params));
+            CHECK(!equivalence_check(smaller, bigger, &alph, params));
             CHECK(!equivalence_check(smaller, bigger, params));
             CHECK(!equivalence_check(smaller, bigger));
 
-            CHECK(!equivalence_check(bigger, smaller , alph, params));
+            CHECK(!equivalence_check(bigger, smaller , &alph, params));
             CHECK(!equivalence_check(bigger, smaller, params));
             CHECK(!equivalence_check(bigger, smaller));
         }
@@ -1724,7 +1724,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
     {
         EnumAlphabet alph = { };
 
-        CHECK_THROWS_WITH(equivalence_check(smaller, bigger, alph, params),
+        CHECK_THROWS_WITH(equivalence_check(smaller, bigger, &alph, params),
                           Catch::Contains("requires setting the \"algo\" key"));
         CHECK_THROWS_WITH(equivalence_check(smaller, bigger, params),
                           Catch::Contains("requires setting the \"algo\" key"));
@@ -1736,7 +1736,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
         EnumAlphabet alph = { };
         params["algo"] = "foo";
 
-        CHECK_THROWS_WITH(equivalence_check(smaller, bigger, alph, params),
+        CHECK_THROWS_WITH(equivalence_check(smaller, bigger, &alph, params),
                           Catch::Contains("received an unknown value"));
         CHECK_THROWS_WITH(equivalence_check(smaller, bigger, params),
                           Catch::Contains("received an unknown value"));

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -63,6 +63,26 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 } // }}}
 */
 
+TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()")
+{
+    Nfa a{1};
+    a.add_trans(0, 'a', 0);
+
+    Nfa b{1};
+    b.add_trans(0, 'b', 0);
+    b.add_trans(0, 'a', 0);
+    Nfa c{1};
+    b.add_trans(0, 'c', 0);
+
+    auto alphabet{ EnumAlphabet::from_nfas(a, b, c) };
+
+    auto symbols{ alphabet.get_symbols() };
+    CHECK(symbols == std::list<Symbol>{ 'c', 'b', 'a' });
+
+    //EnumAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
+    //EnumAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
+}
+
 TEST_CASE("Mata::Nfa::Nfa::add_trans()/has_trans()")
 { // {{{
 	Nfa a(3);


### PR DESCRIPTION
As requested, this PR aims to make alphabet parameter in inclusion and equivalence checks optional.

For this reason, I introduce a new constructor for EnumAlphabet to create ad-hoc alphabet computed from a given automaton (looking at transition symbols of the automaton). The alphabet is then computed for those algorithms (currently only naive inclusion algorithm), which truly require the alphabet and work with it in the algorithm.

Then, when the user gives the functions an already precomputed alphabet, the precomputed alphabet can be used. Otherwise, the following happens: If the alphabet is not necessary, it is not computed at all; if it is necessary, it is computed ad-hoc.