### PR TITLE
Change interface and add epsilon

### DIFF
--- a/AUTOMATAFORMAT.md
+++ b/AUTOMATAFORMAT.md
@@ -11,7 +11,7 @@
   * `@` opens the line with a section name and is used in transducer alphabet tokens of the form `x@a1`, `y@[10-55]`,...
   * `%` opens a key-value line.
   * `"` strings containing white spaces and special characters can be written in between `"`. The special characters lose their special meaning. The characters `"` and `\` inside a string must be escaped, i.e. `\"` and `\\`. 
-  * `\` for escaping characters. `\` is also used to concatenate lines.
+  * `\` for escaping characters. `\` is also used to concatenate_over_epsilon lines.
   * `a`,`q`,`n`,`t`,`f` are token type specifiers (alphabet, state, node, attribute, formula). 
   * `#` starts a comment line.
 * There are **words with a special meaning**: `\true`,`\false`,`\min`, and `\max`. Every word with special meaning starts with `\`.

--- a/AUTOMATAFORMAT.md
+++ b/AUTOMATAFORMAT.md
@@ -11,7 +11,7 @@
   * `@` opens the line with a section name and is used in transducer alphabet tokens of the form `x@a1`, `y@[10-55]`,...
   * `%` opens a key-value line.
   * `"` strings containing white spaces and special characters can be written in between `"`. The special characters lose their special meaning. The characters `"` and `\` inside a string must be escaped, i.e. `\"` and `\\`. 
