### PR TITLE
Improve getting epsilon transitions

### DIFF
--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -775,6 +775,15 @@ public:
      */
     TransitionList::const_iterator get_epsilon_transitions(const State state, const Symbol epsilon = EPSILON) const;
 
+    /**
+     * Return all epsilon transitions from epsilon symbol under given state transitions.
+     * @param[in] state_transitions State transitions from which are epsilon transitions checked.
+     * @param[in] epsilon User can define his favourite epsilon or used default
+     * @return Returns reference element of transition list with epsilon transitions or end of transition list when
+     * there are no epsilon transitions.
+     */
+    static TransitionList::const_iterator get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon = EPSILON) ;
+
 private:
 }; // Nfa
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -768,12 +768,12 @@ public:
 
     /**
      * Return all epsilon transitions from epsilon symbol under a given state.
-     * @param state State from which are epsilon transitions checked
-     * @param epsilon User can define his favourite epsilon or used default
+     * @param[in] state State from which are epsilon transitions checked
+     * @param[in] epsilon User can define his favourite epsilon or used default
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    TransitionList::const_iterator get_epsilon_transitions(const State& state, const Symbol& epsilon = EPSILON) const;
+    TransitionList::const_iterator get_epsilon_transitions(const State state, const Symbol epsilon = EPSILON) const;
 
 private:
 }; // Nfa

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1259,19 +1259,22 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
 
 TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const Symbol epsilon) const {
     assert(is_state(state));
-    const auto& trans_from{ get_transitions_from(state) };
-    if (!trans_from.empty()) {
+    return get_epsilon_transitions(get_transitions_from(state));
+}
+
+TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const TransitionList& state_transitions, const Symbol epsilon) {
+    if (!state_transitions.empty()) {
         if (epsilon == EPSILON) {
-            const auto& back = trans_from.back();
+            const auto& back = state_transitions.back();
             if (back.symbol == epsilon) {
-                return std::prev(trans_from.end());
+                return std::prev(state_transitions.end());
             }
         } else {
-            return trans_from.find(TransSymbolStates(epsilon));
+            return state_transitions.find(TransSymbolStates(epsilon));
         }
     }
 
-    return trans_from.end();
+    return state_transitions.end();
 }
 
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1257,34 +1257,21 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
     return res;
 }
 
-TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State& state, const Symbol& epsilon) const {
-    assert(get_num_of_states() >= state + 1);
-    const auto trans_from = this->get_transitions_from(state);
-    if (trans_from.empty()) {
-        return trans_from.end();
-    }
-
-    if (epsilon == EPSILON) {
-        auto& back = this->get_transitions_from(state).back();
-        if (back.symbol == epsilon) {
-            return std::prev(trans_from.end());
+TransitionList::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const Symbol epsilon) const {
+    assert(is_state(state));
+    const auto& trans_from{ get_transitions_from(state) };
+    if (!trans_from.empty()) {
+        if (epsilon == EPSILON) {
+            const auto& back = trans_from.back();
+            if (back.symbol == epsilon) {
+                return std::prev(trans_from.end());
+            }
         } else {
-            return trans_from.end();
-        }
-    } else {
-        const auto eps_trans = TransSymbolStates(epsilon);
-        const auto it = std::lower_bound(trans_from.begin(),
-                           trans_from.end(),
-                           eps_trans,
-                           [](TransSymbolStates x, const TransSymbolStates& y){return x.symbol == y.symbol;});
-        if (it != trans_from.end()) {
-            return std::prev(trans_from.end());
-        } else {
-            return trans_from.end();
+            return trans_from.find(TransSymbolStates(epsilon));
         }
     }
 
-    assert(false);
+    return trans_from.end();
 }
 
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2831,4 +2831,25 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     state_eps_trans = aut.get_epsilon_transitions(3);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+
+    CHECK(aut.get_epsilon_transitions(1) == aut.get_transitions_from(1).end());
+    CHECK(aut.get_epsilon_transitions(5) == aut.get_transitions_from(5).end());
+    CHECK(aut.get_epsilon_transitions(19) == aut.get_transitions_from(19).end());
+
+    auto state_transitions{ aut.transitionrelation[0] };
+    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3 });
+    state_transitions = aut.transitionrelation[3];
+    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+
+    state_transitions = aut.get_transitions_from(1);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+    state_transitions = aut.get_transitions_from(5);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+    state_transitions = aut.get_transitions_from(19);
+    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+
 }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2817,3 +2817,18 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         CHECK(nfa.has_trans(1, 'c', 1));
     }
 }
+
+TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
+    Nfa aut{20};
+    FILL_WITH_AUT_A(aut);
+    aut.add_trans(0, EPSILON, 3);
+    aut.add_trans(3, EPSILON, 3);
+    aut.add_trans(3, EPSILON, 4);
+
+    auto state_eps_trans{ aut.get_epsilon_transitions(0) };
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3 });
+    state_eps_trans = aut.get_epsilon_transitions(3);
+    CHECK(state_eps_trans->symbol == EPSILON);
+    CHECK(state_eps_trans->states_to == StateSet{ 3, 4 });
+}


### PR DESCRIPTION
I have simplified this function and extended its functionality with overloaded function allowing to get epsilon transitions from passed `TransSymbolStates` struct usually used in most algorithms. This new function will be called from within Mata algorithms rather than the function with state as a parameter.

