### PR TITLE
Allow trimming the result in `Nfa::reduce()`

### DIFF
--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -278,7 +278,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         vector[CTrans] get_transitions_to(State)
         vector[CTrans] get_trans_as_sequence()
         vector[CTrans] get_trans_from_as_sequence(State)
-        void trim()
+        void trim(StateToStateMap*)
         void get_one_letter_aut(CNfa&)
         bool is_epsilon(Symbol)
         StateSet get_useful_states()
@@ -323,7 +323,7 @@ cdef extern from "mata/nfa-plumbing.hh" namespace "Mata::Nfa::Plumbing":
     cdef void revert(CNfa*, CNfa&)
     cdef void remove_epsilon(CNfa*, CNfa&, Symbol) except +
     cdef void minimize(CNfa*, CNfa&)
-    cdef void reduce(CNfa*, CNfa&, StateToStateMap*, StringMap&)
+    cdef void reduce(CNfa*, CNfa&, bool, StateToStateMap*, StringMap&)
 
 
 cdef extern from "mata/nfa-strings.hh" namespace "Mata::Strings":

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -987,10 +987,11 @@ cdef class Nfa:
         return result
 
     @classmethod
-    def reduce_with_state_map(cls, Nfa aut, bool trim_result = True, params = None):
+    def reduce_with_state_map(cls, Nfa aut, bool trim_input = True, params = None):
         """Reduce the automaton.
 
         :param Nfa aut: Original automaton to reduce.
+        :param bool trim_input: Whether to trim the input automaton first or not.
         :param Dict params: Additional parameters for the reduction algorithm:
             - "algorithm": "simulation"
         :return: (Reduced automaton, state map of original to new states)
@@ -998,7 +999,7 @@ cdef class Nfa:
         params = params or {"algorithm": "simulation"}
         cdef StateToStateMap state_map
         result = Nfa()
-        mata.reduce(result.thisptr.get(), dereference(aut.thisptr.get()), trim_result, &state_map,
+        mata.reduce(result.thisptr.get(), dereference(aut.thisptr.get()), trim_input, &state_map,
             {
                 k.encode('utf-8'): v.encode('utf-8') for k, v in params.items()
             }
@@ -1007,10 +1008,10 @@ cdef class Nfa:
         return result, {k: v for k, v in state_map}
 
     @classmethod
-    def reduce(cls, Nfa aut, bool trim_result = True, params = None):
+    def reduce(cls, Nfa aut, bool trim_input = True, params = None):
         """Reduce the automaton.
 
-        :param trim_result: Whether to trim the result.
+        :param bool trim_input: Whether to trim the input automaton first or not.
         :param Nfa aut: Original automaton to reduce.
         :param Dict params: Additional parameters for the reduction algorithm:
             - "algorithm": "simulation"
