### PR TITLE
Refactor functions to create alphabet from NFAs

### DIFF
--- a/examples/example04-complement.cc
+++ b/examples/example04-complement.cc
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-    OnTheFlyAlphabet alph{ stsm };
+    Mata::OnTheFlyAlphabet alph{ stsm };
 	Nfa cmpl = complement(aut, alph);
 
 	std::cout << std::to_string(cmpl);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -710,94 +710,6 @@ public:
         m_num_of_states = 0;
     }
 
-
-private:
-    // Adapted from: https://www.fluentcpp.com/2019/01/25/variadic-number-function-parameters-type/.
-    template<bool...> struct bool_pack{};
-    /// Checks for all types in the pack.
-    template<typename... Ts>
-    using conjunction = std::is_same<bool_pack<true,Ts::value...>, bool_pack<Ts::value..., true>>;
-    /// Checks whether all types are 'Nfa'.
-    template<typename... Ts>
-    using AreAllNfas = typename conjunction<std::is_same<Ts, const Mata::Nfa::Nfa&>...>::type;
-
-public:
-
-    /**
-      * Fill @p alphabet with symbols from @p nfa.
-      * @param[in] nfa NFA with symbols to fill @p alphabet with.
-      * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
-      */
-    static void fill_alphabet(const Mata::Nfa::Nfa& nfa, Mata::OnTheFlyAlphabet& alphabet);
-
-    /**
-     * Create alphabet from variable number of NFAs.
-     * @tparam[in] Nfas Type Nfa.
-     * @param[in] nfas NFAs to create alphabet from.
-     * @return Created alphabet.
-     */
-    template<typename... Nfas, typename = AreAllNfas<Nfas...>>
-    static OnTheFlyAlphabet from_nfas(const Nfas&... nfas) {
-        OnTheFlyAlphabet alphabet{};
-        auto f = [&alphabet](const Mata::Nfa::Nfa& aut) {
-            fill_alphabet(aut, alphabet);
-        };
-        (f(nfas), ...);
-        return alphabet;
-    }
-
-    /**
-     * Create alphabet from vector of of NFAs.
-     * @param[in] nfas Vector of NFAs to create alphabet from.
-     * @return Created alphabet.
-     */
-    static OnTheFlyAlphabet from_nfas(const ConstAutRefSequence& nfas) {
-        OnTheFlyAlphabet alphabet{};
-        for (const auto& nfa: nfas) {
-            fill_alphabet(nfa, alphabet);
-        }
-        return alphabet;
-    }
-
-    /**
-     * Create alphabet from vector of of NFAs.
-     * @param[in] nfas Vector of NFAs to create alphabet from.
-     * @return Created alphabet.
-     */
-    static OnTheFlyAlphabet from_nfas(const AutRefSequence& nfas) {
-        OnTheFlyAlphabet alphabet{};
-        for (const auto& nfa: nfas) {
-            fill_alphabet(nfa, alphabet);
-        }
-        return alphabet;
-    }
-
-    /**
-     * Create alphabet from vector of of NFAs.
-     * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
-     * @return Created alphabet.
-     */
-    static OnTheFlyAlphabet from_nfas(const ConstAutPtrSequence& nfas) {
-        OnTheFlyAlphabet alphabet{};
-        for (const Mata::Nfa::Nfa* const nfa: nfas) {
-            fill_alphabet(*nfa, alphabet);
-        }
-        return alphabet;
-    }
-
-    /**
-     * Create alphabet from vector of of NFAs.
-     * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
-     * @return Created alphabet.
-     */
-    static OnTheFlyAlphabet from_nfas(const AutPtrSequence& nfas) {
-        OnTheFlyAlphabet alphabet{};
-        for (const Mata::Nfa::Nfa* const nfa: nfas) {
-            fill_alphabet(*nfa, alphabet);
-        }
-        return alphabet;
-    }
-
     /**
      * @brief Expand alphabet by symbols from this automaton to given alphabet
      *
@@ -805,6 +717,64 @@ public:
      */
     void add_symbols_to(OnTheFlyAlphabet& alphabet);
 }; // Nfa
