### PR TITLE
Remove NfaWrapper

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -77,6 +77,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     # Typedefs
     ctypedef uintptr_t State
     ctypedef uintptr_t Symbol
+    ctypedef COrdVector[Symbol] SymbolSet
     ctypedef COrdVector[State] StateSet
     ctypedef uset[State] UnorderedStateSet
     ctypedef umap[Symbol, StateSet] PostSymb
@@ -174,6 +175,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void clear_final()
         void unify_initial()
         void unify_final()
+        SymbolSet get_symbols()
         void add_trans(CTrans) except +
         void add_trans(State, Symbol, State) except +
         void remove_trans(CTrans) except +
@@ -256,7 +258,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         COnTheFlyAlphabet(Symbol) except +
         COnTheFlyAlphabet(COnTheFlyAlphabet) except +
         COnTheFlyAlphabet(vector[string]) except +
-        clist[Symbol] get_symbols()
+        SymbolSet get_alphabet_symbols()
         StringToSymbolMap get_symbol_map()
         StringToSymbolMap add_symbols_from(StringToSymbolMap)
         StringToSymbolMap add_symbols_from(vector[string])

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -252,6 +252,9 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         Symbol translate_symb(string)
         string reverse_translate_symbol(Symbol)
 
+    cdef cppclass CIntAlphabet "Mata::Nfa::IntAlphabet" (CAlphabet):
+        SymbolSet get_alphabet_symbols()
+
     cdef cppclass COnTheFlyAlphabet "Mata::Nfa::OnTheFlyAlphabet" (CAlphabet):
         StringToSymbolMap symbol_map
         COnTheFlyAlphabet(StringToSymbolMap) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -147,10 +147,13 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         StateSet initialstates
         StateSet finalstates
         TransitionRelation transitionrelation
+        umap[string, void*] attributes
+        CAlphabet* alphabet
 
         # Constructor
         CNfa() except +
         CNfa(unsigned long) except +
+        CNfa(unsigned long, StateSet, StateSet, CAlphabet*)
 
         # Public Functions
         void make_initial(State)
@@ -244,13 +247,15 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef cppclass CAlphabet "Mata::Nfa::Alphabet":
         CAlphabet() except +
 
+        Symbol translate_symb(string)
+        string reverse_translate_symbol(Symbol)
+
     cdef cppclass COnTheFlyAlphabet "Mata::Nfa::OnTheFlyAlphabet" (CAlphabet):
         StringToSymbolMap symbol_map
         COnTheFlyAlphabet(StringToSymbolMap) except +
         COnTheFlyAlphabet(Symbol) except +
         COnTheFlyAlphabet(COnTheFlyAlphabet) except +
         COnTheFlyAlphabet(vector[string]) except +
-        Symbol translate_symb(string)
         clist[Symbol] get_symbols()
         StringToSymbolMap get_symbol_map()
         StringToSymbolMap add_symbols_from(StringToSymbolMap)

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -158,7 +158,7 @@ cdef class Nfa:
         :param Alphabet alphabet: alphabet corresponding to the automaton
         """
         cdef CAlphabet* c_alphabet = NULL
-        cdef COrdVector[State] state_set
+        cdef StateSet state_set
         if alphabet:
             c_alphabet = alphabet.as_base()
         self.thisptr = make_shared[CNfa](mata.CNfa(state_number, state_set, state_set, c_alphabet))
@@ -433,7 +433,7 @@ cdef class Nfa:
         :param State state: state for which we are getting the transitions
         :return: TransSymbolStates
         """
-        cdef TransitionList transitions = self.thisptr.get().get_transitions_from(state)
+        cdef mata.TransitionList transitions = self.thisptr.get().get_transitions_from(state)
         cdef vector[mata.CTransSymbolStates] transitions_list = transitions.ToVector()
 
         cdef vector[mata.CTransSymbolStates].iterator it = transitions_list.begin()
@@ -596,7 +596,7 @@ cdef class Nfa:
         :return: dictionary mapping symbols to set of reachable states from the symbol
         """
         symbol_map = {}
-        for symbol in alphabet.get_symbols():
+        for symbol in alphabet.get_alphabet_symbols():
             symbol_map[symbol] = self.post_of({st}, symbol)
         return symbol_map
 
@@ -1194,7 +1194,14 @@ cdef class Nfa:
                 }
             )
 
+    def get_symbols(self):
+        """
+        Return a set of symbols used on the transitions in NFA.
 
+        :return: Set of symbols.
+        """
+        cdef SymbolSet symbols = self.thisptr.get().get_symbols()
+        return {s for s in symbols}
 
     @classmethod
     def is_complete(cls, Nfa lhs, Alphabet alphabet):
@@ -1374,13 +1381,13 @@ cdef class OnTheFlyAlphabet(Alphabet):
         """
         return self.thisptr.reverse_translate_symbol(symbol).decode('utf-8')
 
-    cpdef get_symbols(self):
-        """Returns list of supported symbols
+    cpdef get_alphabet_symbols(self):
+        """Returns a set of supported symbols.
 