-  * `\` for escaping characters. `\` is also used to concatenate_over_epsilon lines.
+  * `\` for escaping characters. `\` is also used to concatenate lines.
   * `a`,`q`,`n`,`t`,`f` are token type specifiers (alphabet, state, node, attribute, formula). 
   * `#` starts a comment line.
 * There are **words with a special meaning**: `\true`,`\false`,`\min`, and `\max`. Every word with special meaning starts with `\`.

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -203,7 +203,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void intersection(CNfa*, CNfa&, CNfa&, Symbol)
     cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, ProductMap*)
     cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
-    cdef void concatenate(CNfa*, CNfa&, CNfa&)
+    cdef void concatenate_over_epsilon(CNfa*, CNfa&, CNfa&)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +
     cdef void revert(CNfa*, CNfa&)

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -223,8 +223,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void uni(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
-    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol)
-    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
+    cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol)
+    cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
     cdef void concatenate(CNfa*, CNfa&, CNfa&)
     cdef void concatenate_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -201,8 +201,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void uni(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&, Symbol)
-    cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
-    cdef void intersection(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
+    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, ProductMap*)
+    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
     cdef void concatenate(CNfa*, CNfa&, CNfa&)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -56,6 +56,23 @@ cdef extern from "mata/ord_vector.hh" namespace "Mata::Util":
         COrdVector(vector[T]) except+
         vector[T] ToVector()
 
+        cppclass const_iterator:
+            const T operator *()
+            const_iterator operator++()
+            bint operator ==(const_iterator)
+            bint operator !=(const_iterator)
+        const_iterator cbegin()
+        const_iterator cend()
+
+        cppclass iterator:
+            T operator *()
+            iterator operator++()
+            bint operator ==(iterator)
+            bint operator !=(iterator)
+        iterator begin()
+        iterator end()
+
+
 cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     # Typedefs
     ctypedef uintptr_t State
@@ -82,6 +99,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     ctypedef vector[CNfa*] AutPtrSequence
     ctypedef vector[const CNfa*] ConstAutPtrSequence
 
+    cdef const Symbol CEPSILON "Mata::Nfa::EPSILON"
+
     cdef cppclass CTrans "Mata::Nfa::Trans":
         # Public Attributes
         State src
@@ -104,6 +123,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         StateSet states_to
 
         # Constructors
+        CTransSymbolStates() except +
         CTransSymbolStates(Symbol) except +
         CTransSymbolStates(Symbol, State) except +
         CTransSymbolStates(Symbol, StateSet) except +
@@ -180,6 +200,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         StateSet get_reachable_states()
         StateSet get_terminating_states()
         void remove_epsilon(Symbol) except +
+        COrdVector[CTransSymbolStates].const_iterator get_epsilon_transitions(State state, Symbol epsilon)
+        COrdVector[CTransSymbolStates].const_iterator get_epsilon_transitions(TransitionList& state_transitions, Symbol epsilon)
 
 
     # Automata tests
@@ -200,10 +222,11 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void determinize(CNfa*, CNfa&, SubsetMap*)
     cdef void uni(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&)
-    cdef void intersection(CNfa*, CNfa&, CNfa&, Symbol)
-    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, ProductMap*)
+    cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
+    cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol)
     cdef void intersection_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
-    cdef void concatenate_over_epsilon(CNfa*, CNfa&, CNfa&)
+    cdef void concatenate(CNfa*, CNfa&, CNfa&)
+    cdef void concatenate_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +
     cdef void revert(CNfa*, CNfa&)

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -748,11 +748,11 @@ cdef class Nfa:
         Concatenate two NFAs.
 
         :param Nfa lhs: First automaton to concatenate.
-        :param Nfa rhs: Second automaton to concatenate.
+        :param Nfa rhs: Second automaton to concatenate_over_epsilon.
         :return: Nfa: Concatenated automaton.
         """
         result = Nfa()
-        mata.concatenate(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
+        mata.concatenate_over_epsilon(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
         return result
 
     @classmethod

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -681,7 +681,7 @@ cdef class Nfa:
     @classmethod
     def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
         """
-        Performs intersection of lhs and rhs preserving epsilon transitions.
+        Performs intersection_over_epsilon of lhs and rhs preserving epsilon transitions.
 
         Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -712,7 +712,7 @@ cdef class Nfa:
         """
         result = Nfa()
         cdef ProductMap c_product_map
-        mata.intersection(
+        mata.intersection_over_epsilon(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), &c_product_map
         )
         return result, {tuple(k): v for k, v in c_product_map}

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -11,6 +11,11 @@ import shlex
 import subprocess
 import tabulate
 
+cdef Symbol EPSILON = CEPSILON
+
+def epsilon():
+    return EPSILON
+
 cdef class Trans:
     """
     Wrapper over the transitions in NFA
@@ -132,6 +137,7 @@ cdef class TransSymbolStates:
 
     def __repr__(self):
         return str(self)
+
 
 cdef class Nfa:
     """
@@ -666,20 +672,18 @@ cdef class Nfa:
 
     @classmethod
     def intersection(cls, Nfa lhs, Nfa rhs):
-        """Performs intersection of lhs and rhs
+        """Performs intersection of lhs and rhs.
 
-        :param Nfa lhs: first automaton
-        :param Nfa rhs: second automaton
-        :return: intersection of lhs and rhs.
+        :param Nfa lhs: First automaton.
+        :param Nfa rhs: Second automaton.
+        :return: Intersection of lhs and rhs.
         """
         result = Nfa()
-        mata.intersection(
-            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get())
-        )
+        mata.intersection(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
         return result
 
     @classmethod
-    def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
+    def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
         """
         Performs intersection of lhs and rhs preserving epsilon transitions.
 
@@ -697,18 +701,18 @@ cdef class Nfa:
          to new states.
         """
         result = Nfa()
-        mata.intersection(
+        mata.intersection_over_epsilon(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon
         )
         return result
 
     @classmethod
     def intersection_with_product_map(cls, Nfa lhs, Nfa rhs):
-        """Performs intersection of lhs and rhs
+        """Performs intersection of lhs and rhs.
 
-        :param Nfa lhs: first automaton
-        :param Nfa rhs: second automaton
-        :return: intersection of lhs and rhs, product map of original pairs of states to new states.
+        :param Nfa lhs: First automaton.
+        :param Nfa rhs: Second automaton.
+        :return: Intersection of lhs and rhs, product map of original pairs of states to new states.
         """
         result = Nfa()
         cdef ProductMap c_product_map
@@ -718,7 +722,7 @@ cdef class Nfa:
         return result, {tuple(k): v for k, v in c_product_map}
 
     @classmethod
-    def intersection_pres_eps_trans_with_prod_map(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
+    def intersection_pres_eps_trans_with_prod_map(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
         """
         Performs intersection of lhs and rhs preserving epsilon transitions.
 
@@ -737,7 +741,7 @@ cdef class Nfa:
         """
         result = Nfa()
         cdef ProductMap c_product_map
-        mata.intersection(
+        mata.intersection_over_epsilon(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon, &c_product_map
         )
         return result, {tuple(k): v for k, v in c_product_map}
@@ -753,6 +757,20 @@ cdef class Nfa:
         """
         result = Nfa()
         mata.concatenate(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
+        return result
+
+    @classmethod
+    def concatenate_over_epsilon(cls, Nfa lhs, Nfa rhs, epsilon = CEPSILON):
+        """
+        Concatenate two NFAs over an epsilon symbol.
+
+        :param Nfa lhs: First automaton to concatenate over epsilon.
+        :param Nfa rhs: Second automaton to concatenate over epsilon.
+        :param Symbol epsilon: Symbol to concatenate over (Default: Default Mata epsilon value).
+        :return: Nfa: Concatenated automaton over epsilon.
+        """
+        result = Nfa()
+        mata.concatenate_over_epsilon(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon)
         return result
 
     @classmethod
@@ -793,7 +811,7 @@ cdef class Nfa:
          the equation in a way that libMata understands. The left side automata represent the left side of the equation
          and the right automaton represents the right side of the equation. To create noodles, we need a segment automaton
          representing the intersection. That can be achieved by computing a product of both sides. First, the left side
-         has to be concatenated over an epsilon transitions into a single automaton to compute the intersection on, though.
+         has to be concatenated over an epsilon transition into a single automaton to compute the intersection on, though.
 
         :param: list[Nfa] aut: Segment automata representing the left side of the equation to noodlify.
         :param: Nfa aut: Segment automaton representing the right side of the equation to noodlify.
@@ -897,20 +915,18 @@ cdef class Nfa:
         return result
 
     @classmethod
-    def remove_epsilon(cls, Nfa lhs, Symbol epsilon):
-        """Removes transitions that contain epsilon symbol
+    def remove_epsilon(cls, Nfa lhs, Symbol epsilon = CEPSILON):
+        """Removes transitions that contain epsilon symbol.
 
-        TODO: Possibly there may be issue with setting the size of the automaton beforehand?
-
-        :param Nfa lhs: automaton, where epsilon transitions will be removed
-        :param Symbol epsilon: symbol representing the epsilon
-        :return: automaton, with epsilon transitions removed
+        :param Nfa lhs: Automaton, where epsilon transitions will be removed.
+        :param Symbol epsilon: Symbol representing the epsilon.
+        :return: Nfa: Automaton with epsilon transitions removed.
         """
         result = Nfa()
         mata.remove_epsilon(result.thisptr.get(), dereference(lhs.thisptr.get()), epsilon)
         return result
 
-    def remove_epsilon(self, Symbol epsilon):
+    def remove_epsilon(self, Symbol epsilon = CEPSILON):
         """
         Removes transitions which contain epsilon symbol.
 
@@ -920,9 +936,36 @@ cdef class Nfa:
         """
         self.thisptr.get().remove_epsilon(epsilon)
 
+    def get_epsilon_transitions(self, State state, Symbol epsilon = CEPSILON) -> TransSymbolStates | None:
+        """
+        Get epsilon transitions for a state.
+        :param state: State to get epsilon transitions for.
+        :param epsilon: Epsilon symbol.
+        :return: Epsilon transitions if there are any epsilon transitions for the passed state. None otherwise.
+        """
+        cdef COrdVector[CTransSymbolStates].const_iterator c_epsilon_transitions_iter = self.thisptr.get().get_epsilon_transitions(
+            state, epsilon
+        )
+        if c_epsilon_transitions_iter == self.thisptr.get().get_transitions_from(state).cend():
+            return None
+
+        cdef CTransSymbolStates epsilon_transitions = dereference(c_epsilon_transitions_iter)
+        return TransSymbolStates(epsilon_transitions.symbol, epsilon_transitions.states_to.ToVector())
+
+
+    #@classmethod
+    #def get_epsilon_transitions(cls, TransitionList state_transitions, Symbol epsilon = CEPSILON) -> TransSymbolStates | None:
+    #    """
+    #    Get epsilon transitions for a state.
+    #    :param state: State to get epsilon transitions for.
+    #    :param epsilon: Epsilon symbol.
+    #    :return: Epsilon transitions if there are any epsilon transitions for the passed state. None otherwise.
+    #    """
+
+
     @classmethod
     def minimize(cls, Nfa lhs):
-        """Minimies the automaton lhs
+        """Minimizes the automaton lhs
 
         :param Nfa lhs: automaton to be minimized
         :return: minimized automaton
@@ -1653,7 +1696,7 @@ cdef class Segmentation:
     """Wrapper over Segmentation."""
     cdef mata.CSegmentation* thisptr
 
-    def __cinit__(self, Nfa aut, Symbol symbol):
+    def __cinit__(self, Nfa aut, Symbol symbol = CEPSILON):
         """
         Compute segmentation.
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -681,7 +681,7 @@ cdef class Nfa:
     @classmethod
     def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon):
         """
-        Performs intersection_over_epsilon of lhs and rhs preserving epsilon transitions.
+        Performs intersection of lhs and rhs preserving epsilon transitions.
 
         Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -712,7 +712,7 @@ cdef class Nfa:
         """
         result = Nfa()
         cdef ProductMap c_product_map
-        mata.intersection_over_epsilon(
+        mata.intersection(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), &c_product_map
         )
         return result, {tuple(k): v for k, v in c_product_map}
@@ -748,11 +748,11 @@ cdef class Nfa:
         Concatenate two NFAs.
 
         :param Nfa lhs: First automaton to concatenate.
-        :param Nfa rhs: Second automaton to concatenate_over_epsilon.
+        :param Nfa rhs: Second automaton to concatenate.
         :return: Nfa: Concatenated automaton.
         """
         result = Nfa()
-        mata.concatenate_over_epsilon(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
+        mata.concatenate(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
         return result
 
     @classmethod

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -701,7 +701,7 @@ cdef class Nfa:
          to new states.
         """
         result = Nfa()
-        mata.intersection_over_epsilon(
+        mata.intersection_preserving_epsilon_transitions(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon
         )
         return result
@@ -741,7 +741,7 @@ cdef class Nfa:
         """
         result = Nfa()
         cdef ProductMap c_product_map
-        mata.intersection_over_epsilon(
+        mata.intersection_preserving_epsilon_transitions(
             result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon, &c_product_map
         )
         return result, {tuple(k): v for k, v in c_product_map}
@@ -951,16 +951,6 @@ cdef class Nfa:
 
         cdef CTransSymbolStates epsilon_transitions = dereference(c_epsilon_transitions_iter)
         return TransSymbolStates(epsilon_transitions.symbol, epsilon_transitions.states_to.ToVector())
-
-
-    #@classmethod
-    #def get_epsilon_transitions(cls, TransitionList state_transitions, Symbol epsilon = CEPSILON) -> TransSymbolStates | None:
-    #    """
-    #    Get epsilon transitions for a state.
-    #    :param state: State to get epsilon transitions for.
-    #    :param epsilon: Epsilon symbol.
-    #    :return: Epsilon transitions if there are any epsilon transitions for the passed state. None otherwise.
-    #    """
 
 
     @classmethod

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -391,6 +391,22 @@ def test_concatenate():
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
 
+    result = mata.Nfa.concatenate_over_epsilon(lhs, rhs)
+    assert result.has_initial_state(0)
+    assert result.has_final_state(3)
+    assert result.get_num_of_states() == 4
+    assert result.has_trans_raw(0, ord('b'), 1)
+    assert result.has_trans_raw(1, 0xffffffffffffffff, 2)
+    assert result.has_trans_raw(2, ord('a'), 3)
+
+    result = mata.Nfa.concatenate_over_epsilon(lhs, rhs, ord('e'))
+    assert result.has_initial_state(0)
+    assert result.has_final_state(3)
+    assert result.get_num_of_states() == 4
+    assert result.has_trans_raw(0, ord('b'), 1)
+    assert result.has_trans_raw(1, ord('e'), 2)
+    assert result.has_trans_raw(2, ord('a'), 3)
+
 
 def test_completeness(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
@@ -1059,3 +1075,27 @@ def test_unify():
     nfa.unify_initial()
     assert nfa.has_initial_state(10)
     assert nfa.has_trans_raw(10, 1, 2)
+
+
+def test_get_epsilon_transitions():
+    nfa = mata.Nfa(10)
+    nfa.make_initial_state(0)
+    nfa.make_final_state(1)
+
+    nfa.add_trans_raw(1, 1, 2)
+    nfa.add_trans_raw(1, 2, 2)
+    nfa.add_trans_raw(1, mata.epsilon(), 2)
+    nfa.add_trans_raw(1, mata.epsilon(), 3)
+    epsilon_transitions = nfa.get_epsilon_transitions(1)
+    assert epsilon_transitions.symbol == mata.epsilon()
+    assert epsilon_transitions.states_to == [2, 3]
+
+    nfa.add_trans_raw(0, 1, 2)
+    nfa.add_trans_raw(0, 2, 2)
+    nfa.add_trans_raw(0, 8, 5)
+    nfa.add_trans_raw(0, 8, 6)
+    epsilon_transitions = nfa.get_epsilon_transitions(0, 8)
+    assert epsilon_transitions.symbol == 8
+    assert epsilon_transitions.states_to == [5, 6]
+
+    assert nfa.get_epsilon_transitions(5) is None

--- a/doc/nfa.rst
+++ b/doc/nfa.rst
@@ -12,8 +12,8 @@ Operations
 
 .. doxygenfunction:: Mata::Nfa::uni(Nfa*, const Nfa&, const Nfa&)
 .. doxygenfunction:: Mata::Nfa::uni(const Nfa&, const Nfa&)
-.. doxygenfunction:: Mata::Nfa::intersection(Nfa*, const Nfa&, const Nfa&, Symbol, ProductMap*)
-.. doxygenfunction:: Mata::Nfa::intersection(const Nfa&, const Nfa&, Symbol, ProductMap*)
+.. doxygenfunction:: Mata::Nfa::intersection_over_epsilon(Nfa*, const Nfa&, const Nfa&, Symbol, ProductMap*)
+.. doxygenfunction:: Mata::Nfa::intersection_over_epsilon(const Nfa&, const Nfa&, Symbol, ProductMap*)
 .. doxygenfunction:: Mata::Nfa::determinize(Nfa*, const Nfa&, SubsetMap*)
 .. doxygenfunction:: Mata::Nfa::determinize(const Nfa&, SubsetMap*)
 .. doxygenfunction:: Mata::Nfa::revert(Nfa* result, const Nfa& aut)

--- a/doc/nfa.rst
+++ b/doc/nfa.rst
@@ -12,8 +12,8 @@ Operations
 
 .. doxygenfunction:: Mata::Nfa::uni(Nfa*, const Nfa&, const Nfa&)
 .. doxygenfunction:: Mata::Nfa::uni(const Nfa&, const Nfa&)
-.. doxygenfunction:: Mata::Nfa::intersection_over_epsilon(Nfa*, const Nfa&, const Nfa&, Symbol, ProductMap*)
-.. doxygenfunction:: Mata::Nfa::intersection_over_epsilon(const Nfa&, const Nfa&, Symbol, ProductMap*)
+.. doxygenfunction:: Mata::Nfa::intersection_preserving_epsilon_transitions(Nfa*, const Nfa&, const Nfa&, Symbol, ProductMap*)
+.. doxygenfunction:: Mata::Nfa::intersection_preserving_epsilon_transitions(const Nfa&, const Nfa&, Symbol, ProductMap*)
 .. doxygenfunction:: Mata::Nfa::determinize(Nfa*, const Nfa&, SubsetMap*)
 .. doxygenfunction:: Mata::Nfa::determinize(const Nfa&, SubsetMap*)
 .. doxygenfunction:: Mata::Nfa::revert(Nfa* result, const Nfa& aut)
@@ -23,4 +23,3 @@ Operations
 .. doxygenfunction:: Mata::Nfa::is_in_lang
 .. doxygenfunction:: Mata::Nfa::is_deterministic
 .. doxygenfunction:: Mata::Nfa::is_complete
-

--- a/examples/example05-parsing.cc
+++ b/examples/example05-parsing.cc
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
             std::cout << ia << '\n';
 
         if (inter_auts[0].is_nfa())
-            construct(&aut, inter_auts[0]);
+            aut = construct(inter_auts[0]);
     }
     catch (const std::exception& ex) {
         fs.close();

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
-#include <climits>
+#include <limits>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -156,13 +156,11 @@ public:
 
 const PostSymb EMPTY_POST{};
 
-// FIXME: We can use newer library header <limits> and its built-in functions. Furthermore, we use signed long max here
-//  for unsigned Symbol and State.
-static const struct Limits {
-    State maxState = LONG_MAX;
-    State minState = 0;
-    Symbol maxSymbol = LONG_MAX;
-    Symbol minSymbol = 0;
+static constexpr struct Limits {
+    State maxState = std::numeric_limits<State>::max();
+    State minState = std::numeric_limits<State>::min();
+    Symbol maxSymbol = std::numeric_limits<Symbol>::max();
+    Symbol minSymbol = std::numeric_limits<Symbol>::min();
 } limits;
 
 /// A transition.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -775,6 +775,15 @@ public:
      */
     TransitionList::const_iterator get_epsilon_transitions(const State state, const Symbol epsilon = EPSILON) const;
 
+    /**
+     * Return all epsilon transitions from epsilon symbol under given state transitions.
+     * @param[in] state_transitions State transitions from which are epsilon transitions checked.
+     * @param[in] epsilon User can define his favourite epsilon or used default
+     * @return Returns reference element of transition list with epsilon transitions or end of transition list when
+     * there are no epsilon transitions.
+     */
+    static TransitionList::const_iterator get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon = EPSILON) ;
+
 private:
 }; // Nfa
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -825,7 +825,7 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
 } // uni }}}
 
 /**
- * @brief Compute intersection_over_epsilon of two NFAs preserving epsilon transitions.
+ * @brief Compute intersection of two NFAs preserving epsilon transitions.
  *
  * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
  * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -843,7 +843,7 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
 Nfa intersection_over_epsilon(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON, ProductMap* prod_map = nullptr);
 
 /**
- * @brief Compute intersection_over_epsilon of two NFAs preserving epsilon transitions.
+ * @brief Compute intersection of two NFAs preserving epsilon transitions.
  *
  * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
  * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -852,7 +852,7 @@ Nfa intersection_over_epsilon(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = E
  *
  * Automata must share alphabets.
  *
- * @param[out] res Result product NFA of the intersection_over_epsilon of @p lhs and @p rhs with ε-transitions preserved.
+ * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs with ε-transitions preserved.
  * @param[in] lhs First NFA with possible epsilon symbols @p epsilon.
  * @param[in] rhs Second NFA with possible epsilon symbols @p epsilon.
  * @param[in] epsilon Symbol to handle as an epsilon symbol.
@@ -862,9 +862,9 @@ void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol 
                                ProductMap* prod_map = nullptr);
 
 /**
- * @brief Compute intersection_over_epsilon of two NFAs.
+ * @brief Compute intersection of two NFAs.
  *
- * @param[out] res Result product NFA of the intersection_over_epsilon of @p lhs and @p rhs.
+ * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs.
  * @param[in] lhs First NFA to compute intersection for.
  * @param[in] rhs Second NFA to compute intersection for.
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
@@ -912,7 +912,7 @@ void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol e
  * @param[in] epsilon Epsilon symbol to concatenate @p lhs with @p rhs over.
  * @return Concatenated automaton.
  */
-Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon);
+Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon = EPSILON);
 
 /// makes the transition relation complete
 void make_complete(

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1063,9 +1063,9 @@ inline void revert(Nfa* result, const Nfa& aut)
 } // revert }}}
 
 /// Removing epsilon transitions
-Nfa remove_epsilon(const Nfa& aut, Symbol epsilon);
+Nfa remove_epsilon(const Nfa& aut, Symbol epsilon = EPSILON);
 
-inline void remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
+inline void remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon = EPSILON)
 { // {{{
     *result = remove_epsilon(aut, epsilon);
 } // remove_epsilon }}}
@@ -1189,7 +1189,7 @@ public:
      * @param[in] aut Segment automaton to make segments for.
      * @param[in] epsilon Symbol to execute segmentation for.
      */
-    Segmentation(const SegNfa& aut, const Symbol epsilon) : epsilon(epsilon), automaton(aut)
+    Segmentation(const SegNfa& aut, const Symbol epsilon = EPSILON) : epsilon(epsilon), automaton(aut)
     {
         compute_epsilon_depths(); // Map depths to epsilon transitions.
     }

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -768,12 +768,12 @@ public:
 
     /**
      * Return all epsilon transitions from epsilon symbol under a given state.
-     * @param state State from which are epsilon transitions checked
-     * @param epsilon User can define his favourite epsilon or used default
+     * @param[in] state State from which are epsilon transitions checked
+     * @param[in] epsilon User can define his favourite epsilon or used default
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    TransitionList::const_iterator get_epsilon_transitions(const State& state, const Symbol& epsilon = EPSILON) const;
+    TransitionList::const_iterator get_epsilon_transitions(const State state, const Symbol epsilon = EPSILON) const;
 
 private:
 }; // Nfa

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -816,7 +816,7 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
 } // uni }}}
 
 /**
- * @brief Compute intersection of two NFAs preserving epsilon transitions.
+ * @brief Compute intersection_over_epsilon of two NFAs preserving epsilon transitions.
  *
  * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
  * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -831,10 +831,10 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
  * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
  */
-Nfa intersection(const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map = nullptr);
+Nfa intersection_over_epsilon(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON, ProductMap* prod_map = nullptr);
 
 /**
- * @brief Compute intersection of two NFAs preserving epsilon transitions.
+ * @brief Compute intersection_over_epsilon of two NFAs preserving epsilon transitions.
  *
  * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
  * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -843,18 +843,19 @@ Nfa intersection(const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* pro
  *
  * Automata must share alphabets.
  *
- * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs with ε-transitions preserved.
+ * @param[out] res Result product NFA of the intersection_over_epsilon of @p lhs and @p rhs with ε-transitions preserved.
  * @param[in] lhs First NFA with possible epsilon symbols @p epsilon.
  * @param[in] rhs Second NFA with possible epsilon symbols @p epsilon.
  * @param[in] epsilon Symbol to handle as an epsilon symbol.
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
  */
-void intersection(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map = nullptr);
+void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON,
+                               ProductMap* prod_map = nullptr);
 
 /**
- * @brief Compute intersection of two NFAs.
+ * @brief Compute intersection_over_epsilon of two NFAs.
  *
- * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs.
+ * @param[out] res Result product NFA of the intersection_over_epsilon of @p lhs and @p rhs.
  * @param[in] lhs First NFA to compute intersection for.
  * @param[in] rhs Second NFA to compute intersection for.
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -766,6 +766,15 @@ public:
         return transitionrelation[state];
     } // operator[] }}}
 
+    /**
+     * Return all epsilon transitions from epsilon symbol under a given state.
+     * @param state State from which are epsilon transitions checked
+     * @param epsilon User can define his favourite epsilon or used default
+     * @return Returns reference element of transition list with epsilon transitions or end of transition list when
+     * there are no epsilon transitions.
+     */
+    TransitionList::const_iterator get_epsilon_transitions(const State& state, const Symbol& epsilon = EPSILON) const;
+
 private:
 }; // Nfa
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -233,6 +233,9 @@ using TransitionList = Mata::Util::OrdVector<TransSymbolStates>;
 /// Transition relation for an NFA. Each index 'i' to the vector represents a state 'i' in the automaton.
 using TransitionRelation = std::vector<TransitionList>;
 
+/// An epsilon symbol which is now defined as the maximal value of data type used for symbols
+const Symbol EPSILON = limits.maxSymbol;
+
 /**
  * A struct representing an NFA.
  */

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -231,7 +231,7 @@ using TransitionList = Mata::Util::OrdVector<TransSymbolStates>;
 /// Transition relation for an NFA. Each index 'i' to the vector represents a state 'i' in the automaton.
 using TransitionRelation = std::vector<TransitionList>;
 
-/// An epsilon symbol which is now defined as the maximal value of data type used for symbols
+/// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = limits.maxSymbol;
 
 /**
@@ -604,7 +604,7 @@ public:
     /**
      * Remove epsilon transitions from the automaton.
      */
-    void remove_epsilon(Symbol epsilon);
+    void remove_epsilon(Symbol epsilon = EPSILON);
 
     bool has_trans(Trans trans) const
     {
@@ -773,7 +773,7 @@ public:
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    TransitionList::const_iterator get_epsilon_transitions(const State state, const Symbol epsilon = EPSILON) const;
+    TransitionList::const_iterator get_epsilon_transitions(State state, Symbol epsilon = EPSILON) const;
 
     /**
      * Return all epsilon transitions from epsilon symbol under given state transitions.
@@ -782,7 +782,7 @@ public:
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    static TransitionList::const_iterator get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon = EPSILON) ;
+    static TransitionList::const_iterator get_epsilon_transitions(const TransitionList& state_transitions, Symbol epsilon = EPSILON) ;
 
 private:
 }; // Nfa

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -870,7 +870,7 @@ void intersection(Nfa* res, const Nfa& lhs, const Nfa& rhs, ProductMap* prod_map
  * @param[in] rhs Second NFA to compute intersection for.
  * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
  */
-Nfa intersection(const Nfa &lhs, const Nfa &rhs);
+Nfa intersection(const Nfa &lhs, const Nfa &rhs, ProductMap* prod_map = nullptr);
 
 /**
  * Concatenate two NFAs.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -232,7 +232,7 @@ using TransitionList = Mata::Util::OrdVector<TransSymbolStates>;
 using TransitionRelation = std::vector<TransitionList>;
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols
-const Symbol EPSILON = limits.maxSymbol;
+constexpr Symbol EPSILON = limits.maxSymbol;
 
 /**
  * A struct representing an NFA.
@@ -926,6 +926,17 @@ Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon = EP
 /// makes the transition relation complete
 void make_complete(
         Nfa&             aut,
+        const Alphabet&  alphabet,
+        State            sink_state);
+
+/**
+ * Make the transition relation complete.
+ * @param[out] aut Automaton with transition relation to be made complete.
+ * @param[in] alphabet Alphabet of the automaton.
+ * @param[in] sink_state State to handle as a sink state.
+ */
+void make_complete(
+        Nfa*             aut,
         const Alphabet&  alphabet,
         State            sink_state);
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -894,7 +894,7 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs);
  * @param[in] rhs Second automaton to concatenate.
  * @param[in] epsilon Epsilon symbol to concatenate @p lhs with @p rhs over.
  */
-void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon);
+void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon = EPSILON);
 
 /**
  * Concatenate two NFAs over epsilon transitions.
@@ -903,7 +903,7 @@ void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon);
  * @param[in] epsilon Epsilon symbol to concatenate @p lhs with @p rhs over.
  * @return Concatenated automaton.
  */
-Nfa concatenate(const Nfa& lhs, const Nfa& rhs, Symbol epsilon);
+Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon);
 
 /// makes the transition relation complete
 void make_complete(

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -849,7 +849,7 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
  * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
  */
-Nfa intersection_over_epsilon(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON, ProductMap* prod_map = nullptr);
+Nfa intersection_preserving_epsilon_transitions(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON, ProductMap* prod_map = nullptr);
 
 /**
  * @brief Compute intersection of two NFAs preserving epsilon transitions.
@@ -867,8 +867,8 @@ Nfa intersection_over_epsilon(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = E
  * @param[in] epsilon Symbol to handle as an epsilon symbol.
  * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
  */
-void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON,
-                               ProductMap* prod_map = nullptr);
+void intersection_preserving_epsilon_transitions(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON,
+                                                 ProductMap* prod_map = nullptr);
 
 /**
  * @brief Compute intersection of two NFAs.

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -470,6 +470,14 @@ public:   // Public methods
 		return vec_.empty();
 	}
 
+	inline bool back() const
+	{
+		// Assertions
+		assert(vectorIsSorted());
+
+		return vec_.back();
+	}
+
 	inline const_iterator begin() const
 	{
 		// Assertions

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -470,7 +470,7 @@ public:   // Public methods
 		return vec_.empty();
 	}
 
-	inline bool back() const
+	inline const_reference back() const
 	{
 		// Assertions
 		assert(vectorIsSorted());

--- a/include/mata/ord_vector.hh
+++ b/include/mata/ord_vector.hh
@@ -68,14 +68,12 @@ template
 class Mata::Util::OrdVector
 {
 private:  // Private data types
-
-	typedef std::vector<Key> VectorType;
+	using VectorType = std::vector<Key>;
 
 public:   // Public data types
-
-	typedef typename VectorType::iterator iterator;
-	typedef typename VectorType::const_iterator const_iterator;
-	typedef typename VectorType::const_reference const_reference;
+	using iterator = typename VectorType::iterator ;
+	using const_iterator = typename VectorType::const_iterator;
+	using const_reference = typename VectorType::const_reference;
 
 private:  // Private data members
 

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -23,25 +23,24 @@ using namespace Mata::util;
 
 namespace { // anonymous namespace
 
-void complement_classical(
-	Nfa*               result,
+Nfa complement_classical(
 	const Nfa&         aut,
 	const Alphabet&    alphabet,
 	SubsetMap*         subset_map)
 { // {{{
-	assert(nullptr != result);
+ 	Nfa result;
 
-	bool delete_subset_map = false;
+ 	bool delete_subset_map = false;
 	if  (nullptr == subset_map)
 	{
 		subset_map = new SubsetMap();
 		delete_subset_map = true;
 	}
 
-	*result = determinize(aut, subset_map);
-	State sink_state = result->get_num_of_states() + 1;
-	result->increase_size(sink_state+1);
-	assert(sink_state < result->get_num_of_states());
+	result = determinize(aut, subset_map);
+	State sink_state = result.get_num_of_states() + 1;
+	result.increase_size(sink_state+1);
+	assert(sink_state < result.get_num_of_states());
 	auto it_inserted_pair = subset_map->insert({{}, sink_state});
 	if (!it_inserted_pair.second)
 	{
@@ -49,20 +48,20 @@ void complement_classical(
 	}
 
 	make_complete(result, alphabet, sink_state);
-	StateSet old_fs = std::move(result->finalstates);
-	result->finalstates = { };
-	assert(result->initialstates.size() == 1);
+	StateSet old_fs = std::move(result.finalstates);
+	result.finalstates = { };
+	assert(result.initialstates.size() == 1);
 
 	auto make_final_if_not_in_old = [&](const State& state) {
 		if (!haskey(old_fs, state))
 		{
-			result->finalstates.insert(state);
+			result.finalstates.insert(state);
 		}
 	};
 
-	make_final_if_not_in_old(*result->initialstates.begin());
+	make_final_if_not_in_old(*result.initialstates.begin());
 
-	for (const auto& trs : *result) {
+	for (const auto& trs : result) {
                 make_final_if_not_in_old(trs.tgt);
 	}
 
@@ -70,29 +69,44 @@ void complement_classical(
 	{
 		delete subset_map;
 	}
+
+	return result;
 } // complement_classical }}}
 
 } // namespace
 
 /// Complement
-void complement_naive(
-        Nfa*               result,
+Nfa complement_naive(
         const Nfa&         aut,
         const Alphabet&    alphabet,
         const StringDict&  params,
         SubsetMap*         subset_map)
 {
-    determinize(result, aut);
-    complement_in_place(*result);
+    Nfa result = determinize(aut);
+    complement_in_place(result);
+
+    return result;
 }
 
-void Mata::Nfa::complement(
-	Nfa*               result,
+void Mata::Nfa::complement_in_place(Nfa& aut) {
+    StateSet newFinalStates;
+
+    for (State q = 0; q < aut.transitionrelation.size(); ++q) {
+        if (aut.finalstates.count(q) == 0) {
+            newFinalStates.insert(q);
+        }
+    }
+
+    aut.finalstates = newFinalStates;
+}
+
+Nfa Mata::Nfa::complement(
 	const Nfa&         aut,
 	const Alphabet&    alphabet,
 	const StringDict&  params,
 	SubsetMap*         subset_map)
 {
+	Nfa result;
 	// setting the default algorithm
 	decltype(complement_classical)* algo = complement_classical;
 	if (!haskey(params, "algo")) {
@@ -108,5 +122,5 @@ void Mata::Nfa::complement(
 			" received an unknown value of the \"algo\" key: " + str_algo);
 	}
 
-	algo(result, aut, alphabet, subset_map);
+	return algo(aut, alphabet, subset_map);
 } // complement

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -91,7 +91,8 @@ Nfa complement_naive(
 void Mata::Nfa::complement_in_place(Nfa& aut) {
     StateSet newFinalStates;
 
-    for (State q = 0; q < aut.transitionrelation.size(); ++q) {
+    const size_t size = aut.transitionrelation.size();
+    for (State q = 0; q < size; ++q) {
         if (aut.finalstates.count(q) == 0) {
             newFinalStates.insert(q);
         }

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -299,11 +299,11 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs)
     return Concatenation(lhs, rhs).get_result();
 }
 
-void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
+void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon) {
     *res = Concatenation(lhs, rhs, epsilon).get_result();
 }
 
-Nfa concatenate(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
+Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon) {
     return Concatenation(lhs, rhs, epsilon).get_result();
 }
 

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -299,11 +299,11 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs)
     return Concatenation(lhs, rhs).get_result();
 }
 
-void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon) {
+void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
     *res = Concatenation(lhs, rhs, epsilon).get_result();
 }
 
-Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon) {
+Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
     return Concatenation(lhs, rhs, epsilon).get_result();
 }
 

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -378,8 +378,14 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon, ProductMa
     return intersection.get_product();
 }
 
-Nfa intersection(const Nfa& lhs, const Nfa& rhs)
+Nfa intersection(const Nfa& lhs, const Nfa& rhs, ProductMap* prod_map)
 {
+    Intersection intersection { Intersection::compute(lhs, rhs) };
+    if (prod_map != nullptr)
+    {
+        *prod_map = intersection.get_product_map();
+    }
+
     return Intersection{ lhs, rhs }.get_product();
 }
 

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -386,7 +386,7 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs, ProductMap* prod_map)
         *prod_map = intersection.get_product_map();
     }
 
-    return Intersection{ lhs, rhs }.get_product();
+    return intersection.get_product();
 }
 
 } // Nfa

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -48,7 +48,7 @@ public:
     }
 
     /**
-     * Compute epsilon transitions preserving intersection_over_epsilon of NFAs @p lhs and @p rhs.
+     * Compute epsilon transitions preserving intersection of NFAs @p lhs and @p rhs.
      * @param lhs First NFA to compute intersection for.
      * @param rhs Second NFA to compute intersection for.
      * @param epsilon Symbol to handle as an epsilon symbol.
@@ -358,7 +358,7 @@ void intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMap*  prod_ma
     *res = intersection.get_product();
 }
 
-void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
+void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, const Symbol epsilon, ProductMap* prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)
@@ -368,7 +368,7 @@ void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol 
     *res = intersection.get_product();
 }
 
-Nfa intersection_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon, ProductMap*  prod_map)
+Nfa intersection_over_epsilon(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon, ProductMap*  prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -358,7 +358,7 @@ void intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMap*  prod_ma
     *res = intersection.get_product();
 }
 
-void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, const Symbol epsilon, ProductMap* prod_map)
+void intersection_preserving_epsilon_transitions(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)
@@ -368,7 +368,7 @@ void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, const S
     *res = intersection.get_product();
 }
 
-Nfa intersection_over_epsilon(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon, ProductMap*  prod_map)
+Nfa intersection_preserving_epsilon_transitions(const Nfa& lhs, const Nfa& rhs, Symbol epsilon, ProductMap*  prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -48,7 +48,7 @@ public:
     }
 
     /**
-     * Compute epsilon transitions preserving intersection of NFAs @p lhs and @p rhs.
+     * Compute epsilon transitions preserving intersection_over_epsilon of NFAs @p lhs and @p rhs.
      * @param lhs First NFA to compute intersection for.
      * @param rhs Second NFA to compute intersection for.
      * @param epsilon Symbol to handle as an epsilon symbol.
@@ -358,7 +358,7 @@ void intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMap*  prod_ma
     *res = intersection.get_product();
 }
 
-void intersection(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
+void intersection_over_epsilon(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)
@@ -368,7 +368,7 @@ void intersection(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, Prod
     *res = intersection.get_product();
 }
 
-Nfa intersection(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon, ProductMap*  prod_map)
+Nfa intersection_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon, ProductMap*  prod_map)
 {
     Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
     if (prod_map != nullptr)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1257,6 +1257,36 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
     return res;
 }
 
+TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State& state, const Symbol& epsilon) const {
+    assert(get_num_of_states() >= state + 1);
+    const auto trans_from = this->get_transitions_from(state);
+    if (trans_from.empty()) {
+        return trans_from.end();
+    }
+
+    if (epsilon == EPSILON) {
+        auto& back = this->get_transitions_from(state).back();
+        if (back.symbol == epsilon) {
+            return std::prev(trans_from.end());
+        } else {
+            return trans_from.end();
+        }
+    } else {
+        const auto eps_trans = TransSymbolStates(epsilon);
+        const auto it = std::lower_bound(trans_from.begin(),
+                           trans_from.end(),
+                           eps_trans,
+                           [](TransSymbolStates x, const TransSymbolStates& y){return x.symbol == y.symbol;});
+        if (it != trans_from.end()) {
+            return std::prev(trans_from.end());
+        } else {
+            return trans_from.end();
+        }
+    }
+
+    assert(false);
+}
+
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {
     Nfa unionAutomaton = rhs;
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -77,7 +77,8 @@ namespace {
         return LTSforSimulation.compute_simulation();
     }
 
-	void reduce_size_by_simulation(Nfa* result, const Nfa& aut, StateToStateMap &state_map) {
+	Nfa reduce_size_by_simulation(const Nfa& aut, StateToStateMap &state_map) {
+        Nfa result;
         const auto sim_relation = compute_relation(aut, StringDict{{"relation", "simulation"}, {"direction","forward"}});
 
         auto sim_relation_symmetric = sim_relation;
@@ -93,7 +94,7 @@ namespace {
 		for (State q = 0; q < num_of_states; ++q) {
 			const State qReprState = quot_proj[q];
 			if (state_map.count(qReprState) == 0) { // we need to map q's class to a new state in reducedAut
-				const State qClass = result->add_new_state();
+				const State qClass = result.add_new_state();
 				state_map[qReprState] = qClass;
 				state_map[q] = qClass;
 			} else {
@@ -105,7 +106,7 @@ namespace {
             const State q_class_state = state_map.at(q);
 
             if (aut.has_initial(q)) { // if a symmetric class contains initial state, then the whole class should be initial
-                result->make_initial(q_class_state);
+                result.make_initial(q_class_state);
             }
 
             if (quot_proj[q] == q) { // we process only transitions starting from the representative state, this is enough for simulation
@@ -136,14 +137,16 @@ namespace {
 
                     // add the transition 'q_class_state-q_trans.symbol->representatives_class_states' at the end of transition list of transitions starting from q_class_state
                     // as the q_trans.symbol should be largest symbol we saw (as we iterate trough getTransitionsFromState(q) which is ordered)
-                    result->transitionrelation[q_class_state].push_back(TransSymbolStates(q_trans.symbol, representatives_class_states));
+                    result.transitionrelation[q_class_state].push_back(TransSymbolStates(q_trans.symbol, representatives_class_states));
                 }
 
                 if (aut.has_final(q)) { // if q is final, then all states in its class are final => we make q_class_state final
-                    result->make_final(q_class_state);
+                    result.make_final(q_class_state);
                 }
             }
         }
+
+        return result;
     }
 
     /**
@@ -620,16 +623,14 @@ bool Mata::Nfa::are_state_disjoint(const Nfa& lhs, const Nfa& rhs)
 } // are_disjoint }}}
 
 void Mata::Nfa::make_complete(
-        Nfa*             aut,
+        Nfa&             aut,
         const Alphabet&  alphabet,
         State            sink_state)
 {
-    assert(nullptr != aut);
-
-    std::list<State> worklist(aut->initialstates.begin(),
-                              aut->initialstates.end());
-    std::unordered_set<State> processed(aut->initialstates.begin(),
-                                        aut->initialstates.end());
+    std::list<State> worklist(aut.initialstates.begin(),
+                              aut.initialstates.end());
+    std::unordered_set<State> processed(aut.initialstates.begin(),
+                                        aut.initialstates.end());
     worklist.push_back(sink_state);
     processed.insert(sink_state);
     while (!worklist.empty())
@@ -638,9 +639,9 @@ void Mata::Nfa::make_complete(
         worklist.pop_front();
 
         std::set<Symbol> used_symbols;
-        if (!aut->trans_empty())
+        if (!aut.trans_empty())
         {
-            for (const auto &symb_stateset: (*aut)[state]) {
+            for (const auto &symb_stateset: aut[state]) {
                 // TODO: Possibly fix insert.
                 used_symbols.insert(symb_stateset.symbol);
 
@@ -656,17 +657,17 @@ void Mata::Nfa::make_complete(
         auto unused_symbols = alphabet.get_complement(used_symbols);
         for (Symbol symb : unused_symbols)
         {
-            aut->add_trans(state, symb, sink_state);
+            aut.add_trans(state, symb, sink_state);
         }
     }
 }
 
-void Mata::Nfa::remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
+Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
 {
-    assert(nullptr != result);
+    Nfa result;
 
-    result->clear_nfa();
-    result->increase_size(aut.get_num_of_states());
+    result.clear_nfa();
+    result.increase_size(aut.get_num_of_states());
 
     // cannot use multimap, because it can contain multiple occurrences of (a -> a), (a -> a)
     StateMap<StateSet> eps_closure;
@@ -712,45 +713,49 @@ void Mata::Nfa::remove_epsilon(Nfa* result, const Nfa& aut, Symbol epsilon)
     }
 
     // now we construct the automaton without epsilon transitions
-    result->initialstates.insert(aut.initialstates);
-    result->finalstates.insert(aut.finalstates);
+    result.initialstates.insert(aut.initialstates);
+    result.finalstates.insert(aut.finalstates);
     State max_state{};
     for (const auto& state_closure_pair : eps_closure) { // for every state
         State src_state = state_closure_pair.first;
         for (State eps_cl_state : state_closure_pair.second) { // for every state in its eps cl
-            if (aut.has_final(eps_cl_state)) result->make_final(src_state);
+            if (aut.has_final(eps_cl_state)) result.make_final(src_state);
             for (const auto& symb_set : aut[eps_cl_state]) {
                 if (symb_set.symbol == epsilon) continue;
 
                 // TODO: this could be done more efficiently if we had a better add_trans method
                 for (State tgt_state : symb_set.states_to) {
                     max_state = std::max(src_state, tgt_state);
-                    if (result->get_num_of_states() < max_state) {
-                        result->increase_size_for_state(max_state);
+                    if (result.get_num_of_states() < max_state) {
+                        result.increase_size_for_state(max_state);
                     }
-                    result->add_trans(src_state, symb_set.symbol, tgt_state);
+                    result.add_trans(src_state, symb_set.symbol, tgt_state);
                 }
             }
         }
     }
+
+    return result;
 }
 
-void Mata::Nfa::revert(Nfa* result, const Nfa& aut) {
-    assert(nullptr != result);
-    result->clear_nfa();
+Nfa Mata::Nfa::revert(const Nfa& aut) {
+    Nfa result;
+    result.clear_nfa();
     const size_t num_of_states{ aut.get_num_of_states() };
-    result->increase_size(num_of_states);
+    result.increase_size(num_of_states);
 
     for (State sourceState{ 0 }; sourceState < num_of_states; ++sourceState) {
         for (const TransSymbolStates &transition: aut.transitionrelation[sourceState]) {
             for (const State targetState: transition.states_to) {
-                result->add_trans(targetState, transition.symbol, sourceState);
+                result.add_trans(targetState, transition.symbol, sourceState);
             }
         }
     }
 
-    result->initialstates = aut.finalstates;
-    result->finalstates = aut.initialstates;
+    result.initialstates = aut.finalstates;
+    result.finalstates = aut.initialstates;
+
+    return result;
 }
 
 bool Mata::Nfa::is_deterministic(const Nfa& aut)
@@ -1012,27 +1017,12 @@ bool Mata::Nfa::is_lang_empty_cex(const Nfa& aut, Word* cex)
     return false;
 }
 
-void Mata::Nfa::complement_in_place(Nfa& aut) {
-    StateSet newFinalStates;
-
-    for (State q = 0; q < aut.transitionrelation.size(); ++q) {
-        if (aut.finalstates.count(q) == 0) {
-            newFinalStates.insert(q);
-        }
-    }
-
-    aut.finalstates = newFinalStates;
-}
-
-void Mata::Nfa::minimize(Nfa *res, const Nfa& aut) {
+Nfa Mata::Nfa::minimize(const Nfa& aut) {
     //compute the minimal deterministic automaton, Brzozovski algorithm
-    Nfa inverted;
-    Nfa trimmed_inverted;
-    Nfa tmp;
-    revert(&inverted, aut);
-    determinize(&tmp, inverted);
-    revert(&trimmed_inverted, tmp);
-    determinize(res, trimmed_inverted);
+    Nfa inverted = revert(aut);
+    Nfa tmp = determinize(inverted);
+    Nfa deter = revert(tmp);
+    return determinize(deter);
 }
 
 void Nfa::print_to_DOT(std::ostream &outputStream) const {
@@ -1267,20 +1257,20 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
     return res;
 }
 
-void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {
-    *unionAutomaton = rhs;
+Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {
+    Nfa unionAutomaton = rhs;
 
     StateToStateMap thisStateToUnionState;
     for (State thisState = 0; thisState < lhs.transitionrelation.size(); ++thisState) {
-        thisStateToUnionState[thisState] = unionAutomaton->add_new_state();
+        thisStateToUnionState[thisState] = unionAutomaton.add_new_state();
     }
 
     for (State thisInitialState : lhs.initialstates) {
-        unionAutomaton->make_initial(thisStateToUnionState[thisInitialState]);
+        unionAutomaton.make_initial(thisStateToUnionState[thisInitialState]);
     }
 
     for (State thisFinalState : lhs.finalstates) {
-        unionAutomaton->make_final(thisStateToUnionState[thisFinalState]);
+        unionAutomaton.make_final(thisStateToUnionState[thisFinalState]);
     }
 
     for (State thisState = 0; thisState < lhs.transitionrelation.size(); ++thisState) {
@@ -1293,9 +1283,11 @@ void Mata::Nfa::uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) {
                 transitionFromUnionState.states_to.insert(thisStateToUnionState[stateTo]);
             }
 
-            unionAutomaton->transitionrelation[unionState].push_back(transitionFromUnionState);
+            unionAutomaton.transitionrelation[unionState].push_back(transitionFromUnionState);
         }
     }
+
+    return unionAutomaton;
 }
 
 Simlib::Util::BinaryRelation Mata::Nfa::compute_relation(const Nfa& aut, const StringDict& params) {
@@ -1321,21 +1313,23 @@ Simlib::Util::BinaryRelation Mata::Nfa::compute_relation(const Nfa& aut, const S
     }
 }
 
-void Mata::Nfa::reduce(Nfa* result, const Nfa &aut, StateToStateMap *state_map, const StringDict& params) {
+Nfa Mata::Nfa::reduce(const Nfa &aut, StateToStateMap *state_map, const StringDict& params) {
+    Nfa result;
+
     if (!haskey(params, "algorithm")) {
         throw std::runtime_error(std::to_string(__func__) +
                                  " requires setting the \"algorithm\" key in the \"params\" argument; "
                                  "received: " + std::to_string(params));
     }
 
-    result->clear_nfa();
+    result.clear_nfa();
     const std::string& algorithm = params.at("algorithm");
     if ("simulation" == algorithm) {
         if (state_map == nullptr) {
             std::unordered_map<State,State> tmp_state_map;
-            reduce_size_by_simulation(result, aut, tmp_state_map);
+            return reduce_size_by_simulation(aut, tmp_state_map);
         } else {
-            reduce_size_by_simulation(result, aut, *state_map);
+            return reduce_size_by_simulation(aut, *state_map);
         }
     } else {
         throw std::runtime_error(std::to_string(__func__) +
@@ -1343,11 +1337,11 @@ void Mata::Nfa::reduce(Nfa* result, const Nfa &aut, StateToStateMap *state_map, 
     }
 }
 
-void Mata::Nfa::determinize(
-        Nfa*        result,
+Nfa Mata::Nfa::determinize(
         const Nfa&  aut,
         SubsetMap*  subset_map)
 {
+    Nfa result;
     //assuming all sets states_to are non-empty
     std::vector<std::pair<State, StateSet>> worklist;
     bool deallocate_subset_map = false;
@@ -1356,25 +1350,25 @@ void Mata::Nfa::determinize(
         deallocate_subset_map = true;
     }
 
-    result->clear_nfa();
+    result.clear_nfa();
 
     const StateSet S0 =  Mata::Util::OrdVector<State>(aut.initialstates.ToVector());
-    const State S0id = result->add_new_state();
-    result->make_initial(S0id);
+    const State S0id = result.add_new_state();
+    result.make_initial(S0id);
     //for fast detection of a final state in a set.
     std::vector<bool> isFinal(aut.get_num_of_states(), false);
     for (const auto &q: aut.finalstates) {
         isFinal[q] = true;
     }
     if (contains_final(S0, isFinal)) {
-        result->make_final(S0id);
+        result.make_final(S0id);
     }
     worklist.emplace_back(std::make_pair(S0id, S0));
 
     (*subset_map)[Mata::Util::OrdVector<State>(S0)] = S0id;
 
     if (aut.trans_empty())
-        return;
+        return result;
 
     while (!worklist.empty()) {
         const auto Spair = worklist.back();
@@ -1395,27 +1389,28 @@ void Mata::Nfa::determinize(
             if (existingTitr != subset_map->end()) {
                 Tid = existingTitr->second;
             } else {
-                Tid = result->add_new_state();
+                Tid = result.add_new_state();
                 (*subset_map)[Mata::Util::OrdVector<State>(T)] = Tid;
                 if (contains_final(T, isFinal)) {
-                    result->make_final(Tid);
+                    result.make_final(Tid);
                 }
                 worklist.emplace_back(std::make_pair(Tid, T));
             }
-            result->transitionrelation[Sid].push_back(TransSymbolStates(currentSymbol, Tid));
+            result.transitionrelation[Sid].push_back(TransSymbolStates(currentSymbol, Tid));
         }
     }
 
     if (deallocate_subset_map) { delete subset_map; }
+
+    return result;
 }
 
-void Mata::Nfa::construct(
-        Nfa*                                 aut,
-        const Mata::Parser::ParsedSection&  parsec,
+Nfa Mata::Nfa::construct(
+        const Mata::Parser::ParsedSection&   parsec,
         Alphabet*                            alphabet,
         StringToStateMap*                    state_map)
 { // {{{
-    assert(nullptr != aut);
+    Nfa aut;
     assert(nullptr != alphabet);
 
     if (parsec.type != Mata::Nfa::TYPE_NFA) {
@@ -1432,7 +1427,7 @@ void Mata::Nfa::construct(
     // a lambda for translating state names to identifiers
     auto get_state_name = [&state_map, &aut](const std::string& str) {
         if (!state_map->count(str)) {
-            State state = aut->add_new_state();
+            State state = aut.add_new_state();
             state_map->insert({str, state});
             return state;
         } else {
@@ -1452,7 +1447,7 @@ void Mata::Nfa::construct(
         for (const auto& str : it->second)
         {
             State state = get_state_name(str);
-            aut->initialstates.insert(state);
+            aut.initialstates.insert(state);
         }
     }
 
@@ -1463,7 +1458,7 @@ void Mata::Nfa::construct(
         for (const auto& str : it->second)
         {
             State state = get_state_name(str);
-            aut->finalstates.insert(state);
+            aut.finalstates.insert(state);
         }
     }
 
@@ -1490,20 +1485,21 @@ void Mata::Nfa::construct(
         Symbol symbol = alphabet->translate_symb(body_line[1]);
         State tgt_state = get_state_name(body_line[2]);
 
-        aut->add_trans(src_state, symbol, tgt_state);
+        aut.add_trans(src_state, symbol, tgt_state);
     }
 
     // do the dishes and take out garbage
     clean_up();
+
+    return aut;
 } // construct }}}
 
-void Mata::Nfa::construct(
-        Nfa*                                 aut,
-        const Mata::IntermediateAut&          inter_aut,
+Nfa Mata::Nfa::construct(
+        const Mata::IntermediateAut&         inter_aut,
         Alphabet*                            alphabet,
         StringToStateMap*                    state_map)
 { // {{{
-    assert(nullptr != aut);
+    Nfa aut;
     assert(nullptr != alphabet);
 
     if (!inter_aut.is_nfa()) {
@@ -1520,7 +1516,7 @@ void Mata::Nfa::construct(
     // a lambda for translating state names to identifiers
     auto get_state_name = [&state_map, &aut](const std::string& str) {
         if (!state_map->count(str)) {
-            State state = aut->add_new_state();
+            State state = aut.add_new_state();
             state_map->insert({str, state});
             return state;
         } else {
@@ -1536,13 +1532,13 @@ void Mata::Nfa::construct(
     for (const auto& str : inter_aut.initial_formula.collect_node_names())
     {
         State state = get_state_name(str);
-        aut->initialstates.insert(state);
+        aut.initialstates.insert(state);
     }
 
     for (const auto& str : inter_aut.final_formula.collect_node_names())
     {
         State state = get_state_name(str);
-        aut->finalstates.insert(state);
+        aut.finalstates.insert(state);
     }
 
     for (const auto& trans : inter_aut.transitions)
@@ -1566,11 +1562,13 @@ void Mata::Nfa::construct(
         Symbol symbol = alphabet->translate_symb(trans.second.children[0].node.name);
         State tgt_state = get_state_name(trans.second.children[1].node.name);
 
-        aut->add_trans(src_state, symbol, tgt_state);
+        aut.add_trans(src_state, symbol, tgt_state);
     }
 
     // do the dishes and take out garbage
     clean_up();
+
+    return aut;
 } // construct }}}
 
 bool Nfa::state_set_post_iterator::has_next() const

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -662,6 +662,10 @@ void Mata::Nfa::make_complete(
     }
 }
 
+void Mata::Nfa::make_complete(Nfa* aut, const Alphabet& alphabet, const State sink_state) {
+    make_complete(*aut, alphabet, sink_state);
+}
+
 Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
 {
     Nfa result;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1259,19 +1259,22 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
 
 TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const Symbol epsilon) const {
     assert(is_state(state));
-    const auto& trans_from{ get_transitions_from(state) };
-    if (!trans_from.empty()) {
+    return get_epsilon_transitions(get_transitions_from(state));
+}
+
+TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon) {
+    if (!state_transitions.empty()) {
         if (epsilon == EPSILON) {
-            const auto& back = trans_from.back();
+            const auto& back = state_transitions.back();
             if (back.symbol == epsilon) {
-                return std::prev(trans_from.end());
+                return std::prev(state_transitions.end());
             }
         } else {
-            return trans_from.find(TransSymbolStates(epsilon));
+            return state_transitions.find(TransSymbolStates(epsilon));
         }
     }
 
-    return trans_from.end();
+    return state_transitions.end();
 }
 
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1263,7 +1263,7 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
 
 TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const Symbol epsilon) const {
     assert(is_state(state));
-    return get_epsilon_transitions(get_transitions_from(state));
+    return get_epsilon_transitions(get_transitions_from(state), epsilon);
 }
 
 TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1257,34 +1257,21 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
     return res;
 }
 
-TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State& state, const Symbol& epsilon) const {
-    assert(get_num_of_states() >= state + 1);
-    const auto trans_from = this->get_transitions_from(state);
-    if (trans_from.empty()) {
-        return trans_from.end();
-    }
-
-    if (epsilon == EPSILON) {
-        auto& back = this->get_transitions_from(state).back();
-        if (back.symbol == epsilon) {
-            return std::prev(trans_from.end());
+TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const Symbol epsilon) const {
+    assert(is_state(state));
+    const auto& trans_from{ get_transitions_from(state) };
+    if (!trans_from.empty()) {
+        if (epsilon == EPSILON) {
+            const auto& back = trans_from.back();
+            if (back.symbol == epsilon) {
+                return std::prev(trans_from.end());
+            }
         } else {
-            return trans_from.end();
-        }
-    } else {
-        const auto eps_trans = TransSymbolStates(epsilon);
-        const auto it = std::lower_bound(trans_from.begin(),
-                           trans_from.end(),
-                           eps_trans,
-                           [](TransSymbolStates x, const TransSymbolStates& y){return x.symbol == y.symbol;});
-        if (it != trans_from.end()) {
-            return std::prev(trans_from.end());
-        } else {
-            return trans_from.end();
+            return trans_from.find(TransSymbolStates(epsilon));
         }
     }
 
-    assert(false);
+    return trans_from.end();
 }
 
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -186,7 +186,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
         concatenated_left_side = concatenate(concatenated_left_side, *next_left_automaton_it, epsilon);
     }
 
-    auto product_pres_eps_trans{ intersection(concatenated_left_side, right_automaton, epsilon) };
+    auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -238,7 +238,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
         concatenated_left_side = concatenate(concatenated_left_side, *(*next_left_automaton_it), epsilon);
     }
 
-    auto product_pres_eps_trans{ intersection(concatenated_left_side, right_automaton, epsilon) };
+    auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -186,7 +186,8 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
         concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *next_left_automaton_it, epsilon);
     }
 
-    auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };
+    auto product_pres_eps_trans{
+            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, epsilon) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -238,7 +239,8 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
         concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *(*next_left_automaton_it), epsilon);
     }
 
-    auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };
+    auto product_pres_eps_trans{
+            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, epsilon) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -255,4 +257,3 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
     }
     return noodlify(product_pres_eps_trans, epsilon, include_empty);
 }
-

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -183,7 +183,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
     Nfa concatenated_left_side{ *left_automata_begin };
     for (auto next_left_automaton_it{ left_automata_begin + 1 }; next_left_automaton_it != left_automata_end;
          ++next_left_automaton_it) {
-        concatenated_left_side = concatenate(concatenated_left_side, *next_left_automaton_it, epsilon);
+        concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *next_left_automaton_it, epsilon);
     }
 
     auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };
@@ -235,7 +235,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
     Nfa concatenated_left_side{ *(*left_automata_begin) };
     for (auto next_left_automaton_it{ left_automata_begin + 1 }; next_left_automaton_it != left_automata_end;
          ++next_left_automaton_it) {
-        concatenated_left_side = concatenate(concatenated_left_side, *(*next_left_automaton_it), epsilon);
+        concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *(*next_left_automaton_it), epsilon);
     }
 
     auto product_pres_eps_trans{intersection_over_epsilon(concatenated_left_side, right_automaton, epsilon) };

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -398,7 +398,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
     SECTION("Empty automaton") {
         lhs.increase_size(1);
         rhs.increase_size(1);
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.get_num_of_states() == 0);
         CHECK(result.initialstates.empty());
@@ -413,7 +413,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         rhs.make_initial(0);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.get_num_of_states() == 0);
         CHECK(result.initialstates.empty());
@@ -429,7 +429,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         rhs.make_initial(0);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.finalstates.empty());
@@ -447,7 +447,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_initial(0);
         rhs.make_final(0);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(1));
@@ -465,7 +465,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_initial(0);
         rhs.make_final(1);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
@@ -484,7 +484,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(1);
         rhs.add_trans(0, 'a', 1);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
@@ -505,7 +505,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(1);
         rhs.add_trans(0, 'a', 1);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(3));
@@ -532,7 +532,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.add_trans(0, 'a', 1);
         rhs.add_trans(0, 'c', 3);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(3));
@@ -559,7 +559,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(0);
         rhs.add_trans(0, 'a', 0);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
@@ -581,7 +581,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size_for_state(14);
         FILL_WITH_AUT_B(rhs);
 
-        result = concatenate(lhs, rhs, epsilon);
+        result = concatenate_over_epsilon(lhs, rhs, epsilon);
 
         CHECK(result.initialstates.size() == 2);
         CHECK(result.has_initial(1));
@@ -604,7 +604,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size_for_state(14);
         FILL_WITH_AUT_B(rhs);
 
-        result = concatenate(rhs, lhs, epsilon);
+        result = concatenate_over_epsilon(rhs, lhs, epsilon);
 
         CHECK(result.get_num_of_states() == 26);
 

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -216,7 +216,7 @@ TEST_CASE("Mata::Nfa::intersection() with preserving epsilon transitions")
     b.add_trans(6, 'a', 9);
     b.add_trans(6, 'b', 7);
 
-    Nfa result{intersection_over_epsilon(a, b, epsilon, &prod_map) };
+    Nfa result{intersection_preserving_epsilon_transitions(a, b, epsilon, &prod_map) };
 
     // Check states.
     CHECK(result.is_state(prod_map[{0, 0}]));
@@ -318,6 +318,6 @@ TEST_CASE("Mata::Nfa::intersection() for profiling", "[.profiling],[intersection
     b.add_trans(6, 'b', 7);
 
     for (size_t i{ 0 }; i < 10000; ++i) {
-        Nfa result{intersection_over_epsilon(a, b, epsilon) };
+        Nfa result{intersection_preserving_epsilon_transitions(a, b, epsilon) };
     }
 }

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -75,7 +75,7 @@ TEST_CASE("Mata::Nfa::intersection()")
 
     SECTION("Intersection of empty automata")
     {
-        intersection(&res, a, b, &prod_map);
+        res = intersection(a, b, &prod_map);
 
         REQUIRE(res.initialstates.empty());
         REQUIRE(res.finalstates.empty());
@@ -85,7 +85,7 @@ TEST_CASE("Mata::Nfa::intersection()")
 
     SECTION("Intersection of empty automata 2")
     {
-        intersection(&res, a, b);
+        res = intersection(a, b);
 
         REQUIRE(res.initialstates.empty());
         REQUIRE(res.finalstates.empty());
@@ -108,7 +108,7 @@ TEST_CASE("Mata::Nfa::intersection()")
         REQUIRE(!a.finalstates.empty());
         REQUIRE(!b.finalstates.empty());
 
-        intersection(&res, a, b, &prod_map);
+        res = intersection(a, b, &prod_map);
 
         REQUIRE(!res.initialstates.empty());
         REQUIRE(!res.finalstates.empty());
@@ -127,7 +127,7 @@ TEST_CASE("Mata::Nfa::intersection()")
         FILL_WITH_AUT_A(a);
         FILL_WITH_AUT_B(b);
 
-        intersection(&res, a, b, &prod_map);
+        res = intersection(a, b, &prod_map);
 
         REQUIRE(res.has_initial(prod_map[{1, 4}]));
         REQUIRE(res.has_initial(prod_map[{3, 4}]));
@@ -178,7 +178,7 @@ TEST_CASE("Mata::Nfa::intersection()")
         FILL_WITH_AUT_B(b);
         b.finalstates = {12};
 
-        intersection(&res, a, b, &prod_map);
+        res = intersection(a, b, &prod_map);
 
         REQUIRE(res.has_initial(prod_map[{1, 4}]));
         REQUIRE(res.has_initial(prod_map[{3, 4}]));

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -216,7 +216,7 @@ TEST_CASE("Mata::Nfa::intersection() with preserving epsilon transitions")
     b.add_trans(6, 'a', 9);
     b.add_trans(6, 'b', 7);
 
-    Nfa result{ intersection(a, b, epsilon, &prod_map) };
+    Nfa result{intersection_over_epsilon(a, b, epsilon, &prod_map) };
 
     // Check states.
     CHECK(result.is_state(prod_map[{0, 0}]));
@@ -318,6 +318,6 @@ TEST_CASE("Mata::Nfa::intersection() for profiling", "[.profiling],[intersection
     b.add_trans(6, 'b', 7);
 
     for (size_t i{ 0 }; i < 10000; ++i) {
-        Nfa result{ intersection(a, b, epsilon) };
+        Nfa result{intersection_over_epsilon(a, b, epsilon) };
     }
 }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2832,6 +2832,14 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
 
+    aut.add_trans(8, 42, 3);
+    aut.add_trans(8, 42, 4);
+    aut.add_trans(8, 42, 6);
+
+    state_eps_trans = aut.get_epsilon_transitions(8, 42);
+    CHECK(state_eps_trans->symbol == 42);
+    CHECK(state_eps_trans->states_to == StateSet{ 3, 4, 6 });
+
     CHECK(aut.get_epsilon_transitions(1) == aut.get_transitions_from(1).end());
     CHECK(aut.get_epsilon_transitions(5) == aut.get_transitions_from(5).end());
     CHECK(aut.get_epsilon_transitions(19) == aut.get_transitions_from(19).end());

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2831,4 +2831,25 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     state_eps_trans = aut.get_epsilon_transitions(3);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+
+    CHECK(aut.get_epsilon_transitions(1) == aut.get_transitions_from(1).end());
+    CHECK(aut.get_epsilon_transitions(5) == aut.get_transitions_from(5).end());
+    CHECK(aut.get_epsilon_transitions(19) == aut.get_transitions_from(19).end());
+
+    auto state_transitions{ aut.transitionrelation[0] };
+    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3 });
+    state_transitions = aut.transitionrelation[3];
+    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+
+    state_transitions = aut.get_transitions_from(1);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+    state_transitions = aut.get_transitions_from(5);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+    state_transitions = aut.get_transitions_from(19);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+
 }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -594,7 +594,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 	{
 		parsec.type = Mata::Nfa::TYPE_NFA;
 
-		construct(&aut, parsec);
+		aut = construct(parsec);
 
 		REQUIRE(is_lang_empty(aut));
 	}
@@ -605,7 +605,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 		parsec.dict.insert({"Initial", {"q1"}});
 		parsec.dict.insert({"Final", {"q1"}});
 
-		construct(&aut, parsec);
+		aut = construct(parsec);
 
 		REQUIRE(!is_lang_empty(aut));
 	}
@@ -616,7 +616,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 		parsec.dict.insert({"Initial", {"q1", "q2"}});
 		parsec.dict.insert({"Final", {"q1", "q2", "q3"}});
 
-		construct(&aut, parsec);
+		aut = construct(parsec);
 
 		REQUIRE(aut.initialstates.size() == 2);
 		REQUIRE(aut.finalstates.size() == 3);
@@ -629,7 +629,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 		parsec.dict.insert({"Final", {"q2"}});
 		parsec.body = { {"q1", "a", "q2"} };
 
-		construct(&aut, parsec, &symbol_map);
+		aut = construct(parsec, &symbol_map);
 
 		Path cex;
 		REQUIRE(!is_lang_empty(aut, &cex));
@@ -661,7 +661,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 		parsec.body.push_back({"q5", "a", "q5"});
 		parsec.body.push_back({"q5", "c", "q9"});
 
-		construct(&aut, parsec, &symbol_map);
+		aut = construct(parsec, &symbol_map);
 
 		// some samples
 		REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"b", "a"})));
@@ -684,7 +684,7 @@ TEST_CASE("Mata::Nfa::construct() invalid calls")
 	{
 		parsec.type = "FA";
 
-		CHECK_THROWS_WITH(construct(&aut, parsec),
+		CHECK_THROWS_WITH(construct(parsec),
 			Catch::Contains("expecting type"));
 	}
 
@@ -693,7 +693,7 @@ TEST_CASE("Mata::Nfa::construct() invalid calls")
 		parsec.type = Mata::Nfa::TYPE_NFA;
 		parsec.body = { {"q1", "q2"} };
 
-		CHECK_THROWS_WITH(construct(&aut, parsec),
+		CHECK_THROWS_WITH(construct(parsec),
 			Catch::Contains("Epsilon transition"));
 	}
 
@@ -717,7 +717,7 @@ TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
     {
         inter_aut.automaton_type = Mata::IntermediateAut::NFA;
         REQUIRE(is_lang_empty(aut));
-        construct(&aut, inter_aut);
+        aut = construct(inter_aut);
         REQUIRE(is_lang_empty(aut));
     }
 
@@ -732,7 +732,7 @@ TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
         const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
         inter_aut = auts[0];
 
-        construct(&aut, inter_aut);
+        aut = construct(inter_aut);
 
         REQUIRE(!is_lang_empty(aut));
     }
@@ -955,7 +955,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 	{
 		EnumAlphabet alph = { };
 
-		make_complete(&aut, alph, 0);
+		make_complete(aut, alph, 0);
 
 		REQUIRE(aut.initialstates.empty());
 		REQUIRE(aut.finalstates.empty());
@@ -966,7 +966,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 	{
 		EnumAlphabet alph = {"a", "b"};
 
-		make_complete(&aut, alph, 0);
+		make_complete(aut, alph, 0);
 
 		REQUIRE(aut.initialstates.empty());
 		REQUIRE(aut.finalstates.empty());
@@ -980,7 +980,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 		aut.initialstates = {1};
 
-		make_complete(&aut, alphabet, 0);
+		make_complete(aut, alphabet, 0);
 
 		REQUIRE(aut.initialstates.size() == 1);
 		REQUIRE(*aut.initialstates.begin() == 1);
@@ -995,7 +995,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 		aut.initialstates = {1};
 
-		make_complete(&aut, alph, SINK);
+		make_complete(aut, alph, SINK);
 
 		REQUIRE(aut.initialstates.size() == 1);
 		REQUIRE(*aut.initialstates.begin() == 1);
@@ -1020,7 +1020,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 		aut.add_trans(3, alph["b"], 5);
 		aut.add_trans(4, alph["c"], 8);
 
-		make_complete(&aut, alph, SINK);
+		make_complete(aut, alph, SINK);
 
 		REQUIRE(aut.has_trans(1, alph["a"], 2));
 		REQUIRE(aut.has_trans(1, alph["b"], SINK));
@@ -1953,7 +1953,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 		REQUIRE(!is_complete(aut, alph));
 
-		make_complete(&aut, alph, 100);
+		make_complete(aut, alph, 100);
 		REQUIRE(is_complete(aut, alph));
 	}
 
@@ -1994,7 +1994,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 		REQUIRE(!is_complete(aut, alph));
 
-		make_complete(&aut, alph, 100);
+		make_complete(aut, alph, 100);
 		REQUIRE(is_complete(aut, alph));
 	}
 } // }}}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -513,7 +513,7 @@ TEST_CASE("Mata::Nfa::determinize()")
 
 	SECTION("empty automaton")
 	{
-		determinize(&result, aut);
+		result = determinize(aut);
 
 		REQUIRE(result.has_initial(subset_map[{}]));
 		REQUIRE(result.finalstates.empty());
@@ -524,7 +524,7 @@ TEST_CASE("Mata::Nfa::determinize()")
 	{
 		aut.initialstates = { 1 };
 		aut.finalstates = { 1 };
-		determinize(&result, aut, &subset_map);
+		result = determinize(aut, &subset_map);
 
 		REQUIRE(result.has_initial(subset_map[{1}]));
 		REQUIRE(result.has_final(subset_map[{1}]));
@@ -536,7 +536,7 @@ TEST_CASE("Mata::Nfa::determinize()")
 		aut.initialstates = { 1 };
 		aut.finalstates = { 2 };
 		aut.add_trans(1, 'a', 2);
-		determinize(&result, aut, &subset_map);
+		result = determinize(aut, &subset_map);
 
 		REQUIRE(result.has_initial(subset_map[{1}]));
         REQUIRE(result.has_final(subset_map[{2}]));
@@ -2225,8 +2225,7 @@ TEST_CASE("Mata::Nfa::union_norename()") {
     REQUIRE(!is_in_lang(rhs, zero));
 
     SECTION("failing minimal scenario") {
-        Nfa result;
-        uni(&result, lhs, rhs);
+        Nfa result = uni(lhs, rhs);
         REQUIRE(is_in_lang(result, one));
         REQUIRE(is_in_lang(result, zero));
     }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2817,3 +2817,18 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         CHECK(nfa.has_trans(1, 'c', 1));
     }
 }
+
+TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
+    Nfa aut{20};
+    FILL_WITH_AUT_A(aut);
+    aut.add_trans(0, EPSILON, 3);
+    aut.add_trans(3, EPSILON, 3);
+    aut.add_trans(3, EPSILON, 4);
+
+    auto state_eps_trans{ aut.get_epsilon_transitions(0) };
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3 });
+    state_eps_trans = aut.get_epsilon_transitions(3);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+}


### PR DESCRIPTION
This PR:

- Changes default interface from result of function passed via parameter pointer to result returned by function directly by its return value. 
- Adds support for epsilon. Epsilon is the maximal value of symobl data type. It also add back() to OrdVector to enable accesing epsilon transitions faster

What is not included:
-  I did not move the functions returning results via parameter pointer to a special file. Actually, I didn't notice that this was approved on the last meeting and I don't think it is a clear solution. We would need to use friend function or create some kind of helping structure. I think neither one of the options is worth tradeoff for increasing entropy by creating new file. Moreover, any mediocre C++ programmer will understand why there are different signatures for the same function.