### PR TITLE
Bug fixing in parser

### DIFF
--- a/examples/example05-parsing.cc
+++ b/examples/example05-parsing.cc
@@ -29,18 +29,13 @@ int main(int argc, char *argv[])
         parsed = Mata::Parser::parse_mf(fs, true);
         fs.close();
 
-            /*
-        if (p.type.find("FA") == std::string::npos) {
-             throw std::runtime_error("The type of input automaton is not FA\n");
-        }
-           */
+        std::vector<Mata::IntermediateAut> inter_auts = Mata::IntermediateAut::parse_from_mf(parsed);
+        for (const auto& ia : inter_auts)
+            std::cout << ia << '\n';
 
-        std::vector<Mata::IntermediateAut> inter_aut = Mata::IntermediateAut::parse_from_mf(parsed);
-
-        if (inter_aut[0].is_nfa())
-            construct(&aut, inter_aut[0]);
-        }
-
+        if (inter_auts[0].is_nfa())
+            construct(&aut, inter_auts[0]);
+    }
     catch (const std::exception& ex) {
         fs.close();
         std::cerr << "libMATA error: " << ex.what() << "\n";

--- a/examples/example05-parsing.cc
+++ b/examples/example05-parsing.cc
@@ -29,19 +29,17 @@ int main(int argc, char *argv[])
         parsed = Mata::Parser::parse_mf(fs, true);
         fs.close();
 
-        if (parsed.size() != 1) {
-            throw std::runtime_error(
-                    "The number of sections in the input file is not 1\n");
+            /*
+        if (p.type.find("FA") == std::string::npos) {
+             throw std::runtime_error("The type of input automaton is not FA\n");
         }
-        if (parsed[0].type.find("NFA") == std::string::npos) {
-            throw std::runtime_error("The type of input automaton is not NFA\n");
-        }
+           */
 
         std::vector<Mata::IntermediateAut> inter_aut = Mata::IntermediateAut::parse_from_mf(parsed);
 
         if (inter_aut[0].is_nfa())
             construct(&aut, inter_aut[0]);
-    }
+        }
 
     catch (const std::exception& ex) {
         fs.close();

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -176,6 +176,9 @@ public:
     FormulaGraph initial_formula;
     FormulaGraph final_formula;
 
+    bool initial_enumerated = false;
+    bool final_enumerated = false;
+
     /**
      * Transitions are pairs where the first member is left-hand side of transition (i.e., a state)
      * and the second item is a graph representing transition formula (which can contain symbols, nodes, and states).
@@ -200,6 +203,9 @@ public:
     bool are_nodes_enum_type() const {return node_naming == Naming::ENUM;}
 
     bool is_nfa() const {return automaton_type == AutomatonType::NFA;}
+
+    std::unordered_set<std::string> get_enumerated_initials() const {return initial_formula.collect_node_names();}
+    std::unordered_set<std::string> get_enumerated_finals() const {return final_formula.collect_node_names();}
 };
 
 } /* Mata */

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -159,9 +159,9 @@ struct IntermediateAut
     };
 
 public:
-    Naming state_naming;
-    Naming symbol_naming;
-    Naming node_naming;
+    Naming state_naming = MARKED;
+    Naming symbol_naming = MARKED;
+    Naming node_naming = MARKED;
     AlphabetType alphabet_type;
     AutomatonType automaton_type;
 

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -137,12 +137,15 @@ struct IntermediateAut
      * Naming could be automatic (all things in formula not belonging to other sets will be assigned to a
      * set with automatic naming), marker based (everything beginning with `q` is a state, with `s` is a symbol,
      * with `n` is a node), or enumerated (the given set is defined by enumeration).
