### PR TITLE
Create basic automata

### DIFF
--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -321,8 +321,8 @@ namespace Mata {
         /**
          * @brief Update next symbol value when appropriate.
          *
-         * When the newly inserted value is larger or equal to the current next symbol value, update he next symbol value to
-         * a value one larger than the new value.
+         * When the newly inserted value is larger or equal to the current next symbol value, update the next symbol
+         *  value to a value one larger than the new value.
          * @param value The value of the newly added symbol.
          */
         void update_next_symbol_value(Symbol value) {

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -736,15 +736,15 @@ public:
 /**
  * Create automaton accepting only epsilon string.
  */
-[[nodiscard]] Nfa create_empty_string_nfa();
+Nfa create_empty_string_nfa();
 
 /**
  * Create automaton accepting sigma star over the passed alphabet.
  *
  * @param[in] alphabet Alphabet to construct sigma star automaton with. When alphabet is left empty, the default empty
- *  alphabet is used, creating an automaton accepting only the epsilon string.
+ *  alphabet is used, creating an automaton accepting only the empty string.
  */
-[[nodiscard]] Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
+Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
 
 /**
   * Fill @p alphabet with symbols from @p nfa.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -851,9 +851,6 @@ void make_complete(
         const Alphabet&  alphabet,
         State            sink_state);
 
-// assumes deterministic automaton
-void complement_in_place(Nfa &aut);
-
 /// Co
 Nfa complement(
         const Nfa&         aut,

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -435,17 +435,17 @@ struct Nfa {
     ///  therefore always zero (or less than the actual number of states in the whole automaton), unless
     ///  'Nfa::Nfa::add_state(n)' was called. In that case, this variable will be set to n to store the information
     ///  that the user manually added (requested) new states.
-    size_t m_num_of_requested_states;
+    size_t m_num_of_requested_states{ 0 };
 
 public:
-    Nfa() : delta(), initial(), final(), m_num_of_states(0) {}
+    Nfa() : delta(), initial(), final(), m_num_of_requested_states(0) {}
 
     /**
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
      */
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
                  const StateSet& final_states = StateSet{}, Alphabet* alphabet = new IntAlphabet())
-        : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet), m_num_of_states(0) {}
+        : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet), m_num_of_requested_states(0) {}
 
     /**
      * @brief Construct a new explicit NFA from other NFA.
@@ -477,7 +477,7 @@ public:
     State add_state(State state)
     {
         if (state >= size())
-            m_num_of_states = state+1;
+            m_num_of_requested_states = state + 1;
 
         return state;
     }
@@ -489,7 +489,7 @@ public:
      * @return The number of states.
      */
      size_t size() const {
-        return std::max({m_num_of_states, delta.num_of_states(), initial.domain_size(), final.domain_size() });
+        return std::max({m_num_of_requested_states, delta.num_of_states(), initial.domain_size(), final.domain_size() });
     }
 
     /**
@@ -513,7 +513,7 @@ public:
         delta.clear();
         initial.clear();
         final.clear();
-        m_num_of_states = 0;
+        m_num_of_requested_states = 0;
     }
 
     /**
@@ -712,7 +712,7 @@ public:
      * Method defragments transition relation. It eventually clears empty space in vector
      * containing transitions and decreases size.
      * TODO: once merged with new initial and final state predicate, do renaming of these sets of states.
-     * TODO: Modify Nfa::m_num_of_states as well. Or not?
+     * TODO: Modify Nfa::m_num_of_requested_states as well. Or not?
      */
     void defragment() {
         std::vector<State> renaming = delta.defragment();
@@ -720,7 +720,7 @@ public:
         initial.truncate_domain();
         final.rename(renaming, delta.num_of_states());
         final.truncate_domain();
-        m_num_of_states = 0;
+        m_num_of_requested_states = 0;
     }
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -37,10 +37,7 @@
 #include <mata/inter-aut.hh>
 #include <mata/synchronized-iterator.hh>
 