-        :return: list of supported symbols
+        :return: Set of supported symbols.
         """
-        cdef clist[Symbol] symbols = self.thisptr.get_symbols()
-        return [s for s in symbols]
+        cdef SymbolSet symbols = self.thisptr.get_alphabet_symbols()
+        return {s for s in symbols}
 
     cdef mata.CAlphabet* as_base(self):
         """Retypes the alphabet to its base class

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -17,9 +17,7 @@ def epsilon():
     return EPSILON
 
 cdef class Trans:
-    """
-    Wrapper over the transitions in NFA
-    """
+    """Wrapper over the transitions in NFA."""
     cdef mata.CTrans *thisptr
 
     @property
@@ -53,9 +51,7 @@ cdef class Trans:
         self.thisptr = new mata.CTrans(src, s, tgt)
 
     def __dealloc__(self):
-        """
-        Destructor
-        """
+        """Destructor"""
         if self.thisptr != NULL:
             del self.thisptr
 
@@ -82,9 +78,7 @@ cdef class Trans:
 
 
 cdef class TransSymbolStates:
-    """
-    Wrapper over pair of symbol and states for transitions
-    """
+    """Wrapper over pair of symbol and states for transitions"""
     cdef mata.CTransSymbolStates *thisptr
 
     @property
@@ -140,9 +134,7 @@ cdef class TransSymbolStates:
 
 
 cdef class Nfa:
-    """
-    Wrapper over NFA
-    """
+    """Wrapper over NFA"""
 
     # TODO: Shared pointers are not ideal as they bring some overhead which could be substantial in theory. We are not
     #  sure whether the shared pointers will be a problem in this case, but it would be good to pay attention to this and
@@ -151,17 +143,17 @@ cdef class Nfa:
     cdef shared_ptr[mata.CNfa] thisptr
 
     def __cinit__(self, state_number = 0, Alphabet alphabet = None):
-        """
-        Constructor of the NFA.
+        """Constructor of the NFA.
 
         :param int state_number: number of states in automaton
         :param Alphabet alphabet: alphabet corresponding to the automaton
         """
         cdef CAlphabet* c_alphabet = NULL
-        cdef StateSet state_set
+        cdef StateSet empty_default_state_set
         if alphabet:
             c_alphabet = alphabet.as_base()
-        self.thisptr = make_shared[CNfa](mata.CNfa(state_number, state_set, state_set, c_alphabet))
+        self.thisptr = make_shared[CNfa](mata.CNfa(state_number, empty_default_state_set, empty_default_state_set,
+                                                   c_alphabet))
 
     @property
     def initial_states(self):
@@ -199,16 +191,14 @@ cdef class Nfa:
         return self.thisptr.get().add_new_state()
 
     def make_initial_state(self, State state):
-        """
-        Makes specified state from the automaton initial.
+        """Makes specified state from the automaton initial.
 
         :param State state: State to be made initial.
         """
         self.thisptr.get().make_initial(state)
 
     def make_initial_states(self, vector[State] states):
-        """
-        Makes specified states from the automaton initial.
+        """Makes specified states from the automaton initial.
 
         :param list states: List of states to be made initial.
         """
@@ -223,32 +213,28 @@ cdef class Nfa:
         return self.thisptr.get().has_initial(st)
 
     def remove_initial_state(self, State state):
-        """
-        Removes state from initial state set of the automaton.
+        """Removes state from initial state set of the automaton.
 
         :param State state: State to be removed from initial states.
         """
         self.thisptr.get().remove_initial(state)
 
     def remove_initial_states(self, vector[State] states):
-        """
-        Removes states from initial state set of the automaton.
+        """Removes states from initial state set of the automaton.
 
         :param list State states: States to be removed from initial states.
         """
         self.thisptr.get().remove_initial(states)
 
     def reset_initial_state(self, State state):
-        """
-        Resets initial state set of the automaton to the specified state.
+        """Resets initial state set of the automaton to the specified state.
 
         :param State state: State to be made initial.
         """
         self.thisptr.get().reset_initial(state)
 
     def reset_initial_states(self, vector[State] states):
-        """
-        Resets initial state set of the automaton to the specified states.
+        """Resets initial state set of the automaton to the specified states.
 
         :param list states: List of states to be made initial.
         """
@@ -259,16 +245,14 @@ cdef class Nfa:
         self.thisptr.get().clear_initial()
 
     def make_final_state(self, State state):
-        """
-        Makes specified state from the automaton final.
+        """Makes specified state from the automaton final.
 
         :param State state: State to be made final.
         """
         self.thisptr.get().make_final(state)
 
     def make_final_states(self, vector[State] states):
-        """
-        Makes specified states from the automaton final.
+        """Makes specified states from the automaton final.
 
         :param vector[State] states: List of states to be made final.
         """
@@ -283,32 +267,28 @@ cdef class Nfa:
         return self.thisptr.get().has_final(st)
 
     def remove_final_state(self, State state):
-        """
-        Removes state from final state set of the automaton.
+        """Removes state from final state set of the automaton.
 
         :param State state: State to be removed from final states.
         """
         self.thisptr.get().remove_final(state)
 
     def remove_final_states(self, vector[State] states):
-        """
-        Removes states from final state set of the automaton.
+        """Removes states from final state set of the automaton.
 
         :param list State states: States to be removed from final states.
         """
         self.thisptr.get().remove_final(states)
 
     def reset_final_state(self, State state):
-        """
-        Resets final state set of the automaton to the specified state.
+        """Resets final state set of the automaton to the specified state.
 
         :param State state: State to be made final.
         """
         self.thisptr.get().reset_final(state)
 
     def reset_final_states(self, vector[State] states):