@@ -1018,7 +1019,7 @@ cdef class Nfa:
         """
         params = params or {"algorithm": "simulation"}
         result = Nfa()
-        mata.reduce(result.thisptr.get(), dereference(aut.thisptr.get()), trim_result, NULL,
+        mata.reduce(result.thisptr.get(), dereference(aut.thisptr.get()), trim_input, NULL,
             {
                 k.encode('utf-8'): v.encode('utf-8') for k, v in params.items()
             }

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -923,7 +923,7 @@ def test_reduce():
     nfa = mata.Nfa()
 
     # Test the reduction of an empty automaton.
-    result, state_map = mata.Nfa.reduce_with_state_map(nfa)
+    result, state_map = mata.Nfa.reduce_with_state_map(nfa, False)
     assert result.get_num_of_trans() == 0
     assert len(result.initial_states) == 0
     assert len(result.final_states) == 0
@@ -932,13 +932,17 @@ def test_reduce():
     nfa.add_state(2)
     nfa.make_initial_state(1)
     nfa.make_final_state(2)
-    result, state_map = mata.Nfa.reduce_with_state_map(nfa)
+    result, state_map = mata.Nfa.reduce_with_state_map(nfa, False)
     assert result.get_num_of_trans() == 0
     assert result.size() == 2
     assert result.has_initial_state(state_map[1])
     assert result.has_final_state(state_map[2])
     assert state_map[1] == state_map[0]
     assert state_map[2] != state_map[0]
+
+    result, state_map = mata.Nfa.reduce_with_state_map(nfa, True)
+    assert result.get_num_of_trans() == 0
+    assert result.size() == 0
 
     # Test the reduction of a bigger automaton.
     nfa.add_state(9)
@@ -960,7 +964,7 @@ def test_reduce():
     nfa.add_transition(9, ord('c'), 0)
     nfa.add_transition(0, ord('a'), 4)
 
-    result, state_map = mata.Nfa.reduce_with_state_map(nfa)
+    result, state_map = mata.Nfa.reduce_with_state_map(nfa, False)
     assert result.size() == 6
     assert result.has_initial_state(state_map[1])
     assert result.has_initial_state(state_map[2])

--- a/include/mata/nfa-plumbing.hh
+++ b/include/mata/nfa-plumbing.hh
@@ -61,10 +61,11 @@ namespace Plumbing {
     inline void reduce(
             Nfa* result,
             const Nfa &aut,
+            bool trim_result = true,
             StateToStateMap *state_map = nullptr,
             const StringMap&  params = {{"algorithm", "simulation"}})
     { // {{{
-        *result = reduce(aut, state_map, params);
+        *result = reduce(aut, trim_result, state_map, params);
     } // reduce }}}
 
     inline void revert(Nfa* result, const Nfa& aut)

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -881,7 +881,7 @@ Nfa determinize(
  * Reduce the size of the automaton.
  *
  * @param[in] aut Automaton to reduce.
- * @param[in] trim_result Whether to trim the result automaton or not.
+ * @param[in] trim_input Whether to trim the input automaton first or not.
  * @param[out] state_map Mapping of trimmed states to new states.
  * @param params[in] Optional parameters to control the reduction algorithm:
  * - "algorithm": "simulation".
@@ -889,7 +889,7 @@ Nfa determinize(
  */
 Nfa reduce(
         const Nfa &aut,
-        bool trim_result = true,
+        bool trim_input = true,
         StateToStateMap *state_map = nullptr,
         const StringMap&  params = {{"algorithm", "simulation"}});
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -556,8 +556,10 @@ public:
      * Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
      * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
      * the starting point of a path ending in a final state).
+     *
+     * @param[out] state_map Mapping of trimmed states to new states.
      */
-    void trim();
+    void trim(StateToStateMap* state_map = nullptr);
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
@@ -566,9 +568,10 @@ public:
      * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
      * the starting point of a path ending in a final state).
      *
+     * @param[out] state_map Mapping of trimmed states to new states.
      * @return Trimmed automaton.
      */
-    Nfa get_trimmed_automaton();
+    Nfa get_trimmed_automaton(StateToStateMap* state_map = nullptr);
 
     // FIXME: Resolve this comment and delete it.
     /* Lukas: the above is nice. The good thing is that access to [q] is constant,
@@ -874,9 +877,19 @@ Nfa determinize(
         const Nfa&  aut,
         std::unordered_map<StateSet, State> *subset_map = nullptr);
 
-// Reduce the size of the automaton
+/**
+ * Reduce the size of the automaton.
+ *
+ * @param[in] aut Automaton to reduce.
+ * @param[in] trim_result Whether to trim the result automaton or not.
+ * @param[out] state_map Mapping of trimmed states to new states.
+ * @param params[in] Optional parameters to control the reduction algorithm:
+ * - "algorithm": "simulation".
+ * @return Reduced automaton.
+ */
 Nfa reduce(
         const Nfa &aut,
+        bool trim_result = true,
         StateToStateMap *state_map = nullptr,
         const StringMap&  params = {{"algorithm", "simulation"}});
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1197,7 +1197,7 @@ Nfa Mata::Nfa::reduce(const Nfa &aut, bool trim_result, StateToStateMap *state_m
             StateToStateMap result_state_map{ *state_map };
             for (const auto& reduced_mapping : *state_map) {
                 const auto trimmed_mapping{ trimmed_state_map.find(reduced_mapping.second) };
-                if (trimmed_state_map.find(reduced_mapping.second) != trimmed_state_map.end()) {
+                if (trimmed_mapping != trimmed_state_map.end()) {
                     result_state_map[reduced_mapping.first] = trimmed_mapping->second;
                 }
             }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -40,14 +40,10 @@ namespace {
         const size_t state_num = aut.size();
         Simlib::ExplicitLTS LTSforSimulation(state_num);
 
-        for (State stateFrom = 0; stateFrom < state_num; ++stateFrom) {
-            for (const Move &t : aut.get_moves_from(stateFrom)) {
-                for (State stateTo : t.targets) {
-                    LTSforSimulation.add_transition(stateFrom, t.symbol, stateTo);
-                }
-                if (t.symbol > maxSymbol) {
-                    maxSymbol = t.symbol;
-                }
+        for (const auto& transition : aut.delta) {
+            LTSforSimulation.add_transition(transition.src, transition.symb, transition.tgt);
+            if (transition.symb > maxSymbol) {
+                maxSymbol = transition.symb;
             }
         }
 


### PR DESCRIPTION
This PR implements use of `Nfa::Nfa::trim()` inside `Nfa::reduce()` as suggested by #163.

Resolves #163.