### PR TITLE
Rewrite automata algorithms with epsilons

### DIFF
--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -227,10 +227,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     # Automata operations
     cdef void determinize(CNfa*, CNfa&, SubsetMap*)
     cdef void uni(CNfa*, CNfa&, CNfa&)
-    cdef void intersection(CNfa*, CNfa&, CNfa&)
-    cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
-    cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol)
-    cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
+    cdef void intersection(CNfa*, CNfa&, CNfa&, bool, ProductMap*)
     cdef void concatenate(CNfa*, CNfa&, CNfa&, bool, StateToStateMap*, StateToStateMap*)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +

--- a/bindings/python/mata.pxd
+++ b/bindings/python/mata.pxd
@@ -231,8 +231,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
     cdef void intersection(CNfa*, CNfa&, CNfa&, ProductMap*)
     cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol)
     cdef void intersection_preserving_epsilon_transitions(CNfa*, CNfa&, CNfa&, Symbol, ProductMap*)
-    cdef void concatenate(CNfa*, CNfa&, CNfa&)
-    cdef void concatenate_over_epsilon(CNfa*, CNfa&, CNfa&, Symbol)
+    cdef void concatenate(CNfa*, CNfa&, CNfa&, bool, StateToStateMap*, StateToStateMap*)
     cdef void complement(CNfa*, CNfa&, CAlphabet&, StringDict&, SubsetMap*) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +
     cdef void revert(CNfa*, CNfa&)

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -659,6 +659,8 @@ cdef class Nfa:
     def intersection(cls, Nfa lhs, Nfa rhs, preserve_epsilon: bool = False):
         """Performs intersection of lhs and rhs.
 
+        Supports epsilon symbols when preserve_epsilon is set to True.
+
         When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
          an ε-transition `(s,a)-ε->(p,a)` is created. Furthermore, for each ε-transition `s-ε->p` and `a-ε->b`,
@@ -680,6 +682,8 @@ cdef class Nfa:
     @classmethod
     def intersection_with_product_map(cls, Nfa lhs, Nfa rhs, preserve_epsilon: bool = False):
         """Performs intersection of lhs and rhs.
+
+        Supports epsilon symbols when preserve_epsilon is set to True.
 
         When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
@@ -705,6 +709,7 @@ cdef class Nfa:
     def concatenate(cls, Nfa lhs, Nfa rhs, use_epsilon: bool = False) -> Nfa:
         """Concatenate two NFAs.
 
+        Supports epsilon symbols when @p use_epsilon is set to true.
         :param Nfa lhs: First automaton to concatenate.
         :param Nfa rhs: Second automaton to concatenate.
         :param use_epsilon: Whether to concatenate over an epsilon symbol.

--- a/bindings/python/mata.pyx
+++ b/bindings/python/mata.pyx
@@ -656,44 +656,39 @@ cdef class Nfa:
         return result
 
     @classmethod
-    def intersection(cls, Nfa lhs, Nfa rhs):
+    def intersection(cls, Nfa lhs, Nfa rhs, preserve_epsilon: bool = False):
         """Performs intersection of lhs and rhs.
 
-        :param Nfa lhs: First automaton.
-        :param Nfa rhs: Second automaton.
-        :return: Intersection of lhs and rhs.
-        """
-        result = Nfa()
-        mata.intersection(result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()))
-        return result
-
-    @classmethod
-    def intersection_preserving_epsilon_transitions(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
-        """Performs intersection of lhs and rhs preserving epsilon transitions.
-
-        Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
+        When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
          of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
          an ε-transition `(s,a)-ε->(p,a)` is created. Furthermore, for each ε-transition `s-ε->p` and `a-ε->b`,
          a product state `(s,a)-ε->(p,b)` is created.
 
         Automata must share alphabets.
 
-        :param: Nfa lhs: First automaton with possible epsilon symbols.
-        :param: Nfa rhs: Second automaton with possible epsilon symbols.
-        :param: Symbol epsilon: Symbol to handle as an epsilon symbol.
-        :return: Intersection of lhs and rhs with epsilon transitions preserved, product map of original pairs of states
-         to new states.
+        :param preserve_epsilon: Whether to compute intersection preserving epsilon transitions.
+        :param Nfa lhs: First automaton.
+        :param Nfa rhs: Second automaton.
+        :return: Intersection of lhs and rhs.
         """
         result = Nfa()
-        mata.intersection_preserving_epsilon_transitions(
-            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon
+        mata.intersection(
+            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), preserve_epsilon, NULL
         )
         return result
 
     @classmethod
-    def intersection_with_product_map(cls, Nfa lhs, Nfa rhs):
+    def intersection_with_product_map(cls, Nfa lhs, Nfa rhs, preserve_epsilon: bool = False):
         """Performs intersection of lhs and rhs.
 
+        When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
+         of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
+         an ε-transition `(s,a)-ε->(p,a)` is created. Furthermore, for each ε-transition `s-ε->p` and `a-ε->b`,
+         a product state `(s,a)-ε->(p,b)` is created.
+
+        Automata must share alphabets.
+
+        :param preserve_epsilon: Whether to compute intersection preserving epsilon transitions.
         :param Nfa lhs: First automaton.
         :param Nfa rhs: Second automaton.
         :return: Intersection of lhs and rhs, product map of original pairs of states to new states.
@@ -701,31 +696,8 @@ cdef class Nfa:
         result = Nfa()
         cdef ProductMap c_product_map
         mata.intersection(
-            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), &c_product_map
-        )
-        return result, {tuple(k): v for k, v in c_product_map}
-
-    @classmethod
-    def intersection_pres_eps_trans_with_prod_map(cls, Nfa lhs, Nfa rhs, Symbol epsilon = CEPSILON):
-        """Performs intersection of lhs and rhs preserving epsilon transitions.
-
-        Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
-         of both automata. This means that for each ε-transition of the form `s-ε->p` and each product state `(s,a)`,
-         an ε-transition `(s,a)-ε->(p,a)` is created. Furthermore, for each ε-transition `s-ε->p` and `a-ε->b`,
-         a product state `(s,a)-ε->(p,b)` is created.
-
-        Automata must share alphabets.
-
-        :param: Nfa lhs: First automaton with possible epsilon symbols.
-        :param: Nfa rhs: Second automaton with possible epsilon symbols.
-        :param: Symbol epsilon: Symbol to handle as an epsilon symbol.
-        :return: Intersection of lhs and rhs with epsilon transitions preserved, product map of original pairs of states
-         to new states.
-        """
-        result = Nfa()
-        cdef ProductMap c_product_map
-        mata.intersection_preserving_epsilon_transitions(
-            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), epsilon, &c_product_map
+            result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), preserve_epsilon,
+            &c_product_map
         )
         return result, {tuple(k): v for k, v in c_product_map}
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -502,12 +502,12 @@ def test_intersection_preserving_epsilon_transitions():
     a = mata.Nfa(6)
     a.make_initial_state(0)
     a.make_final_states([1, 4, 5])
-    a.add_trans_raw(0, epsilon, 1)
+    a.add_trans_raw(0, mata.epsilon(), 1)
     a.add_trans_raw(1, ord('a'), 1)
     a.add_trans_raw(1, ord('b'), 1)
     a.add_trans_raw(1, ord('c'), 2)
     a.add_trans_raw(2, ord('b'), 4)
-    a.add_trans_raw(2, epsilon, 3)
+    a.add_trans_raw(2, mata.epsilon(), 3)
     a.add_trans_raw(3, ord('a'), 5)
 
     b = mata.Nfa(10)
@@ -516,15 +516,15 @@ def test_intersection_preserving_epsilon_transitions():
     b.add_trans_raw(0, ord('b'), 1)
     b.add_trans_raw(0, ord('a'), 2)
     b.add_trans_raw(2, ord('a'), 4)
-    b.add_trans_raw(2, epsilon, 3)
+    b.add_trans_raw(2, mata.epsilon(), 3)
     b.add_trans_raw(3, ord('b'), 4)
     b.add_trans_raw(0, ord('c'), 5)
     b.add_trans_raw(5, ord('a'), 8)
-    b.add_trans_raw(5, epsilon, 6)
+    b.add_trans_raw(5, mata.epsilon(), 6)
     b.add_trans_raw(6, ord('a'), 9)
     b.add_trans_raw(6, ord('b'), 7)
 
-    result, product_map = mata.Nfa.intersection_pres_eps_trans_with_prod_map(a, b, epsilon)
+    result, product_map = mata.Nfa.intersection_with_product_map(a, b, True)
 
     # Check states.
     assert result.get_num_of_states() == 13
@@ -553,7 +553,7 @@ def test_intersection_preserving_epsilon_transitions():
     # Check transitions.
     assert result.get_num_of_trans() == 15
 
-    assert result.has_trans_raw(product_map[(0, 0)], epsilon, product_map[(1, 0)])
+    assert result.has_trans_raw(product_map[(0, 0)], mata.epsilon(), product_map[(1, 0)])
     assert len(result.get_trans_from_state_as_sequence(product_map[(0, 0)])) == 1
 
     assert result.has_trans_raw(product_map[(1, 0)], ord('b'), product_map[(1, 1)])