+
+/**
+  * Fill @p alphabet with symbols from @p nfa.
+  * @param[in] nfa NFA with symbols to fill @p alphabet with.
+  * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
+  */
+void fill_alphabet(const Mata::Nfa::Nfa& nfa, Mata::OnTheFlyAlphabet& alphabet);
+
+// Adapted from: https://www.fluentcpp.com/2019/01/25/variadic-number-function-parameters-type/.
+template<bool...> struct bool_pack{};
+/// Checks for all types in the pack.
+template<typename... Ts> using conjunction = std::is_same<bool_pack<true,Ts::value...>, bool_pack<Ts::value..., true>>;
+/// Checks whether all types are 'Nfa'.
+template<typename... Ts> using AreAllNfas = typename conjunction<std::is_same<Ts, const Mata::Nfa::Nfa&>...>::type;
+
+/**
+ * Create alphabet from variable number of NFAs.
+ * @tparam[in] Nfas Type Nfa.
+ * @param[in] nfas NFAs to create alphabet from.
+ * @return Created alphabet.
+ */
+template<typename... Nfas, typename = AreAllNfas<Nfas...>>
+inline OnTheFlyAlphabet create_alphabet(const Nfas&... nfas) {
+    Mata::OnTheFlyAlphabet alphabet{};
+    auto f = [&alphabet](const Mata::Nfa::Nfa& aut) {
+        fill_alphabet(aut, alphabet);
+    };
+    (f(nfas), ...);
+    return alphabet;
+}
+
+/**
+ * Create alphabet from a vector of NFAs.
+ * @param[in] nfas Vector of NFAs to create alphabet from.
+ * @return Created alphabet.
+ */
+OnTheFlyAlphabet create_alphabet(const ConstAutRefSequence& nfas);
+
+/**
+ * Create alphabet from a vector of NFAs.
+ * @param[in] nfas Vector of NFAs to create alphabet from.
+ * @return Created alphabet.
+ */
+OnTheFlyAlphabet create_alphabet(const AutRefSequence& nfas);
+
+/**
+ * Create alphabet from a vector of NFAs.
+ * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
+ * @return Created alphabet.
+ */
+OnTheFlyAlphabet create_alphabet(const ConstAutPtrSequence& nfas);
+
+/**
+ * Create alphabet from a vector of NFAs.
+ * @param[in] nfas Vector of pointers to NFAs to create alphabet from.
+ * @return Created alphabet.
+ */
+OnTheFlyAlphabet create_alphabet(const AutPtrSequence& nfas);
 
 /// Do the automata have disjoint sets of states?
 bool are_state_disjoint(const Nfa& lhs, const Nfa& rhs);

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -31,7 +31,7 @@ bool Mata::Nfa::Algorithms::is_included_naive(
         const StringMap &  /* params*/) { // {{{
     Nfa bigger_cmpl;
     if (alphabet == nullptr) {
-        bigger_cmpl = complement(bigger, Nfa::from_nfas(smaller, bigger));
+        bigger_cmpl = complement(bigger, create_alphabet(smaller, bigger));
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
@@ -268,7 +268,7 @@ bool Mata::Nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet *a
 
     if (params.at("algo") == "naive") {
         if (alphabet == nullptr) {
-            const auto computed_alphabet{ Nfa::from_nfas(lhs, rhs) };
+            const auto computed_alphabet{create_alphabet(lhs, rhs) };
             return compute_equivalence(lhs, rhs, &computed_alphabet, params, algo);
         }
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1568,7 +1568,7 @@ void Nfa::unify_final() {
     final.add(new_final_state);
 }
 
-void Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
+void Mata::Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
     size_t nfa_num_of_states{nfa.size() };
     for (Mata::Nfa::State state{ 0 }; state < nfa_num_of_states; ++state) {
         for (const auto state_transitions: nfa.delta) {
@@ -1577,6 +1577,7 @@ void Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
         }
     }
 }
+
 void Nfa::add_symbols_to(OnTheFlyAlphabet& alphabet) {
     size_t aut_num_of_states{size() };
     for (Mata::Nfa::State state{ 0 }; state < aut_num_of_states; ++state) {
@@ -1585,4 +1586,36 @@ void Nfa::add_symbols_to(OnTheFlyAlphabet& alphabet) {
             alphabet.try_add_new_symbol(std::to_string(state_transitions.symbol), state_transitions.symbol);
         }
     }
+}
+
+Mata::OnTheFlyAlphabet Mata::Nfa::create_alphabet(const ConstAutRefSequence& nfas) {
+    Mata::OnTheFlyAlphabet alphabet{};
+    for (const auto& nfa: nfas) {
+        fill_alphabet(nfa, alphabet);
+    }
+    return alphabet;
+}
+
+Mata::OnTheFlyAlphabet Mata::Nfa::create_alphabet(const AutRefSequence& nfas) {
+    Mata::OnTheFlyAlphabet alphabet{};
+    for (const auto& nfa: nfas) {
+        fill_alphabet(nfa, alphabet);
+    }
+    return alphabet;
+}
+
+Mata::OnTheFlyAlphabet Mata::Nfa::create_alphabet(const ConstAutPtrSequence& nfas) {
+    Mata::OnTheFlyAlphabet alphabet{};
+    for (const Mata::Nfa::Nfa* const nfa: nfas) {
+        fill_alphabet(*nfa, alphabet);
+    }
+    return alphabet;
+}
+
+Mata::OnTheFlyAlphabet Mata::Nfa::create_alphabet(const AutPtrSequence& nfas) {
+    Mata::OnTheFlyAlphabet alphabet{};
+    for (const Mata::Nfa::Nfa* const nfa: nfas) {
+        fill_alphabet(*nfa, alphabet);
+    }
+    return alphabet;
 }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -127,7 +127,7 @@ TEST_CASE("Mata::Nfa::IntAlphabet") {
     CHECK(different_alphabet.is_equal(&different_alphabet));
 }
 
-TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {
+TEST_CASE("Mata::Nfa::create_alphabet()") {
     Nfa a{1};
     a.delta.add(0, 'a', 0);
 
@@ -137,13 +137,13 @@ TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::from_nfas()") {
     Nfa c{1};
     b.delta.add(0, 'c', 0);
 
-    auto alphabet{ Nfa::from_nfas(a, b, c) };
+    auto alphabet{Mata::Nfa::create_alphabet(a, b, c) };
 
     auto symbols{alphabet.get_alphabet_symbols() };
     CHECK(symbols == Mata::Util::OrdVector<Symbol>{ 'c', 'b', 'a' });
 
-    //OnTheFlyAlphabet::from_nfas(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
-    //OnTheFlyAlphabet::from_nfas(a, b, 4); // Will not compile: '4' is not of the required type.
+    //Mata::Nfa::create_alphabet(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
+    //Mata::Nfa::create_alphabet(a, b, 4); // Will not compile: '4' is not of the required type.
 }
 
 TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {


### PR DESCRIPTION
This PR refactors functions to create alphabet from NFAs passed as function parameter(s). The changes include:
- renaming of said functions from `Mata::Nfa::Nfa::from_nfas()` (nonsensical name as a relict from when the declaration was `Mata::Nfa::OnTheFlyAlphabet::from_nfas` where it made sense) to `Mata::Nfa::create_alphabet()`,
- moving the functions from within class `Nfa` to namespace `Mata::Nfa` as normal functions.

This PR resolves #156.    