### PR TITLE
Fix simulation reduction

### DIFF
--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -36,9 +36,9 @@ const std::string Mata::Nfa::TYPE_NFA = "NFA";
 
 namespace {
     Simlib::Util::BinaryRelation compute_fw_direct_simulation(const Nfa& aut) {
-        Simlib::ExplicitLTS LTSforSimulation;
         Symbol maxSymbol = 0;
         const size_t state_num = aut.size();
+        Simlib::ExplicitLTS LTSforSimulation(state_num);
 
         for (State stateFrom = 0; stateFrom < state_num; ++stateFrom) {
             for (const Move &t : aut.get_moves_from(stateFrom)) {

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2300,6 +2300,14 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 		REQUIRE(result.final[state_map[9]]);
 		REQUIRE(result.final[state_map[3]]);
 	}
+
+	SECTION("no transitions from non-final state")
+	{
+		aut.delta.add(0, 'a', 1);
+		aut.initial = { 0 };
+		Nfa result = reduce(aut, &state_map);
+		CHECK(Mata::Nfa::are_equivalent(result, aut));
+	}
 }
 
 TEST_CASE("Mata::Nfa::union_norename()") {


### PR DESCRIPTION
This PR fixes simulation computation for automata that have non-final states without transitions. Before, this would lead to segfault.