-        """
-        Resets final state set of the automaton to the specified states.
+        """Resets final state set of the automaton to the specified states.
 
         :param list states: List of states to be made final.
         """
@@ -350,16 +330,14 @@ cdef class Nfa:
         self.thisptr.get().add_trans(src, symb, tgt)
 
     def remove_trans(self, Trans tr):
-        """
-        Removes transition from the automaton.
+        """Removes transition from the automaton.
 
         :param Trans tr: Transition to be removed.
         """
         self.thisptr.get().remove_trans(dereference(tr.thisptr))
 
     def remove_trans_raw(self, State src, Symbol symb, State tgt):
-        """
-        Constructs transition and removes it from the automaton.
+        """Constructs transition and removes it from the automaton.
 
         :param State src: Source state of the transition to be removed.
         :param Symbol symb: Symbol of the transition to be removed.
@@ -407,8 +385,7 @@ cdef class Nfa:
         self.thisptr.get().increase_size(size)
 
     def resize_for_state(self, State state):
-        """
-        Increases the size of the automaton to include state.
+        """Increases the size of the automaton to include state.
 
         :param State state: State to resize for.
         """
@@ -449,8 +426,7 @@ cdef class Nfa:
         return transsymbols
 
     def get_transitions_to_state(self, State state_to):
-        """
-        Get transitions leading to state_to (state_to is their target state).
+        """Get transitions leading to state_to (state_to is their target state).
 
         :return: List mata.CTrans: List of transitions leading to state_to.
         """
@@ -461,8 +437,8 @@ cdef class Nfa:
         return trans
 
     def get_trans_as_sequence(self):
-        """
-        Get automaton transitions as a sequence.
+        """Get automaton transitions as a sequence.
+
         :return: List of automaton transitions.
         """
         cdef vector[CTrans] c_transitions = self.thisptr.get().get_trans_as_sequence()
@@ -472,8 +448,8 @@ cdef class Nfa:
         return transitions
 
     def get_trans_from_state_as_sequence(self, State state_from):
-        """
-        Get automaton transitions from state_from as a sequence.
+        """Get automaton transitions from state_from as a sequence.
+
         :return: List of automaton transitions.
         """
         cdef vector[CTrans] c_transitions = self.thisptr.get().get_trans_from_as_sequence(state_from)
@@ -483,32 +459,31 @@ cdef class Nfa:
         return transitions
 
     def get_useful_states(self):
-        """
-        Get useful states (states which are reachable and terminating at the same time).
+        """Get useful states (states which are reachable and terminating at the same time).
+
         :return: A set of useful states.
         """
         cdef vector[State] return_value = self.thisptr.get().get_useful_states().ToVector()
         return {state for state in return_value}
 
     def get_reachable_states(self):
-        """
-        Get reachable states.
+        """Get reachable states.
+
         :return: A set of reachable states.
         """
         cdef vector[State] return_value = self.thisptr.get().get_reachable_states().ToVector()
         return {state for state in return_value}
 
     def get_terminating_states(self):
-        """
-        Get terminating states (states with a path from them leading to any final state).
+        """Get terminating states (states with a path from them leading to any final state).
+
         :return: A set of terminating states.
         """
         cdef vector[State] return_value = self.thisptr.get().get_terminating_states().ToVector()
         return {state for state in return_value}
 
     def trim(self):
-        """
-        Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
+        """Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
 
         Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
          starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
@@ -517,8 +492,7 @@ cdef class Nfa:
         self.thisptr.get().trim()
 
     def get_digraph(self) -> Nfa:
-        """
-        Unify transitions to create a directed graph with at most a single transition between two states.
+        """Unify transitions to create a directed graph with at most a single transition between two states.
 
         :return: mata.Nfa: An automaton representing a directed graph.
         """
@@ -527,8 +501,8 @@ cdef class Nfa:
         return digraph
 
     def is_epsilon(self, Symbol symbol) -> bool:
-        """
-        Check whether passed symbol is epsilon symbol or not.
+        """Check whether passed symbol is epsilon symbol or not.
+
         :param Symbol symbol: The symbol to check.
         :return: True if the passed symbol is epsilon symbol, False otherwise.
         """
@@ -695,8 +669,7 @@ cdef class Nfa:
 
     @classmethod
     def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
-        """
-        Performs intersection of lhs and rhs preserving epsilon transitions.
+        """Performs intersection of lhs and rhs preserving epsilon transitions.
 
         Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -734,8 +707,7 @@ cdef class Nfa:
 
     @classmethod
     def intersection_pres_eps_trans_with_prod_map(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
-        """
-        Performs intersection of lhs and rhs preserving epsilon transitions.
+        """Performs intersection of lhs and rhs preserving epsilon transitions.
 
         Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -759,8 +731,7 @@ cdef class Nfa:
 
     @classmethod
     def concatenate(cls, Nfa lhs, Nfa rhs):
-        """
-        Concatenate two NFAs.
+        """Concatenate two NFAs.
 
         :param Nfa lhs: First automaton to concatenate.
         :param Nfa rhs: Second automaton to concatenate.
@@ -772,8 +743,7 @@ cdef class Nfa:
 
     @classmethod
     def concatenate_over_epsilon(cls, Nfa lhs, Nfa rhs, epsilon = CEPSILON):
-        """
-        Concatenate two NFAs over an epsilon symbol.
+        """Concatenate two NFAs over an epsilon symbol.
 
         :param Nfa lhs: First automaton to concatenate over epsilon.
         :param Nfa rhs: Second automaton to concatenate over epsilon.
@@ -786,8 +756,7 @@ cdef class Nfa:
 
     @classmethod
     def noodlify(cls, Nfa aut, Symbol symbol, include_empty = False):
-        """
-        Create noodles from segment automaton.
+        """Create noodles from segment automaton.
 
         Segment automaton is a chain of finite automata (segments) connected via ε-transitions.
         A noodle is a copy of the segment automaton with exactly one ε-transition between each two consecutive segments.
@@ -812,8 +781,7 @@ cdef class Nfa:
 
     @classmethod
     def noodlify_for_equation(cls, left_side_automata: list[Nfa], Nfa right_side_automaton, include_empty = False, params = None):
-        """
-        Create noodles for equation.
+        """Create noodles for equation.
 
         Segment automaton is a chain of finite automata (segments) connected via ε-transitions.
         A noodle is a copy of the segment automaton with exactly one ε-transition between each two consecutive segments.
@@ -938,8 +906,7 @@ cdef class Nfa:
         return result
 
     def remove_epsilon(self, Symbol epsilon = CEPSILON):
-        """
-        Removes transitions which contain epsilon symbol.
+        """Removes transitions which contain epsilon symbol.
 
         TODO: Possibly there may be issue with setting the size of the automaton beforehand?
 
@@ -948,8 +915,8 @@ cdef class Nfa:
         self.thisptr.get().remove_epsilon(epsilon)
 
     def get_epsilon_transitions(self, State state, Symbol epsilon = CEPSILON) -> TransSymbolStates | None:
-        """
-        Get epsilon transitions for a state.
+        """Get epsilon transitions for a state.
+
         :param state: State to get epsilon transitions for.
         :param epsilon: Epsilon symbol.
         :return: Epsilon transitions if there are any epsilon transitions for the passed state. None otherwise.
@@ -977,8 +944,7 @@ cdef class Nfa:
 
     @classmethod
     def reduce_with_state_map(cls, Nfa aut, params = None):
-        """
-        Reduce the automaton.
+        """Reduce the automaton.
 
         :param Nfa aut: Original automaton to reduce.
         :param Dict params: Additional parameters for the reduction algorithm:
@@ -998,8 +964,7 @@ cdef class Nfa:
 
     @classmethod
     def reduce(cls, Nfa aut, params = None):
-        """
-        Reduce the automaton.
+        """Reduce the automaton.
 
         :param Nfa aut: Original automaton to reduce.
         :param Dict params: Additional parameters for the reduction algorithm:
@@ -1161,8 +1126,7 @@ cdef class Nfa:
 
     @classmethod
     def equivalence_check(cls, Nfa lhs, Nfa rhs, Alphabet alphabet = None, params = None) -> bool:
-        """
-        Test equivalence of two automata.
+        """Test equivalence of two automata.
 
         :param Nfa lhs: Smaller automaton.
         :param Nfa rhs: Bigger automaton.
@@ -1195,8 +1159,7 @@ cdef class Nfa:
             )
 
     def get_symbols(self):
-        """
-        Return a set of symbols used on the transitions in NFA.
+        """Return a set of symbols used on the transitions in NFA.
 
         :return: Set of symbols.
         """
@@ -1281,8 +1244,7 @@ cdef class Nfa:
         )
 
 cdef class Alphabet:
-    """
-    Base class for alphabets
+    """Base class for alphabets
     """
     def __cinit__(self):
         pass
@@ -1304,9 +1266,7 @@ cdef class Alphabet:
 
 
 cdef class OnTheFlyAlphabet(Alphabet):
-    """
-    OnTheFlyAlphabet represents alphabet that is not known before hand and is constructed on-the-fly
-    """
+    """OnTheFlyAlphabet represents alphabet that is not known before hand and is constructed on-the-fly."""
     cdef mata.COnTheFlyAlphabet *thisptr
 
     def __cinit__(self, State initial_symbol = 0):
@@ -1314,8 +1274,8 @@ cdef class OnTheFlyAlphabet(Alphabet):
 
     @classmethod
     def from_symbol_map(cls, symbol_map: dict[str, int]) -> OnTheFlyAlphabet:
-        """
-        Create on the fly alphabet filled with symbol_map.
+        """Create on the fly alphabet filled with symbol_map.
+
         :param symbol_map: Map mapping symbol names to symbol values.
         :return: On the fly alphabet.
         """
@@ -1330,8 +1290,8 @@ cdef class OnTheFlyAlphabet(Alphabet):
         return alphabet
 
     def add_symbols_from_symbol_map(self, symbol_map: dict[str, int]) -> None:
-        """
-        Add symbols from symbol_map to the current alphabet.
+        """Add symbols from symbol_map to the current alphabet.
+
         :param symbol_map: Map mapping strings to symbols.
         """
         cdef StringToSymbolMap c_symbol_map
@@ -1340,8 +1300,8 @@ cdef class OnTheFlyAlphabet(Alphabet):
         self.thisptr.add_symbols_from(c_symbol_map)
 
     def add_symbols_for_names(self, symbol_names: list[str]) -> None:
-        """
-        Add symbols for symbol names to the current alphabet.
+        """Add symbols for symbol names to the current alphabet.
+
         :param symbol_names: Vector of symbol names.
         """
         cdef vector[string] c_symbol_names
@@ -1353,8 +1313,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
         del self.thisptr
 
     def get_symbol_map(self) -> dict[str, int]:
-        """
-        Get map mapping strings to symbols.
+        """Get map mapping strings to symbols.
 
         :return: Map of strings to symbols.
         """
@@ -1373,8 +1332,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
         return self.thisptr.translate_symb(symbol.encode('utf-8'))
 
     def reverse_translate_symbol(self, Symbol symbol) -> str:
-        """
-        Translate internal symbol value to the original symbol name.
+        """Translate internal symbol value to the original symbol name.
 
         :param Symbol symbol: Internal symbol value to be translated.
         :return str: Original symbol string name.
@@ -1397,9 +1355,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
         return <mata.CAlphabet*> self.thisptr
 
 cdef class BinaryRelation:
-    """
-    Wrapper for binary relation
-    """
+    """Wrapper for binary relation."""
     cdef mata.CBinaryRelation *thisptr
 
     def __cinit__(self, size_t size=0, bool defVal=False, size_t rowSize=16):
@@ -1570,9 +1526,7 @@ cdef subset_map_to_dictionary(SubsetMap subset_map):
 
 # Temporary for testing
 def divisible_by(k: int):
-    """
-    Constructs automaton accepting strings containing ones divisible by "k"
-    """
+    """Constructs automaton accepting strings containing ones divisible by "k"."""
     assert k > 1
     lhs = Nfa(k+1)
     lhs.make_initial_state(0)
@@ -1650,8 +1604,7 @@ cdef class Segmentation:
     cdef mata.CSegmentation* thisptr
 
     def __cinit__(self, Nfa aut, Symbol symbol = CEPSILON):
-        """
-        Compute segmentation.
+        """Compute segmentation.
 
         :param aut: Segment automaton to compute epsilon depths for.
         :param symbol: Symbol to execute segmentation for.
@@ -1662,8 +1615,7 @@ cdef class Segmentation:
         del self.thisptr
 
     def get_epsilon_depths(self):
-        """
-        Get segmentation depths for ε-transitions.
+        """Get segmentation depths for ε-transitions.
 
         :return: Map of depths to lists of ε-transitions.
         """
@@ -1679,8 +1631,7 @@ cdef class Segmentation:
         return result
 
     def get_segments(self):
-        """
-        Get segment automata.
+        """Get segment automata.
 
         :return: A vector of segments for the segment automaton in the order from the left (initial state in segment
                  automaton) to the right (final states of segment automaton).

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -1354,6 +1354,41 @@ cdef class OnTheFlyAlphabet(Alphabet):
         """
         return <mata.CAlphabet*> self.thisptr
 
+
+cdef class IntAlphabet(Alphabet):
+    """IntAlphabet represents integer alphabet that directly maps integer string to their values."""
+
+    cdef mata.CIntAlphabet *thisptr
+
+    def __cinit__(self):
+        self.thisptr = new mata.CIntAlphabet()
+
+    def __dealloc__(self):
+        del self.thisptr
+
+    def translate_symbol(self, str symbol):
+        """Translates symbol to the position of the seen values
+
+        :param str symbol: translated symbol
+        :return: order of the symbol as was seen during the construction
+        """
+        return self.thisptr.translate_symb(symbol.encode('utf-8'))
+
+    def reverse_translate_symbol(self, Symbol symbol) -> str:
+        """Translate internal symbol value to the original symbol name.
+
+        :param Symbol symbol: Internal symbol value to be translated.
+        :return str: Original symbol string name.
+        """
+        return self.thisptr.reverse_translate_symbol(symbol).decode('utf-8')
+
+    cdef mata.CAlphabet* as_base(self):
+        """Retypes the alphabet to its base class
+
+        :return: alphabet as CAlphabet*
+        """
+        return <mata.CAlphabet*> self.thisptr
+
 cdef class BinaryRelation:
     """Wrapper for binary relation."""
     cdef mata.CBinaryRelation *thisptr

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -1334,6 +1334,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
     def reverse_translate_symbol(self, Symbol symbol) -> str:
         """Translate internal symbol value to the original symbol name.
 
