### PR TITLE
AFA data structures, Closed set data structures, functions for inspecting an AFA, two AFA emptiness tests

### DIFF
--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -222,7 +222,7 @@ public:
 		this->add_inverse_trans({src, symb, dst});
 	} // }}}
 
-	std::unique_ptr<Nodes> perform_trans (State src, Symbol symb) const;
+	Nodes perform_trans (State src, Symbol symb) const;
 
 	std::vector<InverseResults> perform_inverse_trans(State src, Symbol symb) const;
 	std::vector<InverseResults> perform_inverse_trans(Node src, Symbol symb) const;

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -272,7 +272,7 @@ public:
 
 	StateClosedSet get_initial_nodes(void) const;
 	StateClosedSet get_non_initial_nodes(void) const;
-	StateClosedSet get_final_nodes(void) const;
+	StateClosedSet get_final_nodes(void) const {return StateClosedSet(downward_closed_set, 0, transitionrelation.size()-1, finalstates);};
 	StateClosedSet get_non_final_nodes(void) const;
 
 }; // Afa }}}

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -99,50 +99,50 @@ using TransRelation = std::vector<TransList>;
 * A tuple (result_nodes, sharing_list). If 'a' is an element of result_nodes, it means that there exists a symbol
 * 'b' such that sharing_list belongs to delta(a, b), where sharing_list is a node (vector of states). 
 */
