### PR TITLE
Upgrade to C++17

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -71,7 +71,7 @@ extensions = [
             cudd_include_dir,
         ],
         language="c++",
-        extra_compile_args=["-std=c++14", "-DNO_THROW_DISPATCHER"],
+        extra_compile_args=["-std=c++17", "-DNO_THROW_DISPATCHER"],
     ),
 ]
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CMAKE_COLOR_MAKEFILE ON)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_CXX_STANDARD 17)
 
 project(libmata)
 
@@ -13,7 +14,6 @@ set(cxx_compiler_flags
   -Wfloat-equal
   -fms-extensions
   -fdiagnostics-show-option
-  -std=c++14
   -Wctor-dtor-privacy
   -Weffc++
   -fPIC


### PR DESCRIPTION
This PR upgrades Mata and Python binding to C++17 standard.

Resolves #34.