### PR TITLE
Unify alphabets

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -196,6 +196,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         vector[CTrans] get_trans_from_as_sequence(State)
         void trim()
         void get_digraph(CNfa&)
+        bool is_epsilon(Symbol)
         StateSet get_useful_states()
         StateSet get_reachable_states()
         StateSet get_terminating_states()
@@ -267,7 +268,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
 
 cdef extern from "mata/noodlify.hh" namespace "Mata::Nfa::SegNfa":
     ctypedef vector[vector[shared_ptr[CNfa]]] NoodleSequence
-    
+
     cdef NoodleSequence noodlify(CNfa&, Symbol, bool)
     cdef NoodleSequence noodlify_for_equation(const AutPtrSequence&, CNfa&, bool, StringDict&)
 

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -243,27 +243,15 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef cppclass CAlphabet "Mata::Nfa::Alphabet":
         CAlphabet() except +
 
-    cdef cppclass CCharAlphabet "Mata::Nfa::CharAlphabet" (CAlphabet):
-        CCharAlphabet() except +
-        Symbol translate_symb(string)
-        clist[Symbol] get_symbols()
-
-    cdef cppclass CDirectAlphabet "Mata::Nfa::DirectAlphabet" (CAlphabet):
-        CDirectAlphabet() except +
-        Symbol translate_symb(string)
-        clist[Symbol] get_symbols()
-
-    cdef cppclass CEnumAlphabet "Mata::Nfa::EnumAlphabet" (CAlphabet):
-        CEnumAlphabet() except +
-        CEnumAlphabet(vector[string].iterator, vector[string].iterator) except +
-        Symbol translate_symb(string) except +
-        clist[Symbol] get_symbols()
-
     cdef cppclass COnTheFlyAlphabet "Mata::Nfa::OnTheFlyAlphabet" (CAlphabet):
-        StringToSymbolMap* symbol_map
-        COnTheFlyAlphabet(StringToSymbolMap*, Symbol) except +
+        StringToSymbolMap symbol_map
+        COnTheFlyAlphabet(StringToSymbolMap) except +
+        COnTheFlyAlphabet(Symbol) except +
+        COnTheFlyAlphabet(COnTheFlyAlphabet) except +
         Symbol translate_symb(string)
         clist[Symbol] get_symbols()
+        StringToSymbolMap get_symbol_map()
+        StringToSymbolMap add_symbols_from(StringToSymbolMap)
 
     cdef cppclass CSegmentation "Mata::Nfa::SegNfa::Segmentation":
         CSegmentation(CNfa&, Symbol) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -248,10 +248,12 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         COnTheFlyAlphabet(StringToSymbolMap) except +
         COnTheFlyAlphabet(Symbol) except +
         COnTheFlyAlphabet(COnTheFlyAlphabet) except +
+        COnTheFlyAlphabet(vector[string]) except +
         Symbol translate_symb(string)
         clist[Symbol] get_symbols()
         StringToSymbolMap get_symbol_map()
         StringToSymbolMap add_symbols_from(StringToSymbolMap)
+        StringToSymbolMap add_symbols_from(vector[string])
 
     cdef cppclass CSegmentation "Mata::Nfa::SegNfa::Segmentation":
         CSegmentation(CNfa&, Symbol) except +

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -523,6 +523,14 @@ cdef class Nfa:
         self.thisptr.get().get_digraph(dereference(digraph.thisptr.get()))
         return digraph
 