@@ -563,7 +563,7 @@ def test_intersection_preserving_epsilon_transitions():
 
     assert len(result.get_trans_from_state_as_sequence(product_map[(1, 1)])) == 0
 
-    assert result.has_trans_raw(product_map[(1, 2)], epsilon, product_map[(1, 3)])
+    assert result.has_trans_raw(product_map[(1, 2)], mata.epsilon(), product_map[(1, 3)])
     assert result.has_trans_raw(product_map[(1, 2)], ord('a'), product_map[(1, 4)])
     assert len(result.get_trans_from_state_as_sequence(product_map[(1, 2)])) == 2
 
@@ -572,17 +572,17 @@ def test_intersection_preserving_epsilon_transitions():
 
     assert len(result.get_trans_from_state_as_sequence(product_map[(1, 4)])) == 0
 
-    assert result.has_trans_raw(product_map[(2, 5)], epsilon, product_map[(3, 5)])
-    assert result.has_trans_raw(product_map[(2, 5)], epsilon, product_map[(2, 6)])
-    assert result.has_trans_raw(product_map[(2, 5)], epsilon, product_map[(3, 6)])
+    assert result.has_trans_raw(product_map[(2, 5)], mata.epsilon(), product_map[(3, 5)])
+    assert result.has_trans_raw(product_map[(2, 5)], mata.epsilon(), product_map[(2, 6)])
+    assert result.has_trans_raw(product_map[(2, 5)], mata.epsilon(), product_map[(3, 6)])
     assert len(result.get_trans_from_state_as_sequence(product_map[(2, 5)])) == 3
 
     assert result.has_trans_raw(product_map[(3, 5)], ord('a'), product_map[(5, 8)])
-    assert result.has_trans_raw(product_map[(3, 5)], epsilon, product_map[(3, 6)])
+    assert result.has_trans_raw(product_map[(3, 5)], mata.epsilon(), product_map[(3, 6)])
     assert len(result.get_trans_from_state_as_sequence(product_map[(3, 5)])) == 2
 
     assert result.has_trans_raw(product_map[(2, 6)], ord('b'), product_map[(4, 7)])
-    assert result.has_trans_raw(product_map[(2, 6)], epsilon, product_map[(3, 6)])
+    assert result.has_trans_raw(product_map[(2, 6)], mata.epsilon(), product_map[(3, 6)])
     assert len(result.get_trans_from_state_as_sequence(product_map[(2, 6)])) == 2
 
     assert result.has_trans_raw(product_map[(3, 6)], ord('a'), product_map[(5, 9)])

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -391,21 +391,23 @@ def test_concatenate():
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
 
-    result = mata.Nfa.concatenate_over_epsilon(lhs, rhs)
+    result = mata.Nfa.concatenate(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
     assert result.get_num_of_states() == 4
     assert result.has_trans_raw(0, ord('b'), 1)
-    assert result.has_trans_raw(1, 0xffffffffffffffff, 2)
+    assert result.has_trans_raw(1, mata.epsilon(), 2)
     assert result.has_trans_raw(2, ord('a'), 3)
 
-    result = mata.Nfa.concatenate_over_epsilon(lhs, rhs, ord('e'))
+    result, lhs_map, rhs_map = mata.Nfa.concatenate_with_result_state_maps(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
     assert result.get_num_of_states() == 4
     assert result.has_trans_raw(0, ord('b'), 1)
-    assert result.has_trans_raw(1, ord('e'), 2)
+    assert result.has_trans_raw(1, mata.epsilon(), 2)
     assert result.has_trans_raw(2, ord('a'), 3)
+    assert lhs_map == {}
+    assert rhs_map == {0: 2, 1: 3}
 
 
 def test_completeness(

--- a/examples/example04-complement.cc
+++ b/examples/example04-complement.cc
@@ -24,7 +24,6 @@ int main(int argc, char *argv[])
 	Mata::Parser::Parsed parsed;
 	Nfa aut;
 	StringToSymbolMap stsm;
-	OnTheFlyAlphabet alph(&stsm);
 	try {
 		parsed = Mata::Parser::parse_mf(fs, true);
 		fs.close();
@@ -37,7 +36,7 @@ int main(int argc, char *argv[])
 			throw std::runtime_error("The type of input automaton is not NFA\n");
 		}
 
-		construct(&aut, parsed[0], &alph);
+		construct(&aut, parsed[0], &stsm);
 	}
 	catch (const std::exception& ex) {
 		fs.close();
@@ -45,6 +44,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+    OnTheFlyAlphabet alph{ stsm };
 	Nfa cmpl = complement(aut, alph);
 
 	std::cout << std::to_string(cmpl);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -946,34 +946,24 @@ Nfa intersection(const Nfa &lhs, const Nfa &rhs, ProductMap* prod_map = nullptr)
  * @param[out] res Concatenated automaton as a result of the concatenation of @p lhs and @p rhs.
  * @param[in] lhs First automaton to concatenate.
  * @param[in] rhs Second automaton to concatenate.
+ * @param[out] lhs_result_states_map Map mapping lhs states to result states.
+ * @param[out] rhs_result_states_map Map mapping rhs states to result states.
+ * @param[in] use_epsilon Whether to concatenate over epsilon symbol.
  */
-void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs);
+void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
+                 StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 
 /**
  * Concatenate two NFAs.
  * @param[in] lhs First automaton to concatenate.
  * @param[in] rhs Second automaton to concatenate.
+ * @param[in] use_epsilon Whether to concatenate over epsilon symbol.
+ * @param[out] lhs_result_states_map Map mapping lhs states to result states.
+ * @param[out] rhs_result_states_map Map mapping rhs states to result states.
  * @return Concatenated automaton.
  */
-Nfa concatenate(const Nfa& lhs, const Nfa& rhs);
-
-/**
- * Concatenate two NFAs over epsilon transitions.
- * @param[out] res Concatenated automaton as a result of the concatenation of @p lhs and @p rhs.
- * @param[in] lhs First automaton to concatenate.
- * @param[in] rhs Second automaton to concatenate.
- * @param[in] epsilon Epsilon symbol to concatenate @p lhs with @p rhs over.
- */
-void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, Symbol epsilon = EPSILON);
-
-/**
- * Concatenate two NFAs over epsilon transitions.
- * @param[in] lhs First automaton to concatenate.
- * @param[in] rhs Second automaton to concatenate.
- * @param[in] epsilon Epsilon symbol to concatenate @p lhs with @p rhs over.
- * @return Concatenated automaton.
- */
-Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, Symbol epsilon = EPSILON);
+Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
+                StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 
 /// makes the transition relation complete
 void make_complete(

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -886,60 +886,44 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
 } // uni }}}
 
 /**
- * @brief Compute intersection of two NFAs preserving epsilon transitions.
- *
- * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
- * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
- * an ε-transition `(s, a) -ε-> (p, a)` is created. Furthermore, for each ε-transition `s -ε-> p` and `a -ε-> b`,
- * a product state `(s, a) -ε-> (p, b)` is created.
- *
- * Automata must share alphabets.
- *
- * @param[in] lhs First NFA with possible epsilon symbols @p epsilon.
- * @param[in] rhs Second NFA with possible epsilon symbols @p epsilon.
- * @param[in] epsilon Symbol to handle as an epsilon symbol.
- * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
- * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
- */
-Nfa intersection_preserving_epsilon_transitions(const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON, ProductMap* prod_map = nullptr);
-
-/**
- * @brief Compute intersection of two NFAs preserving epsilon transitions.
- *
- * Create product of two NFAs, where both automata can contain ε-transitions. The product preserves the ε-transitions
- * of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
- * an ε-transition `(s, a) -ε-> (p, a)` is created. Furthermore, for each ε-transition `s -ε-> p` and `a -ε-> b`,
- * a product state `(s, a) -ε-> (p, b)` is created.
- *
- * Automata must share alphabets.
- *
- * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs with ε-transitions preserved.
- * @param[in] lhs First NFA with possible epsilon symbols @p epsilon.
- * @param[in] rhs Second NFA with possible epsilon symbols @p epsilon.
- * @param[in] epsilon Symbol to handle as an epsilon symbol.
- * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
- */
-void intersection_preserving_epsilon_transitions(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon = EPSILON,
-                                                 ProductMap* prod_map = nullptr);
-
-/**
  * @brief Compute intersection of two NFAs.
+ *
+ * When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can
+ *  contain ε-transitions. The product preserves the ε-transitions
+ *  of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
+ *  an ε-transition `(s, a) -ε-> (p, a)` is created. Furthermore, for each ε-transition `s -ε-> p` and `a -ε-> b`,
+ *  a product state `(s, a) -ε-> (p, b)` is created.
+ *
+ * Automata must share alphabets.
  *
  * @param[out] res Result product NFA of the intersection of @p lhs and @p rhs.
  * @param[in] lhs First NFA to compute intersection for.
  * @param[in] rhs Second NFA to compute intersection for.
- * @param[out] prod_map Mapping of pairs of states (lhs_state, rhs_state) to new product states.
+ * @param[out] prod_map Mapping of pairs of original states (lhs_state, rhs_state) to new product states.
+ * @param[in] preserve_epsilon Whether to compute intersection preserving epsilon transitions.
  */
