### PR TITLE
Mintermization of multiple automata

### DIFF
--- a/include/mata/mintermization.hh
+++ b/include/mata/mintermization.hh
@@ -124,8 +124,8 @@ public:
      * @param auts Automata to be mintermized.
      * @return Mintermized automata corresponding to the input autamata
      */
-    std::vector<Mata::IntermediateAut> mintermize(const std::vector<const Mata::IntermediateAut *> auts);
-    std::vector<Mata::IntermediateAut> mintermize(const std::vector<Mata::IntermediateAut> auts);
+    std::vector<Mata::IntermediateAut> mintermize(const std::vector<const Mata::IntermediateAut *> &auts);
+    std::vector<Mata::IntermediateAut> mintermize(const std::vector<Mata::IntermediateAut> &auts);
 
     /**
      * The method performs the mintermization over @aut with given @minterms.

--- a/include/mata/mintermization.hh
+++ b/include/mata/mintermization.hh
@@ -77,10 +77,11 @@ private: // private data members
     std::unordered_map<std::string, BDD> symbol_to_bddvar;
     std::unordered_map<const FormulaGraph *, BDD> trans_to_bddvar;
     std::unordered_map<const FormulaNode*, std::vector<DisjunctStatesPair>> lhs_to_disjuncts_and_states;
+    std::vector<BDD> bdds; // bdds created from transitions
 
 private:
-    std::vector<BDD> trans_to_bdd_nfa(const IntermediateAut& aut);
-    std::vector<BDD> trans_to_bdd_afa(const IntermediateAut& aut);
+    void trans_to_bdd_nfa(const IntermediateAut& aut);
+    void trans_to_bdd_afa(const IntermediateAut& aut);
 
 public:
     /**
@@ -108,7 +109,7 @@ public:
     const OptionalBdd graph_to_bdd_afa(const FormulaGraph& graph);
 
     /**
-     * Methods mintermizes given automaton which has bitvector alphabet.
+     * Method mintermizes given automaton which has bitvector alphabet.
      * It transforms its transitions to BDDs, then build a minterm tree over the BDDs
      * and finally transforms automaton to explicit one.
      * @param aut Automaton to be mintermized.
@@ -117,13 +118,23 @@ public:
     Mata::IntermediateAut mintermize(const Mata::IntermediateAut& aut);
 
     /**
+     * Methods mintermize given automata which have bitvector alphabet.
+     * It transforms transitions of all automata to BDDs, then build a minterm tree over the BDDs
+     * and finally transforms automata to explicit one (sharing the same minterms).
+     * @param auts Automata to be mintermized.
+     * @return Mintermized automata corresponding to the input autamata
+     */
+    std::vector<Mata::IntermediateAut> mintermize(const std::vector<const Mata::IntermediateAut *> auts);
+    std::vector<Mata::IntermediateAut> mintermize(const std::vector<Mata::IntermediateAut> auts);
+
+    /**
      * The method performs the mintermization over @aut with given @minterms.
      * It is method specialized for NFA.
      * @param res The resulting mintermized automaton
      * @param aut Automaton to be mintermized
      * @param minterms Set of minterms for mintermization
      */