-typedef struct InvResults_{
+typedef struct InverseResults_{
 
     Node result_nodes{}; 
     Node sharing_list{};
 
-    InvResults_() : result_nodes(), sharing_list() { }
-    InvResults_(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
-    InvResults_(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
+    InverseResults_() : result_nodes(), sharing_list() { }
+    InverseResults_(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
+    InverseResults_(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
 
-    bool operator==(InvResults_ rhs) const
+    bool operator==(InverseResults_ rhs) const
     { // {{{
         return sharing_list == rhs.sharing_list && result_nodes == rhs.result_nodes;
     } // operator== }}}
     
-    bool operator!=(InvResults_ rhs) const
+    bool operator!=(InverseResults_ rhs) const
     { // {{{
         return !this->operator==(rhs);
     } // operator!= }}}
 
-    bool operator<(InvResults_ rhs) const
+    bool operator<(InverseResults_ rhs) const
     { // {{{
         return sharing_list < rhs.sharing_list || (sharing_list == rhs.sharing_list && result_nodes < rhs.result_nodes);
     } // operator< }}}
 
-}InvResults;
+}InverseResults;
 
 /*
-* A tuple (symb, vector_of_pointers). Each pointer points to the instance of InvResults. If &(result_nodes, sharing_list) belongs to the
+* A tuple (symb, vector_of_pointers). Each pointer points to the instance of InverseResults. If &(result_nodes, sharing_list) belongs to the
 * vector_of_pointers, then for each 'a' which is part of result_nodes holds that 'sharing_list' is a member of delta(a, symbol).
 */
-typedef struct InvTrans_{
+typedef struct InverseTrans_{
 
-    using InvResultPtrs = std::vector<std::shared_ptr<InvResults>>;
+    using InverseResultPtrs = std::vector<std::shared_ptr<InverseResults>>;
 
     Symbol symb;    
-    InvResultPtrs invResultPtrs{};
+    InverseResultPtrs inverseResultPtrs{};
 
-    InvTrans_() : symb(), invResultPtrs() { }
-    InvTrans_(Symbol symb) : symb(symb), invResultPtrs(InvResultPtrs()) { }
-    InvTrans_(Symbol symb, InvResultPtrs invResultPtrs) : symb(symb), invResultPtrs(invResultPtrs) { }
+    InverseTrans_() : symb(), inverseResultPtrs() { }
+    InverseTrans_(Symbol symb) : symb(symb), inverseResultPtrs(InverseResultPtrs()) { }
+    InverseTrans_(Symbol symb, InverseResultPtrs inverseResultPtrs) : symb(symb), inverseResultPtrs(inverseResultPtrs) { }
 
-}InvTrans;
+}InverseTrans;
 
-using InvTransRelation = std::vector<std::vector<InvTrans>>;
+using InverseTransRelation = std::vector<std::vector<InverseTrans>>;
 
 struct Afa;
 
@@ -159,15 +159,15 @@ struct Afa
 public:
 
     TransRelation transRelation{};
-    InvTransRelation invTransRelation{};
+    InverseTransRelation inverseTransRelation{};
 
 public:
 
-    Afa() : transRelation(), invTransRelation() {}
+    Afa() : transRelation(), inverseTransRelation() {}
 
     explicit Afa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
                  const StateSet& final_states = StateSet{})
-        : transRelation(num_of_states), invTransRelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
+        : transRelation(num_of_states), inverseTransRelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
 
 public:
 
@@ -207,20 +207,20 @@ public:
 		this->add_trans({src, symb, dst});
 	} // }}}
 
-	void add_inv_trans(const Trans& trans);
-	void add_inv_trans(State src, Symbol symb, Node dst)
+	void add_inverse_trans(const Trans& trans);
+	void add_inverse_trans(State src, Symbol symb, Node dst)
 	{ // {{{
-		this->add_inv_trans({src, symb, Nodes(dst)});
+		this->add_inverse_trans({src, symb, Nodes(dst)});
 	} // }}}
-	void add_inv_trans(State src, Symbol symb, Nodes dst)
+	void add_inverse_trans(State src, Symbol symb, Nodes dst)
 	{ // {{{
-		this->add_inv_trans({src, symb, dst});
+		this->add_inverse_trans({src, symb, dst});
 	} // }}}
 
     std::unique_ptr<Nodes> perform_trans (State src, Symbol symb) const;
 
-    InvTrans::InvResultPtrs perform_inv_trans(State src, Symbol symb) const;
-    InvTrans::InvResultPtrs perform_inv_trans(Node src, Symbol symb) const;
+    InverseTrans::InverseResultPtrs perform_inverse_trans(State src, Symbol symb) const;
+    InverseTrans::InverseResultPtrs perform_inverse_trans(Node src, Symbol symb) const;
 
 	bool has_trans(const Trans& trans) const;
 	bool has_trans(State src, Symbol symb, Node dst) const
@@ -284,8 +284,12 @@ bool are_state_disjoint(const Afa& lhs, const Afa& rhs);
 bool is_lang_empty(const Afa& aut, Path* cex = nullptr);
 bool is_lang_empty_cex(const Afa& aut, Word* cex);
 
-bool antichain_concrete_forward_emptiness_test(const Afa& aut);
-bool antichain_concrete_backward_emptiness_test(const Afa& aut);
+bool antichain_concrete_forward_emptiness_test_old(const Afa& aut);
+bool antichain_concrete_backward_emptiness_test_old(const Afa& aut);
+
+bool antichain_concrete_forward_emptiness_test_new(const Afa& aut);
+bool antichain_concrete_backward_emptiness_test_new(const Afa& aut);
+
 
 /// Retrieves the states reachable from initial states
 std::unordered_set<State> get_fwd_reach_states(const Afa& aut);

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -80,12 +80,12 @@ using Alphabet = Mata::Nfa::Alphabet;
 */
 struct Trans
 {
-    State src; // source state
-    Symbol symb; // transition symbol
-    Nodes dst; // a vector of vectors of states
+	State src; // source state
+	Symbol symb; // transition symbol
+	Nodes dst; // a vector of vectors of states
 
 	Trans() : src(), symb(), dst() { }
-  	Trans(State src, Symbol symb, Node dst) : src(src), symb(symb), dst(Nodes(dst)) { }
+	Trans(State src, Symbol symb, Node dst) : src(src), symb(symb), dst(Nodes(dst)) { }
 	Trans(State src, Symbol symb, Nodes dst) : src(src), symb(symb), dst(dst) { }
 
 	bool operator==(const Trans& rhs) const
@@ -105,27 +105,27 @@ using TransRelation = std::vector<TransList>;
 */
 struct InverseResults{
 
-    Node result_nodes{}; 
-    Node sharing_list{};
+	Node result_nodes{}; 
+	Node sharing_list{};
 
-    InverseResults() : result_nodes(), sharing_list() { }
-    InverseResults(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
-    InverseResults(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
+	InverseResults() : result_nodes(), sharing_list() { }
+	InverseResults(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
+	InverseResults(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
 
-    bool operator==(InverseResults rhs) const
-    { // {{{
-        return sharing_list == rhs.sharing_list && result_nodes == rhs.result_nodes;
-    } // operator== }}}
-    
-    bool operator!=(InverseResults rhs) const
-    { // {{{
-        return !this->operator==(rhs);
-    } // operator!= }}}
+	bool operator==(InverseResults rhs) const
+	{ // {{{
+		return sharing_list == rhs.sharing_list && result_nodes == rhs.result_nodes;
+	} // operator== }}}
 
-    bool operator<(InverseResults rhs) const
-    { // {{{
-        return sharing_list < rhs.sharing_list || (sharing_list == rhs.sharing_list && result_nodes < rhs.result_nodes);
-    } // operator< }}}
+	bool operator!=(InverseResults rhs) const
+	{ // {{{
+		return !this->operator==(rhs);
+	} // operator!= }}}
+
+	bool operator<(InverseResults rhs) const
+	{ // {{{
+		return sharing_list < rhs.sharing_list || (sharing_list == rhs.sharing_list && result_nodes < rhs.result_nodes);
+	} // operator< }}}
 
 }; // struct InverseResults
 
@@ -135,12 +135,12 @@ struct InverseResults{
 */
 struct InverseTrans{
 
-    Symbol symb;    
-    std::vector<InverseResults> inverseResults{};
+	Symbol symb;    
+	std::vector<InverseResults> inverseResults{};
 
-    InverseTrans() : symb(), inverseResults() { }
-    InverseTrans(Symbol symb) : symb(symb), inverseResults(std::vector<InverseResults>()) { }
-    InverseTrans(Symbol symb, InverseResults inverseResults_) : symb(symb) { inverseResults.push_back(inverseResults_); }
+	InverseTrans() : symb(), inverseResults() { }
+	InverseTrans(Symbol symb) : symb(symb), inverseResults(std::vector<InverseResults>()) { }
+	InverseTrans(Symbol symb, InverseResults inverseResults_) : symb(symb) { inverseResults.push_back(inverseResults_); }
 
 }; // struct InverseTrans
 
@@ -164,20 +164,20 @@ private:
 
 public:
 
-    Afa() : transRelation(), inverseTransRelation() {}
+	Afa() : transRelation(), inverseTransRelation() {}
 
-    explicit Afa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
-                 const StateSet& final_states = StateSet{})
-        : transRelation(num_of_states), inverseTransRelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
+	explicit Afa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
+		         const StateSet& final_states = StateSet{})
+		: transRelation(num_of_states), inverseTransRelation(num_of_states), initialstates(initial_states), finalstates(final_states) {}
 
 public:
 
 	StateSet initialstates = {};
 	StateSet finalstates = {};
 
-    State add_new_state(void);
+	State add_new_state(void);
 
-    auto get_num_of_states() const { return transRelation.size(); }
+	auto get_num_of_states() const { return transRelation.size(); }
 
 	void add_initial(State state) { this->initialstates.insert(state); }
 	void add_initial(const std::vector<State> vec)
@@ -222,10 +222,10 @@ public:
 		this->add_inverse_trans({src, symb, dst});
 	} // }}}
 
-    std::unique_ptr<Nodes> perform_trans (State src, Symbol symb) const;
+	std::unique_ptr<Nodes> perform_trans (State src, Symbol symb) const;
 
-    std::vector<InverseResults> perform_inverse_trans(State src, Symbol symb) const;
-    std::vector<InverseResults> perform_inverse_trans(Node src, Symbol symb) const;
+	std::vector<InverseResults> perform_inverse_trans(State src, Symbol symb) const;
+	std::vector<InverseResults> perform_inverse_trans(Node src, Symbol symb) const;
 
 	bool has_trans(const Trans& trans) const;
 	bool has_trans(State src, Symbol symb, Node dst) const
@@ -241,30 +241,30 @@ public:
 	size_t trans_size() const;/// number of transitions; has linear time complexity
 
 
-    StateClosedSet post(State state, Symbol symb) const;
-    StateClosedSet post(Node node, Symbol symb) const;
-    StateClosedSet post(Nodes nodes, Symbol symb) const;
-    StateClosedSet post(StateClosedSet closed_set, Symbol symb) const;
+	StateClosedSet post(State state, Symbol symb) const;
+	StateClosedSet post(Node node, Symbol symb) const;
+	StateClosedSet post(Nodes nodes, Symbol symb) const;
+	StateClosedSet post(StateClosedSet closed_set, Symbol symb) const;
 
-    StateClosedSet post(Node node) const;
-    StateClosedSet post(Nodes nodes) const;
+	StateClosedSet post(Node node) const;
+	StateClosedSet post(Nodes nodes) const;
 
-    StateClosedSet post(StateClosedSet closed_set) const {return post(closed_set.antichain());};
+	StateClosedSet post(StateClosedSet closed_set) const {return post(closed_set.antichain());};
 
-    StateClosedSet pre(Node node, Symbol symb) const;
-    StateClosedSet pre(State state, Symbol symb) const {return pre(Node(state), symb);};
-    StateClosedSet pre(Nodes nodes, Symbol symb) const;
-    StateClosedSet pre(StateClosedSet closed_set, Symbol symb) const;
+	StateClosedSet pre(Node node, Symbol symb) const;
+	StateClosedSet pre(State state, Symbol symb) const {return pre(Node(state), symb);};
+	StateClosedSet pre(Nodes nodes, Symbol symb) const;
+	StateClosedSet pre(StateClosedSet closed_set, Symbol symb) const;
 
-    StateClosedSet pre(Node node) const;
-    StateClosedSet pre(Nodes nodes) const;
+	StateClosedSet pre(Node node) const;
+	StateClosedSet pre(Nodes nodes) const;
 
-    StateClosedSet pre(StateClosedSet closed_set) const {return pre(closed_set.antichain());};
+	StateClosedSet pre(StateClosedSet closed_set) const {return pre(closed_set.antichain());};
 
-    StateClosedSet get_initial_nodes(void) const;
-    StateClosedSet get_non_initial_nodes(void) const;
-    StateClosedSet get_final_nodes(void) const;
-    StateClosedSet get_non_final_nodes(void) const;
+	StateClosedSet get_initial_nodes(void) const;
+	StateClosedSet get_non_initial_nodes(void) const;
+	StateClosedSet get_final_nodes(void) const;
+	StateClosedSet get_non_final_nodes(void) const;
 
 }; // Afa }}}
 
@@ -503,7 +503,7 @@ struct hash<Mata::Afa::Trans>
 	{
 		size_t accum = std::hash<Mata::Afa::State>{}(trans.src);
 		accum = Mata::util::hash_combine(accum, trans.symb);
-        accum = Mata::util::hash_combine(accum, trans.dst);
+		accum = Mata::util::hash_combine(accum, trans.dst);
 		return accum;
 	}
 };

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -126,14 +126,12 @@ struct InverseResults{
 */
 struct InverseTrans{
 
-    using InverseResultPtrs = std::vector<std::shared_ptr<InverseResults>>;
-
     Symbol symb;    
-    InverseResultPtrs inverseResultPtrs{};
+    std::vector<InverseResults> inverseResults{};
 
-    InverseTrans() : symb(), inverseResultPtrs() { }
-    InverseTrans(Symbol symb) : symb(symb), inverseResultPtrs(InverseResultPtrs()) { }
-    InverseTrans(Symbol symb, InverseResultPtrs inverseResultPtrs) : symb(symb), inverseResultPtrs(inverseResultPtrs) { }
+    InverseTrans() : symb(), inverseResults() { }
+    InverseTrans(Symbol symb) : symb(symb), inverseResults(std::vector<InverseResults>()) { }
+    InverseTrans(Symbol symb, InverseResults inverseResults_) : symb(symb) { inverseResults.push_back(inverseResults_); }
 
 }; // struct InverseTrans
 
@@ -213,8 +211,8 @@ public:
 
     std::unique_ptr<Nodes> perform_trans (State src, Symbol symb) const;
 
-    InverseTrans::InverseResultPtrs perform_inverse_trans(State src, Symbol symb) const;
-    InverseTrans::InverseResultPtrs perform_inverse_trans(Node src, Symbol symb) const;
+    std::vector<InverseResults> perform_inverse_trans(State src, Symbol symb) const;
+    std::vector<InverseResults> perform_inverse_trans(Node src, Symbol symb) const;
 
 	bool has_trans(const Trans& trans) const;
 	bool has_trans(State src, Symbol symb, Node dst) const

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -85,12 +85,7 @@ struct Trans
 	} // operator== }}}
 	bool operator!=(const Trans& rhs) const { return !this->operator==(rhs); }
 
-    /*friend std::ostream& operator<<(std::ostream& os, const Trans trans)
-    {
-        return os << std::to_string(trans.src) + ":" + std::to_string(trans.symb) + "->" + std::to_string(trans.dst) + "\n";
-    }*/
-
-};
+}; // struct Trans
 
 using TransList = std::vector<Trans>;
 using TransRelation = std::vector<TransList>;
@@ -99,48 +94,48 @@ using TransRelation = std::vector<TransList>;
 * A tuple (result_nodes, sharing_list). If 'a' is an element of result_nodes, it means that there exists a symbol
 * 'b' such that sharing_list belongs to delta(a, b), where sharing_list is a node (vector of states). 
 */
-typedef struct InverseResults_{
+struct InverseResults{
 
     Node result_nodes{}; 
     Node sharing_list{};
 
-    InverseResults_() : result_nodes(), sharing_list() { }
-    InverseResults_(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
-    InverseResults_(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
+    InverseResults() : result_nodes(), sharing_list() { }
+    InverseResults(State state, Node sharing_list) : result_nodes(Node(state)), sharing_list(sharing_list) { }
+    InverseResults(Node result_nodes, Node sharing_list) : result_nodes(result_nodes), sharing_list(sharing_list) { }
 
-    bool operator==(InverseResults_ rhs) const
+    bool operator==(InverseResults rhs) const
     { // {{{
         return sharing_list == rhs.sharing_list && result_nodes == rhs.result_nodes;
     } // operator== }}}
     
-    bool operator!=(InverseResults_ rhs) const
+    bool operator!=(InverseResults rhs) const
     { // {{{
         return !this->operator==(rhs);
     } // operator!= }}}
 
-    bool operator<(InverseResults_ rhs) const
+    bool operator<(InverseResults rhs) const
     { // {{{
         return sharing_list < rhs.sharing_list || (sharing_list == rhs.sharing_list && result_nodes < rhs.result_nodes);
     } // operator< }}}
 
-}InverseResults;
+}; // struct InverseResults
 
 /*
 * A tuple (symb, vector_of_pointers). Each pointer points to the instance of InverseResults. If &(result_nodes, sharing_list) belongs to the
 * vector_of_pointers, then for each 'a' which is part of result_nodes holds that 'sharing_list' is a member of delta(a, symbol).
 */
-typedef struct InverseTrans_{
+struct InverseTrans{
 
     using InverseResultPtrs = std::vector<std::shared_ptr<InverseResults>>;
 
     Symbol symb;    
     InverseResultPtrs inverseResultPtrs{};
 
-    InverseTrans_() : symb(), inverseResultPtrs() { }
-    InverseTrans_(Symbol symb) : symb(symb), inverseResultPtrs(InverseResultPtrs()) { }
-    InverseTrans_(Symbol symb, InverseResultPtrs inverseResultPtrs) : symb(symb), inverseResultPtrs(inverseResultPtrs) { }
+    InverseTrans() : symb(), inverseResultPtrs() { }
+    InverseTrans(Symbol symb) : symb(symb), inverseResultPtrs(InverseResultPtrs()) { }
+    InverseTrans(Symbol symb, InverseResultPtrs inverseResultPtrs) : symb(symb), inverseResultPtrs(inverseResultPtrs) { }
 
-}InverseTrans;
+}; // struct InverseTrans
 
 using InverseTransRelation = std::vector<std::vector<InverseTrans>>;
 
@@ -156,8 +151,7 @@ Mata::Parser::ParsedSection serialize(
 ///  An AFA
 struct Afa
 { // {{{
-public:
-
+private:
     TransRelation transRelation{};
     InverseTransRelation inverseTransRelation{};
 
@@ -244,7 +238,7 @@ public:
     ClosedSet<State> post(Node node) const;
     ClosedSet<State> post(Nodes nodes) const;
 
-    ClosedSet<State> post(ClosedSet<State> closed_set) const {return post(closed_set.get_antichain());};
+    ClosedSet<State> post(ClosedSet<State> closed_set) const {return post(closed_set.antichain());};
 
     ClosedSet<State> pre(Node node, Symbol symb) const;
     ClosedSet<State> pre(State state, Symbol symb) const {return pre(Node(state), symb);};
@@ -254,7 +248,7 @@ public:
     ClosedSet<State> pre(Node node) const;
     ClosedSet<State> pre(Nodes nodes) const;
 
-    ClosedSet<State> pre(ClosedSet<State> closed_set) const {return pre(closed_set.get_antichain());};
+    ClosedSet<State> pre(ClosedSet<State> closed_set) const {return pre(closed_set.antichain());};
 
     ClosedSet<State> get_initial_nodes(void) const;
     ClosedSet<State> get_non_initial_nodes(void) const;

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -175,6 +175,10 @@ public:
 	StateSet initialstates = {};
 	StateSet finalstates = {};
 
+    State add_new_state(void);
+
+    auto get_num_of_states() const { return transRelation.size(); }
+
 	void add_initial(State state) { this->initialstates.insert(state); }
 	void add_initial(const std::vector<State> vec)
 	{ // {{{

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -237,6 +237,9 @@ public:
 		return this->has_trans({src, symb, dst});
 	} // }}}
 
+	std::vector<Trans> get_trans_from_state(State state) const;
+	Trans get_trans_from_state(State state, Symbol symbol) const;
+
 	bool trans_empty() const {!transRelation.size();};// no transitions
 	size_t trans_size() const;/// number of transitions; has linear time complexity
 

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -46,7 +46,6 @@ using State = Mata::Nfa::State;
 using Symbol = Mata::Nfa::Symbol;
 
 template<typename T> using OrdVec = Mata::Util::OrdVector<T>;
-template<typename T> using ClosedSet = Mata::ClosedSet<T>;
 
 using Node = OrdVec<State>;
 using Nodes = OrdVec<Node>;
@@ -62,12 +61,22 @@ using Word = Mata::Nfa::Word;
 using StringDict = Mata::Nfa::StringDict;
 
 using StateSet = OrdVec<State>;
+using StateClosedSet = Mata::ClosedSet<Mata::Afa::State>;
 
 using Alphabet = Mata::Nfa::Alphabet;
 
 /*
-* A transition consists of a source state, a symbol and a vector of vector of states / vector of nodes
-* This corresponds to the formula in DNF
+* A node is an ordered vector of states of the automaton.
+* A transition consists of a source state, a symbol on the transition 
+* and a vector of nodes (which are the destination of the transition).
+*
+* In context of an AFA, the transition relation maps a state and a symbol
+* to the positive Boolean formula over states, which is a Boolean formula
+* using states in positive form, conjunctions and disjunctions. Since such
+* a formula can be converted to the DNF, we can represent is as an ordered vector
+* of nodes. The ordered vector represents a set of disjuncts. Each node corresponds
+* to a single disjunct of a formula in DNF (states connected by conjunctions).
+* 
 */
 struct Trans
 {
@@ -228,30 +237,30 @@ public:
 	size_t trans_size() const;/// number of transitions; has linear time complexity
 
 
-    ClosedSet<State> post(State state, Symbol symb) const;
-    ClosedSet<State> post(Node node, Symbol symb) const;
-    ClosedSet<State> post(Nodes nodes, Symbol symb) const;
-    ClosedSet<State> post(ClosedSet<State> closed_set, Symbol symb) const;
+    StateClosedSet post(State state, Symbol symb) const;
+    StateClosedSet post(Node node, Symbol symb) const;
+    StateClosedSet post(Nodes nodes, Symbol symb) const;
+    StateClosedSet post(StateClosedSet closed_set, Symbol symb) const;
 
-    ClosedSet<State> post(Node node) const;
-    ClosedSet<State> post(Nodes nodes) const;
+    StateClosedSet post(Node node) const;
+    StateClosedSet post(Nodes nodes) const;
 
-    ClosedSet<State> post(ClosedSet<State> closed_set) const {return post(closed_set.antichain());};
+    StateClosedSet post(StateClosedSet closed_set) const {return post(closed_set.antichain());};
 
-    ClosedSet<State> pre(Node node, Symbol symb) const;
-    ClosedSet<State> pre(State state, Symbol symb) const {return pre(Node(state), symb);};
-    ClosedSet<State> pre(Nodes nodes, Symbol symb) const;
-    ClosedSet<State> pre(ClosedSet<State> closed_set, Symbol symb) const;
+    StateClosedSet pre(Node node, Symbol symb) const;
+    StateClosedSet pre(State state, Symbol symb) const {return pre(Node(state), symb);};
+    StateClosedSet pre(Nodes nodes, Symbol symb) const;
+    StateClosedSet pre(StateClosedSet closed_set, Symbol symb) const;
 
-    ClosedSet<State> pre(Node node) const;
-    ClosedSet<State> pre(Nodes nodes) const;
+    StateClosedSet pre(Node node) const;
+    StateClosedSet pre(Nodes nodes) const;
 
-    ClosedSet<State> pre(ClosedSet<State> closed_set) const {return pre(closed_set.antichain());};
+    StateClosedSet pre(StateClosedSet closed_set) const {return pre(closed_set.antichain());};
 
-    ClosedSet<State> get_initial_nodes(void) const;
-    ClosedSet<State> get_non_initial_nodes(void) const;
-    ClosedSet<State> get_final_nodes(void) const;
-    ClosedSet<State> get_non_final_nodes(void) const;
+    StateClosedSet get_initial_nodes(void) const;
+    StateClosedSet get_non_initial_nodes(void) const;
+    StateClosedSet get_final_nodes(void) const;
+    StateClosedSet get_non_final_nodes(void) const;
 
 }; // Afa }}}
 

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -159,7 +159,7 @@ struct ClosedSet
         bool operator>=(ClosedSet<T> rhs) const
 	    { // {{{
             assert(type == rhs.type && min_val == rhs.min_val && max_val == rhs.max_val);
-            return this.contains(rhs.antichain);
+            return contains(rhs.antichain);
 	    } // operator<= }}}
 
         // Text representation of a closed set

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -157,7 +157,7 @@ struct ClosedSet
         // has to be upward- or downward-closed set
         bool operator>=(ClosedSet<T> rhs) const
 	    { // {{{
-            assert(type == rhs.type && min_val == rhs.min_val && max_val == rhs.max_val);
+            assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
             return contains(rhs.antichain);
 	    } // operator<= }}}
 
@@ -365,7 +365,7 @@ void ClosedSet<T>::insert(Node node)
 template <typename T>
 ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const
 {
-    assert(type_ == rhs.type() && min_val_ == rhs.min_val() && max_val_ == rhs.max_val());
+    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
     ClosedSet<T> result(type_, min_val_, max_val_, antichain_);
     result.insert(rhs.antichain());
     return result;
@@ -379,7 +379,7 @@ ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const
 template <typename T>
 ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const
 {
-    assert(type == rhs.type() && min_val == rhs.min_val() && max_val == rhs.max_val());
+    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
     ClosedSet<T> result(type_, min_val_, max_val_);
 
     // Iterates through all the tuples from Antichan1 X Antichan2 and creates an union of them

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -187,8 +187,8 @@ struct ClosedSet
        // other methods
        /////////////////////////////////////////////
 
-       bool is_upward_closed(void) const {return type == upward_closed_set;};
-       bool is_downward_closed(void) const {return type == downward_closed_set;};
+       bool is_upward_closed(void) const {return type_ == upward_closed_set;};
+       bool is_downward_closed(void) const {return type_ == downward_closed_set;};
 
        ClosedSetType type() {return type_;}
        const ClosedSetType type() const {return type_;}

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -24,6 +24,7 @@
  *
  * Description:
  * In this context, an upward-closed set is a set of sets of elements of type T,
+ * (set of nodes of type T, where a node is a set of elements of type T)
  * where the elements come from the discrete range <min_val; max_val>. If the upward
  * closed set contains a subset A of the range <min_val; max_val>, it also contains
  * all the supersets of A (in context of the discrete range <min_val; max_val>).
@@ -43,20 +44,21 @@
  *
  * It is not possible to:
  *
- * -> choose a custom carrier which is not a discrete range <min_val; max_val> (???)
+ * -> choose a custom carrier which is not a discrete range <min_val; max_val>
  * -> <=- and >=-compare two closed sets of the different types (nonsense)
- * -> remove a node/more nodes from the closed set (nonsense (???))
+ * -> remove a node/more nodes from the closed set (nonsense)
  * -> perform an union over two closed sets of different types or different carriers (nonsense)
  * -> perform an intersection over two closed sets of different types or different carriers (nonsense) 
  * -> compute a complement of a closed set (TODO)
  *
  * Examples:
  *
- * Let us have the carrier {0, 1, 2, 3} and the upward-closed set with the antichain {{0}, {1, 2}}. We can write
- * ↑{{0}, {1, 2}} = {{0}, {0, 1}, {0, 2}, {0, 3}, {0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2}, {1, 2, 3}, {0, 1, 2, 3}}.
+ * Let us have the carrier {0, 1, 2, 3} and the upward-closed set with the antichain 
+ * {{0}, {1, 2}}. We can write↑{{0}, {1, 2}} = {{0}, {0, 1}, {0, 2}, {0, 3}, {0, 1, 2},
+ * {0, 1, 3}, {0, 2, 3}, {1, 2}, {1, 2, 3}, {0, 1, 2, 3}}.
  *
- * Let us have the carrier {0, 1, 2, 3} and the downward-closed set with the antichain {{0}, {1, 2}}. We can write
- * ↓{{0}, {1, 2}} = {{0}, {1, 2}, {1}, {2}, {}}.
+ * Let us have the carrier {0, 1, 2, 3} and the downward-closed set with the antichain 
+ * {{0}, {1, 2}}. We can write ↓{{0}, {1, 2}} = {{0}, {1, 2}, {1}, {2}, {}}.
  *
  *  @author Tomáš Kocourek
  */
@@ -75,12 +77,13 @@ namespace Mata
 // Ordered vector
 template<typename T> using OrdVec = Mata::Util::OrdVector<T>;
 
+// A closed set could be upward-closed or downward-closed
 enum ClosedSetType {upward_closed_set, downward_closed_set};
 
 // Closed set
 // contains discrete range borders, its type
 // and the corresponding antichain
-// It is neccessary to be able to evaluate relations operators
+// It is neccessary to be able to evaluate relation operators
 // <, <=, >, >=, ==, != over instances of this datatype T
 template <typename T> 
 struct ClosedSet
@@ -131,33 +134,42 @@ struct ClosedSet
        // operators
        /////////////////////////////////////////////
 
-       // Two closed sets are equivalent iff their type, borders and corresponding antichains are the same
+       // Two closed sets are equivalent iff their type, borders 
+	   // and corresponding antichains are the same
        bool operator==(ClosedSet<T> rhs) const
 	    { // {{{
-		    return type_ == rhs.type && min_val_ == rhs.min_val && max_val_ == rhs.max_val && antichain_ == rhs.antichain;
+		    return type_ == rhs.type && min_val_ == rhs.min_val && 
+			max_val_ == rhs.max_val && antichain_ == rhs.antichain;
 	    } // operator== }}}
 
-       // Two closed sets are not equivalent iff their type, borders or corresponding antichains differ
+       // Two closed sets are not equivalent iff their type, 
+	   // borders or corresponding antichains differ
        bool operator!=(ClosedSet<T> rhs) const
 	    { // {{{
-		    return type_ != rhs.type_ || min_val_ != rhs.min_val_ || max_val_ != rhs.max_val_ || antichain_ != rhs.antichain_;
+		    return type_ != rhs.type_ || min_val_ != rhs.min_val_ ||
+			max_val_ != rhs.max_val_ || antichain_ != rhs.antichain_;
 	    } // operator!= }}}
 
-        // A closed set is considered to be smaller than the other one iff it is a subset of the other one
-        // It is not possible to perform <=-comparisons of accros upward- and downward-closed sets, each argument
-        // has to be upward- or downward-closed set
+        // A closed set is considered to be smaller than the other one iff
+		// it is a subset of the other one
+		// It is not possible to perform <=-comparisons accros upward- and downward-closed
+		// sets, each argument has to be upward- or downward-closed set
         bool operator<=(ClosedSet<T> rhs) const
 	    { // {{{
-            assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
+            assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
+			"Types and borders of given closed sets must be the same to perform their <=-comparison.");
             return rhs.contains(antichain_);
 	    } // operator<= }}}
 
-        // A closed set is considered to be bigger than the other one iff it is a superset of the other one
-        // It is not possible to perform <=-comparisons of accros upward- and downward-closed sets, each argument
+        // A closed set is considered to be bigger than the other one iff 
+		// it is a superset of the other one
+        // It is not possible to perform <=-comparisons of accros upward- 
+		// and downward-closed sets, each argument
         // has to be upward- or downward-closed set
         bool operator>=(ClosedSet<T> rhs) const
 	    { // {{{
-            assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
+            assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
+			"Types and borders of given closed sets must be the same to perform their <=-comparison.");
             return contains(rhs.antichain);
 	    } // operator<= }}}
 
@@ -167,7 +179,8 @@ struct ClosedSet
             std::string strType = "TYPE: ";
             strType += cs.get_type() == upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
             strType += "\n";
-            std::string strInterval = "INTERVAL: " + std::to_string(cs.get_min()) + " - " + std::to_string(cs.get_max()) + "\n";
+            std::string strInterval = "INTERVAL: " + std::to_string(cs.get_min()) + 
+			" - " + std::to_string(cs.get_max()) + "\n";
             std::string strValues = "ANTICHAIN: {";
             for(auto node : cs.get_antichain())
             {
@@ -181,11 +194,6 @@ struct ClosedSet
             strValues += "}";
             return os << strType + strInterval + strValues + "\n";
         }
-
-       /////////////////////////////////////////////
-
-       // other methods
-       /////////////////////////////////////////////
 
        bool is_upward_closed(void) const {return type_ == upward_closed_set;};
        bool is_downward_closed(void) const {return type_ == downward_closed_set;};
@@ -254,7 +262,7 @@ bool ClosedSet<T>::contains(Node node) const
 /** This function decides whether a set of sets of elements is a part of the closed set
 * by subset-compraring the input with all elements of the antichain 
 * @brief decides whether the closed set contains a given set of sets of elements
-* @param node a given ordered vector of ordered vectors of elements of the type T
+* @param nodes a given ordered vector of ordered vectors of elements of the type T
 * @return true iff the given ordered vector of ordered vectors belongs to the current closed set
 */
 template <typename T>
@@ -273,7 +281,7 @@ bool ClosedSet<T>::contains(Nodes nodes) const
 /** This function decides whether a given ordered vector of elements of the datatype T
 * belongs to the discrete interval of the current closed set
 * @brief decides whether the given vector respects the borders
-* @param node a given ordered vector elements of the type T which will be inspected
+* @param node a given ordered vector of elements of the type T which will be inspected
 * @return true iff the given ordered vector respects the borders
 */
 template <typename T>
@@ -291,14 +299,16 @@ bool ClosedSet<T>::in_interval(Node node) const
 
 /** Adds a new element to the closed set. If the element is already contained in the closed
 * set, the closed set remains unchanged. Otherwise, the antichain will be recomputed.
-* @brief decides whether the given vector respects the borders
-* @param node a given ordered vector elements of the type T which will be inspected
+* @brief inserts a new element to the closed set
+* @param node a given node which will be added to the closed set
 */
 template <typename T>
 void ClosedSet<T>::insert(Node node)
 {
-    assert(in_interval(node));
+    assert(in_interval(node) && "Each element of the given node has to respect " &&
+	"the carrier of the closed set.");
     // If the closed set is empty, the antichain could be simply changed
+	// by adding the given node as the only node to the antichain
     if(antichain_.empty())
     {
         antichain_.insert(node);
@@ -365,7 +375,8 @@ void ClosedSet<T>::insert(Node node)
 template <typename T>
 ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const
 {
-    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
+    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
+	"Types and borders of given closed sets must be the same to compute their union.");
     ClosedSet<T> result(type_, min_val_, max_val_, antichain_);
     result.insert(rhs.antichain());
     return result;
@@ -379,10 +390,12 @@ ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const
 template <typename T>
 ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const
 {
-    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_);
+    assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
+	"Types and borders of given closed sets must be the same to compute their union.");
     ClosedSet<T> result(type_, min_val_, max_val_);
 
-    // Iterates through all the tuples from Antichan1 X Antichan2 and creates an union of them
+    // Iterates through all the tuples from Antichan1 X Antichan2 
+	// and creates an union of them
     if(type_ == upward_closed_set)
     {
         for(auto element1 : antichain_)
@@ -394,7 +407,8 @@ ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const
         }
     }
 
-    // Iterates through all the tuples from Antichan1 X Antichan2 and creates an intersection of them
+    // Iterates through all the tuples from Antichan1 X Antichan2 
+	// and creates an intersection of them
     if(type_ == downward_closed_set)
     {
         for(auto element1 : antichain_)

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -1,0 +1,408 @@
+/* closed_set.hh --- downward and upward closed sets
+ *
+ * Copyright (c) TODO
+ *
+ * This file is a part of libmata.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/** @file closed_set.hh
+ *  @brief Definition of a closed set
+ *
+ *  This file contains definition of a closed set and function which
+ *  allow us to work with them (membership, inclusion, union, intersection)
+ *
+ *
+ * Description:
+ * In this context, an upward-closed set is a set of sets of elements of type T,
+ * where the elements come from the discrete range <min_val; max_val>. If the upward
+ * closed set contains a subset A of the range <min_val; max_val>, it also contains
+ * all the supersets of A (in context of the discrete range <min_val; max_val>).
+ * Thus, the upward closed set could be easily represented by its 1) type (upward closed),
+ * 2) discrete range borders (min_val, max_val), 3) its antichain.
+ * Analogously, a downward closed set contains all the subsets of the antichain elements.
+ *
+ * It is possible to:
+ *
+ * -> ==- and !=-compare two closed sets
+ * -> <=- and >=-compare two closed sets of the same type
+ * -> get a text representation of the closed set
+ * -> chceck whether the closed set contains a given node/nodes
+ * -> insert a node/more nodes to the closed set
+ * -> perform an union over two closed sets of the same type and with the same carrier
+ * -> perform an intersection over two closed sets of the same type and with the same carrier
+ *
+ * It is not possible to:
+ *
+ * -> choose a custom carrier which is not a discrete range <min_val; max_val> (???)
+ * -> <=- and >=-compare two closed sets of the different types (nonsense)
+ * -> remove a node/more nodes from the closed set (nonsense (???))
+ * -> perform an union over two closed sets of different types or different carriers (nonsense)
+ * -> perform an intersection over two closed sets of different types or different carriers (nonsense) 
+ * -> perform a complement of the closed set (TODO)
+ *
+ * Examples:
+ *
+ * Let us have the carrier {0, 1, 2, 3} and the upward-closed set with the antichain {{0}, {1, 2}}. We can write
+ * ↑{{0}, {1, 2}} = {{0}, {0, 1}, {0, 2}, {0, 3}, {0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2}, {1, 2, 3}, {0, 1, 2, 3}}.
+ *
+ * Let us have the carrier {0, 1, 2, 3} and the downward-closed set with the antichain {{0}, {1, 2}}. We can write
+ * ↓{{0}, {1, 2}} = {{0}, {1, 2}, {1}, {2}, {}}.
+ *
+ *  @author Tomáš Kocourek
+ */
+
+#ifndef _MATA_CLOSED_SET_HH_
+#define _MATA_CLOSED_SET_HH_
+
+#include <cassert>
+
+#include <mata/util.hh>
+#include <mata/ord_vector.hh>
+
+namespace Mata
+{
+
+// Ordered vector
+template<typename T> using OrdVec = Mata::Util::OrdVector<T>;
+
+// Closed set
+// contains discrete range borders, its type
+// and the corresponding antichain
+// It is neccessary to be able to evaluate relations operators
+// <, <=, >, >=, ==, != over instances of this datatype T
+template <typename T> 
+struct ClosedSet
+{
+    // static constants describing the type of closed sets
+    static const bool upward_closed = true;
+    static const bool downward_closed = false;
+    using Node = OrdVec<T>;
+    using Nodes = OrdVec<Node>;
+
+    private:
+
+       bool type{upward_closed}; // upward_closed or downward_closed sets
+       T min_val;
+       T max_val;
+       Nodes antichain{}; 
+
+    public:
+    
+       // constructors
+       /////////////////////////////////////////////
+
+       ClosedSet() : type(), min_val(), max_val(), antichain() { }
+
+       // inserting a single value of the datatype T           
+       ClosedSet(bool type, T min_val, T max_val, T value) : 
+       type(type), min_val(min_val), max_val(max_val), antichain(OrdVec<T>(OrdVec<T>(value))) 
+       { 
+            assert(min_val <= max_val); 
+            assert(min_val <= value && value <= max_val);
+       }
+
+       // inserting a single vector of the datatype T
+       ClosedSet(bool type, T min_val, T max_val, Node node) : 
+       type(type), min_val(min_val), max_val(max_val), antichain(OrdVec<T>(node)) 
+       { 
+            assert(min_val <= max_val);
+            assert(in_interval(node));
+       }
+
+       // inserting a whole antichain
+       ClosedSet(bool type, T min_val, T max_val, Nodes antichain = Nodes()) : 
+       type(type), min_val(min_val), max_val(max_val)
+       { 
+            assert(min_val <= max_val);
+            insert(antichain);
+       }
+
+       /////////////////////////////////////////////
+
+       // operators
+       /////////////////////////////////////////////
+
+       // Two closed sets are equivalent iff their type, borders and corresponding antichains are the same
+       bool operator==(ClosedSet<T> rhs) const
+	    { // {{{
+		    return type == rhs.type && min_val == rhs.min_val && max_val == rhs.max_val && antichain == rhs.antichain;
+	    } // operator== }}}
+
+       // Two closed sets are not equivalent iff their type, borders or corresponding antichains differ
+       bool operator!=(ClosedSet<T> rhs) const
+	    { // {{{
+		    return type != rhs.type || min_val != rhs.min_val || max_val != rhs.max_val || antichain != rhs.antichain;
+	    } // operator!= }}}
+
+        // A closed set is considered to be smaller than the other one iff it is a subset of the other one
+        // It is not possible to perform <=-comparisons of accros upward- and downward-closed sets, each argument
+        // has to be upward- or downward-closed set
+        bool operator<=(ClosedSet<T> rhs) const
+	    { // {{{
+            assert(type == rhs.type && min_val == rhs.min_val && max_val == rhs.max_val);
+            return rhs.contains(antichain);
+	    } // operator<= }}}
+
+        // A closed set is considered to be bigger than the other one iff it is a superset of the other one
+        // It is not possible to perform <=-comparisons of accros upward- and downward-closed sets, each argument
+        // has to be upward- or downward-closed set
+        bool operator>=(ClosedSet<T> rhs) const
+	    { // {{{
+            assert(type == rhs.type && min_val == rhs.min_val && max_val == rhs.max_val);
+            return this.contains(rhs.antichain);
+	    } // operator<= }}}
+
+        // Text representation of a closed set
+        friend std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs)
+        {
+            std::string strType = "TYPE: ";
+            strType += cs.get_type() ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
+            strType += "\n";
+            std::string strInterval = "INTERVAL: " + std::to_string(cs.get_min()) + " - " + std::to_string(cs.get_max()) + "\n";
+            std::string strValues = "ANTICHAIN: {";
+            for(auto node : cs.get_antichain())
+            {
+                strValues += "{";
+                for(auto state : node)
+                {
+                    strValues += " " + std::to_string(state);
+                }
+                strValues += "}";
+            }
+            strValues += "}";
+            return os << strType + strInterval + strValues + "\n";
+        }
+
+       /////////////////////////////////////////////
+
+       // other methods
+       /////////////////////////////////////////////
+
+       bool is_upward_closed(void) const {return type == upward_closed;};
+       bool is_downward_closed(void) const {return type == downward_closed;};
+       const bool get_type(void) const {return (const bool)type;};
+       const Nodes get_antichain(void) const {return (const Nodes)antichain;};
+       const T get_min(void) const {return min_val;};
+       const T get_max(void) const {return max_val;};
+
+       bool contains (Node node) const;
+       bool contains (Nodes nodes) const;
+
+       bool in_interval (Node node) const;      
+
+       void insert(T el) {insert(Node(el));};
+       void insert(Node node);
+       void insert(Nodes nodes) {for(auto node : nodes) insert(node);};
+
+       ClosedSet Union (const ClosedSet rhs) const;
+       ClosedSet intersection (const ClosedSet rhs) const;
+
+       //TODO: complement!!!
+
+       /////////////////////////////////////////////
+}; // ClosedSet }}}
+
+/** This function decides whether a set of elements is part of the closed set
+* by subset-compraring the input with all elements of the antichain 
+* @brief decides whether the closed set contains a given element
+* @param node a given ordered vector of elements of the type T
+* @return true iff the given ordered vector belongs to the current closed set
+*/
+template <typename T>
+bool ClosedSet<T>::contains(Node node) const
+{
+    if(type == upward_closed)
+    {         
+        for(auto element : antichain)
+        {
+            if(element.IsSubsetOf(node))
+            {
+                return true;
+            }
+        }
+    }
+    else if(type == downward_closed)
+    {         
+        for(auto element : antichain)
+        {
+            if(node.IsSubsetOf(element))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+} // contains }}}
+
+/** This function decides whether a set of sets of elements is a part of the closed set
+* by subset-compraring the input with all elements of the antichain 
+* @brief decides whether the closed set contains a given set of sets of elements
+* @param node a given ordered vector of ordered vectors of elements of the type T
+* @return true iff the given ordered vector of ordered vectors belongs to the current closed set
+*/
+template <typename T>
+bool ClosedSet<T>::contains(Nodes nodes) const
+{
+    for(auto node : nodes)
+    {
+        if(!contains(node))
+        {
+            return false;
+        }
+    }
+    return true;
+} // contains }}}
+
+/** This function decides whether a given ordered vector of elements of the datatype T
+* belongs to the discrete interval of the current closed set
+* @brief decides whether the given vector respects the borders
+* @param node a given ordered vector elements of the type T which will be inspected
+* @return true iff the given ordered vector respects the borders
+*/
+template <typename T>
+bool ClosedSet<T>::in_interval(Node node) const
+{
+    for(auto value : node)
+    {
+        if(value < min_val || value > max_val)
+        {
+            return false;
+        }
+    }
+    return true;
+} // in_interval }}}
+
+/** Adds a new element to the closed set. If the element is already contained in the closed
+* set, the closed set remains unchanged. Otherwise, the antichain will be recomputed.
+* @brief decides whether the given vector respects the borders
+* @param node a given ordered vector elements of the type T which will be inspected
+*/
+template <typename T>
+void ClosedSet<T>::insert(Node node)
+{
+    assert(in_interval(node));
+    // If the closed set is empty, the antichain could be simply changed
+    if(antichain.empty())
+    {
+        antichain.insert(node);
+        return;
+    }
+    // If the closed set already contains the given node, there is no
+    // need to change the closed set
+    if(contains(node))
+    {
+        return;
+    }
+    // We need to collect all the elements off the antichain which could be removed
+    // as soon as the new element is added to keep the antichain <=-uncomparable
+    OrdVec<OrdVec<T>> to_erase{};
+
+    // If the closed set is upward-closed, we have to erase all the elements of
+    // the antichain which are supersets of the inserted node
+    // Example: Let us have an upward-closed set ↑{{0, 1}, {2}} with a corresponding 
+    // antichain {{0, 1}, {2}}. If we add {0} to the closed set, the element {0, 1}
+    // needs to be erased from the antichain since the set {{0}, {0, 1}, {2}} contains
+    // <=-comparable elements and the result should be upward-closed.
+    if(type == upward_closed)
+    {
+        for(auto element : antichain)
+        {
+            if(node.IsSubsetOf(element))
+            {
+                to_erase.insert(element);
+            }
+        }
+    }
+
+    // If the closed set is downward-closed, we have to erase all the elements of
+    // the antichain which are subsets of the inserted node
+    // Example: Let us have an upward-closed set ↓{{0, 1}, {2}} with a corresponding 
+    // antichain {{0, 1}, {2}}. If we add {1, 2} to the closed set, the element {2}
+    // needs to be erased from the antichain since the set {{0}, {1, 2}, {2}} contains
+    // <=-comparable elements and the result should be downward-closed.
+    else if(type == downward_closed)
+    {
+        for(auto element : antichain)
+        {
+            if(element.IsSubsetOf(node))
+            {
+                to_erase.insert(element);
+            }
+        }
+    }
+
+    for(auto element : to_erase)
+    {
+        antichain.remove(element);
+    }
+    antichain.insert(node);
+} // insert }}}
+
+/** Performs an union over two closed sets with the same type and carrier. 
+* This function simply adds all the
+* elements of the antichain of the first closed set to the second closed set
+* @brief performs an union over closed sets
+* @param rhs a given closed set which will be unioned with the current one
+* @return an union of the given closed sets
+*/
+template <typename T>
+ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const
+{
+    assert(type == rhs.get_type() && min_val == rhs.get_min() && max_val == rhs.get_max());
+    ClosedSet<T> result(type, min_val, max_val, antichain);
+    result.insert(rhs.get_antichain());
+    return result;
+} // Union }}}
+
+/** Performs an intersection over two closed sets with the same type and carrier.
+* @brief performs an intersection over closed sets
+* @param rhs a given closed set which will be intersectioned with the current one
+* @return an intersection of the given closed sets
+*/
+template <typename T>
+ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const
+{
+    assert(type == rhs.get_type() && min_val == rhs.get_min() && max_val == rhs.get_max());
+    ClosedSet<T> result(type, min_val, max_val);
+
+    // Iterates through all the tuples from Antichan1 X Antichan2 and creates an union of them
+    if(type == upward_closed)
+    {
+        for(auto element1 : antichain)
+        {
+            for(auto element2 : rhs.get_antichain())
+            {
+               result.insert(element1.Union(element2));    
+            }
+        }
+    }
+
+    // Iterates through all the tuples from Antichan1 X Antichan2 and creates an intersection of them
+    if(type == downward_closed)
+    {
+        for(auto element1 : antichain)
+        {
+            for(auto element2 : rhs.get_antichain())
+            {
+               result.insert(element1.intersection(element2));    
+            }
+        }
+    }    
+    return result;
+} // intersection }}}
+
+
+} // std }}}
+
+
+#endif /* _MATA_CLOSED_SET_HH_ */

--- a/include/mata/closed_set.hh
+++ b/include/mata/closed_set.hh
@@ -48,7 +48,7 @@
  * -> remove a node/more nodes from the closed set (nonsense (???))
  * -> perform an union over two closed sets of different types or different carriers (nonsense)
  * -> perform an intersection over two closed sets of different types or different carriers (nonsense) 
- * -> perform a complement of the closed set (TODO)
+ * -> compute a complement of a closed set (TODO)
  *
  * Examples:
  *
@@ -190,8 +190,8 @@ struct ClosedSet
 
        bool is_upward_closed(void) const {return type == upward_closed;};
        bool is_downward_closed(void) const {return type == downward_closed;};
-       const bool get_type(void) const {return (const bool)type;};
-       const Nodes get_antichain(void) const {return (const Nodes)antichain;};
+       const bool get_type(void) const {return type;};
+       const Nodes get_antichain(void) const {return antichain;};
        const T get_min(void) const {return min_val;};
        const T get_max(void) const {return max_val;};
 

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -51,23 +51,23 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::Trans& trans)
 void Afa::add_trans(const Trans& trans)
 { // {{{
 
-    // Performs a transition using given src state and symbol
-    // in context of transitions which have been already added to the automaton
-    // If there is no result, a new transition will be created
-    // If the corresponding transition already exists, given 'dst' will be added to
-    // the transition
-    auto nodesPtr = perform_trans(trans.src, trans.symb);
-    if(!nodesPtr->empty())
-    {
-        // Before the dst nodes are added to the transition, we want to get rid
-        // of redundant clauses. For example, in context of the formula
-        // (1 || (1 && 2)), the clause (1 && 2) could be deleted
-        auto cl = StateClosedSet(upward_closed_set, 0, transRelation.size()-1, *nodesPtr);
-        cl.insert(trans.dst);
-        *nodesPtr = cl.antichain();
-        return;
-    }
-    transRelation[trans.src].push_back(trans);
+	// Performs a transition using given src state and symbol
+	// in context of transitions which have been already added to the automaton
+	// If there is no result, a new transition will be created
+	// If the corresponding transition already exists, given 'dst' will be added to
+	// the transition
+	auto nodesPtr = perform_trans(trans.src, trans.symb);
+	if(!nodesPtr->empty())
+	{
+		// Before the dst nodes are added to the transition, we want to get rid
+		// of redundant clauses. For example, in context of the formula
+		// (1 || (1 && 2)), the clause (1 && 2) could be deleted
+		auto cl = StateClosedSet(upward_closed_set, 0, transRelation.size()-1, *nodesPtr);
+		cl.insert(trans.dst);
+		*nodesPtr = cl.antichain();
+		return;
+	}
+	transRelation[trans.src].push_back(trans);
 
 } // add_trans }}}
 
@@ -80,71 +80,71 @@ void Afa::add_trans(const Trans& trans)
 void Afa::add_inverse_trans(const Trans& trans)
 {// {{{
 
-    // Iterating through all the nodes which were given as a destination of the current transition
-    for(auto node : trans.dst)
-    {
+	// Iterating through all the nodes which were given as a destination of the current transition
+	for(auto node : trans.dst)
+	{
 
-        // If there is already a memory cell which corresponds to the current dst node and a transition symbol,
-        // we have to find it and add the 'src' state to the corresponding result_nodes vector. 
-        // Let us recall that the inverse transition datatype is a vector of vectors of tuples (symbol, vector_of_inverse_results)
-        // Each InverseResult is a tuple (result_nodes, sharing_list). If there exists such a tuple, where
-        // the sharing_list corresponds to the current dst node, we can simply add the current 'src' state to the result_nodes.
-        // Since the corresponding tuple (result_nodes, sharing_list) would be identical for all states of the current node,
-        // we can store it to the memory only once. For this purpose, we choose the minimal element from the current node. 
-        // Then, it is sufficient to choose the minimal element of the dst node and look if there exists such a
-        // tuple (result_nodes, sharing_list), where sharing_list == dst node in context of the current symbol
-        //
-        // Example: We have transitions (0, a, {0, 1}), (0, b, {1}). The inverse transition data structure looks like this:
-        //
-        // 0 -> {('a', {(result_nodes:{0}, sharing_list:{0, 1})})}
-        // 1 -> {('a', {}),
-        //      ('b', {(result_nodes:{0}, sharing_list:{1})})}
-        //
-        // Now, we want to add the transition (1, a, {0, 1}), so we choose only one element of the dst node (0 or 1) and
-        // look if there exists a tuple (result_nodes, sharing_list), where sharing_list == {0, 1}. 
-        // If so, we add 0 to the result_nodes. 
-        bool found = false;
+		// If there is already a memory cell which corresponds to the current dst node and a transition symbol,
+		// we have to find it and add the 'src' state to the corresponding result_nodes vector. 
+		// Let us recall that the inverse transition datatype is a vector of vectors of tuples (symbol, vector_of_inverse_results)
+		// Each InverseResult is a tuple (result_nodes, sharing_list). If there exists such a tuple, where
+		// the sharing_list corresponds to the current dst node, we can simply add the current 'src' state to the result_nodes.
+		// Since the corresponding tuple (result_nodes, sharing_list) would be identical for all states of the current node,
+		// we can store it to the memory only once. For this purpose, we choose the minimal element from the current node. 
+		// Then, it is sufficient to choose the minimal element of the dst node and look if there exists such a
+		// tuple (result_nodes, sharing_list), where sharing_list == dst node in context of the current symbol
+		//
+		// Example: We have transitions (0, a, {0, 1}), (0, b, {1}). The inverse transition data structure looks like this:
+		//
+		// 0 -> {('a', {(result_nodes:{0}, sharing_list:{0, 1})})}
+		// 1 -> {('a', {}),
+		//      ('b', {(result_nodes:{0}, sharing_list:{1})})}
+		//
+		// Now, we want to add the transition (1, a, {0, 1}), so we choose only one element of the dst node (0 or 1) and
+		// look if there exists a tuple (result_nodes, sharing_list), where sharing_list == {0, 1}. 
+		// If so, we add 0 to the result_nodes. 
+		bool found = false;
 
-        State storeTo = *(node.begin());
+		State storeTo = *(node.begin());
 
-        auto inverseTransResults = perform_inverse_trans(storeTo, trans.symb);
-        for(auto result : inverseTransResults)
-        {
-            if(result.sharing_list == node)
-            {
-                result.result_nodes.insert(trans.src);
-                found = true;
-                break;
-            }
-        }
+		auto inverseTransResults = perform_inverse_trans(storeTo, trans.symb);
+		for(auto result : inverseTransResults)
+		{
+			if(result.sharing_list == node)
+			{
+				result.result_nodes.insert(trans.src);
+				found = true;
+				break;
+			}
+		}
 
-        if(found)
-        {
-            continue;
-        }
+		if(found)
+		{
+			continue;
+		}
 
-        // Otherwise, we need to create a new tuple (result_nodes, sharing_list) == ({src state}, node) and store
-        // it to the vector given by the minimal state of the current node and the current symbol
+		// Otherwise, we need to create a new tuple (result_nodes, sharing_list) == ({src state}, node) and store
+		// it to the vector given by the minimal state of the current node and the current symbol
 
-        // If there is no tuple (symbol, vector_of_pointers) in context of the current state and symbol because the
-        // symbol has not been used yet, we need to create it
-        if(perform_inverse_trans(storeTo, trans.symb).empty())
-        {
-            inverseTransRelation[storeTo].push_back(InverseTrans(trans.symb, InverseResults(trans.src, node)));
-            continue;
-        } 
+		// If there is no tuple (symbol, vector_of_pointers) in context of the current state and symbol because the
+		// symbol has not been used yet, we need to create it
+		if(perform_inverse_trans(storeTo, trans.symb).empty())
+		{
+			inverseTransRelation[storeTo].push_back(InverseTrans(trans.symb, InverseResults(trans.src, node)));
+			continue;
+		} 
 
-        // Otherwise, we need to find the appropriate tuple (symbol, vector_of_pointers) and store the inverse result
-        // to the vector of inverse results
-        for(auto & transVec : inverseTransRelation[storeTo])
-        {
-            if(transVec.symb == trans.symb)
-            {
-                transVec.inverseResults.push_back(InverseResults(trans.src, node));
-                break;
-            }
-        }
-    }
+		// Otherwise, we need to find the appropriate tuple (symbol, vector_of_pointers) and store the inverse result
+		// to the vector of inverse results
+		for(auto & transVec : inverseTransRelation[storeTo])
+		{
+			if(transVec.symb == trans.symb)
+			{
+			    transVec.inverseResults.push_back(InverseResults(trans.src, node));
+			    break;
+			}
+		}
+	}
 
 } // add_inverse_trans }}}
 
@@ -173,16 +173,16 @@ State Afa::add_new_state() {
 */
 std::unique_ptr<Nodes> Afa::perform_trans(State src, Symbol symb) const
 {
-    assert(src < this->transRelation.size() && "It is not possible to perform a transition " &&
-    "from non-existing state.");
-    for(auto transVec : transRelation[src])
-    {
-        if(transVec.symb == symb)
-        {
-            return std::make_unique<Nodes>(transVec.dst);
-        }
-    }    
-    return std::make_unique<Nodes>(Nodes());
+	assert(src < this->transRelation.size() && "It is not possible to perform a transition " &&
+	"from non-existing state.");
+	for(auto transVec : transRelation[src])
+	{
+		if(transVec.symb == symb)
+		{
+			return std::make_unique<Nodes>(transVec.dst);
+		}
+	}    
+	return std::make_unique<Nodes>(Nodes());
 } // perform_trans }}}
 
 /** This function takes a single state and a symbol and returns all the nodes which are accessible from the node {state}
@@ -195,13 +195,13 @@ std::unique_ptr<Nodes> Afa::perform_trans(State src, Symbol symb) const
 */
 StateClosedSet Afa::post(State state, Symbol symb) const
 {
-    Nodes result = *perform_trans(state, symb);
-    if(result.size())
-    {
-        return StateClosedSet(upward_closed_set, 0, transRelation.size()-1, result);
-    }   
-    // if there is no proper result, we will return an empty closed set
-    return StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
+	Nodes result = *perform_trans(state, symb);
+	if(result.size())
+	{
+		return StateClosedSet(upward_closed_set, 0, transRelation.size()-1, result);
+	}   
+	// if there is no proper result, we will return an empty closed set
+	return StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
 } // post }}}
 
 /** This function takes a single node and a symbol and returns all the nodes which are accessible from the node
@@ -216,28 +216,28 @@ StateClosedSet Afa::post(State state, Symbol symb) const
 */
 StateClosedSet Afa::post(Node node, Symbol symb) const
 {
-    // initially, the result is empty
-    StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
-    if(node.empty())
-    {
-        result.insert(node);
-        return result;
-    }
+	// initially, the result is empty
+	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
+	if(node.empty())
+	{
+		result.insert(node);
+		return result;
+	}
 
-    // we get the first result without any changes and then, we will perform several intersections
-    // over it
-    bool used = false;
-    for(auto state : node)
-    {
-        if(!used)
-        {
-            result.insert(post(state, symb).antichain());
-            used = true;
-            continue;
-        }
-        result = result.intersection(post(state, symb));
-    }
-    return result;
+	// we get the first result without any changes and then, we will perform several intersections
+	// over it
+	bool used = false;
+	for(auto state : node)
+	{
+		if(!used)
+		{
+			result.insert(post(state, symb).antichain());
+			used = true;
+			continue;
+		}
+		result = result.intersection(post(state, symb));
+	}
+	return result;
 } // post }}}
 
 /** This function takes a whole set of nodes and a symbol and returns all the nodes which are accessible from the
@@ -252,13 +252,13 @@ StateClosedSet Afa::post(Node node, Symbol symb) const
 */
 StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 {
-    // initially, the result is empty
-    StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
-    for(auto node : nodes)
-    {
-        result.insert(post(node, symb).antichain());
-    }
-    return result;
+	// initially, the result is empty
+	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
+	for(auto node : nodes)
+	{
+		result.insert(post(node, symb).antichain());
+	}
+	return result;
 } // post }}}
 
 /** This function allows us to perform post directly over the closed set. The output will be represented
@@ -272,9 +272,9 @@ StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 */
 StateClosedSet Afa::post(StateClosedSet closed_set, Symbol symb) const
 {
-    assert(closed_set.type() == Mata::upward_closed_set && "The predicate transformer " && 
-    " post can be computed only over upward-closed sets.");
-    return post(closed_set.antichain(), symb);
+	assert(closed_set.type() == Mata::upward_closed_set && "The predicate transformer " && 
+	" post can be computed only over upward-closed sets.");
+	return post(closed_set.antichain(), symb);
 } // post }}}
 
 
@@ -289,16 +289,16 @@ StateClosedSet Afa::post(StateClosedSet closed_set, Symbol symb) const
 */
 StateClosedSet Afa::post(Node node) const
 {
-    if(node.empty())
-    {
-        return StateClosedSet(upward_closed_set, 0, transRelation.size()-1, Nodes{Node{}});
-    }
-    StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
-    for(auto transVec : transRelation[*(node.begin())])
-    {
-        result.insert(post(node, transVec.symb).antichain());
-    }
-    return result;
+	if(node.empty())
+	{
+		return StateClosedSet(upward_closed_set, 0, transRelation.size()-1, Nodes{Node{}});
+	}
+	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transRelation.size()-1);
+	for(auto transVec : transRelation[*(node.begin())])
+	{
+		result.insert(post(node, transVec.symb).antichain());
+	}
+	return result;
 } // post }}}
 
 /** This function allows us to perfom "post" and use the whole alphabet to perform individual transitions 
@@ -311,12 +311,12 @@ StateClosedSet Afa::post(Node node) const
 */
 StateClosedSet Afa::post(Nodes nodes) const
 {
-    StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
-    for(auto node : nodes)
-    {
-        result.insert(post(node).antichain());
-    }
-    return result;
+	StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
+	for(auto node : nodes)
+	{
+		result.insert(post(node).antichain());
+	}
+	return result;
 } // post }}}
 
 // The end of the definitions of the "post" functions
@@ -339,14 +339,14 @@ StateClosedSet Afa::post(Nodes nodes) const
 */
 std::vector<InverseResults> Afa::perform_inverse_trans(State src, Symbol symb) const
 {
-    for(auto element : this->inverseTransRelation[src])
-    {
-        if(element.symb == symb)
-        {
-            return element.inverseResults;
-        }
-    }
-    return std::vector<InverseResults>();
+	for(auto element : this->inverseTransRelation[src])
+	{
+		if(element.symb == symb)
+		{
+		    return element.inverseResults;
+		}
+	}
+	return std::vector<InverseResults>();
 }  // perform_inverse_trans }}}
 
 /** This function inspects an inverse transition relation and returns a vector of inverse results
@@ -359,13 +359,13 @@ std::vector<InverseResults> Afa::perform_inverse_trans(State src, Symbol symb) c
 */
 std::vector<InverseResults> Afa::perform_inverse_trans(Node node, Symbol symb) const
 {
-    std::vector<InverseResults> result{};
-    for(auto state : node)
-    {
-        auto subresult = perform_inverse_trans(state, symb);
-        result.insert(result.end(), subresult.begin(), subresult.end());
-    }
-    return result;
+	std::vector<InverseResults> result{};
+	for(auto state : node)
+	{
+		auto subresult = perform_inverse_trans(state, symb);
+		result.insert(result.end(), subresult.begin(), subresult.end());
+	}
+	return result;
 } // perform_inverse_trans }}}
 
 /** This function takes a single node and a symbol and returns all the nodes which are able to access the given node
@@ -378,19 +378,19 @@ std::vector<InverseResults> Afa::perform_inverse_trans(Node node, Symbol symb) c
 */
 StateClosedSet Afa::pre(Node node, Symbol symb) const
 {
-    std::vector<InverseResults> candidates = perform_inverse_trans(node, symb);
-    Node result{};
-    for(auto candidate : candidates)
-    {
-        if(candidate.sharing_list.IsSubsetOf(node))
-        {
-            for(auto el : candidate.result_nodes)
-            {
-                result.insert(el);
-            }
-        }
-    }
-    return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, result);
+	std::vector<InverseResults> candidates = perform_inverse_trans(node, symb);
+	Node result{};
+	for(auto candidate : candidates)
+	{
+		if(candidate.sharing_list.IsSubsetOf(node))
+		{
+			for(auto el : candidate.result_nodes)
+			{
+				result.insert(el);
+			}
+		}
+	}
+	return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, result);
 } // pre }}}
 
 /** This function takes set of nodes and a symbol and returns all the nodes which are able to access the given nodes
@@ -403,12 +403,12 @@ StateClosedSet Afa::pre(Node node, Symbol symb) const
 */
 StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
 {
-    StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
-    for(auto node : nodes)
-    {
-        result = result.Union(pre(node, symb));
-    }
-    return result;
+	StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
+	for(auto node : nodes)
+	{
+		result = result.Union(pre(node, symb));
+	}
+	return result;
 } // pre }}}
 
 /** This function performs pre directly over the given closed set and the given symbol
@@ -419,9 +419,9 @@ StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
 */
 StateClosedSet Afa::pre(StateClosedSet closed_set, Symbol symb) const
 {
-    assert(closed_set.type() == downward_closed_set && "The predicate transformer " &&
-    "pre can be computed only over downward-closed sets.");
-    return pre(closed_set.antichain(), symb);
+	assert(closed_set.type() == downward_closed_set && "The predicate transformer " &&
+	"pre can be computed only over downward-closed sets.");
+	return pre(closed_set.antichain(), symb);
 } // pre }}}
 
 /** This function allows us to perfom pre over a node and use the whole alphabet to perform individual transitions 
@@ -431,16 +431,16 @@ StateClosedSet Afa::pre(StateClosedSet closed_set, Symbol symb) const
 */
 StateClosedSet Afa::pre(Node node) const
 {
-    if(node.empty())
-    {
-        return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, Nodes{Node{}});
-    }
-    StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
-    for(auto transVec : inverseTransRelation[*(node.begin())])
-    {
-        result.insert(pre(node, transVec.symb).antichain());
-    }
-    return result;
+	if(node.empty())
+	{
+		return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, Nodes{Node{}});
+	}
+	StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
+	for(auto transVec : inverseTransRelation[*(node.begin())])
+	{
+		result.insert(pre(node, transVec.symb).antichain());
+	}
+	return result;
 } // pre }}}
 
 /** This function allows us to perfom pre over a set of nodes and use the whole alphabet to perform individual transitions 
@@ -450,12 +450,12 @@ StateClosedSet Afa::pre(Node node) const
 */
 StateClosedSet Afa::pre(Nodes nodes) const
 {
-    StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
-    for(auto node : nodes)
-    {
-        result.insert(pre(node).antichain());
-    }
-    return result;
+	StateClosedSet result(downward_closed_set, 0, transRelation.size()-1);
+	for(auto node : nodes)
+	{
+		result.insert(pre(node).antichain());
+	}
+	return result;
 } // pre }}}
 
 // The end of the definitions of the "pre" functions
@@ -463,23 +463,23 @@ StateClosedSet Afa::pre(Nodes nodes) const
 
 bool Afa::has_trans(const Trans& trans) const
 { // {{{
-    Nodes res = *perform_trans(trans.src, trans.symb);
-    if(res.size() && res.IsSubsetOf(trans.dst))
-    {
-        return true;
-    }
-    return false;
+	Nodes res = *perform_trans(trans.src, trans.symb);
+	if(res.size() && res.IsSubsetOf(trans.dst))
+	{
+		return true;
+	}
+	return false;
 } // has_trans }}}
 
 
 size_t Afa::trans_size() const
 { // {{{
-    size_t result = 0;
-    for(auto state : transRelation)
-    {
-        result += state.size();
-    }
-    return result;
+	size_t result = 0;
+	for(auto state : transRelation)
+	{
+		result += state.size();
+	}
+	return result;
 } // trans_size() }}}
 
 /** This function takes all the initial states and creates a corresponding upward-closed set
@@ -487,15 +487,15 @@ size_t Afa::trans_size() const
 */
 StateClosedSet Afa::get_initial_nodes(void) const
 {
-    StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
-    for(State state = 0; state < transRelation.size(); ++state)
-    {
-        if(has_initial(state))
-        {
-            result.insert(state);
-        }    
-    }
-    return result;
+	StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
+	for(State state = 0; state < transRelation.size(); ++state)
+	{
+		if(has_initial(state))
+		{
+			result.insert(state);
+		}    
+	}
+	return result;
 } // get_initial_nodes() }}}
 
 /** This function returns a downward-closed set of all the nodes which are not initial
@@ -503,15 +503,15 @@ StateClosedSet Afa::get_initial_nodes(void) const
 */
 StateClosedSet Afa::get_non_initial_nodes(void) const
 {
-    OrdVec<State> subresult{};
-    for(State state = 0; state < transRelation.size(); ++state)
-    {
-        if(!has_initial(state))
-        {
-            subresult.insert(state);
-        }  
-    }
-    return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, subresult);
+	OrdVec<State> subresult{};
+	for(State state = 0; state < transRelation.size(); ++state)
+	{
+		if(!has_initial(state))
+		{
+			subresult.insert(state);
+		}  
+	}
+	return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, subresult);
 } // get_non_initial_nodes() }}}
 
 /** This function returns a downward-closed set of all the nodes which are final
@@ -519,15 +519,15 @@ StateClosedSet Afa::get_non_initial_nodes(void) const
 */
 StateClosedSet Afa::get_final_nodes(void) const
 {
-    OrdVec<State> subresult{};
-    for(State state = 0; state < transRelation.size(); ++state)
-    {
-        if(has_final(state))
-        {
-            subresult.insert(state);
-        }  
-    }
-    return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, subresult);
+	OrdVec<State> subresult{};
+	for(State state = 0; state < transRelation.size(); ++state)
+	{
+		if(has_final(state))
+		{
+			subresult.insert(state);
+		}  
+	}
+	return StateClosedSet(downward_closed_set, 0, transRelation.size()-1, subresult);
 } // get_final_nodes() }}}
 
 /** This function returns an upward-closed set of all the nodes which are non-final
@@ -535,15 +535,15 @@ StateClosedSet Afa::get_final_nodes(void) const
 */
 StateClosedSet Afa::get_non_final_nodes(void) const
 {
-    StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
-    for(State state = 0; state < transRelation.size(); ++state)
-    {
-        if(!has_final(state))
-        {
-            result.insert(state);
-        }    
-    }
-    return result;
+	StateClosedSet result(upward_closed_set, 0, transRelation.size()-1);
+	for(State state = 0; state < transRelation.size(); ++state)
+	{
+		if(!has_final(state))
+		{
+			result.insert(state);
+		}    
+	}
+	return result;
 } // get_non_final_nodes() }}}
 
 
