### PR TITLE
Get number of states

### DIFF
--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -269,7 +269,6 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         COrdVector[CMove].const_iterator get_epsilon_transitions(CPost& state_transitions, Symbol epsilon)
         void clear()
         void defragment()
-        size_t max_state()
         size_t states_number()
 
     # Automata tests

--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -270,6 +270,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void clear()
         void defragment()
         size_t max_state()
+        size_t states_number()
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -269,7 +269,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         COrdVector[CMove].const_iterator get_epsilon_transitions(CPost& state_transitions, Symbol epsilon)
         void clear()
         void defragment()
-        size_t states_number()
+        size_t size()
 
     # Automata tests
     cdef bool is_deterministic(CNfa&)

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -1704,7 +1704,7 @@ cdef class Segmentation:
         segments = []
         cdef AutSequence c_segments = self.thisptr.get_segments()
         for c_segment in c_segments:
-            segment = Nfa(c_segment.delta.post_size())
+            segment = Nfa(c_segment.states_number())
             segment.thisptr.get().initial = c_segment.initial
             segment.thisptr.get().final = c_segment.final
             segment.thisptr.get().delta = c_segment.delta

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -321,13 +321,6 @@ cdef class Nfa:
         """Unify final states into a single new final state."""
         self.thisptr.get().unify_final()
 
