### PR TITLE
Rename Python binding method get_digraph to get_one_letter_aut

### DIFF
--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -498,14 +498,15 @@ cdef class Nfa:
         """
         self.thisptr.get().trim()
 
-    def get_digraph(self) -> Nfa:
-        """Unify transitions to create a directed graph with at most a single transition between two states.
+    def get_one_letter_aut(self) -> Nfa:
+        """Unify transitions to create a directed graph with at most a single transition between two states (using only
+         one letter for all transitions).
 
-        :return: mata.Nfa: An automaton representing a directed graph.
+        :return: mata.Nfa: One letter automaton representing a directed graph.
         """
-        cdef Nfa digraph = mata.Nfa()
-        self.thisptr.get().get_one_letter_aut(dereference(digraph.thisptr.get()))
-        return digraph
+        cdef Nfa one_letter_aut = mata.Nfa()
+        self.thisptr.get().get_one_letter_aut(dereference(one_letter_aut.thisptr.get()))
+        return one_letter_aut
 
     def is_epsilon(self, Symbol symbol) -> bool:
         """Check whether passed symbol is epsilon symbol or not.

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -697,20 +697,20 @@ def test_trim(prepare_automaton_a):
     assert nfa.size() == 0
 
 
-def test_get_digraph(prepare_automaton_a):
-    """Test creating digraph from an automaton."""
+def test_get_one_letter_automaton(prepare_automaton_a):
+    """Test creating one letter automaton from an input automaton."""
     abstract_symbol = ord('x')
     nfa = prepare_automaton_a()
 
-    digraph = nfa.get_digraph()
+    one_letter_automaton = nfa.get_one_letter_aut()
 
-    assert digraph.size() == nfa.size()
-    assert digraph.get_num_of_trans() == 12
-    assert digraph.has_transition(1, abstract_symbol, 10)
-    assert digraph.has_transition(10, abstract_symbol, 7)
-    assert not digraph.has_transition(10, ord('a'), 7)
-    assert not digraph.has_transition(10, ord('b'), 7)
-    assert not digraph.has_transition(10, ord('c'), 7)
+    assert one_letter_automaton.size() == nfa.size()
+    assert one_letter_automaton.get_num_of_trans() == 12
+    assert one_letter_automaton.has_transition(1, abstract_symbol, 10)
+    assert one_letter_automaton.has_transition(10, abstract_symbol, 7)
+    assert not one_letter_automaton.has_transition(10, ord('a'), 7)
+    assert not one_letter_automaton.has_transition(10, ord('b'), 7)
+    assert not one_letter_automaton.has_transition(10, ord('c'), 7)
 
 
 def test_simulation(fa_one_divisible_by_four):


### PR DESCRIPTION
This PR renames method `Mata.Nfa.get_digraph()` from Python binding to `Mata.Nfa.get_one_letter_aut()` which is the name used in libMata itself for the corresponding operation. The name `Mata.get_digraph()` is a relict from when the function in libMata was renamed to `Mata::Nfa::get_one_letter_aut()`, but apparently, we forgot to rename the Python binding function, too.