+     * There are two special cases used for alphabet - symbols could be any character (CHARS) or anything from utf (UTF).
      */
     enum Naming
     {
         AUTO,
         MARKED,
-        ENUM
+        ENUM,
+        CHARS,
+        UTF
     };
 
     /**

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -77,7 +77,7 @@ public:
 
     bool is_operator() const { return type == Type::OPERATOR; }
 
-    bool is_righpar() const { return type == Type::RIGHT_PARENTHESIS; }
+    bool is_rightpar() const { return type == Type::RIGHT_PARENTHESIS; }
 
     bool is_leftpar() const { return type == Type::LEFT_PARENTHESIS; }
 

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -322,7 +322,8 @@ namespace
             // symbol and state naming and put conjunction to transition
             if (aut.alphabet_type != Mata::IntermediateAut::BITVECTOR) {
                 assert(rhs.size() == 2);
-                postfix.push_back(create_node(aut,rhs[0]));
+                postfix.push_back(Mata::FormulaNode{Mata::FormulaNode::Type::OPERAND, rhs[0], rhs[0],
+                                         Mata::FormulaNode::OperandType::SYMBOL});
                 postfix.push_back(create_node(aut,rhs[1]));
             } else if (aut.alphabet_type == Mata::IntermediateAut::BITVECTOR) {
                 // this is a case where rhs state not separated by conjunction from rest of trans

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -391,13 +391,17 @@ namespace
 
             if (key.find("Initial") != std::string::npos) {
                 auto postfix = infix_to_postfix(aut, keypair.second);
-                if (no_operators(postfix))
+                if (no_operators(postfix)) {
+                    aut.initial_enumerated = true;
                     postfix = add_disjunction_implicitly(postfix);
+                }
                 aut.initial_formula = postfix_to_graph(postfix);
             } else if (key.find("Final") != std::string::npos) {
                 auto postfix = infix_to_postfix(aut, keypair.second);
-                if (no_operators(postfix))
+                if (no_operators(postfix)) {
                     postfix = add_disjunction_implicitly(postfix);
+                    aut.final_enumerated = true;
+                }
                 aut.final_formula = postfix_to_graph(postfix);
             }
         }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -336,6 +336,9 @@ ParsedSection Mata::Parser::parse_mf_section(
 			continue;
 		}
 
+		if (result.type == "Regex") // so far we do not support regexs
+			continue;
+
 		std::vector<std::pair<std::string, bool>> temp_token_line = tokenize_line(line);
 		if (temp_token_line.empty()) {
 			continue;

--- a/src/tests-parser.cc
+++ b/src/tests-parser.cc
@@ -814,6 +814,21 @@ TEST_CASE("parsing automata to intermediate representation")
 
     }
 
+    SECTION("AFA explicit correct automatic naming - parentheses")
+    {
+        std::string file =
+                "@AFA-explicit\n"
+                "%States-marked\n"
+                "%Alphabet-enum a b c\n"
+                "q1 ((a & !q2) & b) | c\n";
+
+        parsed = parse_mf(file);
+        std::vector<Mata::IntermediateAut> auts = Mata::IntermediateAut::parse_from_mf(parsed);
+        const Mata::IntermediateAut aut = auts[0];
+        REQUIRE(aut.transitions.front().first.name == "1");
+        REQUIRE(aut.transitions.front().first.raw == "q1");
+    }
+
     SECTION("AFA explicit non existing symbol error")
     {
         std::string file =

--- a/src/tests-parser.cc
+++ b/src/tests-parser.cc
@@ -731,6 +731,33 @@ TEST_CASE("parsing automata to intermediate representation")
         REQUIRE(aut.transitions.front().second.children[1].children.empty());
     }
 
+    SECTION("NFA explicit enumeration of initials and finals")
+    {
+        std::string file =
+                "@NFA-explicit\n"
+                "%States-enum q r s t \"(r,s)\"\n"
+                "%Alphabet-auto\n"
+                "%Initial r s\n"
+                "%Final q t\n"
+                "q symbol r\n";
+
+        parsed = parse_mf(file);
+        std::vector<Mata::IntermediateAut> auts = Mata::IntermediateAut::parse_from_mf(parsed);
+        REQUIRE(auts.size() == 1);
+        const Mata::IntermediateAut& aut = auts.back();
+        REQUIRE(aut.transitions.size() == 1);
+        REQUIRE(aut.initial_enumerated);
+        REQUIRE(aut.final_enumerated);
+        const auto initials = aut.get_enumerated_initials();
+        REQUIRE(initials.count("r"));
+        REQUIRE(initials.count("s"));
+        REQUIRE(!initials.count("q"));
+        const auto finals = aut.get_enumerated_finals();
+        REQUIRE(finals.count("t"));
+        REQUIRE(finals.count("q"));
+        REQUIRE(!finals.count("r"));
+    }
+
     SECTION("AFA explicit")
     {
         std::string file =


### PR DESCRIPTION
This PR:
- fixes some bugs found during testing on the benchmark provided by Pavol Vargovcik
- adds support for explicit enumeration of initial and final states in cases when they were specified as enumeration. Internally they are still represented as disjunction of states but I added a flag determining that states were originally enumerated and a fucntion for retrieving them as set instead of formula.