### PR TITLE
Temporarily disable automatic tests for Jupyter notebooks

### DIFF
--- a/.github/workflows/python-binding.yml
+++ b/.github/workflows/python-binding.yml
@@ -59,8 +59,8 @@ jobs:
           python3 -m pip install seaborn==0.12.0
           python3 -m pip install papermill pandas
 
-      - name: Test the jupyter notebooks
-        run: |
-          papermill ./examples/notebooks/example-01-ws1s-formulae.ipynb out.ipynb
-          papermill ./examples/notebooks/example-02-redos-attacks.ipynb out.ipynb
-          papermill ./examples/notebooks/example-03-exploring-maze.ipynb out.ipynb
+      #- name: Test the jupyter notebooks
+      #  run: |
+      #    papermill ./examples/notebooks/example-01-ws1s-formulae.ipynb out.ipynb
+      #    papermill ./examples/notebooks/example-02-redos-attacks.ipynb out.ipynb
+      #    papermill ./examples/notebooks/example-03-exploring-maze.ipynb out.ipynb


### PR DESCRIPTION
This PR hotfixes a bug in papermill dependencies, causing the automatic tests for Jupyter notebooks to execute indefinitely. This PR hotfixes the described issue by completely disabling the automatic tests for Jupyter notebooks. 