### PR TITLE
Fix Python binding for Segmentation

### DIFF
--- a/.github/workflows/python-binding.yml
+++ b/.github/workflows/python-binding.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout latest version
         uses: actions/checkout@v2
-        with:
-          ref: devel
 
       - name: Add some version to VERSION file (since it cannot be inferred from git)
         run: |

--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -332,7 +332,7 @@ cdef extern from "mata/nfa-strings.hh" namespace "Mata::Strings":
 
 cdef extern from "mata/nfa-strings.hh" namespace "Mata::Strings::SegNfa":
     cdef cppclass CSegmentation "Mata::Strings::SegNfa::Segmentation":
-        CSegmentation(CNfa&, Symbol) except +
+        CSegmentation(CNfa&, cset[Symbol]) except +
 
         ctypedef unsigned EpsilonDepth
         ctypedef umap[EpsilonDepth, TransitionSequence] EpsilonDepthTransitions

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -1669,13 +1669,13 @@ cdef class Segmentation:
     """Wrapper over Segmentation."""
     cdef mata.CSegmentation* thisptr
 
-    def __cinit__(self, Nfa aut, Symbol symbol = CEPSILON):
+    def __cinit__(self, Nfa aut, cset[Symbol] symbols):
         """Compute segmentation.
 
         :param aut: Segment automaton to compute epsilon depths for.
         :param symbol: Symbol to execute segmentation for.
         """
-        self.thisptr = new mata.CSegmentation(dereference(aut.thisptr), symbol)
+        self.thisptr = new mata.CSegmentation(dereference(aut.thisptr), symbols)
 
     def __dealloc__(self):
         del self.thisptr

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -892,7 +892,7 @@ def test_segmentation(prepare_automaton_a):
     nfa = prepare_automaton_a()
     epsilon = ord('c')
 
-    segmentation = mata.Segmentation(nfa, epsilon)
+    segmentation = mata.Segmentation(nfa, [epsilon])
     epsilon_depths = segmentation.get_epsilon_depths()
     assert len(epsilon_depths) == 1
     assert 0 in epsilon_depths
@@ -912,7 +912,7 @@ def test_segmentation(prepare_automaton_a):
     nfa.add_transition(6, epsilon, 7)
     nfa.add_transition(7, epsilon, 8)
 
-    segmentation = mata.Segmentation(nfa, epsilon)
+    segmentation = mata.Segmentation(nfa, [epsilon])
     epsilon_depths = segmentation.get_epsilon_depths()
     assert len(epsilon_depths) == 3
     assert 0 in epsilon_depths


### PR DESCRIPTION
This PR fixes the Python binding for Segmentation to reflect the changes made to the constructor of the Segmentation class in #129.

Furthermore, this PR fixes a bug in GitHub Actions config for Python binding: The action will not correctly checkout the current commit, not the devel branch.