@@ -629,12 +629,12 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_old(const Afa& aut)
 
     while(current != next)
     {
-        current = next;
-        next = current.Union(aut.post(current));
-        if(!(next <= goal)) // inclusion test
-        {
-            return false;
-        }
+		current = next;
+		next = current.Union(aut.post(current));
+		if(!(next <= goal)) // inclusion test
+		{
+		    return false;
+		}
     }
     return true;
 }
@@ -647,40 +647,40 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_old(const Afa& aut)
 */
 bool Mata::Afa::antichain_concrete_forward_emptiness_test_new(const Afa& aut)
 {
-    StateClosedSet goal = aut.get_non_final_nodes();
-    StateClosedSet result = aut.get_initial_nodes();
-    std::set<Node> processed = std::set<Node>();
-    std::vector<Node> worklist = std::vector<Node>();
-    for(Node node : aut.get_initial_nodes().antichain())
-    {
-        worklist.push_back(node);
-    }
+	StateClosedSet goal = aut.get_non_final_nodes();
+	StateClosedSet result = aut.get_initial_nodes();
+	std::set<Node> processed = std::set<Node>();
+	std::vector<Node> worklist = std::vector<Node>();
+	for(Node node : aut.get_initial_nodes().antichain())
+	{
+		worklist.push_back(node);
+	}
 
-    if(!(result <= goal))
-    {
-        return false;
-    }
+	if(!(result <= goal))
+	{
+		return false;
+	}
 
-    while(!worklist.empty()) 
-    {
-        Node current = worklist.back();
-        worklist.pop_back();
-        auto post_current = aut.post(current);
-        result = result.Union(post_current);
-        for(Node node : post_current.antichain())
-        {
-            if(!goal.contains(node))
-            {
-                return false;
-            }
-            if(!processed.count(node))
-            {
-                worklist.push_back(node);
-            }
-        }
-        processed.insert(current);
-    }
-    return true;
+	while(!worklist.empty()) 
+	{
+		Node current = worklist.back();
+		worklist.pop_back();
+		auto post_current = aut.post(current);
+		result = result.Union(post_current);
+		for(Node node : post_current.antichain())
+		{
+			if(!goal.contains(node))
+			{
+			    return false;
+			}
+			if(!processed.count(node))
+			{
+			    worklist.push_back(node);
+			}
+		}
+		processed.insert(current);
+	}
+	return true;
 }
 
 /** This function decides whether the given automaton is empty using 
@@ -691,24 +691,24 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_new(const Afa& aut)
 */
 bool Mata::Afa::antichain_concrete_backward_emptiness_test_old(const Afa& aut)
 {
-    // We will iteratively build a set of terminating nodes (next) until we reach a fixed
-    // point or until we find out that there exists a initial node which is terminating (is not part of goal).
-    // We will perform each operation directly over antichains
-    // Note that the fixed point always exists so the while loop always terminates
-    StateClosedSet goal = aut.get_non_initial_nodes();
-    StateClosedSet current = StateClosedSet();
-    StateClosedSet next = aut.get_final_nodes();
+	// We will iteratively build a set of terminating nodes (next) until we reach a fixed
+	// point or until we find out that there exists a initial node which is terminating (is not part of goal).
+	// We will perform each operation directly over antichains
+	// Note that the fixed point always exists so the while loop always terminates
+	StateClosedSet goal = aut.get_non_initial_nodes();
+	StateClosedSet current = StateClosedSet();
+	StateClosedSet next = aut.get_final_nodes();
 
-    while(current != next)
-    {
-        current = next;
-        next = current.Union(aut.pre(current));
-        if(!(next <= goal))
-        {
-            return false;
-        }
-    }
-    return true;
+	while(current != next)
+	{
+		current = next;
+		next = current.Union(aut.pre(current));
+		if(!(next <= goal))
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 
@@ -720,40 +720,40 @@ bool Mata::Afa::antichain_concrete_backward_emptiness_test_old(const Afa& aut)
 */
 bool Mata::Afa::antichain_concrete_backward_emptiness_test_new(const Afa& aut)
 {
-    StateClosedSet goal = aut.get_non_initial_nodes();
-    StateClosedSet result = aut.get_final_nodes();
-    std::set<Node> processed = std::set<Node>();
-    std::vector<Node> worklist = std::vector<Node>();
-    for(Node node : aut.get_final_nodes().antichain())
-    {
-        worklist.push_back(node);
-    }
+	StateClosedSet goal = aut.get_non_initial_nodes();
+	StateClosedSet result = aut.get_final_nodes();
+	std::set<Node> processed = std::set<Node>();
+	std::vector<Node> worklist = std::vector<Node>();
+	for(Node node : aut.get_final_nodes().antichain())
+	{
+		worklist.push_back(node);
+	}
 
-    if(!(result <= goal))
-    {
-        return false;
-    }
+	if(!(result <= goal))
+	{
+		return false;
+	}
 
-    while(!worklist.empty()) 
-    {
-        Node current = worklist.back();
-        worklist.pop_back();
-        auto pre_current = aut.pre(current);
-        result = result.Union(pre_current);
-        for(Node node : pre_current.antichain())
-        {
-            if(!goal.contains(node))
-            {
-                return false;
-            }
-            if(!processed.count(node))
-            {
-                worklist.push_back(node);
-            }
-        }
-        processed.insert(current);
-    }
-    return true;
+	while(!worklist.empty()) 
+	{
+		Node current = worklist.back();
+		worklist.pop_back();
+		auto pre_current = aut.pre(current);
+		result = result.Union(pre_current);
+		for(Node node : pre_current.antichain())
+		{
+			if(!goal.contains(node))
+			{
+				return false;
+			}
+			if(!processed.count(node))
+			{
+				worklist.push_back(node);
+			}
+		}
+		processed.insert(current);
+	}
+	return true;
 }
 
 
@@ -940,11 +940,11 @@ void Mata::Afa::construct(
       formula += body_line[i] + " ";
     }
 
-    // TODO: Transform a positive Boolean formula from the string format
-    // to the inner representation (src state, symbol on transition, ordered
-    // vector of ordered vectors of states which corresponds to the formula in DNF) 
-    // Call the "add_trans" and "add_inverse_trans" functions over the
-    // parsed formula to add it do the automaton
+	// TODO: Transform a positive Boolean formula from the string format
+	// to the inner representation (src state, symbol on transition, ordered
+	// vector of ordered vectors of states which corresponds to the formula in DNF) 
+	// Call the "add_trans" and "add_inverse_trans" functions over the
+	// parsed formula to add it do the automaton
 
 	}
 

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -76,6 +76,30 @@ void Afa::add_trans(const Trans& trans)
 
 } // add_trans }}}
 