-void intersection(Nfa* res, const Nfa& lhs, const Nfa& rhs, ProductMap* prod_map = nullptr);
+void intersection(Nfa* res, const Nfa& lhs, const Nfa& rhs,
+                  bool preserve_epsilon = false, ProductMap* prod_map = nullptr);
 
 /**
  * @brief Compute intersection of two NFAs.
  *
+ * When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can
+ *  contain ε-transitions. The product preserves the ε-transitions
+ *  of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
+ *  an ε-transition `(s, a) -ε-> (p, a)` is created. Furthermore, for each ε-transition `s -ε-> p` and `a -ε-> b`,
+ *  a product state `(s, a) -ε-> (p, b)` is created.
+ *
+ * Automata must share alphabets.
+ *
  * @param[in] lhs First NFA to compute intersection for.
  * @param[in] rhs Second NFA to compute intersection for.
+ * @param[in] preserve_epsilon Whether to compute intersection preserving epsilon transitions.
+ * @param[out] prod_map Mapping of pairs of original states (lhs_state, rhs_state) to new product states.
  * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
  */
-Nfa intersection(const Nfa &lhs, const Nfa &rhs, ProductMap* prod_map = nullptr);
+Nfa intersection(const Nfa& lhs, const Nfa& rhs,
+                 bool preserve_epsilon = false, ProductMap* prod_map = nullptr);
 
 /**
  * Concatenate two NFAs.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -888,6 +888,7 @@ inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs)
 /**
  * @brief Compute intersection of two NFAs.
  *
+ * Supports epsilon symbols when @p preserve_epsilon is set to true.
  * When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can
  *  contain ε-transitions. The product preserves the ε-transitions
  *  of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -908,6 +909,7 @@ void intersection(Nfa* res, const Nfa& lhs, const Nfa& rhs,
 /**
  * @brief Compute intersection of two NFAs.
  *
+ * Supports epsilon symbols when @p preserve_epsilon is set to true.
  * When computing intersection preserving epsilon transitions, create product of two NFAs, where both automata can
  *  contain ε-transitions. The product preserves the ε-transitions
  *  of both automata. This means that for each ε-transition of the form `s -ε-> p` and each product state `(s, a)`,
@@ -926,7 +928,9 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs,
                  bool preserve_epsilon = false, ProductMap* prod_map = nullptr);
 
 /**
- * Concatenate two NFAs.
+ * @brief Concatenate two NFAs.
+ *
+ * Supports epsilon symbols when @p use_epsilon is set to true.
  * @param[out] res Concatenated automaton as a result of the concatenation of @p lhs and @p rhs.
  * @param[in] lhs First automaton to concatenate.
  * @param[in] rhs Second automaton to concatenate.
@@ -938,7 +942,9 @@ void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, bool use_epsilon = fa
                  StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 
 /**
- * Concatenate two NFAs.
+ * @brief Concatenate two NFAs.
+ *
+ * Supports epsilon symbols when @p use_epsilon is set to true.
  * @param[in] lhs First automaton to concatenate.
  * @param[in] rhs Second automaton to concatenate.
  * @param[in] use_epsilon Whether to concatenate over epsilon symbol.

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -33,11 +33,11 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon,
 
     if (lhs.initialstates.empty() || lhs.finalstates.empty() || rhs.initialstates.empty()) { return Nfa{}; }
 
-    const unsigned long lhs_states_num{ lhs.get_num_of_states() }; ///< Number of states in lhs.
-    const unsigned long rhs_states_num{ rhs.get_num_of_states() }; ///< Number of states in rhs.
-    Nfa result{}; ///< Concatenated automaton.
-    StateToStateMap lhs_result_states_map_internal{}; ///< Map mapping rhs states to result states.
-    StateToStateMap rhs_result_states_map_internal{}; ///< Map mapping rhs states to result states.
+    const unsigned long lhs_states_num{ lhs.get_num_of_states() };
+    const unsigned long rhs_states_num{ rhs.get_num_of_states() };
+    Nfa result{}; // Concatenated automaton.
+    StateToStateMap lhs_result_states_map_internal{}; // Map mapping rhs states to result states.
+    StateToStateMap rhs_result_states_map_internal{}; // Map mapping rhs states to result states.
 
     if (use_epsilon) {
         const size_t result_num_of_states{lhs_states_num + rhs_states_num};

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -18,259 +18,138 @@
 
 using namespace Mata::Nfa;
 
-namespace Mata
-{
-namespace Nfa
-{
+namespace Mata {
+namespace Nfa {
 
-/**
- * Class executing a concatenation of two NFAs.
- */
-class Concatenation
-{
-public:
-    /**
-     * Initialize and compute concatenation of two NFAs.
-     *
-     * Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
-     * @param[in] lhs First NFA to concatenate.
-     * @param[in] rhs Second NFA to concatenate.
-     */
-    Concatenation(const Nfa& lhs, const Nfa& rhs)
-            : lhs(lhs), rhs(rhs), lhs_states_num(lhs.get_num_of_states()), rhs_states_num(rhs.get_num_of_states()) {
-        if (lhs.initialstates.empty() || lhs.finalstates.empty() || rhs.initialstates.empty()) { return; }
-        concatenate();
-    }
+void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs, bool use_epsilon,
+                 StateToStateMap* lhs_result_states_map, StateToStateMap* rhs_result_states_map) {
+    *res = concatenate(lhs, rhs, use_epsilon, lhs_result_states_map, rhs_result_states_map);
+}
 
-    /**
-     * Initialize and compute concatenation of two NFAs concatenating over epsilon transitions.
-     *
-     * Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
-     * @param[in] lhs First NFA to concatenate.
-     * @param[in] rhs Second NFA to concatenate.
-     */
-    Concatenation(const Nfa& lhs, const Nfa& rhs, Symbol epsilon)
-            : lhs(lhs), rhs(rhs), lhs_states_num(lhs.get_num_of_states()), rhs_states_num(rhs.get_num_of_states()),
-              epsilon(epsilon) {
-        if (lhs.initialstates.empty() || lhs.finalstates.empty() || rhs.initialstates.empty()) { return; }
-        concatenate_over_epsilon();
-    }
+Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon,
+                StateToStateMap* lhs_result_states_map, StateToStateMap* rhs_result_states_map) {
+    // Compute concatenation of given automata.
+    // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
 
-    /**
-     * Get result of concatenation.
-     * @return Concatenated automaton.
-     */
-    const Nfa& get_result() { return result; }
+    if (lhs.initialstates.empty() || lhs.finalstates.empty() || rhs.initialstates.empty()) { return Nfa{}; }
 
-    /**
-     * Get @c lhs to @c result states map.
-     * @return @c lhs to @c result states map.
-     */
-    const StateToStateMap& get_lhs_result_states_map() { return lhs_result_states_map; }
-
-    /**
-     * Get @c rhs to @c result states map.
-     * @return @c rhs to @c result states map.
-     */
-    const StateToStateMap& get_rhs_result_states_map() { return rhs_result_states_map; }
-
-private:
-    const Nfa& lhs; ///< First automaton to concatenate.
-    const Nfa& rhs; ///< Second automaton to concatenate.
-    const unsigned long lhs_states_num; ///< Number of states in @c lhs.
-    const unsigned long rhs_states_num; ///< Number of states in @c rhs.
-    const Symbol epsilon{}; ///< Symbol to use as an epsilon symbol to concatenate with.
+    const unsigned long lhs_states_num{ lhs.get_num_of_states() }; ///< Number of states in lhs.
+    const unsigned long rhs_states_num{ rhs.get_num_of_states() }; ///< Number of states in rhs.
     Nfa result{}; ///< Concatenated automaton.
-    StateToStateMap lhs_result_states_map{}; ///< Map mapping @c lhs states to @c result states.
-    StateToStateMap rhs_result_states_map{}; ///< Map mapping @c rhs states to @c result states.
+    StateToStateMap lhs_result_states_map_internal{}; ///< Map mapping rhs states to result states.
+    StateToStateMap rhs_result_states_map_internal{}; ///< Map mapping rhs states to result states.
 
-    /**
-     * Compute concatenation of given automata.
-     */
-    void concatenate()
-    {
-        const size_t lhs_num_of_states_in_result{ lhs_states_num - lhs.finalstates.size() };
-        const size_t result_num_of_states{lhs_num_of_states_in_result + rhs_states_num};
-        if (result_num_of_states == 0) { return; }
-        lhs_result_states_map.reserve(lhs_num_of_states_in_result);
-        result.increase_size(result_num_of_states);
-        map_states_to_result_states();
-        make_initial_states();
-        add_lhs_transitions();
-        make_final_states();
-        add_rhs_transitions();
-    }
-
-    /**
-     * Compute concatenation of given automata concatenating over epsilon transitions.
-     */
-    void concatenate_over_epsilon() {
+    if (use_epsilon) {
         const size_t result_num_of_states{lhs_states_num + rhs_states_num};
-        if (result_num_of_states == 0) { return; }
-        map_rhs_states_to_result_states(lhs_states_num);
+        if (result_num_of_states == 0) { return Nfa{}; }
+
+        // Map rhs states to result states.
+        rhs_result_states_map_internal.reserve(rhs_states_num);
+        Symbol result_state_index{ lhs_states_num };
+        for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state) {
+            rhs_result_states_map_internal.insert(std::make_pair(rhs_state, result_state_index));
+            ++result_state_index;
+        }
+
         result = Nfa(lhs.transitionrelation, lhs.initialstates);
         result.increase_size(result_num_of_states);
-        add_epsilon_transitions();
-        make_final_states();
-        add_rhs_transitions();
-    }
 
-    /**
-     * Add epsilon transitions connecting @c lhs and @c rhs automata.
-     *
-     * The epsilon transitions lead from @c lhs original final states to @c rhs original initial states.
-     */
-    void add_epsilon_transitions() {
+        // Add epsilon transitions connecting lhs and rhs automata.
+        // The epsilon transitions lead from lhs original final states to rhs original initial states.
         for (const auto& lhs_final_state: lhs.finalstates) {
             for (const auto& rhs_initial_state: rhs.initialstates) {
-                result.add_trans(lhs_final_state, epsilon, rhs_result_states_map[rhs_initial_state]);
+                result.add_trans(lhs_final_state, EPSILON,
+                                 rhs_result_states_map_internal[rhs_initial_state]);
             }
         }
-    }
+    } else { // !use_epsilon.
+        const size_t lhs_num_of_states_in_result{ lhs_states_num - lhs.finalstates.size() };
+        const size_t result_num_of_states{lhs_num_of_states_in_result + rhs_states_num};
+        if (result_num_of_states == 0) { return Nfa{}; }
+        lhs_result_states_map_internal.reserve(lhs_num_of_states_in_result);
+        result.increase_size(result_num_of_states);
 
-    /**
-     * Map @c lhs and @c rhs states to @c result states.
-     */
-    void map_states_to_result_states() {
+        // Map both lhs and rhs states to result states.
         State result_state_index{ 0 };
         for (State lhs_state{ 0 }; lhs_state < lhs_states_num; ++lhs_state) {
             if (!lhs.has_final(lhs_state)) {
-                lhs_result_states_map.insert(std::make_pair(lhs_state, result_state_index));
+                lhs_result_states_map_internal.insert(std::make_pair(lhs_state, result_state_index));
                 ++result_state_index;
             }
         }
-        map_rhs_states_to_result_states(result_state_index);
 
-        for (const State lhs_initial_state: lhs.initialstates) {
-            if (lhs_result_states_map.find(lhs_initial_state) == lhs_result_states_map.end()) {
-                for (const State rhs_initial_state: rhs.initialstates) {
-                    lhs_result_states_map.insert(std::make_pair(lhs_initial_state, rhs_result_states_map[rhs_initial_state]));
-                }
-            }
-        }
-    }
-
-    /**
-     * Map @c lhs and @c rhs states to @c result states.
-     */
-    void map_rhs_states_to_result_states(State result_state_index) {
-        rhs_result_states_map.reserve(rhs_states_num);
+        // Map rhs states to result states.
+        rhs_result_states_map_internal.reserve(rhs_states_num);
         for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state) {
-            rhs_result_states_map.insert(std::make_pair(rhs_state, result_state_index));
+            rhs_result_states_map_internal.insert(std::make_pair(rhs_state, result_state_index));
             ++result_state_index;
         }
-    }
 