-    def get_num_of_states(self):
-        """Returns number of states in automaton
-
-        :return: number of states in automaton
-        """
-        return self.thisptr.get().delta.post_size()
-
     def add_transition_object(self, Trans tr):
         """Adds transition to automaton
 
@@ -399,11 +392,17 @@ cdef class Nfa:
         """Defragments the internal structures (needed, e.g., after resize."""
         self.thisptr.get().defragment()
 
-    def max_state(self):
+    def max_state(self) -> int:
         """
         :return: maximal seen state in the automaton
         """
         return self.thisptr.get().max_state()
+
+    def states_number(self) -> int:
+        """Get the current number of states in the whole automaton.
+        :return: The number of states.
+        """
+        return self.thisptr.get().states_number()
 
     def resize_for_state(self, State state):
         """Increases the size of the automaton to include state.
@@ -923,7 +922,7 @@ cdef class Nfa:
         :param OnTheFlyAlphabet alphabet: alphabet of the
         """
         if not lhs.thisptr.get().is_state(sink_state):
-            lhs.thisptr.get().increase_size(lhs.get_num_of_states() + 1)
+            lhs.thisptr.get().increase_size(lhs.states_number() + 1)
         mata.make_complete(lhs.thisptr.get(), <CAlphabet&>dereference(alphabet.as_base()), sink_state)
 
     @classmethod
@@ -1812,7 +1811,7 @@ def plot_using_graphviz(
                     )
     else:
         # Only print reachable states
-        for state in range(0, aut.get_num_of_states()):
+        for state in range(0, aut.states_number()):
             # Helper node to simulate initial automaton
             _plot_state(
                 aut, dot, state,

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -392,12 +392,6 @@ cdef class Nfa:
         """Defragments the internal structures (needed, e.g., after resize."""
         self.thisptr.get().defragment()
 
-    def max_state(self) -> int:
-        """
-        :return: maximal seen state in the automaton
-        """
-        return self.thisptr.get().max_state()
-
     def states_number(self) -> int:
         """Get the current number of states in the whole automaton.
         :return: The number of states.

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -392,11 +392,11 @@ cdef class Nfa:
         """Defragments the internal structures (needed, e.g., after resize."""
         self.thisptr.get().defragment()
 
-    def states_number(self) -> int:
+    def size(self) -> int:
         """Get the current number of states in the whole automaton.
         :return: The number of states.
         """
-        return self.thisptr.get().states_number()
+        return self.thisptr.get().size()
 
     def resize_for_state(self, State state):
         """Increases the size of the automaton to include state.
@@ -916,7 +916,7 @@ cdef class Nfa:
         :param OnTheFlyAlphabet alphabet: alphabet of the
         """
         if not lhs.thisptr.get().is_state(sink_state):
-            lhs.thisptr.get().increase_size(lhs.states_number() + 1)
+            lhs.thisptr.get().increase_size(lhs.size() + 1)
         mata.make_complete(lhs.thisptr.get(), <CAlphabet&>dereference(alphabet.as_base()), sink_state)
 
     @classmethod
@@ -1698,7 +1698,7 @@ cdef class Segmentation:
         segments = []
         cdef AutSequence c_segments = self.thisptr.get_segments()
         for c_segment in c_segments:
-            segment = Nfa(c_segment.states_number())
+            segment = Nfa(c_segment.size())
             segment.thisptr.get().initial = c_segment.initial
             segment.thisptr.get().final = c_segment.final
             segment.thisptr.get().delta = c_segment.delta
@@ -1805,7 +1805,7 @@ def plot_using_graphviz(
                     )
     else:
         # Only print reachable states
-        for state in range(0, aut.states_number()):
+        for state in range(0, aut.size()):
             # Helper node to simulate initial automaton
             _plot_state(
                 aut, dot, state,

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -12,6 +12,7 @@ def test_adding_states():
     lhs = mata.Nfa(5)
 
     # Test adding states
+    assert lhs.states_number() == 5
     assert not lhs.has_initial_state(0)
     assert not lhs.has_final_state(0)
     lhs.make_initial_state(0)
@@ -33,27 +34,28 @@ def test_adding_states():
     assert lhs.has_final_state(0)
 
     rhs = mata.Nfa()
-    assert rhs.get_num_of_states() == 0
+    assert rhs.states_number() == 0
     state = rhs.add_new_state()
     assert state == 0
-    assert rhs.get_num_of_states() == 1
+    assert rhs.states_number() == 1
     state = rhs.add_new_state()
     assert state == 1
-    assert rhs.get_num_of_states() == 2
+    assert rhs.states_number() == 2
 
     rhs.resize(10)
-    assert rhs.get_num_of_states() == 10
+    assert rhs.states_number() == 10
     for i in range(0, 10):
         assert rhs.is_state(i)
 
     assert rhs.max_state() == 9
+    assert rhs.states_number() == 10
     rhs.defragment()
     rhs.clear()
-    assert rhs.max_state() == 0
+    assert rhs.states_number() == 0
 
     rhs.resize(1)
     assert rhs.max_state() == 0
-    assert rhs.get_num_of_states() == 1
+    assert rhs.states_number() == 1
     assert rhs.is_state(0)
     assert not rhs.is_state(1)
 
@@ -61,7 +63,7 @@ def test_adding_states():
         rhs.resize(-10)
 
     rhs.resize_for_state(11)
-    assert rhs.get_num_of_states() == 12
+    assert rhs.states_number() == 12
     assert rhs.is_state(11)
     assert not rhs.is_state(12)
 
@@ -366,9 +368,7 @@ def test_concatenate():
 
     result = mata.Nfa.concatenate(lhs, rhs)
 
-    assert len(result.initial_states) > 0
-    assert len(result.final_states) > 0
-
+    assert not mata.Nfa.is_lang_empty(result)
     shortest_words = mata.Nfa.get_shortest_words(result)
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
@@ -376,7 +376,7 @@ def test_concatenate():
     result = mata.Nfa.concatenate(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
-    assert result.get_num_of_states() == 4
+    assert result.states_number() == 4
     assert result.has_transition(0, ord('b'), 1)
     assert result.has_transition(1, mata.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
@@ -384,7 +384,7 @@ def test_concatenate():
     result, lhs_map, rhs_map = mata.Nfa.concatenate_with_result_state_maps(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
-    assert result.get_num_of_states() == 4
+    assert result.states_number() == 4
     assert result.has_transition(0, ord('b'), 1)
     assert result.has_transition(1, mata.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
@@ -507,7 +507,7 @@ def test_intersection_preserving_epsilon_transitions():
     result, product_map = mata.Nfa.intersection_with_product_map(a, b, True)
 
     # Check states.
-    assert result.get_num_of_states() == 13
+    assert result.states_number() == 13
     assert result.is_state(product_map[(0, 0)])
     assert result.is_state(product_map[(1, 0)])
     assert result.is_state(product_map[(1, 1)])
@@ -696,7 +696,7 @@ def test_trim(prepare_automaton_a):
     nfa.remove_final_state(2)  # '2' is the new final state in the earlier trimmed automaton.
     nfa.trim()
     assert nfa.get_num_of_trans() == 0
-    assert nfa.get_num_of_states() == 0
+    assert nfa.states_number() == 0
 
 
 def test_get_digraph(prepare_automaton_a):
@@ -707,7 +707,7 @@ def test_get_digraph(prepare_automaton_a):
 
     digraph = nfa.get_digraph()
 
-    assert digraph.get_num_of_states() == nfa.get_num_of_states()
+    assert digraph.states_number() == nfa.states_number()
     assert digraph.get_num_of_trans() == 12
     assert digraph.has_transition(1, abstract_symbol, 10)
     assert digraph.has_transition(10, abstract_symbol, 7)
@@ -937,7 +937,7 @@ def test_reduce():
     nfa.make_final_state(2)
     result, state_map = mata.Nfa.reduce_with_state_map(nfa)
     assert result.get_num_of_trans() == 0
-    assert result.get_num_of_states() == 2
+    assert result.states_number() == 2
     assert result.has_initial_state(state_map[1])
     assert result.has_final_state(state_map[2])
     assert state_map[1] == state_map[0]
@@ -964,7 +964,7 @@ def test_reduce():
     nfa.add_transition(0, ord('a'), 4)
 
     result, state_map = mata.Nfa.reduce_with_state_map(nfa)
-    assert result.get_num_of_states() == 6
+    assert result.states_number() == 6
     assert result.has_initial_state(state_map[1])
     assert result.has_initial_state(state_map[2])
     assert result.has_final_state(state_map[9])

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -47,14 +47,12 @@ def test_adding_states():
     for i in range(0, 10):
         assert rhs.is_state(i)
 
-    assert rhs.max_state() == 9
     assert rhs.states_number() == 10
     rhs.defragment()
     rhs.clear()
     assert rhs.states_number() == 0
 
     rhs.resize(1)
-    assert rhs.max_state() == 0
     assert rhs.states_number() == 1
     assert rhs.is_state(0)
     assert not rhs.is_state(1)

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -12,7 +12,7 @@ def test_adding_states():
     lhs = mata.Nfa(5)
 
     # Test adding states
-    assert lhs.states_number() == 5
+    assert lhs.size() == 5
     assert not lhs.has_initial_state(0)
     assert not lhs.has_final_state(0)
     lhs.make_initial_state(0)
@@ -34,26 +34,26 @@ def test_adding_states():
     assert lhs.has_final_state(0)
 
     rhs = mata.Nfa()
-    assert rhs.states_number() == 0
+    assert rhs.size() == 0
     state = rhs.add_new_state()
     assert state == 0
-    assert rhs.states_number() == 1
+    assert rhs.size() == 1
     state = rhs.add_new_state()
     assert state == 1
-    assert rhs.states_number() == 2
+    assert rhs.size() == 2
 
     rhs.resize(10)
-    assert rhs.states_number() == 10
+    assert rhs.size() == 10
     for i in range(0, 10):
         assert rhs.is_state(i)
 
-    assert rhs.states_number() == 10
+    assert rhs.size() == 10
     rhs.defragment()
     rhs.clear()
-    assert rhs.states_number() == 0
+    assert rhs.size() == 0
 
     rhs.resize(1)
-    assert rhs.states_number() == 1
+    assert rhs.size() == 1
     assert rhs.is_state(0)
     assert not rhs.is_state(1)
 
@@ -61,7 +61,7 @@ def test_adding_states():
         rhs.resize(-10)
 
     rhs.resize_for_state(11)
-    assert rhs.states_number() == 12
+    assert rhs.size() == 12
     assert rhs.is_state(11)
     assert not rhs.is_state(12)
 
@@ -374,7 +374,7 @@ def test_concatenate():
     result = mata.Nfa.concatenate(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
-    assert result.states_number() == 4
+    assert result.size() == 4
     assert result.has_transition(0, ord('b'), 1)
     assert result.has_transition(1, mata.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
@@ -382,7 +382,7 @@ def test_concatenate():
     result, lhs_map, rhs_map = mata.Nfa.concatenate_with_result_state_maps(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
-    assert result.states_number() == 4
+    assert result.size() == 4
     assert result.has_transition(0, ord('b'), 1)
     assert result.has_transition(1, mata.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
@@ -505,7 +505,7 @@ def test_intersection_preserving_epsilon_transitions():
     result, product_map = mata.Nfa.intersection_with_product_map(a, b, True)
 
     # Check states.
-    assert result.states_number() == 13
+    assert result.size() == 13
     assert result.is_state(product_map[(0, 0)])
     assert result.is_state(product_map[(1, 0)])
     assert result.is_state(product_map[(1, 1)])
@@ -694,7 +694,7 @@ def test_trim(prepare_automaton_a):
     nfa.remove_final_state(2)  # '2' is the new final state in the earlier trimmed automaton.
     nfa.trim()
     assert nfa.get_num_of_trans() == 0
-    assert nfa.states_number() == 0
+    assert nfa.size() == 0
 
 
 def test_get_digraph(prepare_automaton_a):
@@ -704,7 +704,7 @@ def test_get_digraph(prepare_automaton_a):
 
     digraph = nfa.get_digraph()
 
-    assert digraph.states_number() == nfa.states_number()
+    assert digraph.size() == nfa.size()
     assert digraph.get_num_of_trans() == 12
     assert digraph.has_transition(1, abstract_symbol, 10)
     assert digraph.has_transition(10, abstract_symbol, 7)
@@ -934,7 +934,7 @@ def test_reduce():
     nfa.make_final_state(2)
     result, state_map = mata.Nfa.reduce_with_state_map(nfa)
     assert result.get_num_of_trans() == 0
-    assert result.states_number() == 2
+    assert result.size() == 2
     assert result.has_initial_state(state_map[1])
     assert result.has_final_state(state_map[2])
     assert state_map[1] == state_map[0]
@@ -961,7 +961,7 @@ def test_reduce():
     nfa.add_transition(0, ord('a'), 4)
 
     result, state_map = mata.Nfa.reduce_with_state_map(nfa)
-    assert result.states_number() == 6
+    assert result.size() == 6
     assert result.has_initial_state(state_map[1])
     assert result.has_initial_state(state_map[2])
     assert result.has_final_state(state_map[9])

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -576,7 +576,7 @@ def test_intersection_preserving_epsilon_transitions():
 
 
 def test_complement(
-        fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
+        fa_one_divisible_by_two
 ):
     alph = mata.OnTheFlyAlphabet()
     alph.translate_symbol("a")
@@ -586,7 +586,7 @@ def test_complement(
     assert not mata.Nfa.is_in_lang(res, [1, 1])
     assert mata.Nfa.is_in_lang(res, [1, 1, 1])
     assert not mata.Nfa.is_in_lang(res, [1, 1, 1, 1])
-    assert subset_map == {(): 4, (0,): 0, (1,): 1, (2,): 2}
+    assert subset_map == {(): 3, (0,): 0, (1,): 1, (2,): 2}
 
 
 def test_revert():
@@ -703,7 +703,6 @@ def test_get_digraph(prepare_automaton_a):
     """Test creating digraph from an automaton."""
     abstract_symbol = ord('x')
     nfa = prepare_automaton_a()
-    old_nfa = prepare_automaton_a()
 
     digraph = nfa.get_digraph()
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -355,16 +355,16 @@ struct Post : private Util::OrdVector<Move> {
 struct Delta {
 private:
     mutable std::vector<Post> post;
-    mutable size_t m_states_number;
+    mutable size_t m_num_of_states;
 
 public:
-    Delta() : post(), m_states_number(0) {}
-    explicit Delta(size_t n) : post(), m_states_number(n) {}
+    Delta() : post(), m_num_of_states(0) {}
+    explicit Delta(size_t n) : post(), m_num_of_states(n) {}
 
     void reserve(size_t n) {
         post.reserve(n);
-        if (n > m_states_number) {
-            m_states_number = n;
+        if (n > m_num_of_states) {
+            m_num_of_states = n;
         }
     };
 
@@ -379,8 +379,8 @@ public:
         if (q >= post.size()) {
             const size_t new_size{ q + 1 };
             post.resize(new_size);
-            if (new_size > m_states_number) {
-                m_states_number = new_size;
+            if (new_size > m_num_of_states) {
+                m_num_of_states = new_size;
             }
         }
 
@@ -392,8 +392,8 @@ public:
         if (q >= post.size()) {
             const size_t new_size{ q + 1 };
             post.resize(new_size);
-            if (new_size > m_states_number) {
-                m_states_number = new_size;
+            if (new_size > m_num_of_states) {
+                m_num_of_states = new_size;
             }
         }
 
@@ -402,21 +402,21 @@ public:
 
     void emplace_back() {
         post.emplace_back();
-        if (post.size() > m_states_number) { ++m_states_number; }
+        if (post.size() > m_num_of_states) { ++m_num_of_states; }
     }
 
     void clear()
     {
         post.clear();
-        m_states_number = 0;
+        m_num_of_states = 0;
     }
 
     void increase_size(size_t n)
     {
         assert(n >= post.size());
         post.resize(n);
-        if (post.size() > m_states_number)
-            m_states_number = post.size();
+        if (post.size() > m_num_of_states)
+            m_num_of_states = post.size();
     }
 
     size_t post_size() const { return post.size(); }
@@ -434,7 +434,7 @@ public:
      */
     bool empty() const;
 
-    size_t num_of_states() const { return m_states_number; }
+    size_t num_of_states() const { return m_num_of_states; }
 
     /**
      * Function removes empty indices in transition vector and renames states accordingly
@@ -552,10 +552,10 @@ struct Nfa
     //  dictionary in the attributes.
     std::unordered_map<std::string, void*> attributes{};
 
-    size_t m_states_number;
+    size_t m_num_of_states;
 
 public:
-    Nfa() : delta(), initial(), final(), m_states_number(0) {}
+    Nfa() : delta(), initial(), final(), m_num_of_states(0) {}
 
     /**
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
@@ -563,7 +563,7 @@ public:
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
                  const StateSet& final_states = StateSet{}, Alphabet* alphabet_p = new IntAlphabet())
         : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet_p),
-          m_states_number(0) {}
+          m_num_of_states(0) {}
 
     /**
      * @brief Construct a new explicit NFA from other NFA.
@@ -611,7 +611,7 @@ public:
      * @return The number of states.
      */
      size_t size() const {
-        return std::max({m_states_number, delta.num_of_states(), initial.domain_size(), final.domain_size() });
+        return std::max({m_num_of_states, delta.num_of_states(), initial.domain_size(), final.domain_size() });
     }
 
     /**
@@ -635,7 +635,7 @@ public:
         delta.clear();
         initial.clear();
         final.clear();
-        m_states_number = 0;
+        m_num_of_states = 0;
     }
 
     /**
@@ -834,14 +834,14 @@ public:
      * Method defragments transition relation. It eventually clears empty space in vector
      * containing transitions and decreases size.
      * TODO: once merged with new initial and final state predicate, do renaming of these sets of states.
-     * TODO: Modify Nfa::m_states_number as well. Or not?
+     * TODO: Modify Nfa::m_num_of_states as well. Or not?
      */
     void defragment() {
         delta.defragment();
         // FIXME.
         initial.truncate_domain();
         final.truncate_domain();
-        m_states_number = 0;
+        m_num_of_states = 0;
     }
 }; // Nfa
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -561,9 +561,8 @@ public:
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
      */
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
-                 const StateSet& final_states = StateSet{}, Alphabet* alphabet_p = new IntAlphabet())
-        : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet_p),
-          m_num_of_states(0) {}
+                 const StateSet& final_states = StateSet{}, Alphabet* alphabet = new IntAlphabet())
+        : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet), m_num_of_states(0) {}
 
     /**
      * @brief Construct a new explicit NFA from other NFA.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -589,9 +589,26 @@ public:
      */
     State add_state();
 
+    /**
+     * Get the maximal state number currently present in the whole automaton.
+     *
+     * This includes the initial and final states as well as states in the transition relation.
+     * @return The maximal state number.
+     */
     size_t max_state() const
     {
         return std::max({max_state_, delta.max_state(), initial.domain_size(), final.domain_size()});
+    }
+
+    /**
+     * @brief Get the current number of states in the whole automaton.
+     *
+     * This includes the initial and final states as well as states in the transition relation.
+     * @return The number of states.
+     */
+     size_t states_number() const
+    {
+        return max_state() + 1;
     }
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -434,7 +434,12 @@ public:
      */
     bool empty() const;
 
-    size_t max_state() const { return m_states_number - 1; }
+    size_t max_state() const {
+        if (m_states_number == 0) {
+            throw std::runtime_error("The transition relation is empty.");
+        }
+        return m_states_number - 1;
+    }
 
     size_t states_number() const { return m_states_number; }
 
@@ -610,8 +615,11 @@ public:
      * @return The maximal state number.
      */
     size_t max_state() const {
-        // TODO: Should NFA throw exception when states_number() is 0?
-        return states_number() - 1;
+        const size_t states_number{ this->states_number() };
+        if (states_number == 0) {
+            throw std::runtime_error("The automaton is empty and has no states.");
+        }
+        return states_number - 1;
     }
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -434,7 +434,7 @@ public:
      */
     bool empty() const;
 
-    size_t states_number() const { return m_states_number; }
+    size_t num_of_states() const { return m_states_number; }
 
     /**
      * Function removes empty indices in transition vector and renames states accordingly
@@ -610,8 +610,8 @@ public:
      * This includes the initial and final states as well as states in the transition relation.
      * @return The number of states.
      */
-     size_t states_number() const {
-        return std::max({ m_states_number, delta.states_number(), initial.domain_size(), final.domain_size() });
+     size_t size() const {
+        return std::max({m_states_number, delta.num_of_states(), initial.domain_size(), final.domain_size() });
     }
 
     /**
@@ -624,7 +624,7 @@ public:
      */
     void unify_final();
 
-    bool is_state(const State &state_to_check) const { return state_to_check < states_number(); }
+    bool is_state(const State &state_to_check) const { return state_to_check < size(); }
 
     /**
      * @brief Clear the underlying NFA to a blank NFA.
@@ -729,7 +729,7 @@ public:
      */
     const Post& get_moves_from(const State state_from) const
     {
-        assert(state_from < states_number());
+        assert(state_from < size());
         return delta[state_from];
     }
 
@@ -807,7 +807,7 @@ public:
 
     const Post& operator[](State state) const
     { // {{{
-        assert(state < states_number());
+        assert(state < size());
         return delta[state];
     } // operator[] }}}
 
@@ -1311,7 +1311,7 @@ private:
      * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
      */
     static void fill_alphabet(const Nfa& nfa, OnTheFlyAlphabet& alphabet) {
-        size_t nfa_num_of_states{nfa.states_number() };
+        size_t nfa_num_of_states{nfa.size() };
         for (State state{ 0 }; state < nfa_num_of_states; ++state) {
             for (const auto state_transitions: nfa.delta) {
                 alphabet.update_next_symbol_value(state_transitions.symb);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -434,13 +434,6 @@ public:
      */
     bool empty() const;
 
-    size_t max_state() const {
-        if (m_states_number == 0) {
-            throw std::runtime_error("The transition relation is empty.");
-        }
-        return m_states_number - 1;
-    }
-
     size_t states_number() const { return m_states_number; }
 
     /**
@@ -612,20 +605,6 @@ public:
     State add_state();
 
     /**
-     * Get the maximal state number currently present in the whole automaton.
-     *
-     * This includes the initial and final states as well as states in the transition relation.
-     * @return The maximal state number.
-     */
-    size_t max_state() const {
-        const size_t states_number{ this->states_number() };
-        if (states_number == 0) {
-            throw std::runtime_error("The automaton is empty and has no states.");
-        }
-        return states_number - 1;
-    }
-
-    /**
      * @brief Get the current number of states in the whole automaton.
      *
      * This includes the initial and final states as well as states in the transition relation.
@@ -645,7 +624,7 @@ public:
      */
     void unify_final();
 
-    bool is_state(const State &state_to_check) const { return state_to_check <= max_state(); }
+    bool is_state(const State &state_to_check) const { return state_to_check < states_number(); }
 
     /**
      * @brief Clear the underlying NFA to a blank NFA.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -528,6 +528,9 @@ public:
     {
         return cend();
     }
+
+private:
+    State find_max_state();
 };
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
@@ -747,7 +750,7 @@ public:
      */
     const Post& get_moves_from(const State state_from) const
     {
-        assert(state_from < delta.states_number());
+        assert(state_from < states_number());
         return delta[state_from];
     }
 
@@ -1329,7 +1332,7 @@ private:
      * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
      */
     static void fill_alphabet(const Nfa& nfa, OnTheFlyAlphabet& alphabet) {
-        size_t nfa_num_of_states{nfa.delta.post_size() };
+        size_t nfa_num_of_states{nfa.states_number() };
         for (State state{ 0 }; state < nfa_num_of_states; ++state) {
             for (const auto state_transitions: nfa.delta) {
                 alphabet.update_next_symbol_value(state_transitions.symb);

--- a/include/mata/number-predicate.hh
+++ b/include/mata/number-predicate.hh
@@ -159,7 +159,7 @@ namespace Mata {
             }
 
             /**
-             * Note that it returns false if q is out of range of the predicate.
+             * @return True if predicate for @p q is set. False otherwise (even if q is out of range of the predicate).
              */
             bool operator[](Number q) const {
                 if (q < predicate.size())

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -37,9 +37,9 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 	}
 
 	result = determinize(aut, subset_map);
-	State sink_state = result.delta.post_size() + 1;
-	result.increase_size(sink_state+1);
-	assert(sink_state < result.delta.post_size());
+	State sink_state = result.states_number();
+	result.increase_size(sink_state + 1);
+	assert(sink_state < result.states_number());
 	auto it_inserted_pair = subset_map->insert({{}, sink_state});
 	if (!it_inserted_pair.second)
 	{
@@ -48,7 +48,7 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 
 	make_complete(result, alphabet, sink_state);
     NumberPredicate<State> old_fs = std::move(result.final);
-	result.final = { };
+	result.final = NumberPredicate<State>{};
 	assert(result.initial.size() == 1);
 
     //TODO: rewrite this, work with final states properly, after martin introduces classes for trel
@@ -98,7 +98,7 @@ void Mata::Nfa::complement_in_place(Nfa& aut) {
         }
     }
 
-    aut.final = newFinalStates;
+    aut.final = NumberPredicate<State>{ newFinalStates };
 }
 
 Nfa Mata::Nfa::complement(

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -37,9 +37,7 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 	}
 
 	result = determinize(aut, subset_map);
-	State sink_state = result.states_number();
-	result.increase_size(sink_state + 1);
-	assert(sink_state < result.states_number());
+	State sink_state = result.add_state();
 	auto it_inserted_pair = subset_map->insert({{}, sink_state});
 	if (!it_inserted_pair.second)
 	{
@@ -51,10 +49,8 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 	result.final = NumberPredicate<State>{};
 	assert(result.initial.size() == 1);
 
-    //TODO: rewrite this, work with final states properly, after martin introduces classes for trel
 	auto make_final_if_not_in_old = [&](const State& state) {
-		if (!old_fs[state])
-		{
+		if (!old_fs[state]) {
 			result.final.add(state);
 		}
 	};
@@ -75,31 +71,6 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 
 
 /// Complement
-Nfa Mata::Nfa::Algorithms::complement_naive(
-        const Nfa&         aut,
-        const Alphabet&    alphabet,
-        const StringMap&  params,
-        std::unordered_map<StateSet, State>* subset_map)
-{
-    Nfa result = determinize(aut);
-    complement_in_place(result);
-
-    return result;
-}
-
-//TODO: rewrite this, work with final states properly, after martin introduces classes for trans. rel.
-void Mata::Nfa::complement_in_place(Nfa& aut) {
-    StateSet newFinalStates;
-
-    const size_t size = aut.delta.post_size();
-    for (State q = 0; q < size; ++q) {
-        if (!aut.final[q]) {
-            newFinalStates.insert(q);
-        }
-    }
-
-    aut.final = NumberPredicate<State>{ newFinalStates };
-}
 
 Nfa Mata::Nfa::complement(
         const Nfa&         aut,

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -37,8 +37,8 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
         return Nfa{};
     }
 
-    const unsigned long lhs_states_num{lhs.delta.post_size() };
-    const unsigned long rhs_states_num{rhs.delta.post_size() };
+    const unsigned long lhs_states_num{lhs.states_number() };
+    const unsigned long rhs_states_num{rhs.states_number() };
     Nfa result{}; // Concatenated automaton.
     StateToStateMap lhs_result_states_map_internal{}; // Map mapping rhs states to result states.
     StateToStateMap rhs_result_states_map_internal{}; // Map mapping rhs states to result states.

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -32,13 +32,13 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Compute concatenation of given automata.
     // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
 
-    if (lhs.states_number() == 0 || rhs.states_number() == 0 || lhs.initial.empty() || lhs.final.empty() ||
+    if (lhs.size() == 0 || rhs.size() == 0 || lhs.initial.empty() || lhs.final.empty() ||
         rhs.initial.empty() || rhs.final.empty()) {
         return Nfa{};
     }
 
-    const unsigned long lhs_states_num{lhs.states_number() };
-    const unsigned long rhs_states_num{rhs.states_number() };
+    const unsigned long lhs_states_num{lhs.size() };
+    const unsigned long rhs_states_num{rhs.size() };
     Nfa result{}; // Concatenated automaton.
     StateToStateMap lhs_result_states_map_internal{}; // Map mapping rhs states to result states.
     StateToStateMap rhs_result_states_map_internal{}; // Map mapping rhs states to result states.

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -32,7 +32,7 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Compute concatenation of given automata.
     // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
 
-    if (lhs.delta.post_size() == 0 || rhs.delta.post_size() == 0 || lhs.initial.empty() || lhs.final.empty() ||
+    if (lhs.states_number() == 0 || rhs.states_number() == 0 || lhs.initial.empty() || lhs.final.empty() ||
         rhs.initial.empty() || rhs.final.empty()) {
         return Nfa{};
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1087,7 +1087,7 @@ void Nfa::get_one_letter_aut(Nfa& result) const {
 
 TransSequence Nfa::get_transitions_to(State state_to) const {
     TransSequence transitions_to_state{};
-    const size_t num_of_states{delta.post_size() };
+    const size_t num_of_states{ delta.post_size() };
     for (State state_from{ 0 }; state_from < num_of_states; ++state_from) {
         for (const auto& symbol_transitions: delta[state_from]) {
             const auto& symbol_states_to{ symbol_transitions.targets };

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -38,7 +38,7 @@ namespace {
     Simlib::Util::BinaryRelation compute_fw_direct_simulation(const Nfa& aut) {
         Simlib::ExplicitLTS LTSforSimulation;
         Symbol maxSymbol = 0;
-        const size_t state_num = aut.states_number();
+        const size_t state_num = aut.size();
 
         for (State stateFrom = 0; stateFrom < state_num; ++stateFrom) {
             for (const Move &t : aut.get_moves_from(stateFrom)) {
@@ -72,7 +72,7 @@ namespace {
         std::vector<size_t> quot_proj;
         sim_relation_symmetric.get_quotient_projection(quot_proj);
 
-		const size_t num_of_states = aut.states_number();
+		const size_t num_of_states = aut.size();
 
 		// map each state q of aut to the state of the reduced automaton representing the simulation class of q
 		for (State q = 0; q < num_of_states; ++q) {
@@ -141,7 +141,7 @@ namespace {
     StateBoolArray compute_reachability(const Nfa& nfa) {
         std::vector<State> worklist{ nfa.initial.get_elements()};
 
-        StateBoolArray reachable(nfa.states_number(), false);
+        StateBoolArray reachable(nfa.size(), false);
         for (const State state: nfa.initial)
         {
             reachable.at(state) = true;
@@ -178,7 +178,7 @@ namespace {
      */
     StateBoolArray compute_reachability(const Nfa& nfa, const StateBoolArray& states_to_consider) {
         std::vector<State> worklist{};
-        StateBoolArray reachable(nfa.states_number(), false);
+        StateBoolArray reachable(nfa.size(), false);
         for (const State state: nfa.initial) {
             if (states_to_consider[state]) {
                 worklist.push_back(state);
@@ -269,7 +269,7 @@ namespace {
      * @param[out] digraph Digraph to add computed transitions to.
      */
     void collect_directed_transitions(const Nfa& nfa, const Symbol abstract_symbol, Nfa& digraph) {
-        const State num_of_states{nfa.states_number() };
+        const State num_of_states{nfa.size() };
         for (State src_state{ 0 }; src_state < num_of_states; ++src_state) {
             for (const auto& symbol_transitions: nfa.delta[src_state]) {
                 for (const State tgt_state: symbol_transitions.targets) {
@@ -316,7 +316,7 @@ std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms)
 } // OnTheFlyAlphabet::get_complement.
 
 void OnTheFlyAlphabet::add_symbols_from(const Nfa& nfa) {
-    size_t aut_num_of_states{nfa.states_number() };
+    size_t aut_num_of_states{nfa.size() };
     for (State state{ 0 }; state < aut_num_of_states; ++state) {
         for (const auto& state_transitions: nfa.delta[state]) {
             update_next_symbol_value(state_transitions.symbol);
@@ -543,7 +543,7 @@ State Delta::find_max_state() {
 ///// Nfa structure related methods
 
 State Nfa::add_state() {
-    m_states_number = states_number() + 1;
+    m_states_number = size() + 1;
     return m_states_number - 1;
 }
 
@@ -557,7 +557,7 @@ StateSet Nfa::get_reachable_states() const
     StateBoolArray reachable_bool_array{ compute_reachability(*this) };
 
     StateSet reachable_states{};
-    const size_t num_of_states{ states_number() };
+    const size_t num_of_states{size() };
     for (State original_state{ 0 }; original_state < num_of_states; ++original_state)
     {
         if (reachable_bool_array[original_state])
@@ -600,7 +600,7 @@ StateSet Nfa::get_useful_states() const
     // Compute reachability from the initial states and use the reachable states to compute the reachability from the final states.
     const StateBoolArray useful_states_bool_array{ compute_reachability(revert(digraph), compute_reachability(digraph)) };
 
-    const size_t num_of_states{ states_number() };
+    const size_t num_of_states{size() };
     StateSet useful_states{};
     for (State original_state{ 0 }; original_state < num_of_states; ++original_state) {
         if (useful_states_bool_array[original_state]) {
@@ -665,7 +665,7 @@ void Mata::Nfa::make_complete(
                               aut.initial.end());
     std::unordered_set<State> processed(aut.initial.begin(),
                                         aut.initial.end());
-    if (aut.states_number() <= sink_state) {
+    if (aut.size() <= sink_state) {
         aut.increase_size(sink_state+1);
     }
 
@@ -705,14 +705,14 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
     Nfa result;
 
     result.clear();
-    result.increase_size(aut.states_number());
+    result.increase_size(aut.size());
 
     // cannot use multimap, because it can contain multiple occurrences of (a -> a), (a -> a)
     std::unordered_map<State, StateSet> eps_closure;
 
     // TODO: grossly inefficient
     // first we compute the epsilon closure
-    const size_t num_of_states{ aut.states_number() };
+    const size_t num_of_states{aut.size() };
     for (size_t i{ 0 }; i < num_of_states; ++i)
     {
         for (const auto& trans: aut[i])
@@ -779,7 +779,7 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
 Nfa Mata::Nfa::revert(const Nfa& aut) {
     Nfa result;
     result.clear();
-    const size_t num_of_states{aut.states_number() };
+    const size_t num_of_states{aut.size() };
     result.increase_size(num_of_states);
 
     for (State sourceState{ 0 }; sourceState < num_of_states; ++sourceState) {
@@ -802,7 +802,7 @@ bool Mata::Nfa::is_deterministic(const Nfa& aut)
 
     if (aut.delta.empty()) { return true; }
 
-    const size_t aut_size = aut.states_number();
+    const size_t aut_size = aut.size();
     for (size_t i = 0; i < aut_size; ++i)
     {
         for (const auto& symStates : aut[i])
@@ -1076,7 +1076,7 @@ size_t Nfa::get_num_of_trans() const
 }
 
 Nfa Nfa::get_one_letter_aut(Symbol abstract_symbol) const {
-    Nfa digraph{ states_number(), StateSet(initial), StateSet(final) };
+    Nfa digraph{size(), StateSet(initial), StateSet(final) };
     collect_directed_transitions(*this, abstract_symbol, digraph);
     return digraph;
 }
@@ -1140,7 +1140,7 @@ Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {
     Nfa unionAutomaton = rhs;
 
     StateToStateMap thisStateToUnionState;
-    const size_t size = lhs.states_number();
+    const size_t size = lhs.size();
     for (State thisState = 0; thisState < size; ++thisState) {
         thisStateToUnionState[thisState] = unionAutomaton.add_state();
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -346,13 +346,13 @@ void Delta::add(State state_from, Symbol symbol, State state_to)
         post.resize(state_from + 1);
     }
 
-    if (state_from >= m_states_number) {
-        // state_from == 0 && m_states_number == 0 handles the case where delta is empty.
+    if (state_from >= m_num_of_states) {
+        // state_from == 0 && m_num_of_states == 0 handles the case where delta is empty.
 
-        m_states_number = state_from + 1;
+        m_num_of_states = state_from + 1;
     }
-    if (state_to >= m_states_number) {
-        m_states_number = state_to + 1;
+    if (state_to >= m_num_of_states) {
+        m_num_of_states = state_to + 1;
     }
 
     auto& state_transitions{ post[state_from] };
@@ -399,7 +399,7 @@ void Delta::remove(State src, Symbol symb, State tgt) {
             if (symbol_transitions->empty()) {
                 post[src].remove(*symbol_transitions);
             }
-            m_states_number = find_max_state() + 1;
+            m_num_of_states = find_max_state() + 1;
         }
     }
 }
@@ -477,7 +477,7 @@ std::vector<State> Delta::defragment()
     }
 
     // finally we need to find the new max state
-    m_states_number = find_max_state() + 1;
+    m_num_of_states = find_max_state() + 1;
 
     return renaming;
 }
@@ -543,8 +543,8 @@ State Delta::find_max_state() {
 ///// Nfa structure related methods
 
 State Nfa::add_state() {
-    m_states_number = size() + 1;
-    return m_states_number - 1;
+    m_num_of_states = size() + 1;
+    return m_num_of_states - 1;
 }
 
 void Nfa::remove_epsilon(const Symbol epsilon)

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -79,7 +79,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
     SECTION("Empty automaton without states") {
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -90,7 +90,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -101,7 +101,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -113,7 +113,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.initial.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -125,7 +125,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.initial.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -138,7 +138,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.final.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -151,7 +151,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.final.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -163,7 +163,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -178,7 +178,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
 
         result = concatenate(lhs, rhs);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -370,7 +370,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs, true);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -385,7 +385,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         result = concatenate(lhs, rhs, true);
 
-        CHECK(result.delta.post_size() == 0);
+        CHECK(result.states_number() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -416,7 +416,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[1]);
-        CHECK(result.delta.post_size() > 0);
+        CHECK(result.states_number() == 2);
         CHECK(result.get_num_of_trans() == 1);
         CHECK(result.delta.contains(0, EPSILON, 1));
     }
@@ -434,7 +434,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.delta.post_size() == 3);
+        CHECK(result.states_number() == 3);
         CHECK(result.get_num_of_trans() == 1);
         CHECK(result.delta.contains(0, EPSILON, 1));
     }
@@ -453,7 +453,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.delta.post_size() == 3);
+        CHECK(result.states_number() == 3);
         CHECK(result.get_num_of_trans() == 2);
         CHECK(result.delta.contains(1, 'a', 2));
         CHECK(result.delta.contains(0, EPSILON, 1));
@@ -474,7 +474,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[3]);
-        CHECK(result.delta.post_size() == 4);
+        CHECK(result.states_number() == 4);
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 3));
@@ -501,7 +501,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[3]);
-        CHECK(result.delta.post_size() == 6);
+        CHECK(result.states_number() == 6);
         CHECK(result.get_num_of_trans() == 4);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 3));
@@ -532,7 +532,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.delta.post_size() == 3);
+        CHECK(result.states_number() == 3);
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 2));
@@ -556,7 +556,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         CHECK(result.initial[1]);
         CHECK(result.initial[3]);
 
-        CHECK(result.delta.post_size() == 26);
+        CHECK(result.states_number() == 26);
 
         auto shortest_words{ get_shortest_words(result) };
         CHECK(shortest_words.size() == 4);
@@ -575,7 +575,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         result = concatenate(rhs, lhs, true);
 
-        CHECK(result.delta.post_size() == 26);
+        CHECK(result.states_number() == 26);
 
         CHECK(result.initial.size() == 1);
         CHECK(result.initial[4]);

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -79,7 +79,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
     SECTION("Empty automaton without states") {
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -90,7 +90,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -101,7 +101,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -113,7 +113,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.initial.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -125,7 +125,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.initial.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -138,7 +138,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         lhs.final.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -151,7 +151,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.final.add(0);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -163,7 +163,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -178,7 +178,7 @@ TEST_CASE("Mata::Nfa::concatenate()") {
 
         result = concatenate(lhs, rhs);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -370,7 +370,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         rhs.increase_size(1);
         result = concatenate(lhs, rhs, true);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -385,7 +385,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         result = concatenate(lhs, rhs, true);
 
-        CHECK(result.states_number() == 0);
+        CHECK(result.size() == 0);
         CHECK(result.initial.empty());
         CHECK(result.final.empty());
         CHECK(result.delta.empty());
@@ -416,7 +416,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[1]);
-        CHECK(result.states_number() == 2);
+        CHECK(result.size() == 2);
         CHECK(result.get_num_of_trans() == 1);
         CHECK(result.delta.contains(0, EPSILON, 1));
     }
@@ -434,7 +434,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.states_number() == 3);
+        CHECK(result.size() == 3);
         CHECK(result.get_num_of_trans() == 1);
         CHECK(result.delta.contains(0, EPSILON, 1));
     }
@@ -453,7 +453,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.states_number() == 3);
+        CHECK(result.size() == 3);
         CHECK(result.get_num_of_trans() == 2);
         CHECK(result.delta.contains(1, 'a', 2));
         CHECK(result.delta.contains(0, EPSILON, 1));
@@ -474,7 +474,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[3]);
-        CHECK(result.states_number() == 4);
+        CHECK(result.size() == 4);
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 3));
@@ -501,7 +501,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[3]);
-        CHECK(result.states_number() == 6);
+        CHECK(result.size() == 6);
         CHECK(result.get_num_of_trans() == 4);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 3));
@@ -532,7 +532,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         CHECK(result.initial[0]);
         CHECK(result.final[2]);
-        CHECK(result.states_number() == 3);
+        CHECK(result.size() == 3);
         CHECK(result.get_num_of_trans() == 3);
         CHECK(result.delta.contains(0, 'b', 1));
         CHECK(result.delta.contains(2, 'a', 2));
@@ -556,7 +556,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
         CHECK(result.initial[1]);
         CHECK(result.initial[3]);
 
-        CHECK(result.states_number() == 26);
+        CHECK(result.size() == 26);
 
         auto shortest_words{ get_shortest_words(result) };
         CHECK(shortest_words.size() == 4);
@@ -575,7 +575,7 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         result = concatenate(rhs, lhs, true);
 
-        CHECK(result.states_number() == 26);
+        CHECK(result.size() == 26);
 
         CHECK(result.initial.size() == 1);
         CHECK(result.initial[4]);

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -231,7 +231,7 @@ TEST_CASE("Mata::Nfa::intersection() with preserving epsilon transitions")
     CHECK(result.is_state(prod_map[{4, 7}]));
     CHECK(result.is_state(prod_map[{5, 9}]));
     CHECK(result.is_state(prod_map[{5, 8}]));
-    CHECK(result.delta.post_size() == 13);
+    CHECK(result.states_number() == 13);
 
     CHECK(result.initial[prod_map[{0, 0}]]);
     CHECK(result.initial.size() == 1);

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -231,7 +231,7 @@ TEST_CASE("Mata::Nfa::intersection() with preserving epsilon transitions")
     CHECK(result.is_state(prod_map[{4, 7}]));
     CHECK(result.is_state(prod_map[{5, 9}]));
     CHECK(result.is_state(prod_map[{5, 8}]));
-    CHECK(result.states_number() == 13);
+    CHECK(result.size() == 13);
 
     CHECK(result.initial[prod_map[{0, 0}]]);
     CHECK(result.initial.size() == 1);

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -67,34 +67,34 @@ template<class T> void unused(const T &) {}
 bool nothing_in_trans(const Nfa& nfa)
 {
     bool all_empty = true;
-    for (size_t i = 0; i < nfa.states_number(); ++i) {
+    for (size_t i = 0; i < nfa.size(); ++i) {
         all_empty &= nfa.delta[i].empty();
     }
 
     return all_empty;
 }
 
-TEST_CASE("Mata::Nfa::states_number()") {
+TEST_CASE("Mata::Nfa::size()") {
     Nfa nfa{};
-    CHECK(nfa.states_number() == 0);
+    CHECK(nfa.size() == 0);
 
     nfa.increase_size(4);
-    CHECK(nfa.states_number() == 4);
+    CHECK(nfa.size() == 4);
 
     nfa.clear();
     nfa.add_state();
-    CHECK(nfa.states_number() == 1);
+    CHECK(nfa.size() == 1);
 
     nfa.clear();
     FILL_WITH_AUT_A(nfa);
-    CHECK(nfa.states_number() == 11);
+    CHECK(nfa.size() == 11);
 
     nfa.clear();
     FILL_WITH_AUT_B(nfa);
-    CHECK(nfa.states_number() == 15);
+    CHECK(nfa.size() == 15);
 
     nfa = Nfa{ 0, {}, {} };
-    CHECK(nfa.states_number() == 0);
+    CHECK(nfa.size() == 0);
 }
 
 /*
@@ -1888,7 +1888,7 @@ TEST_CASE("Mata::Nfa::revert()")
 		REQUIRE(result.initial[2]);
 		REQUIRE(result.final[1]);
 		REQUIRE(result.delta.contains(2, 'a', 1));
-		REQUIRE(result.delta.states_number() == aut.delta.states_number());
+		REQUIRE(result.delta.num_of_states() == aut.delta.num_of_states());
 	}
 
 	SECTION("bigger automaton")
@@ -2253,7 +2253,7 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 		REQUIRE(nothing_in_trans(result));
 		REQUIRE(result.initial[state_map[1]]);
 		REQUIRE(result.final[state_map[2]]);
-		REQUIRE(result.states_number() == 2);
+		REQUIRE(result.size() == 2);
 		REQUIRE(state_map[1] == state_map[0]);
 		REQUIRE(state_map[2] != state_map[0]);
 	}
@@ -2282,7 +2282,7 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 
 		Nfa result = reduce(aut, &state_map);
 
-		REQUIRE(result.states_number() == 6);
+		REQUIRE(result.size() == 6);
 		REQUIRE(result.initial[state_map[1]]);
 		REQUIRE(result.initial[state_map[2]]);
 		REQUIRE(result.delta.contains(state_map[9], 'c', state_map[0]));
@@ -2496,7 +2496,7 @@ TEST_CASE("Mata::Nfa::get_one_letter_aut()")
 
     Nfa digraph{aut.get_one_letter_aut() };
 
-    REQUIRE(digraph.states_number() == aut.states_number());
+    REQUIRE(digraph.size() == aut.size());
     REQUIRE(digraph.get_num_of_trans() == 12);
     REQUIRE(digraph.delta.contains(1, abstract_symbol, 10));
     REQUIRE(digraph.delta.contains(10, abstract_symbol, 7));
@@ -2609,7 +2609,7 @@ TEST_CASE("Mata::Nfa::trim()")
     aut.trim();
     CHECK(aut.initial.size() == old_aut.initial.size());
     CHECK(aut.final.size() == old_aut.final.size());
-    CHECK(aut.states_number() == 4);
+    CHECK(aut.size() == 4);
     for (const Word& word: get_shortest_words(old_aut))
     {
         CHECK(is_in_lang(aut, Run{word,{}}));
@@ -2618,7 +2618,7 @@ TEST_CASE("Mata::Nfa::trim()")
     aut.final.remove(2); // '2' is the new final state in the earlier trimmed automaton.
     aut.trim();
     CHECK(aut.delta.empty());
-    CHECK(aut.states_number() == 0);
+    CHECK(aut.size() == 0);
 }
 
 TEST_CASE("Mata::Nfa::Nfa::delta.empty()")
@@ -2678,16 +2678,16 @@ TEST_CASE("Mata::Nfa::delta.operator[]")
     REQUIRE(aut.get_num_of_trans() == 15);
     aut.delta[25];
 
-    REQUIRE(aut.states_number() == 26);
+    REQUIRE(aut.size() == 26);
     REQUIRE(aut.delta[25].empty());
 
     aut.delta[50];
-    REQUIRE(aut.states_number() == 51);
+    REQUIRE(aut.size() == 51);
     REQUIRE(aut.delta[50].empty());
 
     const Nfa aut1 = aut;
     aut1.delta[60];
-    REQUIRE(aut1.states_number() == 61);
+    REQUIRE(aut1.size() == 61);
     REQUIRE(aut1.delta[60].empty());
 }
 
@@ -2696,7 +2696,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
 
     SECTION("No initial") {
         nfa.unify_initial();
-        CHECK(nfa.states_number() == 10);
+        CHECK(nfa.size() == 10);
         CHECK(nfa.initial.empty());
     }
 
@@ -2705,7 +2705,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.final.add(0);
         nfa.final.add(1);
         nfa.unify_final();
-        REQUIRE(nfa.states_number() == 11);
+        REQUIRE(nfa.size() == 11);
         CHECK(nfa.final.size() == 1);
         CHECK(nfa.final[10]);
         CHECK(nfa.initial[10]);
@@ -2716,7 +2716,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.initial.add(1);
         nfa.final.add(0);
         nfa.unify_initial();
-        REQUIRE(nfa.states_number() == 11);
+        REQUIRE(nfa.size() == 11);
         CHECK(nfa.initial.size() == 1);
         CHECK(nfa.initial[10]);
         CHECK(nfa.final[10]);
@@ -2725,7 +2725,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
     SECTION("Single initial") {
         nfa.initial.add(0);
         nfa.unify_initial();
-        CHECK(nfa.states_number() == 10);
+        CHECK(nfa.size() == 10);
         CHECK(nfa.initial.size() == 1);
         CHECK(nfa.initial[0]);
     }
@@ -2734,7 +2734,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.initial.add(0);
         nfa.initial.add(1);
         nfa.unify_initial();
-        CHECK(nfa.states_number() == 11);
+        CHECK(nfa.size() == 11);
         CHECK(nfa.initial.size() == 1);
         CHECK(nfa.initial[10]);
     }
@@ -2746,7 +2746,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.delta.add(1, 'b', 0);
         nfa.delta.add(1, 'c', 1);
         nfa.unify_initial();
-        CHECK(nfa.states_number() == 11);
+        CHECK(nfa.size() == 11);
         CHECK(nfa.initial.size() == 1);
         CHECK(nfa.initial[10]);
         CHECK(nfa.delta.contains(10, 'a', 3));
@@ -2759,14 +2759,14 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
 
     SECTION("No final") {
         nfa.unify_final();
-        CHECK(nfa.states_number() == 10);
+        CHECK(nfa.size() == 10);
         CHECK(nfa.final.empty());
     }
 
     SECTION("Single final") {
         nfa.final.add(0);
         nfa.unify_final();
-        CHECK(nfa.states_number() == 10);
+        CHECK(nfa.size() == 10);
         CHECK(nfa.final.size() == 1);
         CHECK(nfa.final[0]);
     }
@@ -2775,7 +2775,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.final.add(0);
         nfa.final.add(1);
         nfa.unify_final();
-        CHECK(nfa.states_number() == 11);
+        CHECK(nfa.size() == 11);
         CHECK(nfa.final.size() == 1);
         CHECK(nfa.final[10]);
     }
@@ -2787,7 +2787,7 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         nfa.delta.add(4, 'b', 1);
         nfa.delta.add(1, 'c', 1);
         nfa.unify_final();
-        CHECK(nfa.states_number() == 11);
+        CHECK(nfa.size() == 11);
         CHECK(nfa.final.size() == 1);
         CHECK(nfa.final[10]);
         CHECK(nfa.delta.contains(3, 'a', 10));
@@ -2852,14 +2852,14 @@ TEST_CASE("Mata::Nfa::Nfa::defragment()") {
     aut.delta.add(4, 42, 2);
     aut.delta.add(4, 42, 1);
     aut.delta.add(5, 42, 4);
-    CHECK(aut.states_number() == 6);
+    CHECK(aut.size() == 6);
     CHECK(aut.delta.contains(1, 42, 2));
     aut.defragment();
-    CHECK(aut.states_number() == 5);
+    CHECK(aut.size() == 5);
     CHECK(aut.delta.contains(1, 42, 3));
     CHECK(aut.delta.contains(4, 42, 3)); // previously (5,42,4)
     aut.defragment();
-    CHECK(aut.states_number() == 5);
+    CHECK(aut.size() == 5);
     // transitions contains not been changed
     CHECK(aut.delta.contains(1, 42, 3));
     CHECK(aut.delta.contains(4, 42, 3));

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2362,8 +2362,7 @@ TEST_CASE("Mata::Nfa::delta.remove()")
             REQUIRE_THROWS_AS(aut.delta.remove(1, 1, 5), std::invalid_argument);
         }
 
-        SECTION("Remove the last state_to from targets")
-        {
+        SECTION("Remove the last state_to from targets") {
             REQUIRE(aut.delta.contains(6, 'a', 2));
             aut.delta.remove(6, 'a', 2);
             REQUIRE(!aut.delta.contains(6, 'a', 2));

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -490,8 +490,8 @@ namespace {
                         if (static_cast<int>(renumbered_states[stateTo]) == -1) {
                             renumbered_states[stateTo] = renumbered_explicit_nfa.add_state();
                         }
-                        assert(renumbered_states[state] <= renumbered_explicit_nfa.states_number());
-                        assert(renumbered_states[stateTo] <= renumbered_explicit_nfa.states_number());
+                        assert(renumbered_states[state] <= renumbered_explicit_nfa.size());
+                        assert(renumbered_states[stateTo] <= renumbered_explicit_nfa.size());
                         renumbered_explicit_nfa.delta.add(renumbered_states[state], transition.symbol,
                                                           renumbered_states[stateTo]);
                     }

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -490,8 +490,8 @@ namespace {
                         if (static_cast<int>(renumbered_states[stateTo]) == -1) {
                             renumbered_states[stateTo] = renumbered_explicit_nfa.add_state();
                         }
-                        assert(renumbered_states[state] <= renumbered_explicit_nfa.delta.post_size());
-                        assert(renumbered_states[stateTo] <= renumbered_explicit_nfa.delta.post_size());
+                        assert(renumbered_states[state] <= renumbered_explicit_nfa.states_number());
+                        assert(renumbered_states[stateTo] <= renumbered_explicit_nfa.states_number());
                         renumbered_explicit_nfa.delta.add(renumbered_states[state], transition.symbol,
                                                           renumbered_states[stateTo]);
                     }

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -54,14 +54,14 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
     if (segments.size() == 1) {
         std::shared_ptr<Nfa::Nfa> segment = std::make_shared<Nfa::Nfa>(segments[0]);
         segment->trim();
-        if (segment->states_number() > 0 || include_empty) {
+        if (segment->size() > 0 || include_empty) {
             return {{ segment }};
         } else {
             return {};
         }
     }
 
-    State unused_state = aut.states_number(); // get some State not used in aut
+    State unused_state = aut.size(); // get some State not used in aut
     std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>> segments_one_initial_final;
     segs_one_initial_final(segments, include_empty, unused_state, segments_one_initial_final);
 
@@ -140,7 +140,7 @@ void SegNfa::segs_one_initial_final(
                  */
                 segment_one_final->trim();
 
-                if (segment_one_final->states_number() > 0 || include_empty) {
+                if (segment_one_final->size() > 0 || include_empty) {
                     out[std::make_pair(unused_state, final_state)] = segment_one_final;
                 }
             }
@@ -150,7 +150,7 @@ void SegNfa::segs_one_initial_final(
                 segment_one_init->initial = {init_state };
                 segment_one_init->trim();
 
-                if (segment_one_init->states_number() > 0 || include_empty) {
+                if (segment_one_init->size() > 0 || include_empty) {
                     out[std::make_pair(init_state, unused_state)] = segment_one_init;
                 }
             }
@@ -162,7 +162,7 @@ void SegNfa::segs_one_initial_final(
                     segment_one_init_final->final = {final_state };
                     segment_one_init_final->trim();
 
-                    if (segment_one_init_final->states_number() > 0 || include_empty) {
+                    if (segment_one_init_final->size() > 0 || include_empty) {
                         out[std::make_pair(init_state, final_state)] = segment_one_init_final;
                     }
                 }
@@ -184,14 +184,14 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
     if (segments.size() == 1) {
         std::shared_ptr<Nfa::Nfa> segment = std::make_shared<Nfa::Nfa>(segments[0]);
         segment->trim();
-        if (segment->states_number() > 0 || include_empty) {
+        if (segment->size() > 0 || include_empty) {
             return {{ {segment, def_eps_vector} } };
         } else {
             return {};
         }
     }
 
-    State unused_state = aut.states_number(); // get some State not used in aut
+    State unused_state = aut.size(); // get some State not used in aut
     std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>> segments_one_initial_final;
     segs_one_initial_final(segments, include_empty, unused_state, segments_one_initial_final);
 

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -54,14 +54,14 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
     if (segments.size() == 1) {
         std::shared_ptr<Nfa::Nfa> segment = std::make_shared<Nfa::Nfa>(segments[0]);
         segment->trim();
-        if (segment->delta.post_size() > 0 || include_empty) {
+        if (segment->states_number() > 0 || include_empty) {
             return {{ segment }};
         } else {
             return {};
         }
     }
 
-    State unused_state = aut.delta.post_size(); // get some State not used in aut
+    State unused_state = aut.states_number(); // get some State not used in aut
     std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>> segments_one_initial_final;
     segs_one_initial_final(segments, include_empty, unused_state, segments_one_initial_final);
 
@@ -140,7 +140,7 @@ void SegNfa::segs_one_initial_final(
                  */
                 segment_one_final->trim();
 
-                if (segment_one_final->delta.post_size() > 0 || include_empty) {
+                if (segment_one_final->states_number() > 0 || include_empty) {
                     out[std::make_pair(unused_state, final_state)] = segment_one_final;
                 }
             }
@@ -150,7 +150,7 @@ void SegNfa::segs_one_initial_final(
                 segment_one_init->initial = {init_state };
                 segment_one_init->trim();
 
-                if (segment_one_init->delta.post_size() > 0 || include_empty) {
+                if (segment_one_init->states_number() > 0 || include_empty) {
                     out[std::make_pair(init_state, unused_state)] = segment_one_init;
                 }
             }
@@ -162,7 +162,7 @@ void SegNfa::segs_one_initial_final(
                     segment_one_init_final->final = {final_state };
                     segment_one_init_final->trim();
 
-                    if (segment_one_init_final->delta.post_size() > 0 || include_empty) {
+                    if (segment_one_init_final->states_number() > 0 || include_empty) {
                         out[std::make_pair(init_state, final_state)] = segment_one_init_final;
                     }
                 }
@@ -184,14 +184,14 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
     if (segments.size() == 1) {
         std::shared_ptr<Nfa::Nfa> segment = std::make_shared<Nfa::Nfa>(segments[0]);
         segment->trim();
-        if (segment->delta.post_size() > 0 || include_empty) {
+        if (segment->states_number() > 0 || include_empty) {
             return {{ {segment, def_eps_vector} } };
         } else {
             return {};
         }
     }
 
-    State unused_state = aut.delta.post_size(); // get some State not used in aut
+    State unused_state = aut.states_number(); // get some State not used in aut
     std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>> segments_one_initial_final;
     segs_one_initial_final(segments, include_empty, unused_state, segments_one_initial_final);
 

--- a/src/strings/nfa-segmentation.cc
+++ b/src/strings/nfa-segmentation.cc
@@ -90,7 +90,7 @@ std::deque<SegNfa::Segmentation::StateDepthTuple> SegNfa::Segmentation::initiali
 std::unordered_map<State, bool> SegNfa::Segmentation::initialize_visited_map() const
 {
     std::unordered_map<State, bool> visited{};
-    const size_t state_num = automaton.states_number();
+    const size_t state_num = automaton.size();
     for (State state{ 0 }; state < state_num; ++state)
     {
         visited[state] = false;

--- a/src/strings/nfa-segmentation.cc
+++ b/src/strings/nfa-segmentation.cc
@@ -90,7 +90,7 @@ std::deque<SegNfa::Segmentation::StateDepthTuple> SegNfa::Segmentation::initiali
 std::unordered_map<State, bool> SegNfa::Segmentation::initialize_visited_map() const
 {
     std::unordered_map<State, bool> visited{};
-    const size_t state_num = automaton.delta.post_size();
+    const size_t state_num = automaton.states_number();
     for (State state{ 0 }; state < state_num; ++state)
     {
         visited[state] = false;

--- a/src/strings/tests-nfa-noodlification.cc
+++ b/src/strings/tests-nfa-noodlification.cc
@@ -177,23 +177,22 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation()") {
     }
 
     SECTION("Small automata") {
-        Nfa left1{ 1};
+        Nfa left1{ 1 };
         left1.initial.add(0);
         left1.final.add(0);
-        Nfa left2{ 1};
+        Nfa left2{ 1 };
         left2.initial.add(0);
         left2.final.add(0);
-        Nfa right{ 2};
+        Nfa right{ 2 };
         right.initial.add(0);
         right.final.add(0);
 
-        Nfa noodle{2};
+        Nfa noodle{ 2 };
         noodle.initial.add(0);
         noodle.delta.add(0, 0, 1);
         noodle.final.add(1);
         auto result{ SegNfa::noodlify_for_equation({ left1, left2 }, right) };
         REQUIRE(result.size() == 1);
-        //CHECK(are_equivalent(result[0], noodle));
     }
 
     SECTION("Larger automata") {


### PR DESCRIPTION
This PR refactors the max state counters to instead count the number of states. Therefore, we are able to correctly represent an empty automaton with the number of states in the whole automaton equal to 0, whereas previously, an empty automaton was not distinguishable from an automaton with a single state (with internal value of 0). That is, `Nfa::max_state()` would return `0` as a default value (`size_t` has not nullable representation). This resolves #132.

This PR only changes the counters and adds a method `Nfa::states_number()`. However, the change in counters created a chain reaction where the entire mata library imploded. Therefore, in order to fix all tests, I have proceeded to replace all uses of `Nfa::Delta::post_size()` with the new method `Nfa::states_number()`, which actually returns a valid current number of states in the whole automaton, as opposed to `Nfa::Delta::post_size()`. This resolves #127.

The PR is ready for reviews. I ask the reviewers to please review the code changes carefully. Many of the changes are debatable and based on my interpretation of what to allow the user to do and where to throw an exception, as agreed upon (somewhat) in our meetings. Furthermore, there might be places in the source code where I have forgotten to change the previous occurrence to `Nfa::Delta::post_size()` which the tests did not catch.

I am going to review the changes and look through the code again to see if I have missed anything. Do not merge until I give a review myself.

Additionally, resolves #137. 