+std::vector<Trans> Afa::get_trans_from_state(State state) const
+{
+	assert(state < transRelation.size());
+	std::vector<Trans> result = std::vector<Trans>();
+	for(auto transition : transRelation[state])
+	{
+		result.push_back(transition);
+	}
+	return result;
+}
+
+Trans Afa::get_trans_from_state(State state, Symbol symbol) const
+{
+	assert(state < transRelation.size());
+	for(auto transition : transRelation[state])
+	{
+		if(transition.symb == symbol)
+		{
+			return transition;
+		}
+	}
+	return Trans(state, symbol, Nodes());
+}
+
 
 /** This function adds a new inverse transition to the automaton
 * It changes an inverse transition relation.

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -148,6 +148,13 @@ void Afa::add_inverse_trans(const Trans& trans)
 
 } // add_inverse_trans }}}
 
+
+State Afa::add_new_state() {
+    transRelation.emplace_back();
+    inverseTransRelation.emplace_back();
+    return transRelation.size() - 1;
+}
+
 //***************************************************
 //
 // POST

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -583,24 +583,6 @@ StateClosedSet Afa::get_non_initial_nodes(void) const
 	return StateClosedSet(downward_closed_set, 0, transitionrelation.size()-1, subresult);
 } // get_non_initial_nodes() }}}
 
-/** This function returns a downward-closed set of all
-* the nodes which are final
-* @return closed set of final nodes
-*/
-StateClosedSet Afa::get_final_nodes(void) const
-{
-	OrdVec<State> subresult{};
-	auto transSize = transitionrelation.size();
-	for(State state = 0; state < transSize; ++state)
-	{
-		if(has_final(state))
-		{
-			subresult.insert(state);
-		}  
-	}
-	return StateClosedSet(downward_closed_set, 0, transitionrelation.size()-1, subresult);
-} // get_final_nodes() }}}
-
 /** This function returns an upward-closed set of all
 * the nodes which are non-final
 * @return closed set of non-final nodes

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -18,11 +18,13 @@
 #include <algorithm>
 #include <list>
 #include <unordered_set>
+#include <memory>
 
 // MATA headers
 #include <mata/afa.hh>
 #include <mata/nfa.hh>
 #include <mata/util.hh>
+#include <mata/closed_set.hh>
 
 using std::tie;
 
@@ -34,28 +36,530 @@ const std::string Mata::Afa::TYPE_AFA = "AFA";
 
 std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::Trans& trans)
 { // {{{
-	std::string result = "(" + std::to_string(trans.src) + ", " + trans.formula + ")";
+	std::string result = "(" + std::to_string(trans.src) + ", " 
+                       + std::to_string(trans.symb) + ", " 
+                       + std::to_string(trans.dst) + ")";
 	return os << result;
 } // operator<<(ostream, Trans) }}}
 
-
+/** This function adds a new transition to the automaton. It changes a transition
+* relation. 
+* @brief adds a new transition
+* @param trans a given transition
+*/
 void Afa::add_trans(const Trans& trans)
 { // {{{
-	this->transitions.push_back(trans);
+    assert(!this->transRelation.empty());
+
+    // Performs a transition using given src state and symbol
+    // in context of transitions which have been already added to the automaton
+    // If there is no result, a new transition will be created
+    // If the corresponding transition already exists, given 'dst' will be added to
+    // the transition
+    auto nodesPtr = perform_trans(trans.src, trans.symb);
+    if(!nodesPtr->empty())
+    {
+        // TODO: It would be nice to remove redundant clauses (like (1 || (1 && 2)))
+        // The clause (1 && 2) could be deleted. Solution:
+        // create closed set -> add the new transition -> extract the antichain ->
+        // store it to the transition (???). Working solution:
+        //        
+        // auto cl = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, max_state_used, *nodesPtr);
+        // cl.insert(trans.dst);
+        // *nodesPtr = cl.get_antichain();
+        //        
+        // Is it worth it?         
+
+        *nodesPtr = nodesPtr->Union(trans.dst);
+        return;
+    }
+    transRelation[trans.src].push_back(trans);
+
 } // add_trans }}}