-    /**
-     * Make @c result initial states.
-     */
-    void make_initial_states() {
         for (const State lhs_initial_state: lhs.initialstates) {
-            result.make_initial(lhs_result_states_map[lhs_initial_state]);
-        }
-    }
-
-    /**
-     * Make @c result final states.
-     */
-    void make_final_states()
-    {
-        for (const auto& rhs_final_state: rhs.finalstates)
-        {
-            result.make_final(rhs_result_states_map[rhs_final_state]);
-        }
-    }
-
-    /**
-     * Add @c rhs transitions to the @c result.
-     */
-    void add_rhs_transitions()
-    {
-        for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
-        {
-            for (const auto& symbol_transitions: rhs.get_transitions_from(rhs_state))
-            {
-                for (const auto& rhs_state_to: symbol_transitions.states_to)
-                {
-                    result.add_trans(rhs_result_states_map[rhs_state],
-                                     symbol_transitions.symbol,
-                                     rhs_result_states_map[rhs_state_to]);
+            if (lhs_result_states_map_internal.find(lhs_initial_state) == lhs_result_states_map_internal.end()) {
+                for (const State rhs_initial_state: rhs.initialstates) {
+                    lhs_result_states_map_internal.insert(
+                            std::make_pair(lhs_initial_state, rhs_result_states_map_internal[rhs_initial_state])
+                    );
                 }
             }
         }
-    }
 
-    /**
-     * Add @c lhs transitions from final states to the @c result.
-     */
-    void add_lhs_final_states_transitions()
-    {
-        // For all lhs final states, copy all their transitions, except for self-loops on final states.
-        for (const auto& lhs_final_state: lhs.finalstates)
-        {
-            for (const auto& transitions_from_lhs_final_state: lhs.get_transitions_from(lhs_final_state))
-            {
-                for (const auto& lhs_state_to: transitions_from_lhs_final_state.states_to) {
-                    if (lhs_state_to != lhs_final_state) // Self-loops on final states already handled.
-                    {
-                        for (const auto& rhs_initial_state: rhs.initialstates) {
-                            result.add_trans(rhs_result_states_map[rhs_initial_state],
-                                             transitions_from_lhs_final_state.symbol,
-                                             lhs_result_states_map[lhs_state_to]);
-                        }
-                    }
-                }
-            }
+        // Make initial states of the result.
+        for (const State lhs_initial_state: lhs.initialstates) {
+            result.make_initial(lhs_result_states_map_internal[lhs_initial_state]);
         }
-    }
 
-    /**
-     * Add @c lhs transitions to @c lhs final states to the @c result.
-     */
-    void add_lhs_transitions_to_final_states()
-    {
-        // For all transitions to lhs final states, point them to rhs initial states.
-        for (const auto& lhs_final_state: lhs.finalstates)
-        {
-            for (const auto& lhs_trans_to_final_state: lhs.get_transitions_to(lhs_final_state))
-            {
-                for (const auto& rhs_initial_state: rhs.initialstates)
-                {
-                    if (lhs_trans_to_final_state.src == lhs_trans_to_final_state.tgt)
-                    {
-                        // Handle self-loops on final states as lhs final states will not be present in the result automaton.
-                        result.add_trans(rhs_result_states_map[rhs_initial_state], lhs_trans_to_final_state.symb,
-                                         rhs_result_states_map[rhs_initial_state]);
-                    }
-                    else // All other transitions can be copied with updated initial state number.
-                    {
-                        result.add_trans(lhs_result_states_map[lhs_trans_to_final_state.src], lhs_trans_to_final_state.symb,
-                                         rhs_result_states_map[rhs_initial_state]);
-                    }
-                }
-            }
-        }
-    }
+        // Add lhs transitions to the result.
 
-    /**
-     * Add @c lhs transitions from @c lhs final states.
-     */
-    void add_lhs_non_final_states_transitions()
-    {
-        // Reindex all states in transitions in lhs, except for transitions concerning final states (both to and form final states).
-        for (State lhs_state{ 0 }; lhs_state < lhs_states_num; ++lhs_state)
-        {
-            if (!lhs.has_final(lhs_state))
-            {
-                for (const auto& symbol_transitions: lhs.get_transitions_from(lhs_state))
-                {
-                    for (const State lhs_state_to: symbol_transitions.states_to)
-                    {
-                        if (!lhs.has_final(lhs_state_to))
-                        {
-                            result.add_trans(lhs_result_states_map[lhs_state],
+        // Reindex all states in transitions in lhs, except for transitions concerning final states (both to and from
+        //  final states).
+        for (State lhs_state{ 0 }; lhs_state < lhs_states_num; ++lhs_state) {
+            if (!lhs.has_final(lhs_state)) {
+                for (const auto& symbol_transitions:
+                     lhs.get_transitions_from(lhs_state)) {
+                    for (const State lhs_state_to: symbol_transitions.states_to) {
+                        if (!lhs.has_final(lhs_state_to)) {
+                            result.add_trans(lhs_result_states_map_internal[lhs_state],
                                              symbol_transitions.symbol,
-                                             lhs_result_states_map[lhs_state_to]);
+                                             lhs_result_states_map_internal[lhs_state_to]);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add lhs transitions to lhs final states to the result.
+        // For all transitions to lhs final states, point them to rhs initial states.
+        for (const auto& lhs_final_state: lhs.finalstates) {
+            for (const auto& lhs_trans_to_final_state: lhs.get_transitions_to(lhs_final_state)) {
+                for (const auto& rhs_initial_state: rhs.initialstates) {
+                    if (lhs_trans_to_final_state.src == lhs_trans_to_final_state.tgt) {
+                        // Handle self-loops on final states as lhs final states will not be present in the result
+                        //  automaton.
+                        result.add_trans(rhs_result_states_map_internal[rhs_initial_state],
+                                         lhs_trans_to_final_state.symb,
+                                         rhs_result_states_map_internal[rhs_initial_state]);
+                    } else { // All other transitions can be copied with updated initial state number.
+                        result.add_trans(lhs_result_states_map_internal[lhs_trans_to_final_state.src],
+                                         lhs_trans_to_final_state.symb,
+                                         rhs_result_states_map_internal[rhs_initial_state]);
+                    }
+                }
+            }
+        }
+
+        // Add lhs transitions from final states to the result.
+        // For all lhs final states, copy all their transitions, except for self-loops on final states.
+        for (const auto& lhs_final_state: lhs.finalstates) {
+            for (const auto& transitions_from_lhs_final_state:
+                 lhs.get_transitions_from(lhs_final_state)) {
+                for (const auto& lhs_state_to: transitions_from_lhs_final_state.states_to) {
+                    if (lhs_state_to != lhs_final_state) { // Self-loops on final states already handled.
+                        for (const auto& rhs_initial_state: rhs.initialstates) {
+                            result.add_trans(rhs_result_states_map_internal[rhs_initial_state],
+                                             transitions_from_lhs_final_state.symbol,
+                                             lhs_result_states_map_internal[lhs_state_to]);
                         }
                     }
                 }
@@ -278,33 +157,29 @@ private:
         }
     }
 
-    /**
-     * Add @c lhs transitions to the @c result.
-     */
-    void add_lhs_transitions()
+    // Make result final states.
+    for (const auto& rhs_final_state: rhs.finalstates)
     {
-        add_lhs_non_final_states_transitions();
-        add_lhs_transitions_to_final_states();
-        add_lhs_final_states_transitions();
+        result.make_final(rhs_result_states_map_internal[rhs_final_state]);
     }
-}; // Concatenation
 
-void concatenate(Nfa* res, const Nfa& lhs, const Nfa& rhs)
-{
-    *res = Concatenation(lhs, rhs).get_result();
-}
+    // Add rhs transitions to the result.
+    for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
+    {
+        for (const auto& symbol_transitions: rhs.get_transitions_from(rhs_state))
+        {
+            for (const auto& rhs_state_to: symbol_transitions.states_to)
+            {
+                result.add_trans(rhs_result_states_map_internal[rhs_state],
+                                 symbol_transitions.symbol,
+                                 rhs_result_states_map_internal[rhs_state_to]);
+            }
+        }
+    }
 
-Nfa concatenate(const Nfa& lhs, const Nfa& rhs)
-{
-    return Concatenation(lhs, rhs).get_result();
-}
-
-void concatenate_over_epsilon(Nfa* res, const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
-    *res = Concatenation(lhs, rhs, epsilon).get_result();
-}
-
-Nfa concatenate_over_epsilon(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) {
-    return Concatenation(lhs, rhs, epsilon).get_result();
+    if (lhs_result_states_map != nullptr) { *lhs_result_states_map = lhs_result_states_map_internal; }
+    if (rhs_result_states_map != nullptr) { *rhs_result_states_map = rhs_result_states_map_internal; }
+    return result;
 }
 
 } // Nfa

--- a/src/nfa/nfa-incl.cc
+++ b/src/nfa/nfa-incl.cc
@@ -36,7 +36,7 @@ bool Mata::Nfa::Algorithms::is_incl_naive(
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
-	Nfa nfa_isect = intersection(smaller, bigger_cmpl);
+	Nfa nfa_isect = intersection(smaller, bigger_cmpl, false, nullptr);
 
 	bool result;
 	if (nullptr == cex) {

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -54,9 +54,16 @@ void add_product_transition(Nfa& product, ProductMap& product_map, const StatePa
  * @param[in] rhs_state_to Target state in NFA @c rhs.
  * @param[out] intersect_transitions Transitions of the product state.
  */
-void create_product_state_and_trans(Nfa& product, ProductMap& product_map, const Nfa& lhs, const Nfa& rhs,
-                                    std::unordered_set<StatePair>& pairs_to_process, const State lhs_state_to,
-                                    const State rhs_state_to, TransSymbolStates& intersect_transitions) {
+void create_product_state_and_trans(
+        Nfa& product,
+        ProductMap& product_map,
+        const Nfa& lhs,
+        const Nfa& rhs,
+        std::unordered_set<StatePair>& pairs_to_process,
+        const State lhs_state_to,
+        const State rhs_state_to,
+        TransSymbolStates& intersect_transitions
+) {
     const StatePair intersect_state_pair_to(lhs_state_to, rhs_state_to);
     State intersect_state_to;
     if (product_map.find(intersect_state_pair_to) == product_map.end()) {

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -19,390 +19,167 @@
 using namespace Mata::Nfa;
 
 namespace {
-    void union_to_left(StateSet &receivingSet, const StateSet &addedSet) {
-        receivingSet.insert(addedSet);
+
+void union_to_left(StateSet &receivingSet, const StateSet &addedSet) {
+    receivingSet.insert(addedSet);
+}
+
+/**
+ * Add transition to the product.
+ * @param[out] product Created product automaton.
+ * @param[out] product_map Created product map.
+ * @param[in] pair_to_process Currently processed pair of original states.
+ * @param[in] intersection_transition State transitions to add to the product.
+ */
+void add_product_transition(Nfa& product, ProductMap& product_map, const StatePair& pair_to_process,
+                            TransSymbolStates& intersection_transition) {
+    if (intersection_transition.states_to.empty()) { return; }
+
+    auto& intersect_state_transitions{ product.transitionrelation[product_map[pair_to_process]] };
+    auto symbol_transitions_iter{ intersect_state_transitions.find(intersection_transition) };
+    if (symbol_transitions_iter == intersect_state_transitions.end()) {
+        intersect_state_transitions.push_back(intersection_transition);
+    } else {
+        // Product already has some target states for the given symbol from the current product state.
+        union_to_left(symbol_transitions_iter->states_to, intersection_transition.states_to);
     }
 }
 
-namespace Mata
-{
-namespace Nfa
-{
-
 /**
- * Class handling intersection of automata.
- *
- * Implements a normal intersection and an intersection preserving epsilon transitions.
+ * Create product state and its transitions.
+ * @param[out] product Created product automaton.
+ * @param[out] product_map Created product map.
+ * @param[out] pairs_to_process Set of product states to process
+ * @param[in] lhs_state_to Target state in NFA @c lhs.
+ * @param[in] rhs_state_to Target state in NFA @c rhs.
+ * @param[out] intersect_transitions Transitions of the product state.
  */
-class Intersection
-{
-public:
-    /**
-     * Compute classic intersection of NFAs @p lhs and @p rhs.
-     * @param lhs First NFA to compute intersection for.
-     * @param rhs Second NFA to compute intersection for.
-     */
-    Intersection(const Nfa& lhs, const Nfa& rhs) : lhs(lhs), rhs(rhs)
-    {
-        compute();
+void create_product_state_and_trans(Nfa& product, ProductMap& product_map, const Nfa& lhs, const Nfa& rhs,
+                                    std::unordered_set<StatePair>& pairs_to_process, const State lhs_state_to,
+                                    const State rhs_state_to, TransSymbolStates& intersect_transitions) {
+    const StatePair intersect_state_pair_to(lhs_state_to, rhs_state_to);
+    State intersect_state_to;
+    if (product_map.find(intersect_state_pair_to) == product_map.end()) {
+        intersect_state_to = product.add_new_state();
+        product_map[intersect_state_pair_to] = intersect_state_to;
+        pairs_to_process.insert(intersect_state_pair_to);
+
+        if (lhs.has_final(lhs_state_to) && rhs.has_final(rhs_state_to)) {
+            product.make_final(intersect_state_to);
+        }
+    } else {
+        intersect_state_to = product_map[intersect_state_pair_to];
     }
+    intersect_transitions.states_to.insert(intersect_state_to);
+}
 
-    /**
-     * Compute epsilon transitions preserving intersection of NFAs @p lhs and @p rhs.
-     * @param lhs First NFA to compute intersection for.
-     * @param rhs Second NFA to compute intersection for.
-     * @param epsilon Symbol to handle as an epsilon symbol.
-     */
-    Intersection(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon) : lhs(lhs), rhs(rhs), epsilon(epsilon)
-    {
-        compute_preserving_epsilon_transitions();
-    }
+} // Anonymous namespace.
 
-    /**
-     * Compute classic intersection of NFAs @p lhs and @p rhs.
-     * @param lhs First NFA to compute intersection for.
-     * @param rhs Second NFA to compute intersection for.
-     */
-    static Intersection compute(const Nfa& lhs, const Nfa& rhs)
-    {
-        return Intersection{ lhs, rhs };
-    }
+namespace Mata {
+namespace Nfa {
 
-    /**
-     * Compute epsilon transitions preserving intersection of NFAs @p lhs and @p rhs.
-     * @param lhs First NFA to compute intersection for.
-     * @param rhs Second NFA to compute intersection for.
-     * @param epsilon Symbol to handle as an epsilon symbol.
-     */
-    static Intersection compute(const Nfa& lhs, const Nfa& rhs, const Symbol epsilon)
-    {
-        return Intersection{ lhs, rhs, epsilon };
-    }
+void intersection(Nfa* res, const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon, ProductMap* prod_map) {
+    *res = intersection(lhs, rhs, preserve_epsilon, prod_map);
+}
 
-    /**
-     * Get the final product NFA of the intersection.
-     * @return Product NFA of the intersection.
-     */
-    const Nfa& get_product() { return product; }
-
-    /**
-     * Get product map for the generated product NFA.
-     * @return Product map mapping original state pairs to new product states.
-     */
-    const ProductMap& get_product_map() { return product_map; }
-
-private:
-    Nfa product{}; ///< Product of the intersection.
-    /// Product map for the generated intersection mapping original state pairs to new product states.
+Nfa intersection(const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon, ProductMap* prod_map) {
+    Nfa product{}; // Product of the intersection.
+    // Product map for the generated intersection mapping original state pairs to new product states.
     ProductMap product_map{};
-    const Nfa& lhs; ///< First NFA to compute intersection for.
-    const Nfa& rhs; ///< Second NFA to compute intersection for.
-    const Symbol epsilon{}; ///< Symbol to handle as an epsilon symbol.
+    StatePair pair_to_process{}; // State pair of original states currently being processed.
+    std::unordered_set<StatePair> pairs_to_process{}; // Set of state pairs of original states to process.
 
-    StatePair pair_to_process{}; ///< State pair of original states currently being processed.
-    std::unordered_set<StatePair> pairs_to_process{}; ///< Set of state pairs of original states to process.
+    // Initialize pairs to process with initial state pairs.
+    for (const State lhs_initial_state : lhs.initialstates) {
+        for (const State rhs_initial_state : rhs.initialstates) {
+            // Update product with initial state pairs.
+            const StatePair this_and_other_initial_state_pair(lhs_initial_state, rhs_initial_state);
+            const State new_intersection_state = product.add_new_state();
 
-    /**
-     * Compute classic intersection.
-     */
-    void compute()
-    {
-        // TODO probably remove this since we use prod_map as parameter
-        //std::unordered_map<StatePair, State, decltype(hashStatePair)> thisAndOtherStateToIntersectState(10, hashStatePair); // TODO default buckets?
+            product_map[this_and_other_initial_state_pair] = new_intersection_state;
+            pairs_to_process.insert(this_and_other_initial_state_pair);
 
-        initialize_pairs_to_process();
-
-        while (!pairs_to_process.empty())
-        {
-            pair_to_process = *pairs_to_process.cbegin();
-            pairs_to_process.erase(pair_to_process);
-
-            // TODO rewrite this (TODO from previous Vata implementation -- rewrite the algorithm, or the format?).
-
-            //compute_for_state_pair();
-            compute_for_state_pair_using_sui();
-        }
-    }
-
-    /**
-     * Compute intersection preserving epsilon transitions.
-     */
-    void compute_preserving_epsilon_transitions() {
-        initialize_pairs_to_process();
-
-        while (!pairs_to_process.empty()) {
-            pair_to_process = *pairs_to_process.cbegin();
-            pairs_to_process.erase(pair_to_process);
-            compute_transitions_for_state_pair_eps_pres();
-        }
-    }
-
-    /**
-     * Add transitions of the current state pair for an epsilon preserving product.
-     */
-    void compute_transitions_for_state_pair_eps_pres() {
-        for (const auto& lhs_state_transitions: lhs.transitionrelation[pair_to_process.first]) {
-            // Check for lhs epsilon transitions.
-            if (lhs_state_transitions.symbol == epsilon) {
-                compute_for_lhs_state_epsilon_transitions(lhs_state_transitions);
-            }
-
-            for (const auto& rhs_state_transitions: rhs.transitionrelation[pair_to_process.second]) {
-                // Find all transitions that have the same symbol for first and the second state in the pair_to_process.
-                if (lhs_state_transitions.symbol == rhs_state_transitions.symbol) {
-                    compute_for_same_symbols(lhs_state_transitions, rhs_state_transitions);
-                }
-            }
-        }
-
-        // Check for rhs epsilon transitions.
-        add_rhs_epsilon_transitions();
-    }
-
-    /**
-     * Check for epsilon transitions in case only rhs has any transitions and add them.
-     */
-    void add_rhs_epsilon_transitions() {
-        for (const auto& rhs_state_transitions: rhs.transitionrelation[pair_to_process.second]) {
-            if (rhs_state_transitions.symbol == epsilon) {
-                compute_for_rhs_state_epsilon_transitions(rhs_state_transitions);
+            product.initialstates.push_back(new_intersection_state);
+            if (lhs.has_final(lhs_initial_state) && rhs.has_final(rhs_initial_state)) {
+                product.finalstates.push_back(new_intersection_state);
             }
         }
     }
 
-    /**
-     * Initialize pairs to process with initial state pairs.
-     */
-    void initialize_pairs_to_process() {
-        for (const State this_initial_state : lhs.initialstates) {
-            for (const State other_initial_state : rhs.initialstates) {
-                handle_initial_state_pairs(this_initial_state, other_initial_state);
-            }
-        }
-    }
-
-    /**
-     * Add transition to the product.
-     * @param[in] intersection_transition State transitions to add to the product.
-     */
-    void add_product_transition(const TransSymbolStates& intersection_transition)
-    {
-        if (intersection_transition.states_to.empty()) { return; }
-
-        auto& intersect_state_transitions{ product.transitionrelation[product_map[pair_to_process]] };
-        auto symbol_transitions_iter{ intersect_state_transitions.find(intersection_transition) };
-        if (symbol_transitions_iter == intersect_state_transitions.end()) {
-            intersect_state_transitions.push_back(intersection_transition);
-        }
-        else {
-            // Product already has some target states for the given symbol from the current product state.
-            union_to_left(symbol_transitions_iter->states_to, intersection_transition.states_to);
-        }
-    }
-
-    /**
-     * Update product with initial state pairs.
-     * @param[in] lhs_initial_state Initial state of NFA @c lhs.
-     * @param[in] rhs_initial_state Initial state of NFA @c rhs.
-     */
-    void handle_initial_state_pairs(const State lhs_initial_state, const State rhs_initial_state)
-    {
-        const StatePair this_and_other_initial_state_pair(lhs_initial_state, rhs_initial_state);
-        const State new_intersection_state = product.add_new_state();
-
-        product_map[this_and_other_initial_state_pair] = new_intersection_state;
-        pairs_to_process.insert(this_and_other_initial_state_pair);
-
-        product.initialstates.push_back(new_intersection_state);
-        if (lhs.has_final(lhs_initial_state) && rhs.has_final(rhs_initial_state))
-        {
-            product.finalstates.push_back(new_intersection_state);
-        }
-    }
-
-    /**
-     * Compute product for state transitions with same symbols.
-     * @param[in] lhs_state_transitions State transitions of NFA @c lhs to compute product for.
-     * @param[in] rhs_state_transitions State transitions of NFA @c rhs to compute product for.
-     */
-    void compute_for_same_symbols(const TransSymbolStates& lhs_state_transitions,
-                                  const TransSymbolStates& rhs_state_transitions)
-    {
-        // Create transition from the pair_to_process to all pairs between states to which first transition goes and states
-        // to which second one goes.
-        TransSymbolStates intersection_transition{ lhs_state_transitions.symbol };
-        for (const State this_state_to: lhs_state_transitions.states_to)
-        {
-            for (const State other_state_to: rhs_state_transitions.states_to)
-            {
-                create_product_state_and_trans(this_state_to, other_state_to, intersection_transition);
-            }
-        }
-        add_product_transition(intersection_transition);
-    }
-
-    /**
-     * Compute product for state transitions with @c lhs state epsilon transition.
-     * @param[in] lhs_state_transitions State transitions of NFA @c lhs to compute product for.
-     */
-    void compute_for_lhs_state_epsilon_transitions(const TransSymbolStates& lhs_state_transitions)
-    {
-        // Create transition from the pair_to_process to all pairs between states to which first transition goes and states to which second one goes.
-        TransSymbolStates intersection_transition{ lhs_state_transitions.symbol };
-        for (const State this_state_to: lhs_state_transitions.states_to)
-        {
-            create_product_state_and_trans(this_state_to, pair_to_process.second, intersection_transition);
-        }
-        add_product_transition(intersection_transition);
-    }
-
-    /**
-     * Compute product for state transitions with @c rhs state epsilon transition.
-     * @param[in] rhs_state_transitions State transitions of NFA @c rhs to compute product for.
-     */
-    void compute_for_rhs_state_epsilon_transitions(const TransSymbolStates& rhs_state_transitions)
-    {
-        // create transition from the pair_to_process to all pairs between states to which first transition goes and states to which second one goes
-        TransSymbolStates intersection_transition{ rhs_state_transitions.symbol };
-        for (const State other_state_to: rhs_state_transitions.states_to)
-        {
-            create_product_state_and_trans(pair_to_process.first, other_state_to, intersection_transition);
-        }
-        add_product_transition(intersection_transition);
-    }
-
-    /**
-     * Compute classic product for current state pair.
-     */
-    void compute_for_state_pair()
-    {
-        auto this_state_transitions_iter = lhs.transitionrelation[pair_to_process.first].begin();
-        auto other_state_transitions_iter = rhs.transitionrelation[pair_to_process.second].begin();
-        const auto this_state_transitions_iter_end = lhs.transitionrelation[pair_to_process.first].end();
-        const auto other_state_transitions_iter_end = rhs.transitionrelation[pair_to_process.second].end();
-        // find all transitions that have same symbol for first and the second state in the pair_to_process
-        while (this_state_transitions_iter != this_state_transitions_iter_end
-               && other_state_transitions_iter != other_state_transitions_iter_end)
-        {
-            // first iterator points to transition with smaller symbol, move it until it is either same or further than second iterator
-            if (this_state_transitions_iter->symbol < other_state_transitions_iter->symbol)
-            {
-                while (this_state_transitions_iter != this_state_transitions_iter_end
-                       && this_state_transitions_iter->symbol < other_state_transitions_iter->symbol)
-                {
-                    ++this_state_transitions_iter;
-                }
-                if (this_state_transitions_iter == this_state_transitions_iter_end)
-                {
-                    break;
-                }
-            }
-            else
-            {
-                // second iterator points to transition with smaller symbol, move it until it is either same or further than first iterator
-                while (other_state_transitions_iter != other_state_transitions_iter_end
-                       && this_state_transitions_iter->symbol > other_state_transitions_iter->symbol)
-                {
-                    ++other_state_transitions_iter;
-                }
-                if (other_state_transitions_iter == other_state_transitions_iter_end) { break; }
-            }
-
-            // check both iterators point to the transitions with same symbol
-            if (this_state_transitions_iter->symbol == other_state_transitions_iter->symbol)
-            {
-                compute_for_same_symbols(*this_state_transitions_iter,
-                                         *other_state_transitions_iter);
-
-                ++this_state_transitions_iter;
-                ++other_state_transitions_iter;
-            }
-        }
-    }
-
-    // Alternative for the above that uses SynchronizedUniverzalIterator
-    void compute_for_state_pair_using_sui()
-    {
+    while (!pairs_to_process.empty()) {
+        pair_to_process = *pairs_to_process.cbegin();
+        pairs_to_process.erase(pair_to_process);
+        // Compute classic product for current state pair.
         Mata::Util::SynchronizedUniverzalIterator<TransSymbolStates> sui(2);
         sui.push_back(lhs.transitionrelation[pair_to_process.first]);
         sui.push_back(rhs.transitionrelation[pair_to_process.second]);
 
-        while (sui.advance()){
-            std::vector<Mata::Util::OrdVector<TransSymbolStates>::const_iterator> moves = sui.get_current();
-            assert(moves.size() == 2); //one move per state in the pair
-            compute_for_same_symbols(*moves[0],*moves[1]);
-        }
-    }
+        while (sui.advance()) {
+            std::vector<TransitionList::const_iterator> moves = sui.get_current();
+            assert(moves.size() == 2); // One move per state in the pair.
 
-    /**
-     * Create product state and its transitions.
-     * @param[in] lhs_state_to Target state in NFA @c lhs.
-     * @param[in] rhs_state_to Target state in NFA @c rhs.
-     * @param[out] intersect_transitions Transitions of the product state.
-     */
-    void create_product_state_and_trans(const State lhs_state_to, const State rhs_state_to, TransSymbolStates& intersect_transitions)
-    {
-        const StatePair intersect_state_pair_to(lhs_state_to, rhs_state_to);
-        State intersect_state_to;
-        if (product_map.find(intersect_state_pair_to) == product_map.end())
-        {
-            intersect_state_to = product.add_new_state();
-            product_map[intersect_state_pair_to] = intersect_state_to;
-            pairs_to_process.insert(intersect_state_pair_to);
-
-            if (lhs.has_final(lhs_state_to) && rhs.has_final(rhs_state_to))
+            // Compute product for state transitions with same symbols.
+            // Find all transitions that have the same symbol for first and the second state in the pair_to_process.
+            // Create transition from the pair_to_process to all pairs between states to which first transition goes
+            //  and states to which second one goes.
+            TransSymbolStates intersection_transition{ moves[0]->symbol};
+            for (const State this_state_to: moves[0]->states_to)
             {
-                product.make_final(intersect_state_to);
+                for (const State other_state_to: moves[1]->states_to)
+                {
+                    create_product_state_and_trans(
+                            product, product_map, lhs, rhs, pairs_to_process,
+                            this_state_to, other_state_to, intersection_transition
+                    );
+                }
+            }
+            add_product_transition(product, product_map, pair_to_process, intersection_transition);
+        }
+
+        if (preserve_epsilon) {
+            // Add transitions of the current state pair for an epsilon preserving product.
+
+            // Check for lhs epsilon transitions.
+            const auto& lhs_state_symbol_transitions{ lhs.transitionrelation[pair_to_process.first] };
+            if (!lhs_state_symbol_transitions.empty()) {
+                const auto& lhs_state_last_transitions{ lhs_state_symbol_transitions.back() };
+                if (lhs_state_last_transitions.symbol == EPSILON) {
+                    // Compute product for state transitions with lhs state epsilon transition.
+                    // Create transition from the pair_to_process to all pairs between states to which first transition
+                    //  goes and states to which second one goes.
+                    TransSymbolStates intersection_transition{EPSILON};
+                    for (const State lhs_state_to: lhs_state_last_transitions.states_to) {
+                        create_product_state_and_trans(product, product_map, lhs, rhs, pairs_to_process,
+                                                       lhs_state_to, pair_to_process.second,
+                                                       intersection_transition);
+                    }
+                    add_product_transition(product, product_map, pair_to_process, intersection_transition);
+                }
+            }
+
+            // Check for rhs epsilon transitions in case only rhs has any transitions and add them.
+            const auto& rhs_state_symbol_transitions{ rhs.transitionrelation[pair_to_process.second]};
+            if (!rhs_state_symbol_transitions.empty()) {
+                const auto& rhs_state_last_transitions{rhs_state_symbol_transitions.back()};
+                if (rhs_state_last_transitions.symbol == EPSILON) {
+                    // Compute product for state transitions with rhs state epsilon transition.
+                    // Create transition from the pair_to_process to all pairs between states to which first transition
+                    //  goes and states to which second one goes.
+                    TransSymbolStates intersection_transition{EPSILON};
+                    for (const State rhs_state_to: rhs_state_last_transitions.states_to) {
+                        create_product_state_and_trans(product, product_map, lhs, rhs, pairs_to_process,
+                                                       pair_to_process.first, rhs_state_to,
+                                                       intersection_transition);
+                    }
+                    add_product_transition(product, product_map, pair_to_process, intersection_transition);
+                }
             }
         }
-        else
-        {
-            intersect_state_to = product_map[intersect_state_pair_to];
-        }
-        intersect_transitions.states_to.insert(intersect_state_to);
-    }
-}; // Intersection
-
-void intersection(Nfa *res, const Nfa &lhs, const Nfa &rhs, ProductMap*  prod_map)
-{
-    Intersection intersection { Intersection::compute(lhs, rhs) };
-    if (prod_map != nullptr)
-    {
-        *prod_map = intersection.get_product_map();
-    }
-    *res = intersection.get_product();
-}
-
-void intersection_preserving_epsilon_transitions(Nfa* res, const Nfa &lhs, const Nfa &rhs, Symbol epsilon, ProductMap* prod_map)
-{
-    Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
-    if (prod_map != nullptr)
-    {
-        *prod_map = intersection.get_product_map();
-    }
-    *res = intersection.get_product();
-}
-
-Nfa intersection_preserving_epsilon_transitions(const Nfa& lhs, const Nfa& rhs, Symbol epsilon, ProductMap*  prod_map)
-{
-    Intersection intersection { Intersection::compute(lhs, rhs, epsilon) };
-    if (prod_map != nullptr)
-    {
-        *prod_map = intersection.get_product_map();
-    }
-    return intersection.get_product();
-}
-
-Nfa intersection(const Nfa& lhs, const Nfa& rhs, ProductMap* prod_map)
-{
-    Intersection intersection { Intersection::compute(lhs, rhs) };
-    if (prod_map != nullptr)
-    {
-        *prod_map = intersection.get_product_map();
     }
 
-    return intersection.get_product();
-}
+    if (prod_map != nullptr) { *prod_map = product_map; }
+    return product;
+} // intersection().
 
-} // Nfa
-} // Mata
+} // namespace Nfa.
+} // namespace Mata.

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -175,19 +175,15 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
 
     if (left_automata.empty() || is_lang_empty(right_automaton)) { return NoodleSequence{}; }
 
-    auto alphabet{ OnTheFlyAlphabet::from_nfas(left_automata) };
-    alphabet.add_symbols_from(right_automaton);
-    const Symbol epsilon{ alphabet.get_next_value() };
-
     // Automaton representing the left side concatenated over epsilon transitions.
     Nfa concatenated_left_side{ *left_automata_begin };
     for (auto next_left_automaton_it{ left_automata_begin + 1 }; next_left_automaton_it != left_automata_end;
          ++next_left_automaton_it) {
-        concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *next_left_automaton_it, epsilon);
+        concatenated_left_side = concatenate(concatenated_left_side, *next_left_automaton_it, EPSILON);
     }
 
     auto product_pres_eps_trans{
-            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, epsilon) };
+            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, EPSILON) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -203,7 +199,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
             product_pres_eps_trans = revert(product_pres_eps_trans);
         }
     }
-    return noodlify(product_pres_eps_trans, epsilon, include_empty);
+    return noodlify(product_pres_eps_trans, EPSILON, include_empty);
 }
 
 SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_automata, const Nfa& right_automaton,
@@ -228,19 +224,15 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
 
     if (left_automata.empty() || is_lang_empty(right_automaton)) { return NoodleSequence{}; }
 
-    auto alphabet{ OnTheFlyAlphabet::from_nfas(left_automata) };
-    alphabet.add_symbols_from(right_automaton);
-    const Symbol epsilon{ alphabet.get_next_value() };
-
     // Automaton representing the left side concatenated over epsilon transitions.
     Nfa concatenated_left_side{ *(*left_automata_begin) };
     for (auto next_left_automaton_it{ left_automata_begin + 1 }; next_left_automaton_it != left_automata_end;
          ++next_left_automaton_it) {
-        concatenated_left_side = concatenate_over_epsilon(concatenated_left_side, *(*next_left_automaton_it), epsilon);
+        concatenated_left_side = concatenate(concatenated_left_side, *(*next_left_automaton_it), EPSILON);
     }
 
     auto product_pres_eps_trans{
-            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, epsilon) };
+            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, EPSILON) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -255,5 +247,5 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
             product_pres_eps_trans = revert(product_pres_eps_trans);
         }
     }
-    return noodlify(product_pres_eps_trans, epsilon, include_empty);
+    return noodlify(product_pres_eps_trans, EPSILON, include_empty);
 }

--- a/src/nfa/noodlify.cc
+++ b/src/nfa/noodlify.cc
@@ -183,7 +183,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutRefSequence& left_
     }
 
     auto product_pres_eps_trans{
-            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, EPSILON) };
+            intersection(concatenated_left_side, right_automaton, true) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};
@@ -232,7 +232,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
     }
 
     auto product_pres_eps_trans{
-            intersection_preserving_epsilon_transitions(concatenated_left_side, right_automaton, EPSILON) };
+            intersection(concatenated_left_side, right_automaton, true) };
     product_pres_eps_trans.trim();
     if (is_lang_empty(product_pres_eps_trans)) {
         return NoodleSequence{};

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -393,12 +393,11 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
     Nfa lhs{};
     Nfa rhs{};
     Nfa result{};
-    Symbol epsilon{ 'x' };
 
     SECTION("Empty automaton") {
         lhs.increase_size(1);
         rhs.increase_size(1);
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.get_num_of_states() == 0);
         CHECK(result.initialstates.empty());
@@ -413,7 +412,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         rhs.make_initial(0);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.get_num_of_states() == 0);
         CHECK(result.initialstates.empty());
@@ -429,13 +428,13 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         rhs.make_initial(0);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.finalstates.empty());
         CHECK(result.get_num_of_states() == 2);
         CHECK(result.get_num_of_trans() == 1);
-        CHECK(result.has_trans(0, epsilon, 1));
+        CHECK(result.has_trans(0, EPSILON, 1));
     }
 
     SECTION("Single state automata accepting an empty string")
@@ -447,13 +446,13 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_initial(0);
         rhs.make_final(0);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(1));
         CHECK(result.get_num_of_states() == 2);
         CHECK(result.get_num_of_trans() == 1);
-        CHECK(result.has_trans(0, epsilon, 1));
+        CHECK(result.has_trans(0, EPSILON, 1));
     }
 
     SECTION("Empty language rhs automaton")
@@ -465,13 +464,13 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_initial(0);
         rhs.make_final(1);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
         CHECK(result.get_num_of_states() == 3);
         CHECK(result.get_num_of_trans() == 1);
-        CHECK(result.has_trans(0, epsilon, 1));
+        CHECK(result.has_trans(0, EPSILON, 1));
     }
 
     SECTION("Simple two state rhs automaton")
@@ -484,14 +483,14 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(1);
         rhs.add_trans(0, 'a', 1);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
         CHECK(result.get_num_of_states() == 3);
         CHECK(result.get_num_of_trans() == 2);
         CHECK(result.has_trans(1, 'a', 2));
-        CHECK(result.has_trans(0, epsilon, 1));
+        CHECK(result.has_trans(0, EPSILON, 1));
     }
 
     SECTION("Simple two state automata")
@@ -505,7 +504,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(1);
         rhs.add_trans(0, 'a', 1);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(3));
@@ -513,11 +512,11 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.has_trans(0, 'b', 1));
         CHECK(result.has_trans(2, 'a', 3));
-        CHECK(result.has_trans(1, epsilon, 2));
+        CHECK(result.has_trans(1, EPSILON, 2));
 
         auto shortest_words{ result.get_shortest_words() };
         CHECK(shortest_words.size() == 1);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', epsilon, 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', EPSILON, 'a' }) != shortest_words.end());
     }
 
     SECTION("Simple two state automata with higher state num for non-final state")