-    void minterms_to_aut(Mata::IntermediateAut& res, const Mata::IntermediateAut& aut, const std::vector<BDD>& minterms);
+    void minterms_to_aut_nfa(Mata::IntermediateAut& res, const Mata::IntermediateAut& aut, const std::vector<BDD>& minterms);
 
     /**
      * The method for mintermization of alternating finite automaton using

--- a/src/mintermization.cc
+++ b/src/mintermization.cc
@@ -54,9 +54,9 @@ namespace
     }
 }
 
-std::vector<BDD> Mata::Mintermization::trans_to_bdd_nfa(const IntermediateAut &aut)
+void Mata::Mintermization::trans_to_bdd_nfa(const IntermediateAut &aut)
 {
-    std::vector<BDD> bdds;
+    assert(aut.is_nfa());
 
     for (const auto& trans : aut.transitions) {
         // Foreach transition create a BDD
@@ -68,14 +68,11 @@ std::vector<BDD> Mata::Mintermization::trans_to_bdd_nfa(const IntermediateAut &a
         bdds.push_back(bdd);
         trans_to_bddvar[&symbol_part] = bdd;
     }
-
-    return bdds;
 }
 
-std::vector<BDD> Mata::Mintermization::trans_to_bdd_afa(const IntermediateAut &aut)
+void Mata::Mintermization::trans_to_bdd_afa(const IntermediateAut &aut)
 {
     assert(aut.is_afa());
-    std::vector<BDD> bdds;
 
     for (const auto& trans : aut.transitions) {
         lhs_to_disjuncts_and_states[&trans.first] = std::vector<DisjunctStatesPair>();
@@ -118,8 +115,6 @@ std::vector<BDD> Mata::Mintermization::trans_to_bdd_afa(const IntermediateAut &a
             bdds.push_back(bdd.val);
         }
     }
-
-    return bdds;
 }
 
 std::vector<BDD> Mata::Mintermization::compute_minterms(const std::vector<BDD>& bdds)
@@ -216,7 +211,7 @@ const BDD Mata::Mintermization::graph_to_bdd_nfa(const FormulaGraph &graph)
     assert(false);
 }
 
-void Mata::Mintermization::minterms_to_aut(Mata::IntermediateAut& res, const Mata::IntermediateAut& aut,
+void Mata::Mintermization::minterms_to_aut_nfa(Mata::IntermediateAut& res, const Mata::IntermediateAut& aut,
                                            const std::vector<BDD>& minterms)
 {
     for (const auto& trans : aut.transitions) {
@@ -273,26 +268,44 @@ void Mata::Mintermization::minterms_to_aut_afa(Mata::IntermediateAut& res, const
     }
 }
 
-Mata::IntermediateAut Mata::Mintermization::mintermize(const Mata::IntermediateAut& aut)
+Mata::IntermediateAut Mata::Mintermization::mintermize(const Mata::IntermediateAut& aut) {
+    return mintermize(std::vector<const Mata::IntermediateAut *> {&aut})[0];
+}
+
+std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<const Mata::IntermediateAut *> auts)
 {
-    if ((!aut.is_nfa() && !aut.is_afa()) || aut.alphabet_type != IntermediateAut::BITVECTOR) {
-        throw std::runtime_error("We currently support mintermization only for NFA and AFA with bitvectors");
+    for (const Mata::IntermediateAut *aut : auts) {
+        if ((!aut->is_nfa() && !aut->is_afa()) || aut->alphabet_type != IntermediateAut::BITVECTOR) {
+            throw std::runtime_error("We currently support mintermization only for NFA and AFA with bitvectors");
+        }
+
+        aut->is_nfa() ? trans_to_bdd_nfa(*aut) : trans_to_bdd_afa(*aut);
     }
-
-    std::vector<BDD> bdds = aut.is_nfa() ? trans_to_bdd_nfa(aut) : trans_to_bdd_afa(aut);
-
-    assert(aut.transitions.empty() || !bdds.empty());
 
     // Build minterm tree over BDDs
     std::vector<BDD> minterms = compute_minterms(bdds);
-    IntermediateAut res = aut;
-    res.alphabet_type = IntermediateAut::EXPLICIT;
-    res.transitions.clear();
 
-    if (aut.is_nfa())
-        minterms_to_aut(res, aut, minterms);
-    else if (aut.is_afa())
-        minterms_to_aut_afa(res, aut, minterms);
+    std::vector<Mata::IntermediateAut> res;
+    for (const Mata::IntermediateAut *aut : auts) {
+        IntermediateAut mintermized_aut = *aut;
+        mintermized_aut.alphabet_type = IntermediateAut::EXPLICIT;
+        mintermized_aut.transitions.clear();
+
+        if (aut->is_nfa())
+            minterms_to_aut_nfa(mintermized_aut, *aut, minterms);
+        else if (aut->is_afa())
+            minterms_to_aut_afa(mintermized_aut, *aut, minterms);
+
+        res.push_back(mintermized_aut);
+    }
 
     return res;
+}
+
+std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<Mata::IntermediateAut> auts) {
+    std::vector<const Mata::IntermediateAut *> auts_pointers;
+    for (const Mata::IntermediateAut &aut : auts) {
+        auts_pointers.push_back(&aut);
+    }
+    return mintermize(auts_pointers);
 }

--- a/src/mintermization.cc
+++ b/src/mintermization.cc
@@ -272,7 +272,7 @@ Mata::IntermediateAut Mata::Mintermization::mintermize(const Mata::IntermediateA
     return mintermize(std::vector<const Mata::IntermediateAut *> {&aut})[0];
 }
 
-std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<const Mata::IntermediateAut *> auts)
+std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<const Mata::IntermediateAut *> &auts)
 {
     for (const Mata::IntermediateAut *aut : auts) {
         if ((!aut->is_nfa() && !aut->is_afa()) || aut->alphabet_type != IntermediateAut::BITVECTOR) {
@@ -302,7 +302,7 @@ std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::v
     return res;
 }
 
-std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<Mata::IntermediateAut> auts) {
+std::vector<Mata::IntermediateAut> Mata::Mintermization::mintermize(const std::vector<Mata::IntermediateAut> &auts) {
     std::vector<const Mata::IntermediateAut *> auts_pointers;
     for (const Mata::IntermediateAut &aut : auts) {
         auts_pointers.push_back(&aut);

--- a/src/tests-mintermization.cc
+++ b/src/tests-mintermization.cc
@@ -81,7 +81,6 @@ TEST_CASE("Mata::Mintermization::trans_to_bdd_nfa")
         const auto& aut= auts[0];
         REQUIRE(aut.transitions[0].second.children[0].node.is_operator());
         REQUIRE(aut.transitions[0].second.children[1].node.is_operand());
-        std::cout << "Starting mintermization\n";
         const BDD bdd = mintermization.graph_to_bdd_nfa(aut.transitions[0].second.children[0]);
         REQUIRE(bdd.nodeCount() == 4);
         int inputs[] = {0,0,0,0};
@@ -237,7 +236,6 @@ TEST_CASE("Mata::Mintermization::mintermization")
         REQUIRE(aut.transitions[0].second.children[1].node.is_operator());
 
         const auto res = mintermization.mintermize(aut);
-        std::cout << res << '\n';
         REQUIRE(res.transitions.size() == 26);
         REQUIRE(res.transitions[0].first.name == "1");
         REQUIRE(res.transitions[1].first.name == "1");
@@ -357,5 +355,52 @@ TEST_CASE("Mata::Mintermization::mintermization")
         REQUIRE(aut.transitions[0].second.children[1].node.is_operator());
 
         const auto res = mintermization.mintermize(aut);
+    }
+
+    SECTION("Mintermization NFA multiple")
+    {
+        Parsed parsed;
+        Mata::Mintermization mintermization{};
+
+        std::string file =
+                "@NFA-bits\n"
+                "%States-enum q r s t\n"
+                "%Alphabet-auto\n"
+                "%Initial q\n"
+                "%Final q | r\n"
+                "q (a1 | a2) r\n"
+                "s (a3 & a4) t\n"
+                "@NFA-bits\n"
+                "%States-enum q r\n"
+                "%Alphabet-auto\n"
+                "%Initial q\n"
+                "%Final q | r\n"
+                "q (a1 & a4) r\n";
+
+        parsed = parse_mf(file);
+        std::vector<Mata::IntermediateAut> auts = Mata::IntermediateAut::parse_from_mf(parsed);
+
+        const auto res = mintermization.mintermize(auts);
+        REQUIRE(res.size() == 2);
+        REQUIRE(res[0].transitions.size() == 7);
+        REQUIRE(res[0].transitions[0].first.name == "q");
+        REQUIRE(res[0].transitions[1].first.name == "q");
+        REQUIRE(res[0].transitions[2].first.name == "q");
+        REQUIRE(res[0].transitions[3].first.name == "q");
+        REQUIRE(res[0].transitions[4].first.name == "s");
+        REQUIRE(res[0].transitions[5].first.name == "s");
+        REQUIRE(res[0].transitions[6].first.name == "s");
+        REQUIRE(res[0].transitions[0].second.children[1].node.name == "r");
+        REQUIRE(res[0].transitions[1].second.children[1].node.name == "r");
+        REQUIRE(res[0].transitions[2].second.children[1].node.name == "r");
+        REQUIRE(res[0].transitions[3].second.children[1].node.name == "r");
+        REQUIRE(res[0].transitions[4].second.children[1].node.name == "t");
+        REQUIRE(res[0].transitions[5].second.children[1].node.name == "t");
+        REQUIRE(res[0].transitions[6].second.children[1].node.name == "t");
+        REQUIRE(res[1].transitions.size() == 2);
+        REQUIRE(res[1].transitions[0].first.name == "q");
+        REQUIRE(res[1].transitions[1].first.name == "q");
+        REQUIRE(res[1].transitions[0].second.children[1].node.name == "r");
+        REQUIRE(res[1].transitions[1].second.children[1].node.name == "r");
     }
 } // mintermization


### PR DESCRIPTION
This PR extends mintermization of NFA and AFA by adding option to mintermize multiple automata at the same time where resulting automata use the same minterms.