+
+
+/** This function adds a new inverse transition to the automaton
+* It changes an inverse transition relation.
+* @brief adds a new inverse transition
+* @param trans a given TRANSITION (it will be inverted within this function)
+*/
+void Afa::add_inv_trans(const Trans& trans)
+{// {{{
+
+    // Iterating through all the nodes which were given as a destination of the current transition
+    for(auto node : trans.dst)
+    {
+        // TODO: Could this ever happen?
+        if(node.empty())
+        {
+            continue;
+        }
+
+        // If there is already a memory cell which corresponds to the current dst node and a transition symbol,
+        // we have to find it and add the 'src' state to the corresponding result_nodes vector. 
+        // Let us recall that the inverse transition datatype is a vector of vectors of tuples (symbol, vector_of_pointers)
+        // Each mentioned pointer points to the tuple (result_nodes, sharing_list). If there exists such a tuple, where
+        // the sharing_list corresponds to the current dst node, we can simply add the current 'src' state to the result_nodes.
+        // Since the corresponding tuple (result_nodes, sharing_list) must be referred from all the vector_of_pointers, where
+        // symbol == trans.symbol, it is sufficient to choose the first element of the dst node and look if there exists such a
+        // tuple (result_nodes, sharing_list), where sharing_list == dst node in context of the current symbol
+        //
+        // Example: We have transitions (0, a, {0, 1}), (0, b, {1}). The inverse transition data structure looks like this:
+        //
+        // 0 -> {('a', {&(result_nodes:{0}, sharing_list:{0, 1})})}
+        // 1 -> {('a', {&(result_nodes:{0}, sharing_list:{0, 1})}),
+        //      ('b', {&(result_nodes:{0}, sharing_list:{1})})}
+        //
+        // Now, we want to add the transition (1, a, {0, 1}), so we choose only one element of the dst node (0 or 1) and look if there exists
+        // a tuple (result_nodes, sharing_list), where sharing_list == {0, 1}. If so, we add 0 to the result_nodes. 
+        bool found = false;
+
+        auto invTransPtrs = perform_inv_trans(*(node.begin()), trans.symb);
+        for(auto result : invTransPtrs)
+        {
+            if(result->sharing_list == node)
+            {
+                result->result_nodes.insert(trans.src);
+                found = true;
+                break;
+            }
+        }
+
+        if(found)
+        {
+            continue;
+        }
+
+        // Otherwise, we need to create a new tuple (result_nodes, sharing_list) == ({src state}, node) and ensure us
+        // that the pointer to this tuple will be part of all the vectors_of_pointers which correspond to the (dst_state, symbol)
+        // where dst_state is an element of the current node
+        auto result = std::make_shared<InvResults>(InvResults(trans.src, node));
+
+        for(auto state : node)
+        {
+            // If there is no tuple (symbol, vector_of_pointers) in context of the current state and symbol because the
+            // symbol has not been used yet, we need to create it
+            if(perform_inv_trans(state, trans.symb).empty())
+            {
+                invTransRelation[state].push_back(InvTrans(trans.symb, InvTrans::InvResultPtrs{result}));
+                continue;
+            } 
+
+            // Otherwise, we need to find the appropriate tuple (symbol vector_of_pointers) and store the pointer
+            // to the vector of pointers
+            for(auto & transVec : invTransRelation[state])
+            {
+                if(transVec.symb == trans.symb)
+                {
+                    transVec.invResultPtrs.push_back(std::make_shared<InvResults>(trans.src, node));
+                    break;
+                }
+            }
+        }
+    }
+
+} // add_inv_trans }}}
+
+//***************************************************
+//
+// POST
+//
+// Inspection of the automaton in the forward fashion
+//
+//***************************************************
+
+/** This function inspects a transition relation and returns a pointer to the proper result for delta(src, symb)
+* Otherwise, it gives us a pointer to the empty Nodes which means that the result does not exist. We return the pointer
+* to be able to directly change the transition relation if there is a neccessity to add a new transition 
+* @brief performs a transition using a single state and symbol
+* @param src a source state
+* @param symb a symbol used to perform a transition
+* @return a pointer to the set of nodes
+*/
+std::unique_ptr<Nodes> Afa::perform_trans(State src, Symbol symb) const
+{
+    assert(src < this->transRelation.size());
+    for(auto transVec : transRelation[src])
+    {
+        if(transVec.symb == symb)
+        {
+            return std::make_unique<Nodes>(transVec.dst);
+        }
+    }    
+    return std::make_unique<Nodes>(Nodes());
+} // perform_trans }}}
+
+/** This function takes a single state and a symbol and returns all the nodes which are accessible from the node {state}
+* in one step using the given symbol. The output will be represented as a ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* The result is always an upward closed set!
+* @param state a source state
+* @param symb a symbol used to perform a transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(State state, Symbol symb) const
+{
+    assert(state < this->transRelation.size());
+    Nodes result = *perform_trans(state, symb);
+    if(result.size())
+    {
+        return ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1, result);
+    }   
+    // if there is no proper result, we will return an empty closed set
+    return ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+} // post }}}
+
+/** This function takes a single node and a symbol and returns all the nodes which are accessible from the node
+* in one step using the given symbol. The output will be represented as a ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* We will perform a transition for each state of the given node and then, we perform an intersection
+* over these subresults
+* The result is always an upward closed set!
+* @param node a source set of states
+* @param symb a symbol used to perform a transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(Node node, Symbol symb) const
+{
+    // initially, the result is empty
+    ClosedSet<State> result = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    if(node.empty())
+    {
+        result.insert(node);
+        return result;
+    }
+
+    // we get the first result without any changes and then, we will perform several intersections
+    // over it
+    bool used = false;
+    for(auto state : node)
+    {
+        assert(state < this->transRelation.size());
+        if(!used)
+        {
+            result.insert(post(state, symb).get_antichain());
+            used = true;
+            continue;
+        }
+        result = result.intersection(post(state, symb));
+    }
+    return result;
+} // post }}}
+
+/** This function takes a whole set of nodes and a symbol and returns all the nodes which are accessible from the
+* given nodes in one step using the given symbol. The output will be represented as a ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* We will perform a transition for each node of the given set of nodes and then, we perform an union
+* over these subresults
+* The result is always an upward closed set!
+* @param nodes a source set of sets of states
+* @param symb a symbol used to perform a transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(Nodes nodes, Symbol symb) const
+{
+    // initially, the result is empty
+    ClosedSet<State> result = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    for(auto node : nodes)
+    {
+        result.insert(post(node, symb).get_antichain());
+    }
+    return result;
+} // post }}}
+
+/** This function allows us to perform post directly over the closed set. The output will be represented
+* as a ClosedSet to omit the neccessity to explicitly return all the proper nodes
+* We will perform a transition for each node of the antichain of the given set of nodes and then
+* we perform an union over these subresults
+* The result is always an upward closed set!
+* @param closed_set an upward closed set which will be used to perform a transition
+* @param symb a symbol used to perform a transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(ClosedSet<State> closed_set, Symbol symb) const
+{
+    assert(closed_set.get_type() == ClosedSet<State>::upward_closed);
+    return post(closed_set.get_antichain(), symb);
+} // post }}}
+
+
+/** This function takes a single node and and returns all the nodes which are accessible from the node
+* in one step using any symbol. The output will be represented as a ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* We will perform a transition for each state of the given node and then, we perform an intersection
+* over these subresults
+* The result is always an upward closed set!
+* @param node a source set of states
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(Node node) const
+{
+    if(node.empty())
+    {
+        return ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1, Nodes{Node{}});
+    }
+    ClosedSet<State> result = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    for(auto transVec : transRelation[*(node.begin())])
+    {
+        result.insert(post(node, transVec.symb).get_antichain());
+    }
+    return result;
+} // post }}}
+
+/** This function allows us to perfom "post" and use the whole alphabet to perform individual transitions 
+* The output will be represented as a ClosedSet to omit the neccessity to explicitly return all the proper nodes
+* We will perform a transition for each node of the antichain of the given set of nodes and then
+* we perform an union over these subresults
+* The result is always an upward closed set!
+* @param nodes a set of sets of nodes used to perform a transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::post(Nodes nodes) const
+{
+    ClosedSet<State> result(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    for(auto node : nodes)
+    {
+        result.insert(post(node).get_antichain());
+    }
+    return result;
+} // post }}}
+
+// The end of the definitions of the "post" functions
+
+//***************************************************
+//
+// PRE
+//
+// Inspection of the automaton in the backward fashion
+//
+//***************************************************
+
+/** This function inspects an inverse transition relation and returns a vector of pointers
+* according to the given source state and symbol
+* Otherwise, it gives us an empty list which means that the result does not exist. We return pointers
+* to be able to directly change the inverse transition relation if there is a neccessity to add a new transition 
+* @brief performs a transition using a single state and symbol
+* @param src a source state
+* @param symb a symbol used to perform an inverse transition
+* @return a vector of pointers to the inverse results
+*/
+InvTrans::InvResultPtrs Afa::perform_inv_trans(State src, Symbol symb) const
+{
+    for(auto element : this->invTransRelation[src])
+    {
+        if(element.symb == symb)
+        {
+            return element.invResultPtrs;
+        }
+    }
+    return InvTrans::InvResultPtrs();
+}  // perform_inv_trans }}}
+
+/** This function inspects an inverse transition relation and returns a vector of pointers
+* according to the given source states and symbol
+* Otherwise, it gives us an empty list which means that the result does not exist. We return pointers
+* to be able to directly change the inverse transition relation if there is a neccessity to add a new transition 
+* @brief performs a transition using a single state and symbol
+* @param node source states
+* @param symb a symbol used to perform an inverse transition
+* @return a vector of pointers to the inverse results
+*/
+InvTrans::InvResultPtrs Afa::perform_inv_trans(Node node, Symbol symb) const
+{
+    InvTrans::InvResultPtrs result{};
+    bool used = false;
+    for(auto state : node)
+    {
+        if(!used)
+        {
+            result = perform_inv_trans(state, symb);
+            used = true;
+        }
+        else
+        {
+            auto subresult = perform_inv_trans(state, symb);
+            result.insert(result.end(), subresult.begin(), subresult.end());
+        }
+    }
+    return result;
+} // perform_inv_trans }}}
+
+/** This function takes a single node and a symbol and returns all the nodes which are able to access the given node
+* in one step using the given symbol. The output will be represented as ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* The result is always a downward closed set!
+* @param node source nodes
+* @param symb a symbol used to perform an inverse transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::pre(Node node, Symbol symb) const
+{
+    InvTrans::InvResultPtrs ptrs = perform_inv_trans(node, symb);
+    Node result{};
+    for(auto ptr : ptrs)
+    {
+        if(ptr->sharing_list.IsSubsetOf(node))
+        {
+            for(auto el : ptr->result_nodes)
+            {
+                result.insert(el);
+            }
+        }
+    }
+    return ClosedSet<State>(ClosedSet<State>::downward_closed, 0, transRelation.size()-1, result);
+} // pre }}}
+
+/** This function takes set of nodes and a symbol and returns all the nodes which are able to access the given nodes
+* in one step using the given symbol. The output will be represented as ClosedSet to omit the neccessity
+* to explicitly return all the proper nodes
+* The result is always a downward closed set!
+* @param nodes source nodes
+* @param symb a symbol used to perform an inverse transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::pre(Nodes nodes, Symbol symb) const
+{
+    ClosedSet<State> result(ClosedSet<State>::downward_closed, 0, transRelation.size()-1);
+    for(auto node : nodes)
+    {
+        result = result.Union(pre(node, symb));
+    }
+    return result;
+} // pre }}}
+
+/** This function performs pre directly over the given closed set and the given symbol
+* The result is always a downward closed set!
+* @param closed_set a closed set
+* @param symb a symbol used to perform an inverse transition
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::pre(ClosedSet<State> closed_set, Symbol symb) const
+{
+    assert(closed_set.get_type() == ClosedSet<State>::downward_closed);
+    return pre(closed_set.get_antichain(), symb);
+} // pre }}}
+
+/** This function allows us to perfom pre over a node and use the whole alphabet to perform individual transitions 
+* The result is always a downward closed set!
+* @param node a set of states
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::pre(Node node) const
+{
+    if(node.empty())
+    {
+        return ClosedSet<State>(ClosedSet<State>::downward_closed, 0, transRelation.size()-1, Nodes{Node{}});
+    }
+    ClosedSet<State> result(ClosedSet<State>::downward_closed, 0, transRelation.size()-1);
+    for(auto transVec : invTransRelation[*(node.begin())])
+    {
+        result.insert(pre(node, transVec.symb).get_antichain());
+    }
+    return result;
+} // pre }}}
+
+/** This function allows us to perfom pre over a set of nodes and use the whole alphabet to perform individual transitions 
+* The result is always a downward closed set!
+* @param nodes a set of sets of states
+* @return closed set of nodes
+*/
+ClosedSet<State> Afa::pre(Nodes nodes) const
+{
+    ClosedSet<State> result(ClosedSet<State>::downward_closed, 0, transRelation.size()-1);
+    for(auto node : nodes)
+    {
+        result.insert(pre(node).get_antichain());
+    }
+    return result;
+} // pre }}}
+
+// The end of the definitions of the "pre" functions
+////////////////////////////////////////////////////
 
 bool Afa::has_trans(const Trans& trans) const
 { // {{{
-  return std::find(this->transitions.begin(),
-                   this->transitions.end(),
-                   trans) != this->transitions.end();
+    Nodes res = *perform_trans(trans.src, trans.symb);
+    if(res.size() && res.IsSubsetOf(trans.dst))
+    {
+        return true;
+    }
+    return false;
 } // has_trans }}}
 
 
 size_t Afa::trans_size() const
 { // {{{
-	return this->transitions.size();
+    size_t result = 0;
+    for(auto state : transRelation)
+    {
+        result += state.size();
+    }
+    return result;
 } // trans_size() }}}
+
+/** This function takes all the initial states and creates a corresponding upward-closed set
+* @return closed set of initial nodes
+*/
+ClosedSet<State> Afa::get_initial_nodes(void) const
+{
+    ClosedSet<State> result(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    for(State state = 0; state < transRelation.size(); ++state)
+    {
+        if(has_initial(state))
+        {
+            result.insert(state);
+        }    
+    }
+    return result;
+} // get_initial_nodes() }}}
+
+/** This function returns a downward-closed set of all the nodes which are not initial
+* @return closed set of non-initial nodes
+*/
+ClosedSet<State> Afa::get_non_initial_nodes(void) const
+{
+    OrdVec<State> subresult{};
+    for(State state = 0; state < transRelation.size(); ++state)
+    {
+        if(!has_initial(state))
+        {
+            subresult.insert(state);
+        }  
+    }
+    return ClosedSet<State>(ClosedSet<State>::downward_closed, 0, transRelation.size()-1, subresult);
+} // get_non_initial_nodes() }}}
+
+/** This function returns a downward-closed set of all the nodes which are final
+* @return closed set of final nodes
+*/
+ClosedSet<State> Afa::get_final_nodes(void) const
+{
+    OrdVec<State> subresult{};
+    for(State state = 0; state < transRelation.size(); ++state)
+    {
+        if(has_final(state))
+        {
+            subresult.insert(state);
+        }  
+    }
+    return ClosedSet<State>(ClosedSet<State>::downward_closed, 0, transRelation.size()-1, subresult);
+} // get_final_nodes() }}}
+
+/** This function returns an upward-closed set of all the nodes which are non-final
+* @return closed set of non-final nodes
+*/
+ClosedSet<State> Afa::get_non_final_nodes(void) const
+{
+    ClosedSet<State> result(ClosedSet<State>::upward_closed, 0, transRelation.size()-1);
+    for(State state = 0; state < transRelation.size(); ++state)
+    {
+        if(!has_final(state))
+        {
+            result.insert(state);
+        }    
+    }
+    return result;
+} // get_non_final_nodes() }}}
 
 
 std::ostream& Mata::Afa::operator<<(std::ostream& os, const Afa& afa)
@@ -121,6 +625,62 @@ bool Mata::Afa::is_lang_empty_cex(const Afa& aut, Word* cex)
   // TODO
   assert(false);
 } // is_lang_empty_cex }}}