@@ -532,7 +531,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.add_trans(0, 'a', 1);
         rhs.add_trans(0, 'c', 3);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(3));
@@ -541,11 +540,11 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         CHECK(result.has_trans(0, 'b', 1));
         CHECK(result.has_trans(2, 'a', 3));
         CHECK(result.has_trans(2, 'c', 5));
-        CHECK(result.has_trans(1, epsilon, 2));
+        CHECK(result.has_trans(1, EPSILON, 2));
 
         auto shortest_words{ result.get_shortest_words() };
         CHECK(shortest_words.size() == 1);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', epsilon, 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', EPSILON, 'a' }) != shortest_words.end());
     }
 
     SECTION("Simple two state lhs automaton")
@@ -559,7 +558,12 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.make_final(0);
         rhs.add_trans(0, 'a', 0);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        StateToStateMap lhs_map{};
+        StateToStateMap rhs_map{};
+        result = concatenate(lhs, rhs, true, &lhs_map, &rhs_map);
+
+        CHECK(lhs_map.empty());
+        CHECK(rhs_map == StateToStateMap{ { 0, 2 } });
 
         CHECK(result.has_initial(0));
         CHECK(result.has_final(2));
@@ -567,11 +571,11 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.has_trans(0, 'b', 1));
         CHECK(result.has_trans(2, 'a', 2));
