### PR TITLE
Use algorithm instead of algo

### DIFF
--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -877,7 +877,7 @@ cdef class Nfa:
         :return: complemented automaton, map of subsets to states
         """
         result = Nfa()
-        params = params or {'algo': 'classical'}
+        params = params or {'algorithm': 'classical'}
         cdef umap[StateSet, State] subset_map
         mata.complement(
             result.thisptr.get(),
@@ -901,7 +901,7 @@ cdef class Nfa:
         :return: complemented automaton
         """
         result = Nfa()
-        params = params or {'algo': 'classical'}
+        params = params or {'algorithm': 'classical'}
         mata.complement(
             result.thisptr.get(),
             dereference(lhs.thisptr.get()),
@@ -1080,11 +1080,11 @@ cdef class Nfa:
 
         :param Nfa lhs: automaton tested for universality
         :param OnTheFlyAlphabet alphabet: on the fly alphabet
-        :param dict params: additional params to the function, currently supports key 'algo',
+        :param dict params: additional params to the function, currently supports key 'algorithm',
             which determines used universality test
         :return: true if lhs is universal
         """
-        params = params or {'algo': 'antichains'}
+        params = params or {'algorithm': 'antichains'}
         return mata.is_universal(
             dereference(lhs.thisptr.get()),
             <CAlphabet&>dereference(alphabet.as_base()),
@@ -1110,7 +1110,7 @@ cdef class Nfa:
         cdef CAlphabet* c_alphabet = NULL
         if alphabet:
             c_alphabet = alphabet.as_base()
-        params = params or {'algo': 'antichains'}
+        params = params or {'algorithm': 'antichains'}
         result = mata.is_included(
             dereference(lhs.thisptr.get()),
             dereference(rhs.thisptr.get()),
@@ -1138,7 +1138,7 @@ cdef class Nfa:
         cdef CAlphabet* c_alphabet = NULL
         if alphabet:
             c_alphabet = alphabet.as_base()
-        params = params or {'algo': 'antichains'}
+        params = params or {'algorithm': 'antichains'}
         result = mata.is_included(
             dereference(lhs.thisptr.get()),
             dereference(rhs.thisptr.get()),
@@ -1159,10 +1159,10 @@ cdef class Nfa:
         :param Nfa rhs: Bigger automaton.
         :param Alphabet alphabet: Alphabet shared by two automata.
         :param dict params: Additional params:
-            - "algo": "antichains"
+            - "algorithm": "antichains"
         :return: True if lhs is equivalent to rhs, False otherwise.
         """
-        params = params or {'algo': 'antichains'}
+        params = params or {'algorithm': 'antichains'}
         cdef CAlphabet * c_alphabet = NULL
         if alphabet:
             c_alphabet = alphabet.as_base()

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -329,7 +329,7 @@ bool is_universal(
 	const Afa&         aut,
 	const Alphabet&    alphabet,
 	Word*              cex = nullptr,
-	const StringDict&  params = {{"algo", "antichains"}});
+	const StringDict&  params = {{"algorithm", "antichains"}});
 
 inline bool is_universal(
 	const Afa&         aut,
@@ -348,7 +348,7 @@ bool is_incl(
 	const Afa&         bigger,
 	const Alphabet&    alphabet,
 	Word*              cex = nullptr,
-	const StringDict&  params = {{"algo", "antichains"}});
+	const StringDict&  params = {{"algorithm", "antichains"}});
 
 inline bool is_incl(
 	const Afa&         smaller,

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -64,7 +64,7 @@ using StateClosedSet = Mata::ClosedSet<Mata::Afa::State>;
 
 /*
 * A node is an ordered vector of states of the automaton.
-* A transition consists of a source state, a symbol on the transition 
+* A transition consists of a source state, a symbol on the transition
 * and a vector of nodes (which are the destination of the transition).
 *
 * In context of an AFA, the transition relation maps a state and a symbol
@@ -73,7 +73,7 @@ using StateClosedSet = Mata::ClosedSet<Mata::Afa::State>;
 * a formula can be converted to the DNF, we can represent it as an ordered vector
 * of nodes. The ordered vector represents a set of disjuncts. Each node corresponds
 * to a single disjunct of a formula in DNF (states connected by conjunctions).
-* 
+*
 */
 struct Trans
 {
@@ -100,13 +100,13 @@ using TransRelation = std::vector<TransList>;
 * of a given node 'N' if the node 'precondition' is its subset. */
 struct InverseResults{
 
-	Node result_node{}; 
+	Node result_node{};
 	Node precondition{};
 
 	InverseResults() : result_node(), precondition() { }
-	InverseResults(State state, Node precondition) : result_node(Node(state)), 
+	InverseResults(State state, Node precondition) : result_node(Node(state)),
 	precondition(precondition) { }
-	InverseResults(Node result_node, Node precondition) : result_node(result_node), 
+	InverseResults(Node result_node, Node precondition) : result_node(result_node),
 	precondition(precondition) { }
 
 	bool operator==(InverseResults rhs) const
@@ -121,7 +121,7 @@ struct InverseResults{
 
 	bool operator<(InverseResults rhs) const
 	{ // {{{
-		return precondition < rhs.precondition || 
+		return precondition < rhs.precondition ||
 		(precondition == rhs.precondition && result_node < rhs.result_node);
 	} // operator< }}}
 
@@ -130,18 +130,18 @@ struct InverseResults{
 /*
 * A tuple (state, symb, inverseResults). The structure inverseResults contains tuples (inverseResult,
 * precondition). If a node is a subset of 'precondition', the 'inverseResult' is a predecessor
-* of the given node which is accessible through the symbol 'symb'. 
+* of the given node which is accessible through the symbol 'symb'.
 * The state 'state' is always part of all 'preconditions' and it is a minimal element of them.
 */
 struct InverseTrans{
 
 	State state;
-	Symbol symb;    
+	Symbol symb;
 	std::vector<InverseResults> inverseResults{};
 
 	InverseTrans() : symb(), inverseResults() { }
 	InverseTrans(Symbol symb) : symb(symb), inverseResults(std::vector<InverseResults>()) { }
-	InverseTrans(Symbol symb, InverseResults inverseResults_) : symb(symb) 
+	InverseTrans(Symbol symb, InverseResults inverseResults_) : symb(symb)
 	{ inverseResults.push_back(inverseResults_); }
 	InverseTrans(State state, Symbol symb, InverseResults inverseResults_) : state(state), symb(symb)
 	{ inverseResults.push_back(inverseResults_); }
@@ -172,7 +172,7 @@ public:
 
 	explicit Afa(const unsigned long num_of_states, const Nodes& initial_states = Nodes{},
 		         const StateSet& final_states = StateSet{})
-		: transitionrelation(num_of_states), inverseTransRelation(num_of_states), 
+		: transitionrelation(num_of_states), inverseTransRelation(num_of_states),
 		initialstates(initial_states), finalstates(final_states) {}
 
 public:
@@ -198,7 +198,7 @@ public:
 	} // }}}
 	bool has_initial(Node node) const
 	{ // {{{
-		return StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1, 
+		return StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1,
 		initialstates).contains(node);
 	} // }}}
 	void add_final(State state) { this->finalstates.insert(state); }
@@ -275,7 +275,7 @@ public:
 
 	StateClosedSet pre(StateClosedSet closed_set) const {return pre(closed_set.antichain());};
 
-	StateClosedSet get_initial_nodes(void) const 
+	StateClosedSet get_initial_nodes(void) const
 	{
 		StateClosedSet result = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1);
 		for(const auto& node : initialstates)
@@ -287,7 +287,7 @@ public:
 
 	StateClosedSet get_non_initial_nodes(void) const {return StateClosedSet(upward_closed_set,
 	0, transitionrelation.size()-1, initialstates).complement();};
-	StateClosedSet get_final_nodes(void) const {return StateClosedSet(downward_closed_set, 
+	StateClosedSet get_final_nodes(void) const {return StateClosedSet(downward_closed_set,
 	0, transitionrelation.size()-1, finalstates);};
 	StateClosedSet get_non_final_nodes(void) const;
 

--- a/include/mata/nfa-plumbing.hh
+++ b/include/mata/nfa-plumbing.hh
@@ -39,7 +39,7 @@ namespace Plumbing {
             Nfa*               result,
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            const StringMap&  params = {{"algo", "classical"}},
+            const StringMap&  params = {{"algorithm", "classical"}},
             std::unordered_map<StateSet, State> *subset_map = nullptr)
     { // {{{
         *result = complement(aut, alphabet, params, subset_map);

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -224,7 +224,7 @@ struct Delta {
 private:
     std::vector<Post> post;
 
-    /// Number of actual states occuring in the transition relation.
+    /// Number of actual states occurring in the transition relation.
     ///
     /// These states are used in the transition relation, either on the left side or on the right side.
     /// The value is always consistent with the actual number of states in the transition relation.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -874,7 +874,7 @@ void make_complete(
 Nfa complement(
         const Nfa&         aut,
         const Alphabet&    alphabet,
-        const StringMap&  params = {{"algo", "classical"}},
+        const StringMap&  params = {{"algorithm", "classical"}},
         std::unordered_map<StateSet, State> *subset_map = nullptr);
 
 Nfa minimize(const Nfa &aut);
@@ -905,7 +905,7 @@ bool is_universal(
         const Nfa&         aut,
         const Alphabet&    alphabet,
         Run*              cex = nullptr,
-        const StringMap&  params = {{"algo", "antichains"}});
+        const StringMap&  params = {{"algorithm", "antichains"}});
 
 inline bool is_universal(
         const Nfa&         aut,
@@ -923,7 +923,7 @@ inline bool is_universal(
  * @param cex[out] Counterexample for the inclusion.
  * @param alphabet[in] Alphabet of both NFAs to compute with.
  * @param params[in] Optional parameters to control the equivalence check algorithm:
- * - "algo": "naive", "antichains" (Default: "antichains")
+ * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p smaller is included in @p bigger, false otherwise.
  */
 bool is_included(
@@ -931,18 +931,18 @@ bool is_included(
         const Nfa&         bigger,
         Run*               cex,
         const Alphabet*    alphabet = nullptr,
-        const StringMap&   params = {{"algo", "antichains"}});
+        const StringMap&   params = {{"algorithm", "antichains"}});
 
 /**
  * @brief Checks inclusion of languages of two NFAs: @p smaller and @p bigger (smaller <= bigger).
  * @param params[in] Optional parameters to control the equivalence check algorithm:
- * - "algo": "naive", "antichains" (Default: "antichains")
+ * - "algorithm": "naive", "antichains" (Default: "antichains")
  */
 inline bool is_included(
         const Nfa&             smaller,
         const Nfa&             bigger,
         const Alphabet* const  alphabet = nullptr,
-        const StringMap&      params = {{"algo", "antichains"}})
+        const StringMap&      params = {{"algorithm", "antichains"}})
 { // {{{
     return is_included(smaller, bigger, nullptr, alphabet, params);
 } // }}}
@@ -954,11 +954,11 @@ inline bool is_included(
  * @param rhs[in] Second automaton to concatenate.
  * @param alphabet[in] Alphabet of both NFAs to compute with.
  * @param params[in] Optional parameters to control the equivalence check algorithm:
- * - "algo": "naive", "antichains" (Default: "antichains")
+ * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
 bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet,
-                    const StringMap& params = {{"algo", "antichains"}});
+                    const StringMap& params = {{"algorithm", "antichains"}});
 
 /**
  * @brief Perform equivalence check of two NFAs: @p lhs and @p rhs.
@@ -974,10 +974,10 @@ bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet,
  * @param lhs[in] First automaton to concatenate.
  * @param rhs[in] Second automaton to concatenate.
  * @param params[in] Optional parameters to control the equivalence check algorithm:
- * - "algo": "naive", "antichains" (Default: "antichains")
+ * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
-bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const StringMap& params = {{"algo", "antichains"}});
+bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const StringMap& params = {{"algorithm", "antichains"}});
 
 /// Reverting the automaton
 Nfa revert(const Nfa& aut);

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -81,13 +81,13 @@ Nfa Mata::Nfa::complement(
 	Nfa result;
 	// setting the default algorithm
 	decltype(Algorithms::complement_classical)* algo = Algorithms::complement_classical;
-	if (!haskey(params, "algo")) {
+	if (!haskey(params, "algorithm")) {
 		throw std::runtime_error(std::to_string(__func__) +
 			" requires setting the \"algo\" key in the \"params\" argument; "
 			"received: " + std::to_string(params));
 	}
 
-	const std::string& str_algo = params.at("algo");
+	const std::string& str_algo = params.at("algorithm");
 	if ("classical" == str_algo) {  /* default */ }
 	else {
 		throw std::runtime_error(std::to_string(__func__) +

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -228,14 +228,14 @@ namespace {
     }
 
     AlgoType set_algorithm(const std::string &function_name, const StringMap &params) {
-        if (!haskey(params, "algo")) {
+        if (!haskey(params, "algorithm")) {
             throw std::runtime_error(function_name +
                                      " requires setting the \"algo\" key in the \"params\" argument; "
                                      "received: " + std::to_string(params));
         }
 
         decltype(Algorithms::is_included_naive) *algo;
-        const std::string &str_algo = params.at("algo");
+        const std::string &str_algo = params.at("algorithm");
         if ("naive" == str_algo) {
             algo = Algorithms::is_included_naive;
         } else if ("antichains" == str_algo) {
@@ -266,7 +266,7 @@ bool Mata::Nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet *a
     //TODO: add comment on what this is doing, what is __func__ ...
     AlgoType algo{ set_algorithm(std::to_string(__func__), params) };
 
-    if (params.at("algo") == "naive") {
+    if (params.at("algorithm") == "naive") {
         if (alphabet == nullptr) {
             const auto computed_alphabet{create_alphabet(lhs, rhs) };
             return compute_equivalence(lhs, rhs, &computed_alphabet, params, algo);

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -154,7 +154,7 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
                 }
             }
 
-            for (const State& smaller_succ : smaller_move.targets) {            
+            for (const State& smaller_succ : smaller_move.targets) {
                 const ProdStateType succ = {smaller_succ, bigger_succ};
 
                 if (smaller.final[smaller_succ] &&

--- a/src/nfa/nfa-universal.cc
+++ b/src/nfa/nfa-universal.cc
@@ -156,13 +156,13 @@ bool Mata::Nfa::is_universal(
 
 	// setting the default algorithm
 	decltype(Algorithms::is_universal_naive)* algo = Algorithms::is_universal_naive;
-	if (!haskey(params, "algo")) {
+	if (!haskey(params, "algorithm")) {
 		throw std::runtime_error(std::to_string(__func__) +
 			" requires setting the \"algo\" key in the \"params\" argument; "
 			"received: " + std::to_string(params));
 	}
 
-	const std::string& str_algo = params.at("algo");
+	const std::string& str_algo = params.at("algorithm");
 	if ("naive" == str_algo) { /* default */ }
 	else if ("antichains" == str_algo) {
 		algo = Algorithms::is_universal_antichains;

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -364,7 +364,7 @@ TEST_CASE("Mata::Nfa::union_norename()")
 
 		OnTheFlyAlphabet alph{"a", "b"};
 		StringMap params;
-		params["algo"] = "antichains";
+		params["algorithm"] = "antichains";
 
 		REQUIRE(is_included(a, res, &alph, params));
 		REQUIRE(is_included(b, res, &alph, params));
@@ -380,7 +380,7 @@ TEST_CASE("Mata::Nfa::union_norename()")
 
 		OnTheFlyAlphabet alph{"a", "b"};
 		StringMap params;
-		params["algo"] = "antichains";
+		params["algorithm"] = "antichains";
 
 		REQUIRE(is_included(a, res, &alph, params));
 		REQUIRE(is_included(res, a, &alph, params));
@@ -1361,7 +1361,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		OnTheFlyAlphabet alph{};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, params);
 
 			REQUIRE(!is_univ);
@@ -1375,7 +1375,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.final = {1};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(is_univ);
@@ -1390,7 +1390,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.final = {1};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(!is_univ);
@@ -1409,7 +1409,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(2, alph["b"], 2);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, params);
 
 			REQUIRE(!is_univ);
@@ -1426,7 +1426,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(2, alph["b"], 2);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, params);
 
 			REQUIRE(!is_univ);
@@ -1443,7 +1443,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(1, alph["b"], 1);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, params);
 
 			REQUIRE(is_univ);
@@ -1468,7 +1468,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(5, alph["b"], 5);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(!is_univ);
@@ -1496,7 +1496,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(4, alph["b"], 4);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(is_univ);
@@ -1520,7 +1520,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(4, alph["b"], 3);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(is_univ);
@@ -1536,7 +1536,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 		aut.delta.add(1, alph["a"], 1);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_univ = is_universal(aut, alph, &cex, params);
 
 			REQUIRE(is_univ);
@@ -1554,7 +1554,7 @@ TEST_CASE("Mata::Nfa::is_universal()")
 	SECTION("wrong parameters 2")
 	{
 		OnTheFlyAlphabet alph{};
-		params["algo"] = "foo";
+		params["algorithm"] = "foo";
 
 		CHECK_THROWS_WITH(is_universal(aut, alph, params),
 			Catch::Contains("received an unknown value"));
@@ -1578,7 +1578,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		OnTheFlyAlphabet alph{};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &alph, params);
 			CHECK(is_incl);
 
@@ -1594,7 +1594,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		bigger.final = {1};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
             CHECK(is_incl);
 
@@ -1612,7 +1612,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		bigger.final = {11};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
             CHECK(is_incl);
 
@@ -1628,7 +1628,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		smaller.final = {1};
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
 
 			REQUIRE(!is_incl);
@@ -1654,7 +1654,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		bigger.delta.add(11, alph["b"], 11);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &alph, params);
 			REQUIRE(is_incl);
 
@@ -1677,7 +1677,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		bigger.delta.add(12, alph["b"], 12);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 
 			bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
 
@@ -1717,7 +1717,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 		bigger.delta.add(15, alph["b"], 15);
 
 		for (const auto& algo : ALGORITHMS) {
-			params["algo"] = algo;
+			params["algorithm"] = algo;
 			bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
 			REQUIRE(!is_incl);
 
@@ -1752,7 +1752,7 @@ TEST_CASE("Mata::Nfa::is_included()")
 	SECTION("wrong parameters 2")
 	{
         OnTheFlyAlphabet alph{};
-		params["algo"] = "foo";
+		params["algorithm"] = "foo";
 
 		CHECK_THROWS_WITH(is_included(smaller, bigger, &alph, params),
 			Catch::Contains("received an unknown value"));
@@ -1777,7 +1777,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
         OnTheFlyAlphabet alph{};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algo"] = algo;
+            params["algorithm"] = algo;
 
             CHECK(are_equivalent(smaller, bigger, &alph, params));
             CHECK(are_equivalent(smaller, bigger, params));
@@ -1796,7 +1796,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
         bigger.final = {1};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algo"] = algo;
+            params["algorithm"] = algo;
 
             CHECK(!are_equivalent(smaller, bigger, &alph, params));
             CHECK(!are_equivalent(smaller, bigger, params));
@@ -1817,7 +1817,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
         bigger.final = {11};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algo"] = algo;
+            params["algorithm"] = algo;
 
             CHECK(are_equivalent(smaller, bigger, &alph, params));
             CHECK(are_equivalent(smaller, bigger, params));
@@ -1843,7 +1843,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
         bigger.delta.add(11, alph["b"], 11);
 
         for (const auto& algo : ALGORITHMS) {
-            params["algo"] = algo;
+            params["algorithm"] = algo;
 
             //TODO:what about we test the plumbing versions primarily?
             // Debugging with the dispatcher is annoying.
@@ -1890,7 +1890,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
         bigger.delta.add(15, alph["b"], 15);
 
         for (const auto& algo : ALGORITHMS) {
-            params["algo"] = algo;
+            params["algorithm"] = algo;
 
             CHECK(!are_equivalent(smaller, bigger, &alph, params));
             CHECK(!are_equivalent(smaller, bigger, params));
@@ -1916,7 +1916,7 @@ TEST_CASE("Mata::Nfa::are_equivalent")
     SECTION("wrong parameters 2")
     {
         OnTheFlyAlphabet alph{};
-        params["algo"] = "foo";
+        params["algorithm"] = "foo";
 
         CHECK_THROWS_WITH(are_equivalent(smaller, bigger, &alph, params),
                           Catch::Contains("received an unknown value"));


### PR DESCRIPTION
This PR changes all occurrences of `algo` in additional parameters to several functions to `algorithm` as agreed upon in #170.

This PR resolves #170.