+
+/** This function decides whether the given automaton is empty using 
+* a antichain-based emptiness test working in the concrete domain
+* in the forward fashion
+* @param aut a given automaton
+* @return true iff the automaton is empty
+*/
+bool Mata::Afa::antichain_concrete_forward_emptiness_test(const Afa& aut)
+{
+    // We will iteratively build a set of reachable nodes (next) until we reach a fixed
+    // point or until we find out that there exists a final node which is reachable (is not part of goal).
+    // We will perform each operation directly over antichains
+    // Note that the fixed point always exists so the while loop always terminates
+    ClosedSet<Mata::Afa::State> goal = aut.get_non_final_nodes();
+    ClosedSet<Mata::Afa::State> current = ClosedSet<Mata::Afa::State>();
+    ClosedSet<Mata::Afa::State> next = aut.get_initial_nodes();
+
+    while(current != next)
+    {
+        current = next;
+        next = current.Union(aut.post(current));
+        if(!(next <= goal)) // inclusion test
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** This function decides whether the given automaton is empty using 
+* a antichain-based emptiness test working in the concrete domain
+* in the backward fashion
+* @param aut a given automaton
+* @return true iff the automaton is empty
+*/
+bool Mata::Afa::antichain_concrete_backward_emptiness_test(const Afa& aut)
+{
+    // We will iteratively build a set of terminating nodes (next) until we reach a fixed
+    // point or until we find out that there exists a initial node which is terminating (is not part of goal).
+    // We will perform each operation directly over antichains
+    // Note that the fixed point always exists so the while loop always terminates
+    ClosedSet<Mata::Afa::State> goal = aut.get_non_initial_nodes();
+    ClosedSet<Mata::Afa::State> current = ClosedSet<Mata::Afa::State>();
+    ClosedSet<Mata::Afa::State> next = aut.get_final_nodes();
+
+    while(current != next)
+    {
+        current = next;
+        next = current.Union(aut.pre(current));
+        if(!(next <= goal))
+        {
+            return false;
+        }
+    }
+    return true;
+}
 
 
 void Mata::Afa::make_complete(
@@ -195,12 +755,13 @@ Mata::Parser::ParsedSection Mata::Afa::serialize(
 	}
 	parsec.dict["Final"] = fin_states;
 
-	for (const auto& trans : aut.transitions) {
+	/*for (const auto& trans : aut.transitions) {
 		bool_str_pair src_bsp = state_namer(trans.src);
+		bool_str_pair symb_bsp = symbol_namer(trans.src);
 		if (!src_bsp.first) { throw std::runtime_error("cannot translate state " + std::to_string(trans.src)); }
 
-		parsec.body.push_back({ src_bsp.second, trans.formula });
-	}
+		parsec.body.push_back({ src_bsp.second, symb_bsp.second, trans.dst });
+	}*/ // TODO
 
 	return parsec;
 } // serialize }}}
@@ -311,7 +872,8 @@ void Mata::Afa::construct(
       formula += body_line[i] + " ";
     }
 
-    aut->add_trans(src_state, formula);
+    //aut->add_trans(src_state, formula);
+    //TODO
 	}
 
 	// do the dishes and take out garbage
@@ -336,7 +898,7 @@ void Mata::Afa::construct(
 
 	auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
 
-    Mata::Nfa::OnTheFlyAlphabet alphabet(*symbol_map);
+  Mata::Nfa::OnTheFlyAlphabet alphabet(*symbol_map);
 
 	try
 	{
@@ -405,3 +967,4 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::AfaWrapper& afa
 		"|state_dict: " << std::to_string(afa_wrap.state_dict) << "}";
 	return os;
 } // operator<<(AfaWrapper) }}}
+

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -554,13 +554,9 @@ size_t Afa::trans_size() const
 StateClosedSet Afa::get_initial_nodes(void) const
 {
 	StateClosedSet result(upward_closed_set, 0, transitionrelation.size()-1);
-	auto transSize = transitionrelation.size();
-	for(State state = 0; state < transSize; ++state)
+	for(auto state : initialstates)
 	{
-		if(has_initial(state))
-		{
-			result.insert(state);
-		}    
+		result.insert(state);
 	}
 	return result;
 } // get_initial_nodes() }}}

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -44,7 +44,7 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::Trans& trans)
 } // operator<<(ostream, Trans) }}}
 
 /** This function adds a new transition to the automaton. It changes a transition
-* relation. 
+* relation. The transition is added to the transition relation it its current form.
 * @brief adds a new transition
 * @param trans a given transition
 */
@@ -554,7 +554,8 @@ size_t Afa::trans_size() const
 StateClosedSet Afa::get_initial_nodes(void) const
 {
 	StateClosedSet result(upward_closed_set, 0, transitionrelation.size()-1);
-	for(State state = 0; state < transitionrelation.size(); ++state)
+	auto transSize = transitionrelation.size();
+	for(State state = 0; state < transSize; ++state)
 	{
 		if(has_initial(state))
 		{
@@ -571,7 +572,8 @@ StateClosedSet Afa::get_initial_nodes(void) const
 StateClosedSet Afa::get_non_initial_nodes(void) const
 {
 	OrdVec<State> subresult{};
-	for(State state = 0; state < transitionrelation.size(); ++state)
+	auto transSize = transitionrelation.size();
+	for(State state = 0; state < transSize; ++state)
 	{
 		if(!has_initial(state))
 		{
@@ -588,7 +590,8 @@ StateClosedSet Afa::get_non_initial_nodes(void) const
 StateClosedSet Afa::get_final_nodes(void) const
 {
 	OrdVec<State> subresult{};
-	for(State state = 0; state < transitionrelation.size(); ++state)
+	auto transSize = transitionrelation.size();
+	for(State state = 0; state < transSize; ++state)
 	{
 		if(has_final(state))
 		{
@@ -605,7 +608,8 @@ StateClosedSet Afa::get_final_nodes(void) const
 StateClosedSet Afa::get_non_final_nodes(void) const
 {
 	StateClosedSet result(upward_closed_set, 0, transitionrelation.size()-1);
-	for(State state = 0; state < transitionrelation.size(); ++state)
+	auto transSize = transitionrelation.size();
+	for(State state = 0; state < transSize; ++state)
 	{
 		if(!has_final(state))
 		{

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -18,21 +18,21 @@ TEST_CASE("Mata::Afa::Trans::operator<<")
 
 TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 { // {{{
-    ClosedSet<State> c1 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes());
-    ClosedSet<State> c2 = ClosedSet<State>(ClosedSet<State>::downward_closed, 10, 20, Nodes());
+    ClosedSet<State> c1 = ClosedSet<State>(Mata::upward_closed_set, 0, 2, Nodes());
+    ClosedSet<State> c2 = ClosedSet<State>(Mata::downward_closed_set, 10, 20, Nodes());
 
-    REQUIRE(c1.get_type() == ClosedSet<State>::upward_closed);
-    REQUIRE(c2.get_type() == ClosedSet<State>::downward_closed);
-    REQUIRE(c1.get_type() != c2.get_type());
-    REQUIRE(c1.get_antichain().size() == 0);
-    REQUIRE(c2.get_antichain().size() == 0);
+    REQUIRE(c1.type() == Mata::upward_closed_set);
+    REQUIRE(c2.type() == Mata::downward_closed_set);
+    REQUIRE(c1.type() != c2.type());
+    REQUIRE(c1.antichain().size() == 0);
+    REQUIRE(c2.antichain().size() == 0);
 
 } // }}}
 
 TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 { // {{{
-    ClosedSet<State> c1 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes());
-    ClosedSet<State> c2 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes());
+    ClosedSet<State> c1 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes());
+    ClosedSet<State> c2 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes());
 
     REQUIRE(!c1.contains(Node{0}));
     REQUIRE(!c2.contains(Node{0}));
@@ -51,8 +51,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(!c1.contains(Node{}));
     REQUIRE(c2.contains(Node{}));
 
-    ClosedSet<State> c3 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 1}});
-    ClosedSet<State> c4 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 3}});
+    ClosedSet<State> c3 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
+    ClosedSet<State> c4 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
     
     REQUIRE(c3.Union(c4).contains(Node{0, 1}));
     REQUIRE(c3.Union(c4).contains(Node{0, 3}));
@@ -64,10 +64,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(!c3.Union(c4).contains(Node{}));
     REQUIRE(!c3.intersection(c4).contains(Node{}));
 
-    ///
-
-    ClosedSet<State> c5 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 1}});
-    ClosedSet<State> c6 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 3}});
+    ClosedSet<State> c5 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
+    ClosedSet<State> c6 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
     
     REQUIRE(c5.Union(c6).contains(Node{0, 1}));
     REQUIRE(c5.Union(c6).contains(Node{0, 3}));
@@ -79,26 +77,24 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(c5.Union(c6).contains(Node{}));
     REQUIRE(c5.intersection(c6).contains(Node{}));
 
-    ///
+    REQUIRE(std::to_string(c5.Union(c6).antichain()) == "{ { 0, 1}, { 0, 3}}");
+    REQUIRE(std::to_string(c5.intersection(c6).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(c5.Union(c6).get_antichain()) == "{ { 0, 1}, { 0, 3}}");
-    REQUIRE(std::to_string(c5.intersection(c6).get_antichain()) == "{ { 0}}");
-
-    ClosedSet<State> c7 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 3}});
+    ClosedSet<State> c7 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
     c7.insert(Node{0});
-    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 3}}");
+    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 3}}");
     c7.insert(Node{0, 2});
-    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 2}, { 0, 3}}");
+    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2}, { 0, 3}}");
     c7.insert(Node{0, 2, 3});
-    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 2, 3}}");
+    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2, 3}}");
 
-    ClosedSet<State> c8 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 3}});
+    ClosedSet<State> c8 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
     c8.insert(Node{0, 1, 3});
-    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0, 3}}");
+    REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 3}}");
     c8.insert(Node{0, 2});
-    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0, 2}, { 0, 3}}");
+    REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 2}, { 0, 3}}");
     c8.insert(Node{0});
-    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(c8.antichain()) == "{ { 0}}");
 
 } // }}}
 
@@ -136,58 +132,58 @@ TEST_CASE("Mata::Afa transition test")
 	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(std::to_string(aut.post(Nodes{}).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{}}).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.post(Nodes{}).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{}}).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.post(0, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Node{0}, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(0, 0).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Node{0}, 0).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.post(0, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(Node{0}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(0, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(Node{0}, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
-    REQUIRE(std::to_string(aut.post(1, 0).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{1}, 0).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(1, 0).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{1}, 0).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(1, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{1}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(1, 1).antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{1}, 1).antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).antichain()) == "{ { 0}, { 1, 2}}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
 
-    REQUIRE(std::to_string(aut.post(2, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(Node{2}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(2, 0).antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(Node{2}, 0).antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).antichain()) == "{ { 0, 1}, { 2}}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
 
-    REQUIRE(std::to_string(aut.post(2, 1).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{2}, 1).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(2, 1).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{2}, 1).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(ClosedSet<State>
-    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{}");
+    (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).get_antichain()) == "{ { 0, 1}, { 0, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{1, 2}, 0).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).antichain()) == "{ { 0, 1}, { 0, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{1, 2}, 0).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 0).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Node{0, 1}, 1).get_antichain()) == "{ { 0, 1}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{0, 2}, 1).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{1, 2}, 1).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1}, 1).antichain()) == "{ { 0, 1}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{0, 2}, 1).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{1, 2}, 1).antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 1).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 1).get_antichain()) == "{ { 0}, { 1}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}).get_antichain()) == "{ { 0}, { 1}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 0).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 1).antichain()) == "{ { 0}, { 1}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}).antichain()) == "{ { 0}, { 1}}");
 
 } // }}}
 
@@ -203,60 +199,60 @@ TEST_CASE("Mata::Afa inverse transition test")
 	aut.add_inverse_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_inverse_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(std::to_string(aut.pre(Node{}, 0).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{}, 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{}, 0).antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{}, 1).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.pre(0, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Node{0}, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(0, 0).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Node{0}, 0).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.pre(1, 0).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{1}, 0).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(1, 0).antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{1}, 0).antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{ {}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.pre(2, 0).get_antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{2}, 0).get_antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(2, 0).antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{2}, 0).antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).antichain()) == "{ { 2}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 2}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
 
 
-    REQUIRE(std::to_string(aut.pre(0, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(0, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0}, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
-    REQUIRE(std::to_string(aut.pre(1, 1).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Node{1}, 1).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(1, 1).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Node{1}, 1).antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.pre(2, 1).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{2}, 1).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(2, 1).antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{2}, 1).antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(ClosedSet<State>
-    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{ {}}");
+    (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
 
 
-    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).get_antichain()) == "{ { 0, 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 0).get_antichain()) == "{ { 0, 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 0).get_antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 0).get_antichain()) == "{ { 0, 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).antichain()) == "{ { 0, 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 0).antichain()) == "{ { 0, 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 0).antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 0).antichain()) == "{ { 0, 2}}");
 
-    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 1).get_antichain()) == "{ { 0, 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 1).get_antichain()) == "{ { 0, 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 1).get_antichain()) == "{ { 0, 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 1).antichain()) == "{ { 0, 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 1).antichain()) == "{ { 0, 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 1).antichain()) == "{ { 0, 1}}");
 
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 0).get_antichain()) == "{ { 0}, { 2}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}).get_antichain()) == "{ { 0}, { 1}, { 2}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 0).antichain()) == "{ { 0}, { 2}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 1).antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}).antichain()) == "{ { 0}, { 1}, { 2}}");
 
 } // }}}
 

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -11,11 +11,353 @@ using namespace Mata::Parser;
 
 TEST_CASE("Mata::Afa::Trans::operator<<")
 { // {{{
-	Trans trans(1, "(A and 2) or (B and 3)");
+	Trans trans(1, 0, {{0, 1}, {0, 2}});
 
-	REQUIRE(std::to_string(trans) == "(1, (A and 2) or (B and 3))");
+	REQUIRE(std::to_string(trans) == "(1, 0, { { 0, 1}, { 0, 2}})");
 } // }}}
 
+TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
+{ // {{{
+    ClosedSet<State> c1 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes());
+    ClosedSet<State> c2 = ClosedSet<State>(ClosedSet<State>::downward_closed, 10, 20, Nodes());
+
+    REQUIRE(c1.get_type() == ClosedSet<State>::upward_closed);
+    REQUIRE(c2.get_type() == ClosedSet<State>::downward_closed);
+    REQUIRE(c1.get_type() != c2.get_type());
+    REQUIRE(c1.get_antichain().size() == 0);
+    REQUIRE(c2.get_antichain().size() == 0);
+
+} // }}}
+
+TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
+{ // {{{
+    ClosedSet<State> c1 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes());
+    ClosedSet<State> c2 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes());
+
+    REQUIRE(!c1.contains(Node{0}));
+    REQUIRE(!c2.contains(Node{0}));
+
+    c1.insert(Node{0, 1});    
+    c2.insert(Node{0, 1});
+
+    REQUIRE(!c1.contains(Node{0}));
+    REQUIRE(c2.contains(Node{0}));
+
+    c1.insert(Node{0, 2});    
+    c2.insert(Node{0, 2});
+
+    REQUIRE(c1.contains(Node{0, 1, 2}));
+    REQUIRE(!c2.contains(Node{0, 1, 2}));
+    REQUIRE(!c1.contains(Node{}));
+    REQUIRE(c2.contains(Node{}));
+
+    ClosedSet<State> c3 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 1}});
+    ClosedSet<State> c4 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 3}});
+
+    std::cout << c3.intersection(c4);
+    
+    REQUIRE(c3.Union(c4).contains(Node{0, 1}));
+    REQUIRE(c3.Union(c4).contains(Node{0, 3}));
+    REQUIRE(!c3.intersection(c4).contains(Node{0, 1}));
+    REQUIRE(!c3.intersection(c4).contains(Node{0, 3}));
+
+    REQUIRE(c3.Union(c4).contains(Node{0, 1, 3}));
+    REQUIRE(c3.intersection(c4).contains(Node{0, 1, 3}));
+    REQUIRE(!c3.Union(c4).contains(Node{}));
+    REQUIRE(!c3.intersection(c4).contains(Node{}));
+
+    ///
+
+    ClosedSet<State> c5 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 1}});
+    ClosedSet<State> c6 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 3}});
+    
+    REQUIRE(c5.Union(c6).contains(Node{0, 1}));
+    REQUIRE(c5.Union(c6).contains(Node{0, 3}));
+    REQUIRE(!c5.intersection(c6).contains(Node{0, 1}));
+    REQUIRE(!c5.intersection(c6).contains(Node{0, 3}));
+
+    REQUIRE(!c5.Union(c6).contains(Node{0, 1, 3}));
+    REQUIRE(!c5.intersection(c6).contains(Node{0, 1, 3}));
+    REQUIRE(c5.Union(c6).contains(Node{}));
+    REQUIRE(c5.intersection(c6).contains(Node{}));
+
+    ///
+
+    REQUIRE(std::to_string(c5.Union(c6).get_antichain()) == "{ { 0, 1}, { 0, 3}}");
+    REQUIRE(std::to_string(c5.intersection(c6).get_antichain()) == "{ { 0}}");
+
+    ClosedSet<State> c7 = ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 3, Nodes{Node{0, 3}});
+    c7.insert(Node{0});
+    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 3}}");
+    c7.insert(Node{0, 2});
+    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 2}, { 0, 3}}");
+    c7.insert(Node{0, 2, 3});
+    REQUIRE(std::to_string(c7.get_antichain()) == "{ { 0, 2, 3}}");
+
+    ClosedSet<State> c8 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 3}});
+    c8.insert(Node{0, 1, 3});
+    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0, 3}}");
+    c8.insert(Node{0, 2});
+    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0, 2}, { 0, 3}}");
+    c8.insert(Node{0});
+    REQUIRE(std::to_string(c8.get_antichain()) == "{ { 0}}");
+
+} // }}}
+
+
+TEST_CASE("Mata::Afa creating an AFA, basic properties")
+{ // {{{
+
+    Afa aut(4);
+
+	aut.initialstates = {0};
+	aut.finalstates = {3};
+	aut.add_trans(0, 0, Node{1, 2});
+	aut.add_trans(1, 0, Node{2});
+	aut.add_trans(1, 1, Node{2, 3});
+	aut.add_trans(2, 1, Node{3});
+	aut.add_trans(3, 1, Node{3});
+	aut.add_trans(3, 0, Node{0});
+
+	REQUIRE(aut.trans_size() == 6);
+	REQUIRE(aut.has_final(3));
+	REQUIRE(!aut.has_final(2));
+	REQUIRE(aut.has_initial(0));
+	REQUIRE(!aut.has_initial(1));
+} // }}}
+
+TEST_CASE("Mata::Afa transition test")
+{ // {{{
+
+    Afa aut(3);
+
+	aut.initialstates = {0};
+	aut.finalstates = {2};
+	aut.add_trans(0, 0, Nodes{Node{0}});
+	aut.add_trans(0, 1, Nodes{Node{1}});
+	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+
+    REQUIRE(std::to_string(aut.post(Nodes{}).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{}}).get_antichain()) == "{ {}}");
+
+    REQUIRE(std::to_string(aut.post(0, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Node{0}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+
+    REQUIRE(std::to_string(aut.post(0, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(Node{0}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+
+    REQUIRE(std::to_string(aut.post(1, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{1}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{}");
+
+    REQUIRE(std::to_string(aut.post(1, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{1}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+
+    REQUIRE(std::to_string(aut.post(2, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(Node{2}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+
+    REQUIRE(std::to_string(aut.post(2, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{2}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{}");
+
+    REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).get_antichain()) == "{ { 0, 1}, { 0, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{1, 2}, 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 0).get_antichain()) == "{}");
+
+    REQUIRE(std::to_string(aut.post(Node{0, 1}, 1).get_antichain()) == "{ { 0, 1}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(Node{0, 2}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{1, 2}, 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 1).get_antichain()) == "{}");
+
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 1).get_antichain()) == "{ { 0}, { 1}}");
+    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}).get_antichain()) == "{ { 0}, { 1}}");
+
+} // }}}
+
+TEST_CASE("Mata::Afa inverse transition test")
+{ // {{{
+
+    Afa aut(3);
+
+	aut.initialstates = {0};
+	aut.finalstates = {2};
+	aut.add_inv_trans(0, 0, Nodes{Node{0}});
+	aut.add_inv_trans(0, 1, Nodes{Node{1}});
+	aut.add_inv_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_inv_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+
+    REQUIRE(std::to_string(aut.pre(Node{}, 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{}, 1).get_antichain()) == "{ {}}");
+
+    REQUIRE(std::to_string(aut.pre(0, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Node{0}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+
+    REQUIRE(std::to_string(aut.pre(1, 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{1}, 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{ {}}");
+
+    REQUIRE(std::to_string(aut.pre(2, 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{2}, 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 2}}");
+
+
+    REQUIRE(std::to_string(aut.pre(0, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+
+    REQUIRE(std::to_string(aut.pre(1, 1).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Node{1}, 1).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}}");
+
+    REQUIRE(std::to_string(aut.pre(2, 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Node{2}, 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{ {}}");
+
+
+    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).get_antichain()) == "{ { 0, 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 0).get_antichain()) == "{ { 0, 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 0).get_antichain()) == "{ { 0, 2}}");
+
+    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 1).get_antichain()) == "{ { 0, 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 1).get_antichain()) == "{ { 0, 1}}");
+    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 1).get_antichain()) == "{ { 0, 1}}");
+
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 0).get_antichain()) == "{ { 0}, { 2}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}).get_antichain()) == "{ { 0}, { 1}, { 2}}");
+
+} // }}}
+
+TEST_CASE("Mata::Afa antichain emptiness test")
+{
+    /////////////////////////////////
+    // Example of an automaton
+    /////////////////////////////////
+
+    Afa aut(3);
+
+	aut.initialstates = {0};
+	aut.finalstates = {2};
+
+    // TODO: Add transition and inverse transition simultaneously???
+    // Do we always care about inverse transitions (in context of other
+    // operations than backward emptiness test etc.?) Is it better
+    // to add inverse transitions on demand or always?
+
+	aut.add_trans(0, 0, Nodes{Node{0}});
+	aut.add_trans(0, 1, Nodes{Node{1}});
+	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+	
+    aut.add_inv_trans(0, 0, Nodes{Node{0}});
+	aut.add_inv_trans(0, 1, Nodes{Node{1}});
+	aut.add_inv_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_inv_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+
+    REQUIRE(antichain_concrete_forward_emptiness_test(aut));
+    REQUIRE(antichain_concrete_backward_emptiness_test(aut));
+
+	aut.finalstates = {0};
+    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+
+	aut.finalstates = {1};
+    
+    std::cout << aut.get_initial_nodes();
+    std::cout << aut.post(aut.get_initial_nodes());
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+
+    /////////////////////////////////
+    // Example of an automaton
+    /////////////////////////////////
+
+    Afa aut1(10);
+
+	aut1.initialstates = {0};
+	aut1.finalstates = {9};
+
+    aut1.add_trans(0, 0, Nodes{Node{1}});
+    aut1.add_trans(1, 0, Nodes{Node{2}});
+    aut1.add_trans(2, 0, Nodes{Node{3}});
+    aut1.add_trans(3, 0, Nodes{Node{4}});
+    aut1.add_trans(4, 0, Nodes{Node{5}});
+    aut1.add_trans(5, 0, Nodes{Node{6}});
+    aut1.add_trans(6, 0, Nodes{Node{7}});
+    aut1.add_trans(7, 0, Nodes{Node{8}});
+    aut1.add_trans(8, 0, Nodes{Node{8, 9}});
+
+    aut1.add_inv_trans(0, 0, Nodes{Node{1}});
+    aut1.add_inv_trans(1, 0, Nodes{Node{2}});
+    aut1.add_inv_trans(2, 0, Nodes{Node{3}});
+    aut1.add_inv_trans(3, 0, Nodes{Node{4}});
+    aut1.add_inv_trans(4, 0, Nodes{Node{5}});
+    aut1.add_inv_trans(5, 0, Nodes{Node{6}});
+    aut1.add_inv_trans(6, 0, Nodes{Node{7}});
+    aut1.add_inv_trans(7, 0, Nodes{Node{8}});
+    aut1.add_inv_trans(8, 0, Nodes{Node{8, 9}});
+
+    REQUIRE(antichain_concrete_forward_emptiness_test(aut1));
+    REQUIRE(antichain_concrete_backward_emptiness_test(aut1));
+
+    aut1.add_inv_trans(8, 0, Nodes{Node{9}});
+    aut1.add_inv_trans(8, 0, Nodes{Node{9}});
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+
+    /////////////////////////////////
+    // Automaton with no transitions
+    /////////////////////////////////
+
+    Afa aut2(3);
+
+    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+
+    aut2.initialstates = {0};
+
+    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+
+    aut2.finalstates = {1};
+
+    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+
+    aut2.finalstates = {0};
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test(aut2));
+    REQUIRE(!antichain_concrete_backward_emptiness_test(aut2));
+
+
+}
+
+
+/*
 TEST_CASE("Mata::Afa::construct() correct calls")
 { // {{{
 	Afa aut;
@@ -62,4 +404,4 @@ TEST_CASE("Mata::Afa::construct() correct calls")
 
 		construct(&aut, parsec);
 	}
-} // }}}
+} // }}} */

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -18,8 +18,8 @@ TEST_CASE("Mata::Afa::Trans::operator<<")
 
 TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 { // {{{
-    ClosedSet<State> c1 = ClosedSet<State>(Mata::upward_closed_set, 0, 2, Nodes());
-    ClosedSet<State> c2 = ClosedSet<State>(Mata::downward_closed_set, 10, 20, Nodes());
+    StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 2, Nodes());
+    StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 10, 20, Nodes());
 
     REQUIRE(c1.type() == Mata::upward_closed_set);
     REQUIRE(c2.type() == Mata::downward_closed_set);
@@ -31,8 +31,8 @@ TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 
 TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 { // {{{
-    ClosedSet<State> c1 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes());
-    ClosedSet<State> c2 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes());
+    StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
+    StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
 
     REQUIRE(!c1.contains(Node{0}));
     REQUIRE(!c2.contains(Node{0}));
@@ -51,8 +51,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(!c1.contains(Node{}));
     REQUIRE(c2.contains(Node{}));
 
-    ClosedSet<State> c3 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
-    ClosedSet<State> c4 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
+    StateClosedSet c3 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
+    StateClosedSet c4 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
     
     REQUIRE(c3.Union(c4).contains(Node{0, 1}));
     REQUIRE(c3.Union(c4).contains(Node{0, 3}));
@@ -64,8 +64,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(!c3.Union(c4).contains(Node{}));
     REQUIRE(!c3.intersection(c4).contains(Node{}));
 
-    ClosedSet<State> c5 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
-    ClosedSet<State> c6 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
+    StateClosedSet c5 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
+    StateClosedSet c6 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
     
     REQUIRE(c5.Union(c6).contains(Node{0, 1}));
     REQUIRE(c5.Union(c6).contains(Node{0, 3}));
@@ -80,7 +80,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     REQUIRE(std::to_string(c5.Union(c6).antichain()) == "{ { 0, 1}, { 0, 3}}");
     REQUIRE(std::to_string(c5.intersection(c6).antichain()) == "{ { 0}}");
 
-    ClosedSet<State> c7 = ClosedSet<State>(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
+    StateClosedSet c7 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
     c7.insert(Node{0});
     REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 3}}");
     c7.insert(Node{0, 2});
@@ -88,7 +88,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
     c7.insert(Node{0, 2, 3});
     REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2, 3}}");
 
-    ClosedSet<State> c8 = ClosedSet<State>(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
+    StateClosedSet c8 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
     c8.insert(Node{0, 1, 3});
     REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 3}}");
     c8.insert(Node{0, 2});
@@ -138,37 +138,37 @@ TEST_CASE("Mata::Afa transition test")
     REQUIRE(std::to_string(aut.post(0, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.post(Node{0}, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.post(0, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.post(Node{0}, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
     REQUIRE(std::to_string(aut.post(1, 0).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Node{1}, 0).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
 
     REQUIRE(std::to_string(aut.post(1, 1).antichain()) == "{ { 0}, { 1, 2}}");
     REQUIRE(std::to_string(aut.post(Node{1}, 1).antichain()) == "{ { 0}, { 1, 2}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
 
     REQUIRE(std::to_string(aut.post(2, 0).antichain()) == "{ { 0, 1}, { 2}}");
     REQUIRE(std::to_string(aut.post(Node{2}, 0).antichain()) == "{ { 0, 1}, { 2}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
 
     REQUIRE(std::to_string(aut.post(2, 1).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Node{2}, 1).antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    REQUIRE(std::to_string(aut.post(StateClosedSet
     (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
 
     REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).antichain()) == "{}");
@@ -205,38 +205,38 @@ TEST_CASE("Mata::Afa inverse transition test")
     REQUIRE(std::to_string(aut.pre(0, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Node{0}, 0).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.pre(1, 0).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Node{1}, 0).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
 
     REQUIRE(std::to_string(aut.pre(2, 0).antichain()) == "{ { 2}}");
     REQUIRE(std::to_string(aut.pre(Node{2}, 0).antichain()) == "{ { 2}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
 
 
     REQUIRE(std::to_string(aut.pre(0, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.pre(Node{0}, 1).antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
     REQUIRE(std::to_string(aut.pre(1, 1).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Node{1}, 1).antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.pre(2, 1).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Node{2}, 1).antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    REQUIRE(std::to_string(aut.pre(StateClosedSet
     (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
 
 

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -126,9 +126,37 @@ TEST_CASE("Mata::Afa creating an AFA, basic properties")
 	REQUIRE(aut.add_new_state() == 7);
 	REQUIRE(aut.get_num_of_states() == 8);
 
+	auto transitions1 = aut.get_trans_from_state(0);
+	auto transitions2 = aut.get_trans_from_state(1);
+
+	REQUIRE(transitions1.size() == 1);
+	REQUIRE(transitions2.size() == 2);
+
+	REQUIRE(transitions1[0].src == 0);
+	REQUIRE(transitions1[0].symb == 0);
+	REQUIRE(transitions1[0].dst == Nodes{Node{1, 2}});
+
+	REQUIRE(transitions2[0].src == 1);
+	REQUIRE(transitions2[0].symb == 0);
+	REQUIRE(transitions2[0].dst == Nodes{Node{2}});
+
+	REQUIRE(transitions2[1].src == 1);
+	REQUIRE(transitions2[1].symb == 1);
+	REQUIRE(transitions2[1].dst == Nodes{Node{2, 3}});
+
 	aut.add_trans(7, 0, Node{0});
 
 	REQUIRE(aut.trans_size() == 7);
+
+	aut.add_trans(7, 0, Node{1});
+	aut.add_trans(7, 0, Node{2, 3});
+
+	auto transitions3 = aut.get_trans_from_state(7);
+
+	REQUIRE(transitions3.size() == 1);
+	REQUIRE(transitions3[0].src == 7);
+	REQUIRE(transitions3[0].symb == 0);
+	REQUIRE(transitions3[0].dst == Nodes{Node{0}, Node{1}, Node{2, 3}});
 
 } // }}}
 

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -295,20 +295,13 @@ TEST_CASE("Mata::Afa antichain emptiness test")
     REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
     REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
-
 	aut.finalstates = {1};
-<<<<<<< HEAD
 
     REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
     REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
 
     REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
     REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
-=======
-    
-    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
->>>>>>> refs/remotes/origin/devel
 
     /////////////////////////////////
     // Example of an automaton

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -18,83 +18,83 @@ TEST_CASE("Mata::Afa::Trans::operator<<")
 
 TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 { // {{{
-    StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 2, Nodes());
-    StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 10, 20, Nodes());
+	StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 2, Nodes());
+	StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 10, 20, Nodes());
 
-    REQUIRE(c1.type() == Mata::upward_closed_set);
-    REQUIRE(c2.type() == Mata::downward_closed_set);
-    REQUIRE(c1.type() != c2.type());
-    REQUIRE(c1.antichain().size() == 0);
-    REQUIRE(c2.antichain().size() == 0);
+	REQUIRE(c1.type() == Mata::upward_closed_set);
+	REQUIRE(c2.type() == Mata::downward_closed_set);
+	REQUIRE(c1.type() != c2.type());
+	REQUIRE(c1.antichain().size() == 0);
+	REQUIRE(c2.antichain().size() == 0);
 
 } // }}}
 
 TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 { // {{{
-    StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
-    StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
+	StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
+	StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
 
-    REQUIRE(!c1.contains(Node{0}));
-    REQUIRE(!c2.contains(Node{0}));
+	REQUIRE(!c1.contains(Node{0}));
+	REQUIRE(!c2.contains(Node{0}));
 
-    c1.insert(Node{0, 1});    
-    c2.insert(Node{0, 1});
+	c1.insert(Node{0, 1});    
+	c2.insert(Node{0, 1});
 
-    REQUIRE(!c1.contains(Node{0}));
-    REQUIRE(c2.contains(Node{0}));
+	REQUIRE(!c1.contains(Node{0}));
+	REQUIRE(c2.contains(Node{0}));
 
-    c1.insert(Node{0, 2});    
-    c2.insert(Node{0, 2});
+	c1.insert(Node{0, 2});    
+	c2.insert(Node{0, 2});
 
-    REQUIRE(c1.contains(Node{0, 1, 2}));
-    REQUIRE(!c2.contains(Node{0, 1, 2}));
-    REQUIRE(!c1.contains(Node{}));
-    REQUIRE(c2.contains(Node{}));
+	REQUIRE(c1.contains(Node{0, 1, 2}));
+	REQUIRE(!c2.contains(Node{0, 1, 2}));
+	REQUIRE(!c1.contains(Node{}));
+	REQUIRE(c2.contains(Node{}));
 
-    StateClosedSet c3 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
-    StateClosedSet c4 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
-    
-    REQUIRE(c3.Union(c4).contains(Node{0, 1}));
-    REQUIRE(c3.Union(c4).contains(Node{0, 3}));
-    REQUIRE(!c3.intersection(c4).contains(Node{0, 1}));
-    REQUIRE(!c3.intersection(c4).contains(Node{0, 3}));
+	StateClosedSet c3 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
+	StateClosedSet c4 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
 
-    REQUIRE(c3.Union(c4).contains(Node{0, 1, 3}));
-    REQUIRE(c3.intersection(c4).contains(Node{0, 1, 3}));
-    REQUIRE(!c3.Union(c4).contains(Node{}));
-    REQUIRE(!c3.intersection(c4).contains(Node{}));
+	REQUIRE(c3.Union(c4).contains(Node{0, 1}));
+	REQUIRE(c3.Union(c4).contains(Node{0, 3}));
+	REQUIRE(!c3.intersection(c4).contains(Node{0, 1}));
+	REQUIRE(!c3.intersection(c4).contains(Node{0, 3}));
 
-    StateClosedSet c5 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
-    StateClosedSet c6 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
-    
-    REQUIRE(c5.Union(c6).contains(Node{0, 1}));
-    REQUIRE(c5.Union(c6).contains(Node{0, 3}));
-    REQUIRE(!c5.intersection(c6).contains(Node{0, 1}));
-    REQUIRE(!c5.intersection(c6).contains(Node{0, 3}));
+	REQUIRE(c3.Union(c4).contains(Node{0, 1, 3}));
+	REQUIRE(c3.intersection(c4).contains(Node{0, 1, 3}));
+	REQUIRE(!c3.Union(c4).contains(Node{}));
+	REQUIRE(!c3.intersection(c4).contains(Node{}));
 
-    REQUIRE(!c5.Union(c6).contains(Node{0, 1, 3}));
-    REQUIRE(!c5.intersection(c6).contains(Node{0, 1, 3}));
-    REQUIRE(c5.Union(c6).contains(Node{}));
-    REQUIRE(c5.intersection(c6).contains(Node{}));
+	StateClosedSet c5 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
+	StateClosedSet c6 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
 
-    REQUIRE(std::to_string(c5.Union(c6).antichain()) == "{ { 0, 1}, { 0, 3}}");
-    REQUIRE(std::to_string(c5.intersection(c6).antichain()) == "{ { 0}}");
+	REQUIRE(c5.Union(c6).contains(Node{0, 1}));
+	REQUIRE(c5.Union(c6).contains(Node{0, 3}));
+	REQUIRE(!c5.intersection(c6).contains(Node{0, 1}));
+	REQUIRE(!c5.intersection(c6).contains(Node{0, 3}));
 
-    StateClosedSet c7 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
-    c7.insert(Node{0});
-    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 3}}");
-    c7.insert(Node{0, 2});
-    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2}, { 0, 3}}");
-    c7.insert(Node{0, 2, 3});
-    REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2, 3}}");
+	REQUIRE(!c5.Union(c6).contains(Node{0, 1, 3}));
+	REQUIRE(!c5.intersection(c6).contains(Node{0, 1, 3}));
+	REQUIRE(c5.Union(c6).contains(Node{}));
+	REQUIRE(c5.intersection(c6).contains(Node{}));
 
-    StateClosedSet c8 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
-    c8.insert(Node{0, 1, 3});
-    REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 3}}");
-    c8.insert(Node{0, 2});
-    REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 2}, { 0, 3}}");
-    c8.insert(Node{0});
-    REQUIRE(std::to_string(c8.antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(c5.Union(c6).antichain()) == "{ { 0, 1}, { 0, 3}}");
+	REQUIRE(std::to_string(c5.intersection(c6).antichain()) == "{ { 0}}");
+
+	StateClosedSet c7 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	c7.insert(Node{0});
+	REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 3}}");
+	c7.insert(Node{0, 2});
+	REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2}, { 0, 3}}");
+	c7.insert(Node{0, 2, 3});
+	REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2, 3}}");
+
+	StateClosedSet c8 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	c8.insert(Node{0, 1, 3});
+	REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 3}}");
+	c8.insert(Node{0, 2});
+	REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 2}, { 0, 3}}");
+	c8.insert(Node{0});
+	REQUIRE(std::to_string(c8.antichain()) == "{ { 0}}");
 
 } // }}}
 
@@ -102,7 +102,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 TEST_CASE("Mata::Afa creating an AFA, basic properties")
 { // {{{
 
-    Afa aut(4);
+	Afa aut(4);
 
 	aut.initialstates = {0};
 	aut.finalstates = {3};
@@ -119,23 +119,23 @@ TEST_CASE("Mata::Afa creating an AFA, basic properties")
 	REQUIRE(aut.has_initial(0));
 	REQUIRE(!aut.has_initial(1));
 
-    REQUIRE(aut.get_num_of_states() == 4);
-    REQUIRE(aut.add_new_state() == 4);
-    REQUIRE(aut.add_new_state() == 5);
-    REQUIRE(aut.add_new_state() == 6);
-    REQUIRE(aut.add_new_state() == 7);
-    REQUIRE(aut.get_num_of_states() == 8);
+	REQUIRE(aut.get_num_of_states() == 4);
+	REQUIRE(aut.add_new_state() == 4);
+	REQUIRE(aut.add_new_state() == 5);
+	REQUIRE(aut.add_new_state() == 6);
+	REQUIRE(aut.add_new_state() == 7);
+	REQUIRE(aut.get_num_of_states() == 8);
 
 	aut.add_trans(7, 0, Node{0});
 
-    REQUIRE(aut.trans_size() == 7);
+	REQUIRE(aut.trans_size() == 7);
 
 } // }}}
 
 TEST_CASE("Mata::Afa transition test")
 { // {{{
 
-    Afa aut(3);
+	Afa aut(3);
 
 	aut.initialstates = {0};
 	aut.finalstates = {2};
@@ -144,65 +144,65 @@ TEST_CASE("Mata::Afa transition test")
 	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(std::to_string(aut.post(Nodes{}).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{}}).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.post(Nodes{}).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{}}).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.post(0, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Node{0}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.post(0, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.post(Node{0}, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.post(0, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(Node{0}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.post(0, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.post(Node{0}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
-    REQUIRE(std::to_string(aut.post(1, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{1}, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(1, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{1}, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(1, 1).antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{1}, 1).antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
+	REQUIRE(std::to_string(aut.post(1, 1).antichain()) == "{ { 0}, { 1, 2}}");
+	REQUIRE(std::to_string(aut.post(Node{1}, 1).antichain()) == "{ { 0}, { 1, 2}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).antichain()) == "{ { 0}, { 1, 2}}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
 
-    REQUIRE(std::to_string(aut.post(2, 0).antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(Node{2}, 0).antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
+	REQUIRE(std::to_string(aut.post(2, 0).antichain()) == "{ { 0, 1}, { 2}}");
+	REQUIRE(std::to_string(aut.post(Node{2}, 0).antichain()) == "{ { 0, 1}, { 2}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).antichain()) == "{ { 0, 1}, { 2}}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
 
-    REQUIRE(std::to_string(aut.post(2, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{2}, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(StateClosedSet
-    (Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(2, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{2}, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(StateClosedSet
+	(Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).antichain()) == "{ { 0, 1}, { 0, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{1, 2}, 0).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).antichain()) == "{ { 0, 1}, { 0, 2}}");
+	REQUIRE(std::to_string(aut.post(Node{1, 2}, 0).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 0).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Node{0, 1}, 1).antichain()) == "{ { 0, 1}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(Node{0, 2}, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{1, 2}, 1).antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{0, 1}, 1).antichain()) == "{ { 0, 1}, { 1, 2}}");
+	REQUIRE(std::to_string(aut.post(Node{0, 2}, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{1, 2}, 1).antichain()) == "{}");
+	REQUIRE(std::to_string(aut.post(Node{0, 1, 2}, 1).antichain()) == "{}");
 
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 1).antichain()) == "{ { 0}, { 1}}");
-    REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}).antichain()) == "{ { 0}, { 1}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}, 1).antichain()) == "{ { 0}, { 1}}");
+	REQUIRE(std::to_string(aut.post(Nodes{Node{0}, Node{1}}).antichain()) == "{ { 0}, { 1}}");
 
 } // }}}
 
 TEST_CASE("Mata::Afa inverse transition test")
 { // {{{
 
-    Afa aut(3);
+	Afa aut(3);
 
 	aut.initialstates = {0};
 	aut.finalstates = {2};
@@ -211,192 +211,192 @@ TEST_CASE("Mata::Afa inverse transition test")
 	aut.add_inverse_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_inverse_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(std::to_string(aut.pre(Node{}, 0).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{}, 1).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Node{}, 0).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Node{}, 1).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.pre(0, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Node{0}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(0, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(Node{0}, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.pre(1, 0).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{1}, 0).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(1, 0).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Node{1}, 0).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
 
-    REQUIRE(std::to_string(aut.pre(2, 0).antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{2}, 0).antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
-
-
-    REQUIRE(std::to_string(aut.pre(0, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
-
-    REQUIRE(std::to_string(aut.pre(1, 1).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Node{1}, 1).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
-
-    REQUIRE(std::to_string(aut.pre(2, 1).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Node{2}, 1).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(StateClosedSet
-    (Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(2, 0).antichain()) == "{ { 2}}");
+	REQUIRE(std::to_string(aut.pre(Node{2}, 0).antichain()) == "{ { 2}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).antichain()) == "{ { 2}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
 
 
-    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).antichain()) == "{ { 0, 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 0).antichain()) == "{ { 0, 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 0).antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 0).antichain()) == "{ { 0, 2}}");
+	REQUIRE(std::to_string(aut.pre(0, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.pre(Node{0}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
-    REQUIRE(std::to_string(aut.pre(Node{0, 1}, 1).antichain()) == "{ { 0, 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 2}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{1, 2}, 1).antichain()) == "{ { 0, 1}}");
-    REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 1).antichain()) == "{ { 0, 1}}");
+	REQUIRE(std::to_string(aut.pre(1, 1).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(Node{1}, 1).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).antichain()) == "{ { 0}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
 
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 0).antichain()) == "{ { 0}, { 2}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 1).antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}).antichain()) == "{ { 0}, { 1}, { 2}}");
+	REQUIRE(std::to_string(aut.pre(2, 1).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Node{2}, 1).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).antichain()) == "{ {}}");
+	REQUIRE(std::to_string(aut.pre(StateClosedSet
+	(Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
+
+
+	REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).antichain()) == "{ { 0, 2}}");
+	REQUIRE(std::to_string(aut.pre(Node{0, 2}, 0).antichain()) == "{ { 0, 2}}");
+	REQUIRE(std::to_string(aut.pre(Node{1, 2}, 0).antichain()) == "{ { 2}}");
+	REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 0).antichain()) == "{ { 0, 2}}");
+
+	REQUIRE(std::to_string(aut.pre(Node{0, 1}, 1).antichain()) == "{ { 0, 1}}");
+	REQUIRE(std::to_string(aut.pre(Node{0, 2}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.pre(Node{1, 2}, 1).antichain()) == "{ { 0, 1}}");
+	REQUIRE(std::to_string(aut.pre(Node{0, 1, 2}, 1).antichain()) == "{ { 0, 1}}");
+
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 0).antichain()) == "{ { 0}, { 2}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}, 1).antichain()) == "{ { 1}}");
+	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}, Node{2}}).antichain()) == "{ { 0}, { 1}, { 2}}");
 
 } // }}}
 
 TEST_CASE("Mata::Afa antichain emptiness test")
 {
-    /////////////////////////////////
-    // Example of an automaton
-    /////////////////////////////////
+	/////////////////////////////////
+	// Example of an automaton
+	/////////////////////////////////
 
-    Afa aut(3);
+	Afa aut(3);
 
 	aut.initialstates = {0};
 	aut.finalstates = {2};
 
-    // TODO: Add transition and inverse transition simultaneously???
-    // Do we always care about inverse transitions (in context of other
-    // operations than backward emptiness test etc.?) Is it better
-    // to add inverse transitions on demand or always?
+	// TODO: Add transition and inverse transition simultaneously???
+	// Do we always care about inverse transitions (in context of other
+	// operations than backward emptiness test etc.?) Is it better
+	// to add inverse transitions on demand or always?
 
 	aut.add_trans(0, 0, Nodes{Node{0}});
 	aut.add_trans(0, 1, Nodes{Node{1}});
 	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
-	
-    aut.add_inverse_trans(0, 0, Nodes{Node{0}});
+
+	aut.add_inverse_trans(0, 0, Nodes{Node{0}});
 	aut.add_inverse_trans(0, 1, Nodes{Node{1}});
 	aut.add_inverse_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_inverse_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut));
-    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut));
+	REQUIRE(antichain_concrete_forward_emptiness_test_old(aut));
+	REQUIRE(antichain_concrete_backward_emptiness_test_old(aut));
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
-    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut));
+	REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
+	REQUIRE(antichain_concrete_backward_emptiness_test_new(aut));
 
 	aut.finalstates = {0};
-    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
 	aut.finalstates = {1};
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
-    /////////////////////////////////
-    // Example of an automaton
-    /////////////////////////////////
+	/////////////////////////////////
+	// Example of an automaton
+	/////////////////////////////////
 
-    Afa aut1(10);
+	Afa aut1(10);
 
 	aut1.initialstates = {0};
 	aut1.finalstates = {9};
 
-    aut1.add_trans(0, 0, Nodes{Node{1}});
-    aut1.add_trans(1, 0, Nodes{Node{2}});
-    aut1.add_trans(2, 0, Nodes{Node{3}});
-    aut1.add_trans(3, 0, Nodes{Node{4}});
-    aut1.add_trans(4, 0, Nodes{Node{5}});
-    aut1.add_trans(5, 0, Nodes{Node{6}});
-    aut1.add_trans(6, 0, Nodes{Node{7}});
-    aut1.add_trans(7, 0, Nodes{Node{8}});
-    aut1.add_trans(8, 0, Nodes{Node{8, 9}});
+	aut1.add_trans(0, 0, Nodes{Node{1}});
+	aut1.add_trans(1, 0, Nodes{Node{2}});
+	aut1.add_trans(2, 0, Nodes{Node{3}});
+	aut1.add_trans(3, 0, Nodes{Node{4}});
+	aut1.add_trans(4, 0, Nodes{Node{5}});
+	aut1.add_trans(5, 0, Nodes{Node{6}});
+	aut1.add_trans(6, 0, Nodes{Node{7}});
+	aut1.add_trans(7, 0, Nodes{Node{8}});
+	aut1.add_trans(8, 0, Nodes{Node{8, 9}});
 
-    aut1.add_inverse_trans(0, 0, Nodes{Node{1}});
-    aut1.add_inverse_trans(1, 0, Nodes{Node{2}});
-    aut1.add_inverse_trans(2, 0, Nodes{Node{3}});
-    aut1.add_inverse_trans(3, 0, Nodes{Node{4}});
-    aut1.add_inverse_trans(4, 0, Nodes{Node{5}});
-    aut1.add_inverse_trans(5, 0, Nodes{Node{6}});
-    aut1.add_inverse_trans(6, 0, Nodes{Node{7}});
-    aut1.add_inverse_trans(7, 0, Nodes{Node{8}});
-    aut1.add_inverse_trans(8, 0, Nodes{Node{8, 9}});
+	aut1.add_inverse_trans(0, 0, Nodes{Node{1}});
+	aut1.add_inverse_trans(1, 0, Nodes{Node{2}});
+	aut1.add_inverse_trans(2, 0, Nodes{Node{3}});
+	aut1.add_inverse_trans(3, 0, Nodes{Node{4}});
+	aut1.add_inverse_trans(4, 0, Nodes{Node{5}});
+	aut1.add_inverse_trans(5, 0, Nodes{Node{6}});
+	aut1.add_inverse_trans(6, 0, Nodes{Node{7}});
+	aut1.add_inverse_trans(7, 0, Nodes{Node{8}});
+	aut1.add_inverse_trans(8, 0, Nodes{Node{8, 9}});
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut1));
-    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut1));
+	REQUIRE(antichain_concrete_forward_emptiness_test_old(aut1));
+	REQUIRE(antichain_concrete_backward_emptiness_test_old(aut1));
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut1));
-    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut1));
+	REQUIRE(antichain_concrete_forward_emptiness_test_new(aut1));
+	REQUIRE(antichain_concrete_backward_emptiness_test_new(aut1));
 