-        CHECK(result.has_trans(1, epsilon, 2));
+        CHECK(result.has_trans(1, EPSILON, 2));
 
         auto shortest_words{ result.get_shortest_words() };
         CHECK(shortest_words.size() == 1);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', epsilon }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', EPSILON }) != shortest_words.end());
     }
 
     SECTION("Automaton A concatenate automaton B")
@@ -581,7 +585,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size_for_state(14);
         FILL_WITH_AUT_B(rhs);
 
-        result = concatenate_over_epsilon(lhs, rhs, epsilon);
+        result = concatenate(lhs, rhs, true);
 
         CHECK(result.initialstates.size() == 2);
         CHECK(result.has_initial(1));
@@ -591,10 +595,10 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         auto shortest_words{ result.get_shortest_words() };
         CHECK(shortest_words.size() == 4);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', epsilon, 'a', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', epsilon, 'b', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', epsilon, 'a', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', epsilon, 'b', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', EPSILON, 'a', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', EPSILON, 'b', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', EPSILON, 'a', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', EPSILON, 'b', 'a' }) != shortest_words.end());
     }
 
     SECTION("Automaton B concatenate automaton A")
@@ -604,7 +608,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size_for_state(14);
         FILL_WITH_AUT_B(rhs);
 
-        result = concatenate_over_epsilon(rhs, lhs, epsilon);
+        result = concatenate(rhs, lhs, true);
 
         CHECK(result.get_num_of_states() == 26);
 
@@ -613,9 +617,9 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         auto shortest_words{ result.get_shortest_words() };
         CHECK(shortest_words.size() == 4);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', epsilon, 'a', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', epsilon, 'b', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', epsilon, 'a', 'a' }) != shortest_words.end());
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', epsilon, 'b', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', EPSILON, 'a', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'b', 'a', EPSILON, 'b', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', EPSILON, 'a', 'a' }) != shortest_words.end());
+        CHECK(shortest_words.find(std::vector<Symbol>{ 'a', 'a', EPSILON, 'b', 'a' }) != shortest_words.end());
     }
 }


### PR DESCRIPTION
As per request, this PR refactors algorithms for intersection and concatenation. As agreed upon, I have removed the introduced abstractions of these algorithms, moved all implementation code into a single function wherever possible, removed the corresponding classes and modified how we handle epsilon symbols in these algorithms.

Now, we support only the default epsilon symbol to be used as the epsilon symbol for these algorithms. It was decided that the other operations than the previously mentioned algorithms (specially designed to consider epsilon transitions) will ignore epsilon symbols whatsoever and compute with the default epsilon symbol as if it was a normal alphabet symbol instead, at least for now.