### PR TITLE
removed invert function

### DIFF
--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -860,15 +860,6 @@ inline Nfa determinize(
     return result;
 } // determinize }}}
 
-void invert(Nfa* result, const Nfa &aut);
-
-inline Nfa invert(const Nfa &aut)
-{
-    Nfa inverted;
-    invert(&inverted, aut);
-    return inverted;
-}
-
 Simlib::Util::BinaryRelation compute_relation(
         const Nfa& aut,
         const StringDict&  params = {{"relation", "simulation"}, {"direction","forward"}});

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -593,15 +593,17 @@ void Mata::Nfa::revert(Nfa* result, const Nfa& aut)
 
     if (aut.get_num_of_states() > result->get_num_of_states()) { result->increase_size(aut.get_num_of_states()); }
 
+    for (State sourceState = 0; sourceState < aut.transitionrelation.size(); ++sourceState)
+    {
+        for (const TransSymbolStates &transition: aut.transitionrelation[sourceState])
+        {
+            for(State targetState: transition.states_to)
+                result->add_trans(targetState, transition.symbol, sourceState);
+        }
+    }
+
     result->initialstates = aut.finalstates;
     result->finalstates = aut.initialstates;
-
-    for (size_t i = 0; i < aut.get_num_of_states(); ++i)
-    {
-        for (const auto& symStates : aut[i])
-            for (const State tgt : symStates.states_to)
-                result->add_trans(tgt, symStates.symbol, i);
-    }
 }
 
 bool Mata::Nfa::is_deterministic(const Nfa& aut)
@@ -841,26 +843,8 @@ void Mata::Nfa::complement_in_place(Nfa& aut) {
 void Mata::Nfa::minimize(Nfa *res, const Nfa& aut) {
     //compute the minimal deterministic automaton, Brzozovski algorithm
     Nfa inverted;
-    invert(&inverted, aut);
+    revert(&inverted, aut);
     determinize(res, inverted);
-}
-
-void Mata::Nfa::invert(Nfa *invertedAutomaton, const Nfa& aut) {
-    const size_t states_num = aut.get_num_of_states();
-    for (State i = 0; i < states_num; ++i)
-        invertedAutomaton->add_new_state();
-
-    for (State sourceState = 0; sourceState < aut.transitionrelation.size(); ++sourceState)
-    {
-        for (const TransSymbolStates &transition: aut.transitionrelation[sourceState])
-        {
-            for(State targetState: transition.states_to)
-                invertedAutomaton->add_trans(targetState, transition.symbol, sourceState);
-        }
-    }
-
-    invertedAutomaton->initialstates = aut.finalstates;
-    invertedAutomaton->finalstates = aut.initialstates;
 }
 
 void Nfa::print_to_DOT(std::ostream &outputStream) const {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -593,7 +593,8 @@ void Mata::Nfa::revert(Nfa* result, const Nfa& aut)
 
     if (aut.get_num_of_states() > result->get_num_of_states()) { result->increase_size(aut.get_num_of_states()); }
 
-    for (State sourceState = 0; sourceState < aut.transitionrelation.size(); ++sourceState)
+    const size_t num_of_states{ aut.transitionrelation.size() };
+    for (State sourceState = 0; sourceState < num_of_states; ++sourceState)
     {
         for (const TransSymbolStates &transition: aut.transitionrelation[sourceState])
         {


### PR DESCRIPTION
Based on dicussion in issue #33 this PR removes `invert` function and keep `revert` function (with semantics of removed invert function).
Rationalization: `revert` is a standard name in automato libraries and was implemented by Ondra to data structures initally used in this library. The `invert` function was orignally created by Lukas and Juraj in their library for data structures which were later adopted in the Mata library. Therefore we take behaviour of `invert` but keep the name `revert` which is standard. 