-    aut1.add_trans(8, 0, Nodes{Node{9}});
-    aut1.add_trans(8, 0, Nodes{Node{9}});
+	aut1.add_trans(8, 0, Nodes{Node{9}});
+	aut1.add_trans(8, 0, Nodes{Node{9}});
 
-    aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
-    aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
+	aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
+	aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
-    /////////////////////////////////
-    // Automaton with no transitions
-    /////////////////////////////////
+	/////////////////////////////////
+	// Automaton with no transitions
+	/////////////////////////////////
 
-    Afa aut2(3);
+	Afa aut2(3);
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
-    aut2.initialstates = {0};
+	aut2.initialstates = {0};
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
-    aut2.finalstates = {1};
+	aut2.finalstates = {1};
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
 
-    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+	REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
-    aut2.finalstates = {0};
+	aut2.finalstates = {0};
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut2));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut2));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut2));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut2));
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut2));
-    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut2));
+	REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut2));
+	REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut2));
 
 }
 

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -118,6 +118,18 @@ TEST_CASE("Mata::Afa creating an AFA, basic properties")
 	REQUIRE(!aut.has_final(2));
 	REQUIRE(aut.has_initial(0));
 	REQUIRE(!aut.has_initial(1));
+
+    REQUIRE(aut.get_num_of_states() == 4);
+    REQUIRE(aut.add_new_state() == 4);
+    REQUIRE(aut.add_new_state() == 5);
+    REQUIRE(aut.add_new_state() == 6);
+    REQUIRE(aut.add_new_state() == 7);
+    REQUIRE(aut.get_num_of_states() == 8);
+
+	aut.add_trans(7, 0, Node{0});
+
+    REQUIRE(aut.trans_size() == 7);
+
 } // }}}
 
 TEST_CASE("Mata::Afa transition test")

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -53,8 +53,6 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 
     ClosedSet<State> c3 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 1}});
     ClosedSet<State> c4 = ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 3, Nodes{Node{0, 3}});
-
-    std::cout << c3.intersection(c4);
     
     REQUIRE(c3.Union(c4).contains(Node{0, 1}));
     REQUIRE(c3.Union(c4).contains(Node{0, 3}));
@@ -144,32 +142,38 @@ TEST_CASE("Mata::Afa transition test")
     REQUIRE(std::to_string(aut.post(0, 0).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.post(Node{0}, 0).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.post(0, 1).get_antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.post(Node{0}, 1).get_antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
 
     REQUIRE(std::to_string(aut.post(1, 0).get_antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Node{1}, 0).get_antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{}");
 
     REQUIRE(std::to_string(aut.post(1, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
     REQUIRE(std::to_string(aut.post(Node{1}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}, { 1, 2}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}, { 1, 2}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}, { 1, 2}}");
 
     REQUIRE(std::to_string(aut.post(2, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
     REQUIRE(std::to_string(aut.post(Node{2}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).get_antichain()) == "{ { 0, 1}, { 2}}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 0, 1}, { 2}}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 0, 1}, { 2}}");
 
     REQUIRE(std::to_string(aut.post(2, 1).get_antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Node{2}, 1).get_antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).get_antichain()) == "{}");
-    REQUIRE(std::to_string(aut.post(ClosedSet<State>(ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{}");
+    REQUIRE(std::to_string(aut.post(ClosedSet<State>
+    (ClosedSet<State>::upward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{}");
 
     REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).get_antichain()) == "{}");
     REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).get_antichain()) == "{ { 0, 1}, { 0, 2}}");
@@ -194,10 +198,10 @@ TEST_CASE("Mata::Afa inverse transition test")
 
 	aut.initialstates = {0};
 	aut.finalstates = {2};
-	aut.add_inv_trans(0, 0, Nodes{Node{0}});
-	aut.add_inv_trans(0, 1, Nodes{Node{1}});
-	aut.add_inv_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
-	aut.add_inv_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+	aut.add_inverse_trans(0, 0, Nodes{Node{0}});
+	aut.add_inverse_trans(0, 1, Nodes{Node{1}});
+	aut.add_inverse_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_inverse_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
     REQUIRE(std::to_string(aut.pre(Node{}, 0).get_antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Node{}, 1).get_antichain()) == "{ {}}");
@@ -205,33 +209,39 @@ TEST_CASE("Mata::Afa inverse transition test")
     REQUIRE(std::to_string(aut.pre(0, 0).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Node{0}, 0).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 0).get_antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.pre(1, 0).get_antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Node{1}, 0).get_antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 0).get_antichain()) == "{ {}}");
 
     REQUIRE(std::to_string(aut.pre(2, 0).get_antichain()) == "{ { 2}}");
     REQUIRE(std::to_string(aut.pre(Node{2}, 0).get_antichain()) == "{ { 2}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).get_antichain()) == "{ { 2}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 2}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 0).get_antichain()) == "{ { 2}}");
 
 
     REQUIRE(std::to_string(aut.pre(0, 1).get_antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.pre(Node{0}, 1).get_antichain()) == "{ { 1}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).get_antichain()) == "{ { 1}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{0}}), 1).get_antichain()) == "{ { 1}}");
 
     REQUIRE(std::to_string(aut.pre(1, 1).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Node{1}, 1).get_antichain()) == "{ { 0}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).get_antichain()) == "{ { 0}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{1}}), 1).get_antichain()) == "{ { 0}}");
 
     REQUIRE(std::to_string(aut.pre(2, 1).get_antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Node{2}, 1).get_antichain()) == "{ {}}");
     REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).get_antichain()) == "{ {}}");
-    REQUIRE(std::to_string(aut.pre(ClosedSet<State>(ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{ {}}");
+    REQUIRE(std::to_string(aut.pre(ClosedSet<State>
+    (ClosedSet<State>::downward_closed, 0, 2, Nodes{Node{2}}), 1).get_antichain()) == "{ {}}");
 
 
     REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).get_antichain()) == "{ { 0, 2}}");
@@ -271,25 +281,32 @@ TEST_CASE("Mata::Afa antichain emptiness test")
 	aut.add_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
 	aut.add_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 	
-    aut.add_inv_trans(0, 0, Nodes{Node{0}});
-	aut.add_inv_trans(0, 1, Nodes{Node{1}});
-	aut.add_inv_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
-	aut.add_inv_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
+    aut.add_inverse_trans(0, 0, Nodes{Node{0}});
+	aut.add_inverse_trans(0, 1, Nodes{Node{1}});
+	aut.add_inverse_trans(1, 1, Nodes{Node{0}, Node{1, 2}});
+	aut.add_inverse_trans(2, 0, Nodes{Node{2}, Node{0, 1}});
 
-    REQUIRE(antichain_concrete_forward_emptiness_test(aut));
-    REQUIRE(antichain_concrete_backward_emptiness_test(aut));
+    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut));
+    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut));
+
+    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
+    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut));
 
 	aut.finalstates = {0};
-    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
+
 
 	aut.finalstates = {1};
-    
-    std::cout << aut.get_initial_nodes();
-    std::cout << aut.post(aut.get_initial_nodes());
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
     /////////////////////////////////
     // Example of an automaton
@@ -310,24 +327,33 @@ TEST_CASE("Mata::Afa antichain emptiness test")
     aut1.add_trans(7, 0, Nodes{Node{8}});
     aut1.add_trans(8, 0, Nodes{Node{8, 9}});
 
-    aut1.add_inv_trans(0, 0, Nodes{Node{1}});
-    aut1.add_inv_trans(1, 0, Nodes{Node{2}});
-    aut1.add_inv_trans(2, 0, Nodes{Node{3}});
-    aut1.add_inv_trans(3, 0, Nodes{Node{4}});
-    aut1.add_inv_trans(4, 0, Nodes{Node{5}});
-    aut1.add_inv_trans(5, 0, Nodes{Node{6}});
-    aut1.add_inv_trans(6, 0, Nodes{Node{7}});
-    aut1.add_inv_trans(7, 0, Nodes{Node{8}});
-    aut1.add_inv_trans(8, 0, Nodes{Node{8, 9}});
+    aut1.add_inverse_trans(0, 0, Nodes{Node{1}});
+    aut1.add_inverse_trans(1, 0, Nodes{Node{2}});
+    aut1.add_inverse_trans(2, 0, Nodes{Node{3}});
+    aut1.add_inverse_trans(3, 0, Nodes{Node{4}});
+    aut1.add_inverse_trans(4, 0, Nodes{Node{5}});
+    aut1.add_inverse_trans(5, 0, Nodes{Node{6}});
+    aut1.add_inverse_trans(6, 0, Nodes{Node{7}});
+    aut1.add_inverse_trans(7, 0, Nodes{Node{8}});
+    aut1.add_inverse_trans(8, 0, Nodes{Node{8, 9}});
 
-    REQUIRE(antichain_concrete_forward_emptiness_test(aut1));
-    REQUIRE(antichain_concrete_backward_emptiness_test(aut1));
+    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut1));
+    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut1));
 
-    aut1.add_inv_trans(8, 0, Nodes{Node{9}});
-    aut1.add_inv_trans(8, 0, Nodes{Node{9}});
+    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut1));
+    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut1));
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test(aut));
-    REQUIRE(!antichain_concrete_backward_emptiness_test(aut));
+    aut1.add_trans(8, 0, Nodes{Node{9}});
+    aut1.add_trans(8, 0, Nodes{Node{9}});
+
+    aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
+    aut1.add_inverse_trans(8, 0, Nodes{Node{9}});
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut));
+
+    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut));
 
     /////////////////////////////////
     // Automaton with no transitions
@@ -335,24 +361,35 @@ TEST_CASE("Mata::Afa antichain emptiness test")
 
     Afa aut2(3);
 
-    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+
+    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
     aut2.initialstates = {0};
 
-    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+
+    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
     aut2.finalstates = {1};
 
-    REQUIRE(antichain_concrete_forward_emptiness_test(aut2));
-    REQUIRE(antichain_concrete_backward_emptiness_test(aut2));
+    REQUIRE(antichain_concrete_forward_emptiness_test_old(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_old(aut2));
+
+    REQUIRE(antichain_concrete_forward_emptiness_test_new(aut2));
+    REQUIRE(antichain_concrete_backward_emptiness_test_new(aut2));
 
     aut2.finalstates = {0};
 
-    REQUIRE(!antichain_concrete_forward_emptiness_test(aut2));
-    REQUIRE(!antichain_concrete_backward_emptiness_test(aut2));
+    REQUIRE(!antichain_concrete_forward_emptiness_test_old(aut2));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_old(aut2));
 
+    REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut2));
+    REQUIRE(!antichain_concrete_backward_emptiness_test_new(aut2));
 
 }
 


### PR DESCRIPTION
I've changed the former data structure for alternating automata, I've added structures for transition and inverse transition and several functions which enable us to inspect an alternating automaton using antichains (pre, post). I've also implemented two antichain-based AFA emptiness tests (which work in a forward and backward fashion).
I've also added a file closed_set.hh which makes the work with antichains easier.
I've also added several test cases.