+        Throw an exception when the symbol is missing in the alphabet.
         :param Symbol symbol: Internal symbol value to be translated.
         :return str: Original symbol string name.
         """

--- a/bindings/python/tests/test_alphabets.py
+++ b/bindings/python/tests/test_alphabets.py
@@ -55,3 +55,9 @@ def test_on_the_fly_alphabet():
     assert alphabet.translate_symbol('b') == 4
     assert alphabet.translate_symbol('c') == 5
     assert alphabet.translate_symbol('a') == 3
+
+
+def test_int_alphabet():
+    alphabet = mata.IntAlphabet()
+    assert alphabet.translate_symbol('4') == 4
+    assert alphabet.reverse_translate_symbol(4) == '4'

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -80,7 +80,9 @@ public:
 
     /**
      * Translate internal @p symbol representation back to its original string name.
-     * @param symbol Symbol to translate.
+     * @param[in] symbol Symbol to translate.
+     * @param[in] default_if_missing Value to return if the @p symbol is not in the alphabet. Default: Throw an
+     *  exception when the @p symbol is missing.
      * @return @p symbol original name.
      */
     virtual std::string reverse_translate_symbol(Symbol symbol) const = 0;
@@ -1434,7 +1436,7 @@ public:
                 return symbol_mapping.first;
             }
         }
-        throw std::runtime_error("symbol is out of range of enumeration");
+        throw std::runtime_error("symbol '" + std::to_string(symbol) + "' is out of range of enumeration");
     }
 
 private:

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -76,6 +76,14 @@ public:
 
     /// translates a string into a symbol
     virtual Symbol translate_symb(const std::string& symb) = 0;
+
+    /**
+     * Translate internal @p symbol representation back to its original string name.
+     * @param symbol Symbol to translate.
+     * @return @p symbol original name.
+     */
+    virtual std::string reverse_translate_symbol(Symbol symbol) const = 0;
+
     /// also translates strings to symbols
     Symbol operator[](const std::string& symb) { return this->translate_symb(symb); }
     /// gets a list of symbols in the alphabet
@@ -1080,9 +1088,6 @@ inline Word encode_word(
 	return result;
 } // encode_word }}}
 
-/// operator<<
-std::ostream& operator<<(std::ostream& strm, const Nfa& nfa);
-
 /// global constructor to be called at program startup (from vm-dispatch)
 void init();
 
@@ -1321,6 +1326,15 @@ public:
 
     std::list<Symbol> get_symbols() const override;
     std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
+
+    std::string reverse_translate_symbol(const Symbol symbol) const override {
+        for (const auto& symbol_mapping: symbol_map) {
+            if (symbol_mapping.second == symbol) {
+                return symbol_mapping.first;
+            }
+        }
+        throw std::runtime_error("symbol is out of range of enumeration");
+    }
 
 private:
     OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs);
@@ -1646,6 +1660,7 @@ struct hash<Mata::Nfa::Trans>
 
 std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Trans& trans);
 std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa);
+std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Alphabet& alphabet);
 } // std }}}
 
 #endif /* _MATA_NFA_HH_ */

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -189,6 +189,15 @@ struct Nfa
     TransitionRelation transitionrelation;
     StateSet initialstates = {};
     StateSet finalstates = {};
+    Alphabet* alphabet = nullptr; ///< The alphabet which can be shared between multiple automata.
+    /// Key value store for additional attributes for the NFA. Keys are attribute names as strings and the value types
+    ///  are up to the user.
+    /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
+    ///  respective names, or "transition_dict" for transition dictionary adding a human-readable meaning to each
+    ///  transition.
+    // TODO: When there is a need for state dictionary, consider creating default library implementation of state
+    //  dictionary in the attributes.
+    std::unordered_map<std::string, void*> attributes;
 
 public:
     Nfa() : transitionrelation(), initialstates(), finalstates() {}
@@ -197,15 +206,17 @@ public:
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
      */
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
-                 const StateSet& final_states = StateSet{})
-        : transitionrelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
+                 const StateSet& final_states = StateSet{}, Alphabet* alphabet_p = nullptr)
+        : transitionrelation(num_of_states), initialstates(initial_states), finalstates(final_states),
+          alphabet(alphabet_p) {}
 
     /**
      * @brief Construct a new explicit NFA with already filled transition relation and optionally set initial and final states.
      */
     explicit Nfa(const TransitionRelation& transition_relation, const StateSet& initial_states = StateSet{},
-                 const StateSet& final_states = StateSet{})
-        : transitionrelation(transition_relation), initialstates(initial_states), finalstates(final_states) {}
+                 const StateSet& final_states = StateSet{},Alphabet* alphabet_p = nullptr)
+        : transitionrelation(transition_relation), initialstates(initial_states), finalstates(final_states),
+          alphabet(alphabet_p) {}
 
     /**
      * Clear transitions but keep the automata states.
@@ -739,19 +750,6 @@ public:
 
 private:
 }; // Nfa
-
-/// a wrapper encapsulating @p Nfa for higher-level use
-struct NfaWrapper
-{ // {{{
-	/// the NFA
-	Nfa nfa;
-
-	/// the alphabet
-	Alphabet* alphabet;
-
-	/// mapping of state names (as strings) to their numerical values
-	StringToStateMap state_dict;
-}; // NfaWrapper }}}
 
 /// Do the automata have disjoint sets of states?
 bool are_state_disjoint(const Nfa& lhs, const Nfa& rhs);
@@ -1647,7 +1645,7 @@ struct hash<Mata::Nfa::Trans>
 };
 
 std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Trans& trans);
-std::ostream& operator<<(std::ostream& os, const Mata::Nfa::NfaWrapper& nfa_wrap);
+std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa);
 } // std }}}
 
 #endif /* _MATA_NFA_HH_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(libmata STATIC
 	nfa/nfa-intersection.cc
 	nfa/nfa-concatenation.cc
 	nfa/nfa-segmentation.cc
+	nfa/nfa-alphabets.cc
 	nfa/noodlify.cc
 	rra/rrt.cc
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,6 @@ add_library(libmata STATIC
 	nfa/nfa-intersection.cc
 	nfa/nfa-concatenation.cc
 	nfa/nfa-segmentation.cc
-	nfa/nfa-alphabets.cc
 	nfa/noodlify.cc
 	rra/rrt.cc
 )

--- a/src/nfa/nfa-universal.cc
+++ b/src/nfa/nfa-universal.cc
@@ -76,7 +76,7 @@ bool is_universal_antichains(
 	// initialize
 	WorklistType worklist = { aut.initialstates };
 	ProcessedType processed = { aut.initialstates };
-	std::list<Symbol> alph_symbols = alphabet.get_symbols();
+	SymbolSet alph_symbols = alphabet.get_alphabet_symbols();
 
 	// 'paths[s] == t' denotes that state 's' was accessed from state 't',
 	// 'paths[s] == s' means that 's' is an initial state

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -311,15 +311,15 @@ std::ostream &std::operator<<(std::ostream &os, const Mata::Nfa::Trans &trans) {
 
 ////// Alphabet related functions
 
-std::list<Symbol> OnTheFlyAlphabet::get_symbols() const { // {{{
-	std::list<Symbol> result;
+StateSet OnTheFlyAlphabet::get_alphabet_symbols() const {
+	SymbolSet result;
 	for (const auto& str_sym_pair : symbol_map) {
-		result.push_back(str_sym_pair.second);
+		result.insert(str_sym_pair.second);
 	}
 	return result;
-} // OnTheFlyAlphabet::get_symbols }}}
+} // OnTheFlyAlphabet::get_alphabet_symbols.
 
-std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms) const { // {{{
+std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms) const {
     std::list<Symbol> result;
     // TODO: Could be optimized.
     std::set<Symbol> symbols_alphabet;
@@ -332,7 +332,7 @@ std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms)
             syms.begin(), syms.end(),
             std::inserter(result, result.end()));
     return result;
-} // OnTheFlyAlphabet::get_complement }}}
+} // OnTheFlyAlphabet::get_complement.
 
 void OnTheFlyAlphabet::add_symbols_from(const Nfa& nfa) {
     size_t aut_num_of_states{ nfa.get_num_of_states() };
@@ -712,8 +712,8 @@ bool Mata::Nfa::is_deterministic(const Nfa& aut)
 }
 bool Mata::Nfa::is_complete(const Nfa& aut, const Alphabet& alphabet)
 {
-    std::list<Symbol> symbs_ls = alphabet.get_symbols();
-    std::unordered_set<Symbol> symbs(symbs_ls.cbegin(), symbs_ls.cend());
+    SymbolSet symbs_ls = alphabet.get_alphabet_symbols();
+    SymbolSet symbs(symbs_ls.cbegin(), symbs_ls.cend());
 
     // TODO: make a general function for traversal over reachable states that can
     // be shared by other functions?
@@ -1809,3 +1809,13 @@ void ShortestWordsMap::update_current_words(LengthWordsPair& act, const LengthWo
     }
     act.first = dst.first + 1;
 }
+
+SymbolSet Nfa::get_symbols() const {
+     SymbolSet symbols{};
+     for (const auto& state_transitions: transitionrelation) {
+         for (const auto& symbol_transitions: state_transitions) {
+             symbols.insert(symbol_transitions.symbol);
+         }
+     }
+     return symbols;
+ }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1676,17 +1676,11 @@ Nfa::const_iterator& Nfa::const_iterator::operator++()
     return result;
 }
 
-std::ostream& Mata::Nfa::operator<<(std::ostream& os, const Nfa& nfa)
-{ // {{{
-    return os << std::to_string(serialize(nfa));
-} // Nfa::operator<<(ostream) }}}
-
-std::ostream& std::operator<<(std::ostream& os, const Mata::Nfa::NfaWrapper& nfa_wrap)
-{ // {{{
-	os << "{NFA wrapper|NFA: " << nfa_wrap.nfa << "|alphabet: " << nfa_wrap.alphabet <<
-		"|state_dict: " << std::to_string(nfa_wrap.state_dict) << "}";
-	return os;
-} // operator<<(NfaWrapper) }}}
+std::ostream& std::operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa) {
+    os << "{NFA: " << std::to_string(serialize(nfa)) << "|alphabet: " << nfa.alphabet << "}";
+    // TODO: If the default implementation for state_dict is implemented, consider printing the state dictionary with
+    //  std::to_string(<state_dict_object>);
+}
 
 WordSet ShortestWordsMap::get_shortest_words_for(const StateSet& states) const
 {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1677,9 +1677,18 @@ Nfa::const_iterator& Nfa::const_iterator::operator++()
 }
 
 std::ostream& std::operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa) {
-    os << "{NFA: " << std::to_string(serialize(nfa)) << "|alphabet: " << nfa.alphabet << "}";
+    os << "{ NFA: " << std::to_string(serialize(nfa));
+    if (nfa.alphabet != nullptr) {
+        os << "|alphabet: " << *(nfa.alphabet);
+    }
     // TODO: If the default implementation for state_dict is implemented, consider printing the state dictionary with
     //  std::to_string(<state_dict_object>);
+
+    os << " }";
+}
+
+std::ostream &std::operator<<(std::ostream &os, const Alphabet& alphabet) {
+    return os << std::to_string(alphabet);
 }
 
 WordSet ShortestWordsMap::get_shortest_words_for(const StateSet& states) const

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -63,6 +63,17 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 } // }}}
 */
 
+TEST_CASE("Mata::Nfa::IntAlphabet") {
+    auto alphabet1 = IntAlphabet();
+    auto alphabet2 = IntAlphabet();
+    CHECK(alphabet1 == alphabet2);
+
+    auto& alphabet3 = alphabet2;
+    CHECK(alphabet3 == alphabet1);
+    const auto& alphabet4 = alphabet2;
+    CHECK(alphabet4 == alphabet1);
+}
+
 TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {
     Nfa a{1};
     a.add_trans(0, 'a', 0);

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -66,12 +66,18 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 TEST_CASE("Mata::Nfa::IntAlphabet") {
     auto alphabet1 = IntAlphabet();
     auto alphabet2 = IntAlphabet();
-    CHECK(alphabet1 == alphabet2);
+    CHECK(alphabet1.is_equal(alphabet2));
 
     auto& alphabet3 = alphabet2;
-    CHECK(alphabet3 == alphabet1);
+    CHECK(alphabet3.is_equal(&alphabet1));
     const auto& alphabet4 = alphabet2;
-    CHECK(alphabet4 == alphabet1);
+    CHECK(alphabet4.is_equal(alphabet1));
+
+    OnTheFlyAlphabet different_alphabet{};
+    OnTheFlyAlphabet different_alphabet2{};
+    CHECK(!alphabet1.is_equal(different_alphabet));
+    CHECK(!different_alphabet.is_equal(different_alphabet2));
+    CHECK(different_alphabet.is_equal(&different_alphabet));
 }
 
 TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -86,8 +86,8 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {
 
     auto alphabet{ OnTheFlyAlphabet::from_nfas(a, b, c) };
 
-    auto symbols{ alphabet.get_symbols() };
-    CHECK(symbols == std::list<Symbol>{ 'c', 'b', 'a' });
+    auto symbols{alphabet.get_alphabet_symbols() };
+    CHECK(symbols == SymbolSet{ 'c', 'b', 'a' });
 
     //OnTheFlyAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
     //OnTheFlyAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
@@ -98,10 +98,8 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
     StringToSymbolMap symbol_map{ { "a", 4 }, { "b", 2 }, { "c", 10 } };
     alphabet.add_symbols_from(symbol_map);
 
-    auto symbols{ alphabet.get_symbols() };
-	symbols.sort();
-	std::list<Symbol> expected{ 4, 2, 10 };
-	expected.sort();
+    auto symbols{alphabet.get_alphabet_symbols() };
+	SymbolSet expected{ 4, 2, 10 };
     CHECK(symbols == expected);
     CHECK(alphabet.get_next_value() == 11);
     CHECK(alphabet.get_symbol_map() == symbol_map);
@@ -110,10 +108,8 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
 	symbol_map["e"] = 7;
     alphabet.add_symbols_from(symbol_map);
 
-    symbols = alphabet.get_symbols();
-	symbols.sort();
-	expected = std::list<Symbol>{ 7, 4, 2, 10 };
-	expected.sort();
+    symbols = alphabet.get_alphabet_symbols();
+	expected = SymbolSet{ 7, 4, 2, 10 };
     CHECK(symbols == expected);
     CHECK(alphabet.get_next_value() == 11);
     CHECK(alphabet.get_symbol_map() == StringToSymbolMap{


### PR DESCRIPTION
This PR removes `NfaWrapper` and moves its content to `Nfa` struct as discussed in meetings and in #53 and #55.

As of now, the following changes were introduced:
1. `NfaWrapper` is deleted.
2. Alphabet is now a member variable of `Nfa` struct, passed as a pointer to allow sharing alphabets.
3. Introduces basic key-value store for state dictionary and additional attributes the user might want to store together with the NFA.
4. State dictionary currently does not have any default implementation and will be implemented only when we have a need for it and know precisely how we need the state dictionary to behave.
5. Python binding has been reworked to reflect the above-mentioned changes. Particularly, how to work with the new alphabets.   

This PR resolves #53 and #55 can be safely closed.

#### Additional work to be done in later PRs
1. Support multiple epsilon symbol specified by the user (see the TODO in this PR) by adding a member variable to the Alphabet. The user needs to be able to define:
    - that there are no epsilon symbols at all, not even the default epsilon symbol at all by setting the epsilon symbols to empty set,
    - multiple epsilon symbols without the default epsilon symbol by setting the epsilon symbols to required symbols excluding the default epsilon symbol,
    - multiple epsilon symbols, including the default epsilon symbol by setting the epsilon symbols to required symbols including the default epsilon symbol,

We can solve this with `std::optional<EpsilonSymbols>`, which is, however, C++17 class template. Alternatively, we can use pointers again with `nullptr` representing the no epsilon states option (not a big fan, to be honest) or try to reimplement the behaviour of `std::optional` in C++14 (see for example [this suggestion](https://codereview.stackexchange.com/questions/216669/stdoptional-under-c14-v1)).  

2. Decide whether to implement some basic state dictionary for the prepared key-value store, when the need arises.