### PR TITLE
added support for converting final states in conjunction of negations

### DIFF
--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -88,6 +88,8 @@ public:
 
     bool is_and() const { return type == OPERATOR && operator_type == AND; }
 
+    bool is_neg() const { return type == OPERATOR && operator_type == NEG; }
+
     FormulaNode() : type(UNKNOWN), raw(""), name(""), operator_type(NOT_OPERATOR), operand_type(NOT_OPERAND) {}
 
     FormulaNode(Type t, std::string raw, std::string name,
@@ -228,6 +230,19 @@ public:
 
     std::unordered_set<std::string> get_enumerated_initials() const {return initial_formula.collect_node_names();}
     std::unordered_set<std::string> get_enumerated_finals() const {return final_formula.collect_node_names();}
+
+    bool are_final_states_conjunction_of_negation() const
+    {
+        return is_graph_conjunction_of_negations(final_formula);
+    }
+
+    static bool is_graph_conjunction_of_negations(const FormulaGraph& graph);
+
+    /**
+     * Methods returns a set of final state in the case that they were entered as a conjunction
+     * of negated states. It collects all negated states and subtracts them from set of all states.
+     */
+    std::unordered_set<std::string> get_positive_finals() const;
 
     size_t get_number_of_disjuncts() const;
 

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -239,7 +239,7 @@ public:
     static bool is_graph_conjunction_of_negations(const FormulaGraph& graph);
 
     /**
-     * Methods returns a set of final state in the case that they were entered as a conjunction
+     * Method returns a set of final states in the case that they were entered as a conjunction
      * of negated states. It collects all negated states and subtracts them from set of all states.
      */
     std::unordered_set<std::string> get_positive_finals() const;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1296,7 +1296,9 @@ Nfa Mata::Nfa::construct(
         aut.initial.add(state);
     }
 
-    for (const auto& str : inter_aut.final_formula.collect_node_names())
+    const auto final_states = inter_aut.are_final_states_conjunction_of_negation() ?
+            inter_aut.get_positive_finals() : inter_aut.final_formula.collect_node_names();
+    for (const auto& str : final_states)
     {
         State state = get_state_name(str);
         aut.final.add(state);

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -930,7 +930,7 @@ TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
         REQUIRE(aut.final.size() == 4);
         REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2"})));
         REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3"})));
-        REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3"})));
+        REQUIRE(!is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3", "a4"})));
         REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3", "a5", "a7"})));
     }
 } // }}}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -907,6 +907,32 @@ TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
         REQUIRE(!is_in_lang(aut, encode_word(symbol_map, {"a", "c", "c", "a"})));
         REQUIRE(!is_in_lang(aut, encode_word(symbol_map, {"b", "a", "c", "b"})));
     }
+
+    SECTION("construct - final states from negation")
+    {
+        std::string file =
+                "@NFA-bits\n"
+                "%Alphabet-auto\n"
+                "%Initial q0 q8\n"
+                "%Final !q0 & !q1 & !q4 & !q5 & !q6\n"
+                "q0 a1 q1\n"
+                "q1 a2 q2\n"
+                "q2 a3 q3\n"
+                "q2 a4 q4\n"
+                "q3 a5 q5\n"
+                "q3 a6 q6\n"
+                "q5 a7 q7\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+        construct(&aut, inter_aut, &symbol_map);
+        REQUIRE(aut.final.size() == 4);
+        REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2"})));
+        REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3"})));
+        REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3"})));
+        REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3", "a5", "a7"})));
+    }
 } // }}}
 
 /*

--- a/src/tests-parser.cc
+++ b/src/tests-parser.cc
@@ -758,6 +758,33 @@ TEST_CASE("parsing automata to intermediate representation")
         REQUIRE(!finals.count("r"));
     }
 
+    SECTION("NFA - final states from negation")
+    {
+        std::string file =
+                "@NFA-bits\n"
+                "%Alphabet-auto\n"
+                "%Initial q1 q8\n"
+                "%Final !q0 & !q1 & !q4 & !q5\n"
+                "q0 (!a1 & !a2 & !a3 & (!a0 | a0)) q1\n"
+                "q1 (!a2 & !a3 & !a4 & (!a0 | a0)) q2\n"
+                "q2 (!a3 & !a4 & !a5 & (!a0 | a0)) q3\n"
+                "q2 (!a3 & !a4 & !a5 & (!a0 | a0)) q4\n"
+                "q3 (!a2 & !a3 & !a4 & (!a0 | a0)) q5\n"
+                "q3 (!a2 & !a3 & !a4 & (!a0 | a0)) q6\n"
+                "q5 (!a1 & !a2 & !a3 & (!a0 | a0)) q7\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        const Mata::IntermediateAut inter_aut = auts[0];
+
+        auto final_states = inter_aut.get_positive_finals();
+        REQUIRE(final_states.size() == 5);
+        REQUIRE(final_states.count("2"));
+        REQUIRE(final_states.count("3"));
+        REQUIRE(final_states.count("6"));
+        REQUIRE(final_states.count("7"));
+        REQUIRE(final_states.count("8"));
+    }
+
     SECTION("AFA explicit")
     {
         std::string file =


### PR DESCRIPTION
This PR implements conversion of final states defined as conjunction of negations to set of final states. This is a case of explicit NFA created by mintermization from bitvector NFA where final states where defined by such formula.