+    def is_epsilon(self, Symbol symbol) -> bool:
+        """
+        Check whether passed symbol is epsilon symbol or not.
+        :param Symbol symbol: The symbol to check.
+        :return: True if the passed symbol is epsilon symbol, False otherwise.
+        """
+        return self.thisptr.get().is_epsilon(symbol)
+
     def __str__(self):
         """String representation of the automaton displays states, and transitions
 

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -1296,8 +1296,19 @@ cdef class OnTheFlyAlphabet(Alphabet):
 
     @classmethod
     def from_symbol_map(cls, symbol_map: dict[str, int]) -> OnTheFlyAlphabet:
+        """
+        Create on the fly alphabet filled with symbol_map.
+        :param symbol_map: Map mapping symbol names to symbol values.
+        :return: On the fly alphabet.
+        """
         alphabet = cls()
         alphabet.add_symbols_from_symbol_map(symbol_map)
+        return alphabet
+
+    @classmethod
+    def for_symbol_names(cls, symbol_map: list[str]) -> OnTheFlyAlphabet:
+        alphabet = cls()
+        alphabet.add_symbols_for_names(symbol_map)
         return alphabet
 
     def add_symbols_from_symbol_map(self, symbol_map: dict[str, int]) -> None:
@@ -1309,6 +1320,16 @@ cdef class OnTheFlyAlphabet(Alphabet):
         for symbol, value in symbol_map.items():
             c_symbol_map[symbol.encode('utf-8')] = value
         self.thisptr.add_symbols_from(c_symbol_map)
+
+    def add_symbols_for_names(self, symbol_names: list[str]) -> None:
+        """
+        Add symbols for symbol names to the current alphabet.
+        :param symbol_names: Vector of symbol names.
+        """
+        cdef vector[string] c_symbol_names
+        for symbol_name in symbol_names:
+            c_symbol_names.push_back(symbol_name.encode('utf-8'))
+        self.thisptr.add_symbols_from(c_symbol_names)
 
     def __dealloc__(self):
         del self.thisptr

--- a/bindings/python/tests/test_alphabets.py
+++ b/bindings/python/tests/test_alphabets.py
@@ -4,36 +4,37 @@ import mata
 import pytest
 
 
-def test_char_alphabet():
-    """Tests character alphabet
-
-    CharacterAlphabet translates escaped characters ('a' or "a") into their ascii
-    representation. Integers are kept as they are, other strings are translated to 0.
+def test_on_the_fly_alphabet_with_character_symbols():
     """
-    alphabet = mata.CharAlphabet()
-    assert alphabet.translate_symbol("'a'") == 97
-    assert alphabet.translate_symbol("'b'") == 98
-    assert alphabet.translate_symbol("b") == 0
-    assert alphabet.translate_symbol("1") == 1
-    assert alphabet.translate_symbol("10") == 10
-    assert alphabet.translate_symbol("ahoj") == 0
-    assert alphabet.translate_symbol('"a"') == 97
-    assert alphabet.translate_symbol('"0"') == 48
+    Tests on the fly alphabet with character symbols.
 
-
-def test_enum_alphabet():
-    """Tests enumerated alphabet
-
-    EnumAlphabet translates integers based on fixed list of values.
+    OnTheFlyAlphabet translates the symbols into values on-the-fly, based on a given counter.
     """
-    alphabet = mata.EnumAlphabet(['a', 'b', 'c'])
+    alphabet = mata.OnTheFlyAlphabet()
+    assert alphabet.translate_symbol("'a'") == 0
+    assert alphabet.translate_symbol("'b'") == 1
+    assert alphabet.translate_symbol("b") == 2
+    assert alphabet.translate_symbol("1") == 3
+    assert alphabet.translate_symbol("10") == 4
+    assert alphabet.translate_symbol("ahoj") == 5
+    assert alphabet.translate_symbol('"a"') == 6
+    assert alphabet.translate_symbol('"0"') == 7
+
+
+def test_on_the_fly_alphabet_with_enumeration_of_symbols():
+    """
+    Tests on the fly alphabet.
+
+    OnTheFlyAlphabet translates the symbols into values on-the-fly, based on a given counter.
+    """
+    alphabet = mata.OnTheFlyAlphabet.from_symbol_map({'a': 0, 'b': 1, 'c': 2})
     assert alphabet.translate_symbol('a') == 0
     assert alphabet.translate_symbol('b') == 1
     assert alphabet.translate_symbol('c') == 2
-    with pytest.raises(RuntimeError):
-        assert alphabet.translate_symbol('d') == 2
-    with pytest.raises(RuntimeError):
-        _ = mata.EnumAlphabet(['a', 'a', 'c'])
+    # TODO: Decide on a unified format of specifying that the alphabet cannot be modified (new symbols cannot be added)
+    #  and propagate the information to the Python binding as well.
+    #with pytest.raises(RuntimeError):
+    #    assert alphabet.translate_symbol('d') == 2
 
 
 def test_on_the_fly_alphabet():

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -329,7 +329,7 @@ def test_inclusion(
     # Test equivalence of two NFAs.
     smaller = mata.Nfa(10)
     bigger = mata.Nfa(16)
-    alph = ["a", "b"]
+    symbol_map = {"a": ord("a"), "b": ord("b")}
     smaller.make_initial_state(1)
     smaller.make_final_state(1)
     smaller.add_trans_raw(1, ord('a'), 1)
@@ -349,22 +349,22 @@ def test_inclusion(
     bigger.add_trans_raw(13, ord('b'), 15)
     bigger.add_trans_raw(15, ord('b'), 15)
 
-    assert not mata.Nfa.equivalence_check(smaller, bigger, mata.EnumAlphabet(alph))
+    assert not mata.Nfa.equivalence_check(smaller, bigger, mata.OnTheFlyAlphabet.from_symbol_map(symbol_map))
     assert not mata.Nfa.equivalence_check(smaller, bigger)
-    assert not mata.Nfa.equivalence_check(bigger, smaller, mata.EnumAlphabet(alph))
+    assert not mata.Nfa.equivalence_check(bigger, smaller, mata.OnTheFlyAlphabet.from_symbol_map(symbol_map))
     assert not mata.Nfa.equivalence_check(bigger, smaller)
 
     smaller = mata.Nfa(10)
     bigger = mata.Nfa(16)
-    alph = []
+    symbol_map = {}
     smaller.initial_states = [1]
     smaller.final_states = [1]
     bigger.initial_states = [11]
     bigger.final_states = [11]
 
-    assert mata.Nfa.equivalence_check(smaller, bigger, mata.EnumAlphabet(alph))
+    assert mata.Nfa.equivalence_check(smaller, bigger, mata.OnTheFlyAlphabet.from_symbol_map(symbol_map))
     assert mata.Nfa.equivalence_check(smaller, bigger)
-    assert mata.Nfa.equivalence_check(bigger, smaller, mata.EnumAlphabet(alph))
+    assert mata.Nfa.equivalence_check(bigger, smaller, mata.OnTheFlyAlphabet.from_symbol_map(symbol_map))
     assert mata.Nfa.equivalence_check(bigger, smaller)
 
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -1099,3 +1099,11 @@ def test_get_epsilon_transitions():
     assert epsilon_transitions.states_to == [5, 6]
 
     assert nfa.get_epsilon_transitions(5) is None
+
+
+def test_is_epsilon():
+    nfa = mata.Nfa()
+    assert nfa.is_epsilon(mata.epsilon())
+    assert not nfa.is_epsilon(0)
+
+    # TODO: Add checks for user-specified epsilons when user-specified epsilons are implemented.

--- a/examples/example-jupyter.ipynb
+++ b/examples/example-jupyter.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "enum_alphabet = mata.EnumAlphabet(['red', 'blue', 'yellow', 'black', 'white'])"
+    "alphabet = mata.OnTheFlyAlphabet.for_symbol_names(['red', 'blue', 'yellow', 'black', 'white'])"
    ]
   },
   {
@@ -28,12 +28,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lhs = mata.Nfa(3, enum_alphabet)\n",
+    "lhs = mata.Nfa(3, alphabet)\n",
     "lhs.make_initial_state(0)\n",
-    "lhs.add_trans_raw(0, enum_alphabet.translate_symbol('red'), 1)\n",
-    "lhs.add_trans_raw(0, enum_alphabet.translate_symbol('yellow'), 1)\n",
-    "lhs.add_trans_raw(1, enum_alphabet.translate_symbol('blue'), 2)\n",
-    "lhs.add_trans_raw(1, enum_alphabet.translate_symbol('black'), 2)\n",
+    "lhs.add_trans_raw(0, alphabet.translate_symbol('red'), 1)\n",
+    "lhs.add_trans_raw(0, alphabet.translate_symbol('yellow'), 1)\n",
+    "lhs.add_trans_raw(1, alphabet.translate_symbol('blue'), 2)\n",
+    "lhs.add_trans_raw(1, alphabet.translate_symbol('black'), 2)\n",
     "lhs.make_final_state(2)"
    ]
   },
@@ -41,7 +41,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "45eafb69",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "lhs.to_dot_file('lhs', 'svg')\n",
@@ -55,12 +59,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rhs = mata.Nfa(3, enum_alphabet)\n",
+    "rhs = mata.Nfa(3, alphabet)\n",
     "rhs.make_initial_state(0)\n",
-    "rhs.add_trans_raw(0, enum_alphabet.translate_symbol('white'), 1)\n",
-    "rhs.add_trans_raw(0, enum_alphabet.translate_symbol('yellow'), 1)\n",
-    "rhs.add_trans_raw(1, enum_alphabet.translate_symbol('blue'), 2)\n",
-    "rhs.add_trans_raw(1, enum_alphabet.translate_symbol('red'), 2)\n",
+    "rhs.add_trans_raw(0, alphabet.translate_symbol('white'), 1)\n",
+    "rhs.add_trans_raw(0, alphabet.translate_symbol('yellow'), 1)\n",
+    "rhs.add_trans_raw(1, alphabet.translate_symbol('blue'), 2)\n",
+    "rhs.add_trans_raw(1, alphabet.translate_symbol('red'), 2)\n",
     "rhs.make_final_state(2)"
    ]
   },
@@ -78,13 +82,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "85acd260",
+   "metadata": {},
    "outputs": [],
    "source": [
     "union = mata.Nfa.union(lhs, rhs)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -124,7 +127,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -138,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.7"
   }
  },
  "nbformat": 4,

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -94,66 +94,6 @@ public:
     virtual ~Alphabet() { }
 };
 
-class OnTheFlyAlphabet : public Alphabet
-{
-private:
-    StringToSymbolMap* symbol_map;
-    Symbol cnt_symbol;
-
-private:
-    OnTheFlyAlphabet(const OnTheFlyAlphabet& rhs);
-    OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs);
-
-public:
-
-    explicit OnTheFlyAlphabet(StringToSymbolMap* str_sym_map, Symbol init_symbol = 0) :
-            symbol_map(str_sym_map), cnt_symbol(init_symbol)
-    {
-        assert(nullptr != symbol_map);
-    }
-
-    std::list<Symbol> get_symbols() const override;
-    Symbol translate_symb(const std::string& str) override;
-    std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
-};
-
-class DirectAlphabet : public Alphabet
-{
-public:
-    Symbol translate_symb(const std::string& str) override
-    {
-        Symbol symb;
-        std::istringstream stream(str);
-        stream >> symb;
-        return symb;
-    }
-};
-
-class CharAlphabet : public Alphabet
-{
-public:
-
-    Symbol translate_symb(const std::string& str) override
-    {
-        if (str.length() == 3 &&
-            ((str[0] == '\'' && str[2] == '\'') ||
-             (str[0] == '\"' && str[2] == '\"')
-            ))
-        { // direct occurrence of a character
-            return str[1];
-        }
-
-        Symbol symb;
-        std::istringstream stream(str);
-        stream >> symb;
-        return symb;
-    }
-
-    std::list<Symbol> get_symbols() const override;
-    std::list<Symbol> get_complement(
-            const std::set<Symbol>& syms) const override;
-};
-
 const PostSymb EMPTY_POST{};
 
 static constexpr struct Limits {
@@ -1109,62 +1049,6 @@ bool is_deterministic(const Nfa& aut);
 /// symbol.
 bool is_complete(const Nfa& aut, const Alphabet& alphabet);
 
-/** Loads an automaton from Parsed object */
-Nfa construct(
-        const Mata::Parser::ParsedSection&   parsec,
-        Alphabet*                            alphabet,
-        StringToStateMap*                    state_map = nullptr);
-
-/** Loads an automaton from Parsed object */
-Nfa construct(
-        const Mata::IntermediateAut&         inter_aut,
-        Alphabet*                            alphabet,
-        StringToStateMap*                    state_map = nullptr);
-
-template <class ParsedObject>
-Nfa construct(
-        const ParsedObject&                  parsed,
-        StringToSymbolMap*                   symbol_map = nullptr,
-        StringToStateMap*                    state_map = nullptr)
-{ // {{{
-    Nfa aut;
-
-    bool remove_symbol_map = false;
-    if (nullptr == symbol_map)
-    {
-        symbol_map = new StringToSymbolMap();
-        remove_symbol_map = true;
-    }
-
-    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
-
-    Mata::Nfa::OnTheFlyAlphabet alphabet(symbol_map);
-
-    try
-    {
-        aut = construct(parsed, &alphabet, state_map);
-    }
-    catch (std::exception&)
-    {
-        release_res();
-        throw;
-    }
-
-    release_res();
-    return aut;
-}
-
-/** Loads an automaton from Parsed object */
-template <class ParsedObject>
-void construct(
-        Nfa*                                 result,
-        const ParsedObject&                  parsed,
-        StringToSymbolMap*                   symbol_map = nullptr,
-        StringToStateMap*                    state_map = nullptr)
-{ // {{{
-    *result = construct(parsed, symbol_map, state_map);
-} // construct }}}
-
 std::pair<Word, bool> get_word_for_path(const Nfa& aut, const Path& path);
 
 /// Checks whether a string is in the language of an automaton
@@ -1406,13 +1290,21 @@ private:
     static void update_current_words(LengthWordsPair& act, const LengthWordsPair& dst, Symbol symbol);
 }; // class ShortestWordsMap.
 
-class EnumAlphabet : public Alphabet
-{
+class OnTheFlyAlphabet : public Alphabet {
 public:
     using InsertionResult = std::pair<StringToSymbolMap::const_iterator, bool>; ///< Result of the insertion of a new symbol.
 
-    EnumAlphabet() = default;
-    EnumAlphabet(const EnumAlphabet& rhs) : symbol_map(rhs.symbol_map), next_symbol_value(rhs.next_symbol_value) {}
+    OnTheFlyAlphabet() = default;
+    OnTheFlyAlphabet(const OnTheFlyAlphabet& rhs) : symbol_map(rhs.symbol_map), next_symbol_value(rhs.next_symbol_value) {}
+
+    explicit OnTheFlyAlphabet(const StringToSymbolMap& str_sym_map, Symbol init_symbol = 0)
+        : symbol_map(str_sym_map), next_symbol_value(init_symbol) {}
+
+    std::list<Symbol> get_symbols() const override;
+    std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
+
+private:
+    OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs);
 
 private:
     // Adapted from: https://www.fluentcpp.com/2019/01/25/variadic-number-function-parameters-type/.
@@ -1432,8 +1324,8 @@ public:
      * @return Created alphabet.
      */
     template<typename... Nfas, typename = AreAllNfas<Nfas...>>
-    static EnumAlphabet from_nfas(const Nfas&... nfas) {
-        EnumAlphabet alphabet{};
+    static OnTheFlyAlphabet from_nfas(const Nfas&... nfas) {
+        OnTheFlyAlphabet alphabet{};
         // TODO: When we are on C++17, we can use fold expression here instead of the manual for_each_argument reimplementation.
         for_each_argument([&alphabet](const Nfa& aut) {
             fill_alphabet(aut, alphabet);
@@ -1446,8 +1338,8 @@ public:
      * @param[in] nfas Vector of NFAs to create alphabet from.
      * @return Created alphabet.
      */
-    static EnumAlphabet from_nfas(const ConstAutRefSequence& nfas) {
-        EnumAlphabet alphabet{};
+    static OnTheFlyAlphabet from_nfas(const ConstAutRefSequence& nfas) {
+        OnTheFlyAlphabet alphabet{};
         for (const auto& nfa: nfas) {
             fill_alphabet(nfa, alphabet);
         }
@@ -1459,8 +1351,8 @@ public:
      * @param[in] nfas Vector of NFAs to create alphabet from.
      * @return Created alphabet.
      */
-    static EnumAlphabet from_nfas(const AutRefSequence& nfas) {
-        EnumAlphabet alphabet{};
+    static OnTheFlyAlphabet from_nfas(const AutRefSequence& nfas) {
+        OnTheFlyAlphabet alphabet{};
         for (const auto& nfa: nfas) {
             fill_alphabet(nfa, alphabet);
         }
@@ -1472,8 +1364,8 @@ public:
      * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
      * @return Created alphabet.
      */
-    static EnumAlphabet from_nfas(const ConstAutPtrSequence& nfas) {
-        EnumAlphabet alphabet{};
+    static OnTheFlyAlphabet from_nfas(const ConstAutPtrSequence& nfas) {
+        OnTheFlyAlphabet alphabet{};
         for (const Nfa* const nfa: nfas) {
             fill_alphabet(*nfa, alphabet);
         }
@@ -1485,8 +1377,8 @@ public:
      * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
      * @return Created alphabet.
      */
-    static EnumAlphabet from_nfas(const AutPtrSequence& nfas) {
-        EnumAlphabet alphabet{};
+    static OnTheFlyAlphabet from_nfas(const AutPtrSequence& nfas) {
+        OnTheFlyAlphabet alphabet{};
         for (const Nfa* const nfa: nfas) {
             fill_alphabet(*nfa, alphabet);
         }
@@ -1500,27 +1392,33 @@ public:
     void add_symbols_from(const Nfa& nfa);
 
     template <class InputIt>
-    EnumAlphabet(InputIt first, InputIt last) : EnumAlphabet() {
+    OnTheFlyAlphabet(InputIt first, InputIt last) : OnTheFlyAlphabet() {
         for (; first != last; ++first) {
             add_new_symbol(*first, next_symbol_value);
         }
     }
 
-    EnumAlphabet(std::initializer_list<std::string> l) : EnumAlphabet(l.begin(), l.end()) {}
+    OnTheFlyAlphabet(std::initializer_list<std::string> l) : OnTheFlyAlphabet(l.begin(), l.end()) {}
 
     Symbol translate_symb(const std::string& str) override
     {
-        auto it = symbol_map.find(str);
-        if (symbol_map.end() == it)
-        {
-            throw std::runtime_error("unknown symbol \'" + str + "\'");
+        const auto it_insert_pair = symbol_map.insert({str, next_symbol_value});
+        if (it_insert_pair.second) {
+            return next_symbol_value++;
+        } else {
+            return it_insert_pair.first->second;
         }
 
-        return it->second;
-    }
+        // TODO: How can the user specify to throw exceptions when we encounter an unknown symbol? How to specify that
+        //  the alphabet should have a only the previously fixed symbols?
+        //auto it = symbol_map.find(str);
+        //if (symbol_map.end() == it)
+        //{
+        //    throw std::runtime_error("unknown symbol \'" + str + "\'");
+        //}
 
-    std::list<Symbol> get_symbols() const override;
-    std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
+        //return it->second;
+    }
 
     /**
      * @brief Add new symbol to the alphabet with the value of @c next_symbol_value.
@@ -1571,16 +1469,20 @@ public:
     }
 
     /**
-     * Get next value for a potential new symbol.
+     * Get the next value for a potential new symbol.
      * @return Next Symbol value.
      */
     Symbol get_next_value() const { return next_symbol_value; }
 
+    /**
+     * Get the number of existing symbols, epsilon symbols excluded.
+     * @return The number of symbols.
+     */
+    size_t get_number_of_symbols() const { return next_symbol_value; }
+
 private:
     StringToSymbolMap symbol_map{}; ///< Map of string transition symbols to symbol values.
     Symbol next_symbol_value{}; ///< Next value to be used for a newly added symbol.
-
-    EnumAlphabet& operator=(const EnumAlphabet& rhs);
 
     // Adapted from: https://stackoverflow.com/a/41623721.
     template <typename TF, typename... Ts>
@@ -1607,7 +1509,7 @@ private:
      * @param[in] nfa NFA with symbols to fill @p alphabet with.
      * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
      */
-    static void fill_alphabet(const Nfa& nfa, EnumAlphabet& alphabet) {
+    static void fill_alphabet(const Nfa& nfa, OnTheFlyAlphabet& alphabet) {
         size_t nfa_num_of_states{ nfa.get_num_of_states() };
         for (State state{ 0 }; state < nfa_num_of_states; ++state) {
             for (const auto& state_transitions: nfa.transitionrelation[state]) {
@@ -1616,7 +1518,63 @@ private:
             }
         }
     }
-}; // class EnumAlphabet.
+}; // class OnTheFlyAlphabet.
+
+/** Loads an automaton from Parsed object */
+Nfa construct(
+        const Mata::Parser::ParsedSection&   parsec,
+        Alphabet*                            alphabet,
+        StringToStateMap*                    state_map = nullptr);
+
+/** Loads an automaton from Parsed object */
+Nfa construct(
+        const Mata::IntermediateAut&         inter_aut,
+        Alphabet*                            alphabet,
+        StringToStateMap*                    state_map = nullptr);
+
+template <class ParsedObject>
+Nfa construct(
+        const ParsedObject&                  parsed,
+        StringToSymbolMap*                   symbol_map = nullptr,
+        StringToStateMap*                    state_map = nullptr)
+{ // {{{
+    Nfa aut;
+
+    bool remove_symbol_map = false;
+    if (nullptr == symbol_map)
+    {
+        symbol_map = new StringToSymbolMap();
+        remove_symbol_map = true;
+    }
+
+    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
+
+    Mata::Nfa::OnTheFlyAlphabet alphabet(*symbol_map);
+
+    try
+    {
+        aut = construct(parsed, &alphabet, state_map);
+    }
+    catch (std::exception&)
+    {
+        release_res();
+        throw;
+    }
+
+    release_res();
+    return aut;
+}
+
+/** Loads an automaton from Parsed object */
+template <class ParsedObject>
+void construct(
+        Nfa*                                 result,
+        const ParsedObject&                  parsed,
+        StringToSymbolMap*                   symbol_map = nullptr,
+        StringToStateMap*                    state_map = nullptr)
+{ // {{{
+    *result = construct(parsed, symbol_map, state_map);
+} // construct }}}
 
 // CLOSING NAMESPACES AND GUARDS
 } /* Nfa */

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -632,6 +632,19 @@ public:
     Nfa get_digraph(Symbol abstract_symbol = 'x') const;
 
     /**
+     * Check whether @p symbol is epsilon symbol or not.
+     * @param symbol Symbol to check.
+     * @return True if the passed @p symbol is epsilon, false otherwise.
+     */
+    bool is_epsilon(Symbol symbol) const {
+        // TODO: When multiple epsilon symbols specificatin inside the alphabets is implemented, update this check to
+        //  reflect the new changes:
+        //  Check for alphabet in the NFA, check for specified epsilon symbol and compare. Otherwise, compare with the
+        //  default epsilon symbol EPSILON.
+        return symbol == EPSILON;
+    }
+
+    /**
      * Unify transitions to create a directed graph with at most a single transition between two states.
      *
      * @param[out] result An automaton representing a directed graph.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1294,11 +1294,11 @@ class OnTheFlyAlphabet : public Alphabet {
 public:
     using InsertionResult = std::pair<StringToSymbolMap::const_iterator, bool>; ///< Result of the insertion of a new symbol.
 
-    OnTheFlyAlphabet() = default;
+    explicit OnTheFlyAlphabet(Symbol init_symbol = 0) : next_symbol_value(init_symbol) {};
     OnTheFlyAlphabet(const OnTheFlyAlphabet& rhs) : symbol_map(rhs.symbol_map), next_symbol_value(rhs.next_symbol_value) {}
 
-    explicit OnTheFlyAlphabet(const StringToSymbolMap& str_sym_map, Symbol init_symbol = 0)
-        : symbol_map(str_sym_map), next_symbol_value(init_symbol) {}
+    explicit OnTheFlyAlphabet(const StringToSymbolMap& str_sym_map)
+        : symbol_map(str_sym_map) {}
 
     std::list<Symbol> get_symbols() const override;
     std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
@@ -1386,10 +1386,20 @@ public:
     }
 
     /**
-     * Expand alphabet by symbols from the passed @p nfa.
+     * @brief Expand alphabet by symbols from the passed @p nfa.
+     *
+     * The value of the already existing symbols will NOT be overwritten.
      * @param[in] nfa Automaton with whose transition symbols to expand the current alphabet.
      */
     void add_symbols_from(const Nfa& nfa);
+
+    /**
+     * @brief Expand alphabet by symbols from the passed @p symbol_map.
+     *
+     * The value of the already existing symbols will NOT be overwritten.
+     * @param[in] new_symbol_map Map of strings to symbols.
+     */
+    void add_symbols_from(const StringToSymbolMap& new_symbol_map);
 
     template <class InputIt>
     OnTheFlyAlphabet(InputIt first, InputIt last) : OnTheFlyAlphabet() {
@@ -1480,6 +1490,12 @@ public:
      */
     size_t get_number_of_symbols() const { return next_symbol_value; }
 
+    /**
+     * Get the symbol map used in the alphabet.
+     * @return Map mapping strings to symbols used internally in Mata.
+     */
+    const StringToSymbolMap& get_symbol_map() const { return symbol_map; }
+
 private:
     StringToSymbolMap symbol_map{}; ///< Map of string transition symbols to symbol values.
     Symbol next_symbol_value{}; ///< Next value to be used for a newly added symbol.
@@ -1562,6 +1578,9 @@ Nfa construct(
     }
 
     release_res();
+    if (!remove_symbol_map) {
+        *symbol_map = alphabet.get_symbol_map();
+    }
     return aut;
 }
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1300,6 +1300,14 @@ public:
     explicit OnTheFlyAlphabet(const StringToSymbolMap& str_sym_map)
         : symbol_map(str_sym_map) {}
 
+    /**
+     * Create alphabet from a list of symbol names.
+     * @param symbol_names Names for symbols on transitions.
+     * @param init_symbol Start of a sequence of values to use for new symbols.
+     */
+    explicit OnTheFlyAlphabet(const std::vector<std::string>& symbol_names, Symbol init_symbol = 0)
+            : symbol_map(), next_symbol_value(init_symbol) { add_symbols_from(symbol_names); }
+
     std::list<Symbol> get_symbols() const override;
     std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
 
@@ -1392,6 +1400,18 @@ public:
      * @param[in] nfa Automaton with whose transition symbols to expand the current alphabet.
      */
     void add_symbols_from(const Nfa& nfa);
+
+    /**
+     * @brief Expand alphabet by symbols from the passed @p symbol_names.
+     *
+     * Adding a symbol name which already exists will throw an exception.
+     * @param[in] symbol_names Vector of symbol names.
+     */
+    void add_symbols_from(const std::vector<std::string>& symbol_names) {
+        for (const std::string& symbol_name: symbol_names) {
+            add_new_symbol(symbol_name);
+        }
+    }
 
     /**
      * @brief Expand alphabet by symbols from the passed @p symbol_map.

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -336,7 +336,7 @@ void Mata::Afa::construct(
 
 	auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
 
-  Mata::Nfa::OnTheFlyAlphabet alphabet(symbol_map);
+    Mata::Nfa::OnTheFlyAlphabet alphabet(*symbol_map);
 
 	try
 	{
@@ -405,4 +405,3 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::AfaWrapper& afa
 		"|state_dict: " << std::to_string(afa_wrap.state_dict) << "}";
 	return os;
 } // operator<<(AfaWrapper) }}}
-

--- a/src/nfa/nfa-incl.cc
+++ b/src/nfa/nfa-incl.cc
@@ -33,7 +33,7 @@ bool is_incl_naive(
 { // {{{
     Nfa bigger_cmpl;
     if (alphabet == nullptr) {
-        bigger_cmpl = complement(bigger, EnumAlphabet::from_nfas(smaller, bigger));
+        bigger_cmpl = complement(bigger, OnTheFlyAlphabet::from_nfas(smaller, bigger));
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
@@ -243,7 +243,7 @@ bool Mata::Nfa::equivalence_check(const Nfa& lhs, const Nfa& rhs, const Alphabet
 
     if (params.at("algo") == "naive") {
         if (alphabet == nullptr) {
-            const auto computed_alphabet{ EnumAlphabet::from_nfas(lhs, rhs) };
+            const auto computed_alphabet{ OnTheFlyAlphabet::from_nfas(lhs, rhs) };
             return compute_equivalence(lhs, rhs, &computed_alphabet, params, algo);
         }
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -344,6 +344,13 @@ void OnTheFlyAlphabet::add_symbols_from(const Nfa& nfa) {
     }
 }
 
+void OnTheFlyAlphabet::add_symbols_from(const StringToSymbolMap& new_symbol_map) {
+    for (const auto& symbol_binding: new_symbol_map) {
+        update_next_symbol_value(symbol_binding.second);
+        try_add_new_symbol(symbol_binding.first, symbol_binding.second);
+    }
+}
+
 ///// Nfa structure related methods
 
 void Nfa::add_trans(State state_from, Symbol symbol, State state_to) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -311,33 +311,19 @@ std::ostream &std::operator<<(std::ostream &os, const Mata::Nfa::Trans &trans) {
 
 ////// Alphabet related functions
 
-Symbol OnTheFlyAlphabet::translate_symb(const std::string& str)
-{ // {{{
-    auto it_insert_pair = symbol_map->insert({str, cnt_symbol});
-    if (it_insert_pair.second) { return cnt_symbol++; }
-    else { return it_insert_pair.first->second; }
-} // OnTheFlyAlphabet::translate_symb }}}
-
-std::list<Symbol> OnTheFlyAlphabet::get_symbols() const
-{ // {{{
+std::list<Symbol> OnTheFlyAlphabet::get_symbols() const { // {{{
 	std::list<Symbol> result;
-	for (const auto& str_sym_pair : *(this->symbol_map))
-	{
+	for (const auto& str_sym_pair : symbol_map) {
 		result.push_back(str_sym_pair.second);
 	}
-
 	return result;
 } // OnTheFlyAlphabet::get_symbols }}}
 
-std::list<Symbol> OnTheFlyAlphabet::get_complement(
-        const std::set<Symbol>& syms) const
-{ // {{{
+std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms) const { // {{{
     std::list<Symbol> result;
-
-    // TODO: could be optimized
+    // TODO: Could be optimized.
     std::set<Symbol> symbols_alphabet;
-    for (const auto& str_sym_pair : *(this->symbol_map))
-    {
+    for (const auto& str_sym_pair : symbol_map) {
         symbols_alphabet.insert(str_sym_pair.second);
     }
 
@@ -345,11 +331,10 @@ std::list<Symbol> OnTheFlyAlphabet::get_complement(
             symbols_alphabet.begin(), symbols_alphabet.end(),
             syms.begin(), syms.end(),
             std::inserter(result, result.end()));
-
     return result;
 } // OnTheFlyAlphabet::get_complement }}}
 
-void EnumAlphabet::add_symbols_from(const Nfa& nfa) {
+void OnTheFlyAlphabet::add_symbols_from(const Nfa& nfa) {
     size_t aut_num_of_states{ nfa.get_num_of_states() };
     for (State state{ 0 }; state < aut_num_of_states; ++state) {
         for (const auto& state_transitions: nfa.transitionrelation[state]) {
@@ -358,66 +343,6 @@ void EnumAlphabet::add_symbols_from(const Nfa& nfa) {
         }
     }
 }
-
-std::list<Symbol> CharAlphabet::get_symbols() const
-{ // {{{
-    std::list<Symbol> result;
-    for (size_t i = 0; i < 256; ++i)
-    {
-        result.push_back(i);
-    }
-
-    return result;
-} // CharAlphabet::get_symbols }}}
-
-std::list<Symbol> CharAlphabet::get_complement(
-        const std::set<Symbol>& syms) const
-{ // {{{
-    std::list<Symbol> result;
-
-    std::list<Symbol> symb_list = this->get_symbols();
-
-    // TODO: could be optimized
-    std::set<Symbol> symbols_alphabet(symb_list.begin(), symb_list.end());
-
-    std::set_difference(
-            symbols_alphabet.begin(), symbols_alphabet.end(),
-            syms.begin(), syms.end(),
-            std::inserter(result, result.end()));
-
-    return result;
-} // CharAlphabet::get_complement }}}
-
-std::list<Symbol> EnumAlphabet::get_symbols() const
-{ // {{{
-    std::list<Symbol> result;
-    for (const auto& str_sym_pair : this->symbol_map)
-    {
-        result.push_back(str_sym_pair.second);
-    }
-
-    return result;
-} // EnumAlphabet::get_symbols }}}
-
-std::list<Symbol> EnumAlphabet::get_complement(
-        const std::set<Symbol>& syms) const
-{ // {{{
-    std::list<Symbol> result;
-
-    // TODO: could be optimized
-    std::set<Symbol> symbols_alphabet;
-    for (const auto& str_sym_pair : this->symbol_map)
-    {
-        symbols_alphabet.insert(str_sym_pair.second);
-    }
-
-    std::set_difference(
-            symbols_alphabet.begin(), symbols_alphabet.end(),
-            syms.begin(), syms.end(),
-            std::inserter(result, result.end()));
-
-    return result;
-} // EnumAlphabet::get_complement }}}
 
 ///// Nfa structure related methods
 

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -175,7 +175,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
 
     if (left_automata.empty() || is_lang_empty(right_automaton)) { return NoodleSequence{}; }
 
-    auto alphabet{ EnumAlphabet::from_nfas(left_automata) };
+    auto alphabet{ OnTheFlyAlphabet::from_nfas(left_automata) };
     alphabet.add_symbols_from(right_automaton);
     const Symbol epsilon{ alphabet.get_next_value() };
 
@@ -228,7 +228,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
 
     if (left_automata.empty() || is_lang_empty(right_automaton)) { return NoodleSequence{}; }
 
-    auto alphabet{ EnumAlphabet::from_nfas(left_automata) };
+    auto alphabet{ OnTheFlyAlphabet::from_nfas(left_automata) };
     alphabet.add_symbols_from(right_automaton);
     const Symbol epsilon{ alphabet.get_next_value() };
 

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -63,8 +63,7 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 } // }}}
 */
 
-TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()")
-{
+TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()") {
     Nfa a{1};
     a.add_trans(0, 'a', 0);
 
@@ -74,13 +73,13 @@ TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()")
     Nfa c{1};
     b.add_trans(0, 'c', 0);
 
-    auto alphabet{ EnumAlphabet::from_nfas(a, b, c) };
+    auto alphabet{ OnTheFlyAlphabet::from_nfas(a, b, c) };
 
     auto symbols{ alphabet.get_symbols() };
     CHECK(symbols == std::list<Symbol>{ 'c', 'b', 'a' });
 
-    //EnumAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
-    //EnumAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
+    //OnTheFlyAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
+    //OnTheFlyAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
 }
 
 TEST_CASE("Mata::Nfa::Nfa::add_trans()/has_trans()")
@@ -277,7 +276,7 @@ TEST_CASE("Mata::Nfa::union_norename()")
 
 		union_norename(&res, a, b);
 
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		StringDict params;
 		params["algo"] = "antichains";
 
@@ -293,7 +292,7 @@ TEST_CASE("Mata::Nfa::union_norename()")
 
 		union_norename(&res, a, b);
 
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		StringDict params;
 		params["algo"] = "antichains";
 
@@ -953,7 +952,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 	SECTION("empty automaton, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 
 		make_complete(aut, alph, 0);
 
@@ -964,7 +963,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 	SECTION("empty automaton")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 
 		make_complete(aut, alph, 0);
 
@@ -976,7 +975,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 	SECTION("non-empty automaton, empty alphabet")
 	{
-		EnumAlphabet alphabet{};
+		OnTheFlyAlphabet alphabet{};
 
 		aut.initialstates = {1};
 
@@ -990,7 +989,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 	SECTION("one-state automaton")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		const State SINK = 10;
 
 		aut.initialstates = {1};
@@ -1008,7 +1007,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 	SECTION("bigger automaton")
 	{
-		EnumAlphabet alph = {"a", "b", "c"};
+		OnTheFlyAlphabet alph{"a", "b", "c"};
 		const State SINK = 9;
 
 		aut.initialstates = {1, 2};
@@ -1054,7 +1053,7 @@ TEST_CASE("Mata::Nfa::complement()")
 
 	SECTION("empty automaton, empty alphabet")
 	{
-		EnumAlphabet alph = {};
+		OnTheFlyAlphabet alph{};
 
 		cmpl = complement(aut, alph);
 
@@ -1067,7 +1066,7 @@ TEST_CASE("Mata::Nfa::complement()")
 
 	SECTION("empty automaton")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 
 		cmpl = complement(aut, alph);
 
@@ -1092,7 +1091,7 @@ TEST_CASE("Mata::Nfa::complement()")
 
 	SECTION("empty automaton accepting epsilon, empty alphabet")
 	{
-		EnumAlphabet alph = {};
+		OnTheFlyAlphabet alph{};
 		aut.initialstates = {1};
 		aut.finalstates = {1};
 
@@ -1106,7 +1105,7 @@ TEST_CASE("Mata::Nfa::complement()")
 
 	SECTION("empty automaton accepting epsilon")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1};
 		aut.finalstates = {1};
 
@@ -1129,7 +1128,7 @@ TEST_CASE("Mata::Nfa::complement()")
 
 	SECTION("non-empty automaton accepting a*b*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1,2};
 		aut.finalstates = {1,2};
 
@@ -1172,7 +1171,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("empty automaton, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
@@ -1184,7 +1183,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("empty automaton accepting epsilon, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 		aut.initialstates = {1};
 		aut.finalstates = {1};
 
@@ -1199,7 +1198,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("empty automaton accepting epsilon")
 	{
-		EnumAlphabet alph = {"a"};
+		OnTheFlyAlphabet alph{"a"};
 		aut.initialstates = {1};
 		aut.finalstates = {1};
 
@@ -1214,7 +1213,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("automaton for a*b*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1,2};
 		aut.finalstates = {1,2};
 
@@ -1232,7 +1231,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("automaton for a* + b*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1,2};
 		aut.finalstates = {1,2};
 
@@ -1249,7 +1248,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("automaton for (a + b)*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1};
 		aut.finalstates = {1};
 
@@ -1266,7 +1265,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("automaton for eps + (a+b) + (a+b)(a+b)(a* + b*)")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1};
 		aut.finalstates = {1, 2, 3, 4, 5};
 
@@ -1298,7 +1297,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("automaton for epsilon + a(a + b)* + b(a + b)*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1,3};
 		aut.finalstates = {1,2,4};
 
@@ -1319,7 +1318,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("example from Abdulla et al. TACAS'10")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		aut.initialstates = {1,2};
 		aut.finalstates = {1,2,3};
 
@@ -1343,7 +1342,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("subsumption-pruning in processed")
 	{
-		EnumAlphabet alph = {"a"};
+		OnTheFlyAlphabet alph{"a"};
 		aut.initialstates = {1,2};
 		aut.finalstates = {1};
 
@@ -1359,7 +1358,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("wrong parameters 1")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 
 		CHECK_THROWS_WITH(is_universal(aut, alph, params),
 			Catch::Contains("requires setting the \"algo\" key"));
@@ -1367,7 +1366,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 
 	SECTION("wrong parameters 2")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 		params["algo"] = "foo";
 
 		CHECK_THROWS_WITH(is_universal(aut, alph, params),
@@ -1389,7 +1388,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("{} <= {}, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 
 		for (const auto& algo : ALGORITHMS) {
 			params["algo"] = algo;
@@ -1403,7 +1402,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("{} <= {epsilon}, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 		bigger.initialstates = {1};
 		bigger.finalstates = {1};
 
@@ -1419,7 +1418,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("{epsilon} <= {epsilon}, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 		smaller.initialstates = {1};
 		smaller.finalstates = {1};
 		bigger.initialstates = {11};
@@ -1437,7 +1436,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("{epsilon} !<= {}, empty alphabet")
 	{
-		EnumAlphabet alph = { };
+		OnTheFlyAlphabet alph{};
 		smaller.initialstates = {1};
 		smaller.finalstates = {1};
 
@@ -1456,7 +1455,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("a* + b* <= (a+b)*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		smaller.initialstates = {1,2};
 		smaller.finalstates = {1,2};
 		smaller.add_trans(1, alph["a"], 1);
@@ -1479,7 +1478,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("(a+b)* !<= a* + b*")
 	{
-		EnumAlphabet alph = {"a", "b"};
+		OnTheFlyAlphabet alph{"a", "b"};
 		smaller.initialstates = {1};
 		smaller.finalstates = {1};
 		smaller.add_trans(1, alph["a"], 1);
@@ -1510,7 +1509,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("(a+b)* !<= eps + (a+b) + (a+b)(a+b)(a* + b*)")
 	{
-		EnumAlphabet alph = {"a", "b"};
+        OnTheFlyAlphabet alph{"a", "b"};
 		smaller.initialstates = {1};
 		smaller.finalstates = {1};
 		smaller.add_trans(1, alph["a"], 1);
@@ -1556,7 +1555,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("wrong parameters 1")
 	{
-		EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
 
 		CHECK_THROWS_WITH(is_incl(smaller, bigger, &alph, params),
 			Catch::Contains("requires setting the \"algo\" key"));
@@ -1565,7 +1564,7 @@ TEST_CASE("Mata::Nfa::is_incl()")
 
 	SECTION("wrong parameters 2")
 	{
-		EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
 		params["algo"] = "foo";
 
 		CHECK_THROWS_WITH(is_incl(smaller, bigger, &alph, params),
@@ -1588,7 +1587,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("{} == {}, empty alphabet")
     {
-        EnumAlphabet alph{};
+        OnTheFlyAlphabet alph{};
 
         for (const auto& algo : ALGORITHMS) {
             params["algo"] = algo;
@@ -1605,7 +1604,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("{} == {epsilon}, empty alphabet")
     {
-        EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
         bigger.initialstates = {1};
         bigger.finalstates = {1};
 
@@ -1624,7 +1623,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("{epsilon} == {epsilon}, empty alphabet")
     {
-        EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
         smaller.initialstates = {1};
         smaller.finalstates = {1};
         bigger.initialstates = {11};
@@ -1645,7 +1644,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("a* + b* == (a+b)*")
     {
-        EnumAlphabet alph = {"a", "b"};
+        OnTheFlyAlphabet alph{"a", "b"};
         smaller.initialstates = {1,2};
         smaller.finalstates = {1,2};
         smaller.add_trans(1, alph["a"], 1);
@@ -1671,7 +1670,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("(a+b)* !<= eps + (a+b) + (a+b)(a+b)(a* + b*)")
     {
-        EnumAlphabet alph = {"a", "b"};
+        OnTheFlyAlphabet alph{"a", "b"};
         smaller.initialstates = {1};
         smaller.finalstates = {1};
         smaller.add_trans(1, alph["a"], 1);
@@ -1706,7 +1705,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("wrong parameters 1")
     {
-        EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
 
         CHECK_THROWS_WITH(equivalence_check(smaller, bigger, &alph, params),
                           Catch::Contains("requires setting the \"algo\" key"));
@@ -1717,7 +1716,7 @@ TEST_CASE("Mata::Nfa::equivalence_check")
 
     SECTION("wrong parameters 2")
     {
-        EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
         params["algo"] = "foo";
 
         CHECK_THROWS_WITH(equivalence_check(smaller, bigger, &alph, params),
@@ -1914,8 +1913,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 	SECTION("empty automaton")
 	{
-		StringToSymbolMap ssmap;
-		OnTheFlyAlphabet alph(&ssmap);
+		OnTheFlyAlphabet alph{};
 
 		// is complete for the empty alphabet
 		REQUIRE(is_complete(aut, alph));
@@ -1933,8 +1931,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 	SECTION("small automaton")
 	{
-		StringToSymbolMap ssmap;
-		OnTheFlyAlphabet alph(&ssmap);
+		OnTheFlyAlphabet alph{};
 
 		aut.make_initial(4);
 		aut.add_trans(4, alph["a"], 8);
@@ -1959,8 +1956,7 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 	SECTION("using a non-alphabet symbol")
 	{
-		StringToSymbolMap ssmap;
-		OnTheFlyAlphabet alph(&ssmap);
+		OnTheFlyAlphabet alph{};
 
 		aut.make_initial(4);
 		aut.add_trans(4, alph["a"], 8);
@@ -1971,31 +1967,6 @@ TEST_CASE("Mata::Nfa::is_complete()")
 
 		CHECK_THROWS_WITH(is_complete(aut, alph),
 			Catch::Contains("symbol that is not in the provided alphabet"));
-	}
-
-	SECTION("a small automaton using CharAlphabet")
-	{
-		CharAlphabet alph;
-
-        aut.make_initial(4);
-		aut.add_trans(4, 'a', 8);
-		aut.add_trans(4, 'c', 8);
-		aut.add_trans(4, 'a', 6);
-		aut.add_trans(4, 'b', 6);
-		aut.add_trans(8, 'b', 4);
-		aut.add_trans(6, 'a', 2);
-		aut.add_trans(2, 'b', 2);
-		aut.add_trans(2, 'a', 0);
-		aut.add_trans(2, 'c', 12);
-		aut.add_trans(0, 'a', 2);
-		aut.add_trans(12, 'a', 14);
-		aut.add_trans(14, 'b', 12);
-		aut.make_final({2, 12});
-
-		REQUIRE(!is_complete(aut, alph));
-
-		make_complete(aut, alph, 100);
-		REQUIRE(is_complete(aut, alph));
 	}
 } // }}}
 

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -63,7 +63,7 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 } // }}}
 */
 
-TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()") {
+TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {
     Nfa a{1};
     a.add_trans(0, 'a', 0);
 
@@ -80,6 +80,28 @@ TEST_CASE("Mata::Nfa::EnumAlphabet::from_nfas()") {
 
     //OnTheFlyAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
     //OnTheFlyAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
+}
+
+TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
+    OnTheFlyAlphabet alphabet{};
+    StringToSymbolMap symbol_map{ { "a", 4 }, { "b", 2 }, { "c", 10 } };
+    alphabet.add_symbols_from(symbol_map);
+
+    auto symbols{ alphabet.get_symbols() };
+    CHECK(symbols == std::list<Symbol>{ 4, 2, 10 });
+    CHECK(alphabet.get_next_value() == 11);
+    CHECK(alphabet.get_symbol_map() == symbol_map);
+
+    symbol_map["a"] = 6;
+	symbol_map["e"] = 7;
+    alphabet.add_symbols_from(symbol_map);
+
+    symbols = alphabet.get_symbols();
+    CHECK(symbols == std::list<Symbol>{ 7, 4, 2, 10 });
+    CHECK(alphabet.get_next_value() == 11);
+    CHECK(alphabet.get_symbol_map() == StringToSymbolMap{
+		{ "a", 4 }, { "b", 2 }, { "c", 10 }, { "e", 7 }
+	});
 }
 
 TEST_CASE("Mata::Nfa::Nfa::add_trans()/has_trans()")

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -88,7 +88,10 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
     alphabet.add_symbols_from(symbol_map);
 
     auto symbols{ alphabet.get_symbols() };
-    CHECK(symbols == std::list<Symbol>{ 4, 2, 10 });
+	symbols.sort();
+	std::list<Symbol> expected{ 4, 2, 10 };
+	expected.sort();
+    CHECK(symbols == expected);
     CHECK(alphabet.get_next_value() == 11);
     CHECK(alphabet.get_symbol_map() == symbol_map);
 
@@ -97,7 +100,10 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
     alphabet.add_symbols_from(symbol_map);
 
     symbols = alphabet.get_symbols();
-    CHECK(symbols == std::list<Symbol>{ 7, 4, 2, 10 });
+	symbols.sort();
+	expected = std::list<Symbol>{ 7, 4, 2, 10 };
+	expected.sort();
+    CHECK(symbols == expected);
     CHECK(alphabet.get_next_value() == 11);
     CHECK(alphabet.get_symbol_map() == StringToSymbolMap{
 		{ "a", 4 }, { "b", 2 }, { "c", 10 }, { "e", 7 }

--- a/src/tests-re2parser.cc
+++ b/src/tests-re2parser.cc
@@ -47,7 +47,7 @@ TEST_CASE("Mata::RE2Parser basic_parsing")
         REQUIRE(is_in_lang(aut, Word{127}));
         REQUIRE(is_in_lang(aut, Word{0x7f}));
         REQUIRE(is_in_lang(aut, Word{}));
-        EnumAlphabet alph = { };
+        OnTheFlyAlphabet alph{};
         REQUIRE(is_universal(aut,alph));
     }
 


### PR DESCRIPTION
This PR unifies all alphabets into a single alphabet `OnTheFlyAlphabet`. Further, the PR includes updates to functions using alphabets to reflect introduced changes.

This PR covers the basic unification of alphabets as agreed upon in the last meeting. Additional modifications to alphabets which were suggested in the meeting will be added gradually when the wrapper is removed. 

Merging this PR allows us to remove `NfaWrapper` as proposed in #55.