### PR TITLE
Fix library building

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,10 +106,10 @@ add_custom_command(
 )
 
 add_custom_command(TARGET libmata POST_BUILD
-		COMMAND ${CMAKE_SOURCE_DIR}/merge_static_libraries.sh libcombined.a ${CMAKE_SOURCE_DIR}/build/src/libmata.a
-		${CMAKE_SOURCE_DIR}/build/3rdparty/simlib/libsimlib.a ${CMAKE_SOURCE_DIR}/build/3rdparty/re2/libre2.a
-		${CMAKE_SOURCE_DIR}/build/3rdparty/cudd/lib/libcudd.a
-		COMMAND mv ${CMAKE_SOURCE_DIR}/build/src/libcombined.a ${CMAKE_SOURCE_DIR}/build/src/libmata.a)
+		COMMAND ${CMAKE_SOURCE_DIR}/merge_static_libraries.sh libcombined.a ${CMAKE_BINARY_DIR}/src/libmata.a
+		${CMAKE_BINARY_DIR}/3rdparty/simlib/libsimlib.a ${CMAKE_BINARY_DIR}/3rdparty/re2/libre2.a
+		${CMAKE_BINARY_DIR}/3rdparty/cudd/lib/libcudd.a
+		COMMAND mv ${CMAKE_BINARY_DIR}/src/libcombined.a ${CMAKE_BINARY_DIR}/src/libmata.a)
 
 if(FALSE)
 


### PR DESCRIPTION
Fixed issue where mata could not be compiled in directory other than `build/`.