### PR TITLE
Regex parser bug

### DIFF
--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -561,7 +561,7 @@ namespace {
  * @return mata::Nfa::Nfa corresponding to pattern
  */
 void Mata::RE2Parser::create_nfa(Nfa::Nfa* nfa, const std::string& pattern, bool use_epsilon, int epsilon_value, bool use_reduce) {
-    if (nfa == NULL) {
+    if (nfa == nullptr) {
         throw std::runtime_error("create_nfa: nfa should not be NULL");
     }
 

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -401,11 +401,8 @@ namespace {
             // should have incoming edge set
             for (auto state_to_check: states_for_second_check) {
               re2::Prog::Inst *inst = prog->inst(state_to_check);
-              for (auto mappedState: this->state_cache.state_mapping[inst->out()]) {
-                if (mappedState == state_to_check) {
-                  this->state_cache.has_state_incoming_edge[state_to_check] = true;
-                  break;
-                }
+              for (auto mapped_state: this->state_cache.state_mapping[inst->out()]) {
+                this->state_cache.has_state_incoming_edge[mapped_state] = true;
               }
             }
         }

--- a/src/tests-re2parser.cc
+++ b/src/tests-re2parser.cc
@@ -1258,17 +1258,53 @@ TEST_CASE("Mata::RE2Parser error")
     SECTION("Regex from issue #139") {
         Nfa x;
         Mata::RE2Parser::create_nfa(&x, "(cd(abcde)*)|(a(aaa)*)");
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'a', 'a' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+
+        x.clear();
+        Mata::RE2Parser::create_nfa(&x, "(cd(abcde)*)|(a(aaa)*)", false, 306, false);
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'a', 'a' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
     }
 
     SECTION("Another failing regex") {
         Nfa x;
         Mata::RE2Parser::create_nfa(&x, "(cd(abcde)+)|(a(aaa)+|ccc+)");
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'a', 'a' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'b', 'c', 'd', 'e' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'd' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'c' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c', 'c', 'c', 'c' }, {} }));
+
+        x.clear();
+        Mata::RE2Parser::create_nfa(&x, "(cd(abcde)+)|(a(aaa)+|ccc+)", false, 306, false);
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'd' }, {} }));
+        CHECK(!is_in_lang(x, Run{ Word{ 'c', 'c' }, {} }));
         CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c', 'c', 'c', 'c' }, {} }));
     }
 } // }}}
@@ -1282,7 +1318,3 @@ TEST_CASE("Mata::RE2Parser bug epsilon")
         CHECK(is_in_lang(x, Run{Word{'a', 'a', 'a', 'a'}, {}}));
     }
 } // }}}
-
-
-
-

--- a/src/tests-re2parser.cc
+++ b/src/tests-re2parser.cc
@@ -1259,6 +1259,17 @@ TEST_CASE("Mata::RE2Parser error")
         Nfa x;
         Mata::RE2Parser::create_nfa(&x, "(cd(abcde)*)|(a(aaa)*)");
         CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+    }
+
+    SECTION("Another failing regex") {
+        Nfa x;
+        Mata::RE2Parser::create_nfa(&x, "(cd(abcde)+)|(a(aaa)+|ccc+)");
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a', 'a', 'a', 'a' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'd', 'a', 'b', 'c', 'd', 'e' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c' }, {} }));
+        CHECK(is_in_lang(x, Run{ Word{ 'c', 'c', 'c', 'c', 'c', 'c' }, {} }));
     }
 } // }}}
 

--- a/src/tests-re2parser.cc
+++ b/src/tests-re2parser.cc
@@ -1254,6 +1254,12 @@ TEST_CASE("Mata::RE2Parser error")
         REQUIRE(is_in_lang(aut2, Word{'q','r','q','r'}));
         REQUIRE(!is_in_lang(aut2, Word{'q','R','q'}));
     }
+
+    SECTION("Regex from issue #139") {
+        Nfa x;
+        Mata::RE2Parser::create_nfa(&x, "(cd(abcde)*)|(a(aaa)*)");
+        CHECK(is_in_lang(x, Run{ Word{ 'a', 'a', 'a', 'a' }, {} }));
+    }
 } // }}}
 
 TEST_CASE("Mata::RE2Parser bug epsilon")


### PR DESCRIPTION
This PR fixes the regex parser bug from #139 while keeping the workaround active (as agreed upon). Currently, the default behaviour of RE2 parser is to reduce and trim the result NFA. One can skip these additional operations with bool parameter `use_reduction` set to `false`. 

Fixes #139.