-namespace Mata
-{
-namespace Nfa
-{
+namespace Mata::Nfa {
 extern const std::string TYPE_NFA;
 
 using State = unsigned long;
@@ -73,7 +70,7 @@ using StringMap = std::unordered_map<std::string, std::string>;
  * have names Set, UMap/OMap, State, Symbol, Sequence... and name by Set<State>, State<UMap>, ...
  * maybe something else is needed for the more complex maps*/
 
-static constexpr struct Limits {//TODO: still needed?
+static constexpr struct Limits {
     State maxState = std::numeric_limits<State>::max();
     State minState = std::numeric_limits<State>::min();
     Symbol maxSymbol = std::numeric_limits<Symbol>::max();
@@ -226,6 +223,11 @@ struct Post : private Util::OrdVector<Move> {
 struct Delta {
 private:
     mutable std::vector<Post> post;
+
+    /// Number of actual states occuring in the transition relation.
+    ///
+    /// These states are used in the transition relation, either on the left side or on the right side.
+    /// The value is always consistent with the actual number of states in the transition relation.
     mutable size_t m_num_of_states;
 
 public:
@@ -403,8 +405,7 @@ constexpr Symbol EPSILON = limits.maxSymbol;
 /**
  * A struct representing an NFA.
  */
-struct Nfa
-{
+struct Nfa {
     /**
      * @brief For state q, delta[q] keeps the list of transitions ordered by symbols.
      *
@@ -423,6 +424,10 @@ struct Nfa
     //  dictionary in the attributes.
     std::unordered_map<std::string, void*> attributes{};
 
+    /// Number of prerequested states in the automaton.
+    ///
+    /// These states may be unallocated and they might not be used anywhere in the automaton.
+    /// The value can be always less than the actual number of states in the whole automaton.
     size_t m_num_of_states;
 
 public:
@@ -1021,9 +1026,8 @@ Nfa construct(
     }
     return aut;
 }
-// CLOSING NAMESPACES AND GUARDS
-} /* Nfa */
-} /* Mata */
+
+} // namespace Mata::Nfa.
 
 namespace std
 { // {{{

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -722,7 +722,20 @@ public:
      * The value of the already existing symbols will NOT be overwritten.
      */
     void add_symbols_to(OnTheFlyAlphabet& alphabet);
-}; // Nfa
+}; // struct Nfa.
+
+/**
+ * Create automaton accepting only epsilon string.
+ */
+[[nodiscard]] Nfa create_empty_string_nfa();
+
+/**
+ * Create automaton accepting sigma star over the passed alphabet.
+ *
+ * @param[in] alphabet Alphabet to construct sigma star automaton with. When alphabet is left empty, the default empty
+ *  alphabet is used, creating an automaton accepting only the epsilon string.
+ */
+[[nodiscard]] Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
 
 /**
   * Fill @p alphabet with symbols from @p nfa.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -424,11 +424,18 @@ struct Nfa {
     //  dictionary in the attributes.
     std::unordered_map<std::string, void*> attributes{};
 
-    /// Number of prerequested states in the automaton.
+    /// Number of pre-requested states in the automaton.
     ///
     /// These states may be unallocated and they might not be used anywhere in the automaton.
     /// The value can be always less than the actual number of states in the whole automaton.
-    size_t m_num_of_states;
+    ///
+    /// This variable exists solely for the purpose of pre-requesting a certain number of states with
+    ///  'Nfa::Nfa::add_state(n)' where 'n' is the number of requested states. However, it does not make sense to
+    ///  allocate for these states space in Delta, nor in the sets of initial/final states. The variable should be
+    ///  therefore always zero (or less than the actual number of states in the whole automaton), unless
+    ///  'Nfa::Nfa::add_state(n)' was called. In that case, this variable will be set to n to store the information
+    ///  that the user manually added (requested) new states.
+    size_t m_num_of_requested_states;
 
 public:
     Nfa() : delta(), initial(), final(), m_num_of_states(0) {}

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -442,6 +442,8 @@ public:
 
     /**
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
+     *
+     * @param[in] num_of_states Number of states for which to preallocate Delta.
      */
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
                  const StateSet& final_states = StateSet{}, Alphabet* alphabet = new IntAlphabet())

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(libmata STATIC
 	parser.cc
 	re2parser.cc
 	nfa/nfa.cc
-        nfa/nfa-inclusion.cc
+	nfa/nfa-inclusion.cc
 	nfa/nfa-universal.cc
 	nfa/nfa-complement.cc
 	nfa/nfa-intersection.cc
@@ -66,7 +66,8 @@ add_library(libmata STATIC
 	strings/nfa-noodlification.cc
 	strings/nfa-segmentation.cc
 	strings/nfa-strings.cc
-	rra/rrt.cc)
+	rra/rrt.cc
+)
 
 set_target_properties(libmata PROPERTIES
   OUTPUT_NAME mata

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1619,3 +1619,15 @@ Mata::OnTheFlyAlphabet Mata::Nfa::create_alphabet(const AutPtrSequence& nfas) {
     }
     return alphabet;
 }
+
+Nfa Mata::Nfa::create_empty_string_nfa() {
+    return Nfa{ 1, StateSet{ 0 }, StateSet{ 0 } };
+}
+
+Nfa Mata::Nfa::create_sigma_star_nfa(Mata::Alphabet* alphabet) {
+    Nfa nfa{ 1, StateSet{ 0 }, StateSet{ 0 }, alphabet };
+    for (const Mata::Symbol& symbol : alphabet->get_alphabet_symbols()) {
+        nfa.delta.add(0, symbol, 0);
+    }
+    return nfa;
+}

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -501,8 +501,8 @@ State Delta::find_max_state() {
 ///// Nfa structure related methods
 
 State Nfa::add_state() {
-    m_num_of_states = size() + 1;
-    return m_num_of_states - 1;
+    m_num_of_requested_states = size() + 1;
+    return m_num_of_requested_states - 1;
 }
 
 void Nfa::remove_epsilon(const Symbol epsilon)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -740,9 +740,9 @@ Nfa Mata::Nfa::revert(const Nfa& aut) {
     Nfa result;
     result.clear();
 
-    result.add_state(aut.m_num_of_states);
+    const size_t num_of_states{ aut.size() };
+    result.add_state(num_of_states - 1);
 
-    const size_t num_of_states{aut.size() };
     for (State sourceState{ 0 }; sourceState < num_of_states; ++sourceState) {
         for (const Move &transition: aut.delta[sourceState]) {
             for (const State targetState: transition.targets) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1054,7 +1054,7 @@ TransSequence Nfa::get_transitions_to(State state_to) const {
             const auto& symbol_states_to{ symbol_transitions.targets };
             const auto target_state{ symbol_states_to.find(state_to) };
             if (target_state != symbol_states_to.end()) {
-                transitions_to_state.push_back({ state_from, symbol_transitions.symbol, state_to });
+                transitions_to_state.emplace_back( state_from, symbol_transitions.symbol, state_to );
             }
         }
     }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2897,3 +2897,23 @@ TEST_CASE("A segmentation fault in the make_complement") {
     make_complete(r, alph, 1);
     REQUIRE(is_complete(r, alph));
 }
+
+TEST_CASE("Mata::Nfa:: create simple automata") {
+    Nfa nfa{create_empty_string_nfa() };
+    CHECK(is_in_lang(nfa, { {}, {} }));
+    CHECK(get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
+
+    OnTheFlyAlphabet alphabet{};
+    StringToSymbolMap symbol_map{ { "a", 0 }, { "b", 1 }, { "c", 2 } };
+    alphabet.add_symbols_from(symbol_map);
+    nfa = create_sigma_star_nfa(&alphabet);
+    CHECK(is_in_lang(nfa, { {}, {} }));
+    CHECK(is_in_lang(nfa, { { 0 }, {} }));
+    CHECK(is_in_lang(nfa, { { 1 }, {} }));
+    CHECK(is_in_lang(nfa, { { 2 }, {} }));
+    CHECK(is_in_lang(nfa, { { 0, 1 }, {} }));
+    CHECK(is_in_lang(nfa, { { 1, 0 }, {} }));
+    CHECK(is_in_lang(nfa, { { 2, 2, 2 }, {} }));
+    CHECK(is_in_lang(nfa, { { 0, 1, 2, 2, 0, 1, 2, 1, 0, 0, 2, 1 }, {} }));
+    CHECK(!is_in_lang(nfa, { { 3 }, {} }));
+}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2899,7 +2899,7 @@ TEST_CASE("A segmentation fault in the make_complement") {
 }
 
 TEST_CASE("Mata::Nfa:: create simple automata") {
-    Nfa nfa{create_empty_string_nfa() };
+    Nfa nfa{ create_empty_string_nfa() };
     CHECK(is_in_lang(nfa, { {}, {} }));
     CHECK(get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
 

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -150,13 +150,13 @@ void ShortestWordsMap::update_current_words(LengthWordsPair& act, const LengthWo
 std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& aut) {
     Nfa::Nfa one_letter;
     /// if we are interested in lengths of words, it suffices to forget the different symbols on transitions. 
-    /// The lengths of @p aut are hence equivalent to lengts of the NFA taken from @p aut where all symbols on 
+    /// The lengths of @p aut are hence equivalent to lengths of the NFA taken from @p aut where all symbols on
     /// transitions are renamed to a single symbol (e.g., `a`).
     aut.get_one_letter_aut(one_letter);
     one_letter = determinize(one_letter);
     one_letter.trim();
     if(one_letter.size() == 0) {
-        return std::set<std::pair<int, int>>();
+        return {};
     } 
 
     std::set<std::pair<int, int>> ret;


### PR DESCRIPTION
This PR:
- adds comments to `Delta::m_num_of_states` and `Nfa::m_num_of_states` member variables explaining what we can assume about their values (`Nfa::m_num_of_states` can be less than the actual number of states in the whole automaton, even zero; `Delta::m_num_of_states` has to be equal to the maximal state in `Delta` (both for lhs and rhs) plus one at all times),
- as requested, adds functions to create basic automata (sigma star NFA and empty string NFA).

This PR therefore resolves #155.