### PR TITLE
RE2: parser fixing; workaround

### DIFF
--- a/include/mata/re2parser.hh
+++ b/include/mata/re2parser.hh
@@ -23,7 +23,7 @@
 
 namespace Mata {
     namespace RE2Parser {
-        void create_nfa(Nfa::Nfa* nfa, const std::string &pattern, bool use_epsilon = false, int epsilon_value = 306);
+        void create_nfa(Nfa::Nfa* nfa, const std::string &pattern, bool use_epsilon = false, int epsilon_value = 306, bool use_reduction = true);
     }
 }
 

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -560,6 +560,7 @@ namespace {
  * @param pattern regex as string
  * @param use_epsilon whether to create NFA with epsilon transitions or not
  * @param epsilon_value value, that will represent epsilon on transitions
+ * @param use_reduce if set to true the result is trimmed and reduced using simulation reduction
  * @return mata::Nfa::Nfa corresponding to pattern
  */
 void Mata::RE2Parser::create_nfa(Nfa::Nfa* nfa, const std::string& pattern, bool use_epsilon, int epsilon_value, bool use_reduce) {

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -562,7 +562,7 @@ namespace {
  * @param epsilon_value value, that will represent epsilon on transitions
  * @return mata::Nfa::Nfa corresponding to pattern
  */
-void Mata::RE2Parser::create_nfa(Nfa::Nfa* nfa, const std::string& pattern, bool use_epsilon, int epsilon_value) {
+void Mata::RE2Parser::create_nfa(Nfa::Nfa* nfa, const std::string& pattern, bool use_epsilon, int epsilon_value, bool use_reduce) {
     if (nfa == NULL) {
         throw std::runtime_error("create_nfa: nfa should not be NULL");
     }
@@ -570,8 +570,15 @@ void Mata::RE2Parser::create_nfa(Nfa::Nfa* nfa, const std::string& pattern, bool
     RegexParser regexParser{};
     auto parsed_regex = regexParser.parse_regex_string(pattern);
     auto program = parsed_regex->CompileToProg(regexParser.options.max_mem() * 2 / 3);
-    regexParser.convert_pro_to_nfa(nfa, program, use_epsilon, epsilon_value);
+    regexParser.convert_pro_to_nfa(nfa, program, true, epsilon_value);
     delete program;
     // Decrements reference count and deletes object if the count reaches 0
     parsed_regex->Decref();
+    if(!use_epsilon) {
+        *nfa = Mata::Nfa::remove_epsilon(*nfa, epsilon_value);
+    }
+    if(use_reduce) {
+        nfa->trim();
+        *nfa = Mata::Nfa::reduce(*nfa);
+    }
 }

--- a/src/strings/tests-nfa-noodlification.cc
+++ b/src/strings/tests-nfa-noodlification.cc
@@ -392,10 +392,11 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
         create_nfa(&astar, "a*");
 
         auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( { 
-                {{astar, {0, 0} }, {x, {0, 1} }, {w, {1, 1} }}, 
-                {{astar, {0, 0} }, {x, {0, 1} }}, 
+                {{x, {0, 1} }, {z, {1, 1} }}, 
                 {{x, {0, 0} }, {w, {1, 1} }}, 
-                {{x, {0, 0} }, {y, {1, 0} }, {w, {1, 1} }} } );
+                {{x, {0, 0} }, {x, {0, 1} }, {z, {1, 1} }}, 
+                {{x, {0, 0} }, {z, {1, 0} }, {w, {1, 1} }}, 
+         } );
         SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) }, 
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(z), std::make_shared<Nfa>(w)});

--- a/src/tests-re2parser.cc
+++ b/src/tests-re2parser.cc
@@ -1255,3 +1255,17 @@ TEST_CASE("Mata::RE2Parser error")
         REQUIRE(!is_in_lang(aut2, Word{'q','R','q'}));
     }
 } // }}}
+
+TEST_CASE("Mata::RE2Parser bug epsilon")
+{ // {{{
+    SECTION("failing regex")
+    {
+        Nfa x;
+        Mata::RE2Parser::create_nfa(&x, "(cd(abcde)*)|(a(aaa)*)");
+        CHECK(is_in_lang(x, Run{Word{'a', 'a', 'a', 'a'}, {}}));
+    }
+} // }}}
+
+
+
+


### PR DESCRIPTION
Currently it seems RE2 parser has a problem with removing epsilons (the epsilon removal is somehow hardcoded in the parser). This PR disables the internal epsilon removal and forces to use the mata function instead. Also adds a new parameter to the parser allowing to reduce the resulting automaton (it might be useful). Related to #139 