### PR TITLE
Fix parsing of final states

### DIFF
--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -460,31 +460,15 @@ Afa construct(
         StringToSymbolMap*                   symbol_map = nullptr,
         StringToStateMap*                    state_map = nullptr)
 { // {{{
-    Afa aut;
-
-    bool remove_symbol_map = false;
-    if (nullptr == symbol_map)
-    {
-        symbol_map = new StringToSymbolMap();
-        remove_symbol_map = true;
+    StringToSymbolMap tmp_symbol_map;
+    if (symbol_map) {
+        tmp_symbol_map = *symbol_map;
     }
+    Mata::OnTheFlyAlphabet alphabet(tmp_symbol_map);
 
-    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
+    Afa aut = construct(parsed, &alphabet, state_map);
 
-    Mata::OnTheFlyAlphabet alphabet(*symbol_map);
-
-    try
-    {
-        aut = Mata::Afa::construct(parsed, &alphabet, state_map);
-    }
-    catch (std::exception&)
-    {
-        release_res();
-        throw;
-    }
-
-    release_res();
-    if (!remove_symbol_map) {
+    if (symbol_map) {
         *symbol_map = alphabet.get_symbol_map();
     }
     return aut;

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -460,31 +460,15 @@ Afa construct(
         StringToSymbolMap*                   symbol_map = nullptr,
         StringToStateMap*                    state_map = nullptr)
 { // {{{
-    Afa aut;
-
-    bool remove_symbol_map = false;
-    if (nullptr == symbol_map)
-    {
-        symbol_map = new StringToSymbolMap();
-        remove_symbol_map = true;
+    StringToSymbolMap tmp_symbol_map;
+    if (symbol_map) {
+        tmp_symbol_map = *symbol_map;
     }
+    Mata::OnTheFlyAlphabet alphabet(tmp_symbol_map);
 
-    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
-
-    Mata::OnTheFlyAlphabet alphabet(*symbol_map);
-
-    try
-    {
-        aut = Mata::Afa::construct(parsed, &alphabet, state_map);
-    }
-    catch (std::exception&)
-    {
-        release_res();
-        throw;
-    }
-
-    release_res();
-    if (!remove_symbol_map) {
+    Afa aut = construct(parsed, &alphabet, state_map);
+    
+    if (symbol_map) {
         *symbol_map = alphabet.get_symbol_map();
     }
     return aut;

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -460,15 +460,31 @@ Afa construct(
         StringToSymbolMap*                   symbol_map = nullptr,
         StringToStateMap*                    state_map = nullptr)
 { // {{{
-    StringToSymbolMap tmp_symbol_map;
-    if (symbol_map) {
-        tmp_symbol_map = *symbol_map;
-    }
-    Mata::OnTheFlyAlphabet alphabet(tmp_symbol_map);
+    Afa aut;
 
-    Afa aut = construct(parsed, &alphabet, state_map);
-    
-    if (symbol_map) {
+    bool remove_symbol_map = false;
+    if (nullptr == symbol_map)
+    {
+        symbol_map = new StringToSymbolMap();
+        remove_symbol_map = true;
+    }
+
+    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
+
+    Mata::OnTheFlyAlphabet alphabet(*symbol_map);
+
+    try
+    {
+        aut = Mata::Afa::construct(parsed, &alphabet, state_map);
+    }
+    catch (std::exception&)
+    {
+        release_res();
+        throw;
+    }
+
+    release_res();
+    if (!remove_symbol_map) {
         *symbol_map = alphabet.get_symbol_map();
     }
     return aut;

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -90,6 +90,11 @@ public:
 
     bool is_neg() const { return type == OPERATOR && operator_type == NEG; }
 
+    // TODO: should constant be its own operand type?
+    bool is_constant() const { return type == OPERAND && (name == "true" || name == "false"); }
+    bool is_true() const { return type == OPERAND && name == "true"; }
+    bool is_false() const { return type == OPERAND && name == "false"; }
+
     FormulaNode() : type(UNKNOWN), raw(""), name(""), operator_type(NOT_OPERATOR), operand_type(NOT_OPERAND) {}
 
     FormulaNode(Type t, std::string raw, std::string name,

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -992,31 +992,15 @@ Nfa construct(
         StringToSymbolMap*                   symbol_map = nullptr,
         StringToStateMap*                    state_map = nullptr)
 { // {{{
-    Nfa aut;
-
-    bool remove_symbol_map = false;
-    if (nullptr == symbol_map)
-    {
-        symbol_map = new StringToSymbolMap();
-        remove_symbol_map = true;
+    StringToSymbolMap tmp_symbol_map;
+    if (symbol_map) {
+        tmp_symbol_map = *symbol_map;
     }
+    Mata::OnTheFlyAlphabet alphabet(tmp_symbol_map);
 
-    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
+    Nfa aut = construct(parsed, &alphabet, state_map);
 
-    Mata::OnTheFlyAlphabet alphabet(*symbol_map);
-
-    try
-    {
-        aut = construct(parsed, &alphabet, state_map);
-    }
-    catch (std::exception&)
-    {
-        release_res();
-        throw;
-    }
-
-    release_res();
-    if (!remove_symbol_map) {
+    if (symbol_map) {
         *symbol_map = alphabet.get_symbol_map();
     }
     return aut;

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -992,15 +992,31 @@ Nfa construct(
         StringToSymbolMap*                   symbol_map = nullptr,
         StringToStateMap*                    state_map = nullptr)
 { // {{{
-    StringToSymbolMap tmp_symbol_map;
-    if (symbol_map) {
-        tmp_symbol_map = *symbol_map;
+    Nfa aut;
+
+    bool remove_symbol_map = false;
+    if (nullptr == symbol_map)
+    {
+        symbol_map = new StringToSymbolMap();
+        remove_symbol_map = true;
     }
-    Mata::OnTheFlyAlphabet alphabet(tmp_symbol_map);
 
-    Nfa aut = construct(parsed, &alphabet, state_map);
+    auto release_res = [&](){ if (remove_symbol_map) delete symbol_map; };
 
-    if (symbol_map) {
+    Mata::OnTheFlyAlphabet alphabet(*symbol_map);
+
+    try
+    {
+        aut = construct(parsed, &alphabet, state_map);
+    }
+    catch (std::exception&)
+    {
+        release_res();
+        throw;
+    }
+
+    release_res();
+    if (!remove_symbol_map) {
         *symbol_map = alphabet.get_symbol_map();
     }
     return aut;

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -900,6 +900,7 @@ void Mata::Afa::minimize(
   assert(false);
 } // minimize }}}
 
+// TODO this function should the same thing as the one taking IntermediateAut or be deleted
 Afa Mata::Afa::construct(
 	const Mata::Parser::ParsedSection&  parsec,
 	Alphabet*                            alphabet,
@@ -993,10 +994,9 @@ Afa Mata::Afa::construct(
                                  Mata::Afa::TYPE_AFA + "\"");
     }
 
-    bool remove_state_map = false;
+    StringToStateMap tmp_state_map;
     if (nullptr == state_map) {
-        state_map = new StringToStateMap();
-        remove_state_map = true;
+        state_map = &tmp_state_map;
     }
 
     // a lambda for translating state names to identifiers
@@ -1008,11 +1008,6 @@ Afa Mata::Afa::construct(
         } else {
             return (*state_map)[str];
         }
-    };
-
-    // a lambda for cleanup
-    auto clean_up = [&]() {
-        if (remove_state_map) { delete state_map; }
     };
 
     // lambda returning true if node is operator of given type
@@ -1076,7 +1071,6 @@ Afa Mata::Afa::construct(
         }
         else if (trans.second.children.size() != 2)
         {
-            clean_up();
             if (trans.second.children.size() == 1)
             {
                 throw std::runtime_error("Epsilon transitions not supported");
@@ -1132,10 +1126,6 @@ Afa Mata::Afa::construct(
 			aut.finalstates.insert(state);
 		}
 	}
-
-    // do the dishes and take out garbage
-    clean_up();
-
     return aut;
 } // construct }}}
 

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -1115,6 +1115,7 @@ Afa Mata::Afa::construct(
                       create_node(curr_graph->collect_node_names()));
     }
 
+	// TODO final states can be also given as true/false
 	if (inter_aut.are_final_states_conjunction_of_negation()) {
 		// final states are given as a conjunction of non-final states
 		auto non_final_states = inter_aut.final_formula.collect_node_names();

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -905,79 +905,7 @@ Afa Mata::Afa::construct(
 	Alphabet*                            alphabet,
 	StringToStateMap*                    state_map)
 { // {{{
-	assert(nullptr != alphabet);
-	Afa aut;
-
-	if (parsec.type != Mata::Afa::TYPE_AFA) {
-		throw std::runtime_error(std::string(__FUNCTION__) + ": expecting type \"" +
-                                 Mata::Afa::TYPE_AFA + "\"");
-	}
-
-	bool remove_state_map = false;
-	if (nullptr == state_map) {
-		state_map = new StringToStateMap();
-		remove_state_map = true;
-	}
-
-	State cnt_state = 0;
-
-	// a lambda for translating state names to identifiers
-	auto get_state_name = [state_map, &cnt_state](const std::string& str) {
-		auto it_insert_pair = state_map->insert({str, cnt_state});
-		if (it_insert_pair.second) { return cnt_state++; }
-		else { return it_insert_pair.first->second; }
-	};
-
-	// a lambda for cleanup
-	auto clean_up = [&]() {
-		if (remove_state_map) { delete state_map; }
-	};
-
-
-	auto it = parsec.dict.find("Initial");
-	if (parsec.dict.end() != it) {
-		for (const auto& str : it->second) {
-			State state = get_state_name(str);
-			aut.initialstates.insert(Node{state});
-		}
-	}
-
-
-	it = parsec.dict.find("Final");
-	if (parsec.dict.end() != it) {
-		for (const auto& str : it->second) {
-			State state = get_state_name(str);
-			aut.finalstates.insert(state);
-		}
-	}
-
-	for (const auto& body_line : parsec.body) {
-		if (body_line.size() < 2) {
-			// clean up
-      clean_up();
-
-      throw std::runtime_error("Invalid transition: " +
-        std::to_string(body_line));
-		}
-
-		State src_state = get_state_name(body_line[0]);
-    std::string formula;
-    for (size_t i = 1; i < body_line.size(); ++i) {
-      formula += body_line[i] + " ";
-    }
-
-	// TODO: Transform a positive Boolean formula from the string format
-	// to the inner representation (src state, symbol on transition, ordered
-	// vector of ordered vectors of states which corresponds to the formula in DNF) 
-	// Call the "add_trans" and "add_inverse_trans" functions over the
-	// parsed formula to add it do the automaton
-
-	}
-
-	// do the dishes and take out garbage
-	clean_up();
-
-    return aut;
+	return construct(Mata::IntermediateAut::parse_from_mf(Mata::Parser::Parsed{parsec})[0], alphabet, state_map);
 } // construct }}}
 
 Afa Mata::Afa::construct(
@@ -993,10 +921,9 @@ Afa Mata::Afa::construct(
                                  Mata::Afa::TYPE_AFA + "\"");
     }
 
-    bool remove_state_map = false;
+    StringToStateMap tmp_state_map;
     if (nullptr == state_map) {
-        state_map = new StringToStateMap();
-        remove_state_map = true;
+        state_map = &tmp_state_map;
     }
 
     // a lambda for translating state names to identifiers
@@ -1008,11 +935,6 @@ Afa Mata::Afa::construct(
         } else {
             return (*state_map)[str];
         }
-    };
-
-    // a lambda for cleanup
-    auto clean_up = [&]() {
-        if (remove_state_map) { delete state_map; }
     };
 
     // lambda returning true if node is operator of given type
@@ -1076,7 +998,6 @@ Afa Mata::Afa::construct(
         }
         else if (trans.second.children.size() != 2)
         {
-            clean_up();
             if (trans.second.children.size() == 1)
             {
                 throw std::runtime_error("Epsilon transitions not supported");
@@ -1132,9 +1053,6 @@ Afa Mata::Afa::construct(
 			aut.finalstates.insert(state);
 		}
 	}
-
-    // do the dishes and take out garbage
-    clean_up();
 
     return aut;
 } // construct }}}

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -1065,12 +1065,6 @@ Afa Mata::Afa::construct(
         aut.add_initial(initial_node);
     }
 
-    for (const auto& str : inter_aut.final_formula.collect_node_names())
-    {
-        State state = get_state_name(str);
-        aut.finalstates.insert(state);
-    }
-
     for (const auto& trans : inter_aut.transitions)
     {
         State src_state = get_state_name(trans.first.name);
@@ -1120,6 +1114,23 @@ Afa Mata::Afa::construct(
         aut.add_trans(src_state, symbol,
                       create_node(curr_graph->collect_node_names()));
     }
+
+	if (inter_aut.are_final_states_conjunction_of_negation()) {
+		// final states are given as a conjunction of non-final states
+		auto non_final_states = inter_aut.final_formula.collect_node_names();
+		for (const auto &state_name_and_number : *state_map) {
+			if (!non_final_states.count(state_name_and_number.first)) {
+				aut.finalstates.insert(state_name_and_number.second);
+			}
+		}
+	} else {
+		// final states are given normally
+		for (const auto& str : inter_aut.final_formula.collect_node_names())
+		{
+			State state = get_state_name(str);
+			aut.finalstates.insert(state);
+		}
+	}
 
     // do the dishes and take out garbage
     clean_up();

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -622,6 +622,30 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
         ++it;
         REQUIRE(it->count(state_map["QC0_0"]));
     }
+
+    SECTION("AFA final states from multiple negations")
+    {
+        std::string file =
+                "@AFA-explicit\n"
+                "%Initial q1\n"
+                "%Final !q0 & !q1 & !q3\n"
+                "q0 a1 & q1\n"
+                "q1 a2 & q2\n"
+                "q2 a1 & (q3 | q2)\n"
+                "q2 a2 & (q4 & q1)\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+        StringToStateMap state_map;
+        construct(&aut, inter_aut, &symbol_map, &state_map);
+
+        CHECK(aut.finalstates.size() == 2);
+		CHECK(aut.finalstates.count(state_map.at("2")));
+		CHECK(aut.finalstates.count(state_map.at("4")));
+
+    }
+
 } // }}}
 
 /*

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -444,22 +444,13 @@ void Mata::IntermediateAut::parse_transition(Mata::IntermediateAut &aut, const s
     if (aut.automaton_type == Mata::IntermediateAut::NFA && tokens[tokens.size()-2] != "&") {
         // we need to take care about this case manually since user does not need to determine
         // symbol and state naming and put conjunction to transition
-        if (aut.alphabet_type != Mata::IntermediateAut::BITVECTOR) {  
-            if (rhs.size() != 2) {
-                if (rhs.size() == 1)
-                {
-                    throw std::runtime_error("Epsilon transitions not supported");
-                }
-                else
-                {
-                    throw std::runtime_error("Invalid transition");
-                }
-            }
+        if (aut.alphabet_type != Mata::IntermediateAut::BITVECTOR) {
+            assert(rhs.size() == 2);
             postfix.push_back(Mata::FormulaNode{Mata::FormulaNode::Type::OPERAND, rhs[0], rhs[0],
                                                 Mata::FormulaNode::OperandType::SYMBOL});
             postfix.push_back(create_node(aut,rhs[1]));
         } else if (aut.alphabet_type == Mata::IntermediateAut::BITVECTOR) {
-            // this is a case where rhs state is not separated by conjunction from the rest of trans
+            // this is a case where rhs state not separated by conjunction from rest of trans
             postfix = infix_to_postfix(aut, std::vector<std::string>(rhs.begin(), rhs.end()-1));
             postfix.push_back(create_node(aut,rhs.back()));
         } else

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -589,8 +589,6 @@ std::unordered_set<std::string> Mata::IntermediateAut::get_positive_finals() con
 
 bool Mata::IntermediateAut::is_graph_conjunction_of_negations(const Mata::FormulaGraph &graph) {
     const FormulaGraph *act_graph = &graph;
-    if (act_graph->children.size() != 2)
-        return false;
 
     while (act_graph->children.size() == 2) {
         // this node is conjunction and the left son is negation, otherwise returns false
@@ -601,7 +599,11 @@ bool Mata::IntermediateAut::is_graph_conjunction_of_negations(const Mata::Formul
             return false;
     }
 
-    return true;
+    if (act_graph->node.is_operator() && act_graph->node.is_neg()) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 std::ostream& std::operator<<(std::ostream& os, const Mata::IntermediateAut& inter_aut)

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -444,13 +444,22 @@ void Mata::IntermediateAut::parse_transition(Mata::IntermediateAut &aut, const s
     if (aut.automaton_type == Mata::IntermediateAut::NFA && tokens[tokens.size()-2] != "&") {
         // we need to take care about this case manually since user does not need to determine
         // symbol and state naming and put conjunction to transition
-        if (aut.alphabet_type != Mata::IntermediateAut::BITVECTOR) {
-            assert(rhs.size() == 2);
+        if (aut.alphabet_type != Mata::IntermediateAut::BITVECTOR) {  
+            if (rhs.size() != 2) {
+                if (rhs.size() == 1)
+                {
+                    throw std::runtime_error("Epsilon transitions not supported");
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid transition");
+                }
+            }
             postfix.push_back(Mata::FormulaNode{Mata::FormulaNode::Type::OPERAND, rhs[0], rhs[0],
                                                 Mata::FormulaNode::OperandType::SYMBOL});
             postfix.push_back(create_node(aut,rhs[1]));
         } else if (aut.alphabet_type == Mata::IntermediateAut::BITVECTOR) {
-            // this is a case where rhs state not separated by conjunction from rest of trans
+            // this is a case where rhs state is not separated by conjunction from the rest of trans
             postfix = infix_to_postfix(aut, std::vector<std::string>(rhs.begin(), rhs.end()-1));
             postfix.push_back(create_node(aut,rhs.back()));
         } else

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -599,11 +599,8 @@ bool Mata::IntermediateAut::is_graph_conjunction_of_negations(const Mata::Formul
             return false;
     }
 
-    if (act_graph->node.is_operator() && act_graph->node.is_neg()) {
-        return true;
-    } else {
-        return false;
-    }
+    // the last child needs to be negation
+    return (act_graph->node.is_operator() && act_graph->node.is_neg());
 }
 
 std::ostream& std::operator<<(std::ostream& os, const Mata::IntermediateAut& inter_aut)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1387,14 +1387,6 @@ Nfa Mata::Nfa::construct(
         aut.initial.add(state);
     }
 
-    const auto final_states = inter_aut.are_final_states_conjunction_of_negation() ?
-            inter_aut.get_positive_finals() : inter_aut.final_formula.collect_node_names();
-    for (const auto& str : final_states)
-    {
-        State state = get_state_name(str);
-        aut.final.add(state);
-    }
-
     for (const auto& trans : inter_aut.transitions)
     {
         if (trans.second.children.size() != 2)
@@ -1417,6 +1409,26 @@ Nfa Mata::Nfa::construct(
         State tgt_state = get_state_name(trans.second.children[1].node.name);
 
         aut.delta.add(src_state, symbol, tgt_state);
+    }
+
+    std::unordered_set<std::string> final_formula_nodes;
+    if (!(inter_aut.final_formula.node.name == "true" || inter_aut.final_formula.node.name == "false")) { 
+        final_formula_nodes = inter_aut.final_formula.collect_node_names();
+    }
+    bool final_nodes_are_negated = (inter_aut.final_formula.node.name == "true" || inter_aut.are_final_states_conjunction_of_negation());
+
+    if (final_nodes_are_negated) {
+        for (const auto &state_name_and_id : *state_map) {
+            if (!final_formula_nodes.count(state_name_and_id.first)) {
+                aut.final.add(state_name_and_id.second);
+            }
+        }
+    } else {
+        for (const auto& str : final_formula_nodes)
+        {
+            State state = get_state_name(str);
+            aut.final.add(state);
+        }
     }
 
     // do the dishes and take out garbage

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1412,18 +1412,22 @@ Nfa Mata::Nfa::construct(
     }
 
     std::unordered_set<std::string> final_formula_nodes;
-    if (!(inter_aut.final_formula.node.name == "true" || inter_aut.final_formula.node.name == "false")) { 
+    if (!(inter_aut.final_formula.node.is_constant())) {
+        // we do not want to parse true/false (constant) as a state so we do not collect it
         final_formula_nodes = inter_aut.final_formula.collect_node_names();
     }
-    bool final_nodes_are_negated = (inter_aut.final_formula.node.name == "true" || inter_aut.are_final_states_conjunction_of_negation());
+    // for constant true, we will pretend that final nodes are negated with empty final_formula_nodes
+    bool final_nodes_are_negated = (inter_aut.final_formula.node.is_true() || inter_aut.are_final_states_conjunction_of_negation());
 
     if (final_nodes_are_negated) {
+        // we add all states NOT in final_formula_nodes to final states
         for (const auto &state_name_and_id : *state_map) {
             if (!final_formula_nodes.count(state_name_and_id.first)) {
                 aut.final.add(state_name_and_id.second);
             }
         }
     } else {
+        // we add all states in final_formula_nodes to final states
         for (const auto& str : final_formula_nodes)
         {
             State state = get_state_name(str);

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1257,6 +1257,7 @@ Nfa Mata::Nfa::determinize(
     return result;
 }
 
+// TODO this function should the same thing as the one taking IntermediateAut or be deleted
 Nfa Mata::Nfa::construct(
         const Mata::Parser::ParsedSection&   parsec,
         Alphabet*                            alphabet,
@@ -1359,10 +1360,9 @@ Nfa Mata::Nfa::construct(
                                  Mata::Nfa::TYPE_NFA + "\"");
     }
 
-    bool remove_state_map = false;
+    StringToStateMap tmp_state_map;
     if (nullptr == state_map) {
-        state_map = new StringToStateMap();
-        remove_state_map = true;
+        state_map = &tmp_state_map;
     }
 
     // a lambda for translating state names to identifiers
@@ -1376,11 +1376,6 @@ Nfa Mata::Nfa::construct(
         }
     };
 
-    // a lambda for cleanup
-    auto clean_up = [&]() {
-        if (remove_state_map) { delete state_map; }
-    };
-
     for (const auto& str : inter_aut.initial_formula.collect_node_names())
     {
         State state = get_state_name(str);
@@ -1391,9 +1386,6 @@ Nfa Mata::Nfa::construct(
     {
         if (trans.second.children.size() != 2)
         {
-            // clean up
-            clean_up();
-
             if (trans.second.children.size() == 1)
             {
                 throw std::runtime_error("Epsilon transitions not supported");
@@ -1434,9 +1426,6 @@ Nfa Mata::Nfa::construct(
             aut.final.add(state);
         }
     }
-
-    // do the dishes and take out garbage
-    clean_up();
 
     return aut;
 } // construct }}}

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1262,88 +1262,7 @@ Nfa Mata::Nfa::construct(
         Alphabet*                            alphabet,
         StringToStateMap*                    state_map)
 { // {{{
-    Nfa aut;
-    assert(nullptr != alphabet);
-
-    if (parsec.type != Mata::Nfa::TYPE_NFA) {
-        throw std::runtime_error(std::string(__FUNCTION__) + ": expecting type \"" +
-                                 Mata::Nfa::TYPE_NFA + "\"");
-    }
-
-    bool remove_state_map = false;
-    if (nullptr == state_map) {
-        state_map = new StringToStateMap();
-        remove_state_map = true;
-    }
-
-    // a lambda for translating state names to identifiers
-    auto get_state_name = [&state_map, &aut](const std::string& str) {
-        if (!state_map->count(str)) {
-            State state = aut.add_state();
-            state_map->insert({str, state});
-            return state;
-        } else {
-            return (*state_map)[str];
-        }
-    };
-
-    // a lambda for cleanup
-    auto clean_up = [&]() {
-        if (remove_state_map) { delete state_map; }
-    };
-
-
-    auto it = parsec.dict.find("Initial");
-    if (parsec.dict.end() != it)
-    {
-        for (const auto& str : it->second)
-        {
-            State state = get_state_name(str);
-            aut.initial.add(state);
-        }
-    }
-
-
-    it = parsec.dict.find("Final");
-    if (parsec.dict.end() != it)
-    {
-        for (const auto& str : it->second)
-        {
-            State state = get_state_name(str);
-            aut.final.add(state);
-        }
-    }
-
-    for (const auto& body_line : parsec.body)
-    {
-        if (body_line.size() != 3)
-        {
-            // clean up
-            clean_up();
-
-            if (body_line.size() == 2)
-            {
-                throw std::runtime_error("Epsilon transitions not supported: " +
-                                         std::to_string(body_line));
-            }
-            else
-            {
-                throw std::runtime_error("Invalid transition: " +
-                                         std::to_string(body_line));
-            }
-        }
-
-        State src_state = get_state_name(body_line[0]);
-        Symbol symbol = alphabet->translate_symb(body_line[1]);
-        State tgt_state = get_state_name(body_line[2]);
-
-        aut.delta.add(src_state, symbol, tgt_state);
-    }
-
-    // do the dishes and take out garbage
-    clean_up();
-
-    return aut;
+    return construct(Mata::IntermediateAut::parse_from_mf(Mata::Parser::Parsed{parsec})[0], alphabet, state_map);
 } // construct }}}
 
 Nfa Mata::Nfa::construct(
@@ -1359,10 +1278,9 @@ Nfa Mata::Nfa::construct(
                                  Mata::Nfa::TYPE_NFA + "\"");
     }
 
-    bool remove_state_map = false;
+    StringToStateMap tmp_state_map;
     if (nullptr == state_map) {
-        state_map = new StringToStateMap();
-        remove_state_map = true;
+        state_map = &tmp_state_map;
     }
 
     // a lambda for translating state names to identifiers
@@ -1376,10 +1294,6 @@ Nfa Mata::Nfa::construct(
         }
     };
 
-    // a lambda for cleanup
-    auto clean_up = [&]() {
-        if (remove_state_map) { delete state_map; }
-    };
 
     for (const auto& str : inter_aut.initial_formula.collect_node_names())
     {
@@ -1391,9 +1305,6 @@ Nfa Mata::Nfa::construct(
     {
         if (trans.second.children.size() != 2)
         {
-            // clean up
-            clean_up();
-
             if (trans.second.children.size() == 1)
             {
                 throw std::runtime_error("Epsilon transitions not supported");
@@ -1434,9 +1345,6 @@ Nfa Mata::Nfa::construct(
             aut.final.add(state);
         }
     }
-
-    // do the dishes and take out garbage
-    clean_up();
 
     return aut;
 } // construct }}}

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -960,6 +960,61 @@ TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
         REQUIRE(!is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3", "a4"})));
         REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"a1", "a2", "a3", "a5", "a7"})));
     }
+
+    SECTION("construct - final states given as true")
+    {
+        std::string file =
+                "@NFA-bits\n"
+                "%Alphabet-auto\n"
+                "%Initial q0 q8\n"
+                "%Final true\n"
+                "q0 a1 q1\n"
+                "q1 a2 q2\n"
+                "q2 a3 q3\n"
+                "q2 a4 q4\n"
+                "q3 a5 q5\n"
+                "q3 a6 q6\n"
+                "q5 a7 q7\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+		Mata::Nfa::StringToStateMap state_map;
+        construct(&aut, inter_aut, &symbol_map, &state_map);
+        CHECK(aut.final.size() == 9);
+		CHECK(aut.final[state_map.at("0")]);
+		CHECK(aut.final[state_map.at("1")]);
+		CHECK(aut.final[state_map.at("2")]);
+		CHECK(aut.final[state_map.at("3")]);
+		CHECK(aut.final[state_map.at("4")]);
+		CHECK(aut.final[state_map.at("5")]);
+		CHECK(aut.final[state_map.at("6")]);
+		CHECK(aut.final[state_map.at("7")]);
+		CHECK(aut.final[state_map.at("8")]);
+    }
+
+    SECTION("construct - final states given as false")
+    {
+        std::string file =
+                "@NFA-bits\n"
+                "%Alphabet-auto\n"
+                "%Initial q0 q8\n"
+                "%Final false\n"
+                "q0 a1 q1\n"
+                "q1 a2 q2\n"
+                "q2 a3 q3\n"
+                "q2 a4 q4\n"
+                "q3 a5 q5\n"
+                "q3 a6 q6\n"
+                "q5 a7 q7\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+		Mata::Nfa::StringToStateMap state_map;
+        construct(&aut, inter_aut, &symbol_map, &state_map);
+        CHECK(aut.final.size() == 0);
+    }
 } // }}}
 
 /*

--- a/src/tests-parser.cc
+++ b/src/tests-parser.cc
@@ -758,7 +758,7 @@ TEST_CASE("parsing automata to intermediate representation")
         REQUIRE(!finals.count("r"));
     }
 
-    SECTION("NFA - final states from negation")
+    SECTION("NFA - final states from multiple negations")
     {
         std::string file =
                 "@NFA-bits\n"
@@ -780,6 +780,36 @@ TEST_CASE("parsing automata to intermediate representation")
         REQUIRE(final_states.size() == 5);
         REQUIRE(final_states.count("2"));
         REQUIRE(final_states.count("3"));
+        REQUIRE(final_states.count("6"));
+        REQUIRE(final_states.count("7"));
+        REQUIRE(final_states.count("8"));
+    }
+	
+    SECTION("NFA - final states from one negation")
+    {
+        std::string file =
+                "@NFA-bits\n"
+                "%Alphabet-auto\n"
+                "%Initial q1 q8\n"
+                "%Final !q0\n"
+                "q0 (!a1 & !a2 & !a3 & (!a0 | a0)) q1\n"
+                "q1 (!a2 & !a3 & !a4 & (!a0 | a0)) q2\n"
+                "q2 (!a3 & !a4 & !a5 & (!a0 | a0)) q3\n"
+                "q2 (!a3 & !a4 & !a5 & (!a0 | a0)) q4\n"
+                "q3 (!a2 & !a3 & !a4 & (!a0 | a0)) q5\n"
+                "q3 (!a2 & !a3 & !a4 & (!a0 | a0)) q6\n"
+                "q5 (!a1 & !a2 & !a3 & (!a0 | a0)) q7\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        const Mata::IntermediateAut inter_aut = auts[0];
+
+        auto final_states = inter_aut.get_positive_finals();
+        REQUIRE(final_states.size() == 8);
+        REQUIRE(final_states.count("1"));
+        REQUIRE(final_states.count("2"));
+        REQUIRE(final_states.count("3"));
+        REQUIRE(final_states.count("4"));
+        REQUIRE(final_states.count("5"));
         REQUIRE(final_states.count("6"));
         REQUIRE(final_states.count("7"));
         REQUIRE(final_states.count("8"));


### PR DESCRIPTION
This PR fixes parsing into NFA and AFA when final states are given as a conjuction of negated non-final states. There was a problem if there was only one such negated state for NFA, and for AFA it was completely ignored. Also it fixes parsing into NFA when final formula is given as true/false (then final states are either empty set or all states).