### PR TITLE
Fix concatenate

### DIFF
--- a/include/mata/nfa-strings.hh
+++ b/include/mata/nfa-strings.hh
@@ -110,10 +110,10 @@ namespace Strings {
     WordSet get_shortest_words(const Nfa::Nfa& nfa);
 
     /**
-     * @brief Get the lengths of all words in the automaton @p aut. The function returns a set of pairs <u,v> where for each 
-     * such a pair there is a word with length u+k*v for all ks. The disjunction of such formulae of all pairs hence precisely 
+     * @brief Get the lengths of all words in the automaton @p aut. The function returns a set of pairs <u,v> where for each
+     * such a pair there is a word with length u+k*v for all ks. The disjunction of such formulae of all pairs hence precisely
      * describe lengths of all words in the automaton.
-     * 
+     *
      * @param aut Input automaton
      * @return Set of pairs describing lengths
      */
@@ -163,7 +163,7 @@ namespace SegNfa {
 
         /**
          * Get the epsilon depth trans map object (mapping of depths and states to eps-successors)
-         * 
+         *
          * @return Map of depths to a map of states to transitions
          */
         const EpsilonDepthTransitionMap& get_epsilon_depth_trans_map() const { return this->eps_depth_trans_map; }
@@ -267,7 +267,8 @@ namespace SegNfa {
         /**
          * @brief Remove inner initial and final states.
          *
-         * Remove all initial states for all segments but the first one and all final states for all segments but the last one.
+         * Remove all initial states for all segments but the first one and all final states for all segments but the
+         *  last one.
          */
         void remove_inner_initial_and_final_states();
     }; // Class Segmentation.
@@ -283,7 +284,7 @@ namespace SegNfa {
 
     /**
      * @brief segs_one_initial_final
-     * 
+     *
      * segments_one_initial_final[init, final] is the pointer to automaton created from one of
      * the segments such that init and final are one of the initial and final states of the segment
      * and the created automaton takes this segment, sets initial={init}, final={final}
@@ -292,7 +293,7 @@ namespace SegNfa {
      * segments_one_initial_final[init, unused_state] is similarly for the last segment
      * TODO: should we use unordered_map? then we need hash
      */
-    void segs_one_initial_final(const Mata::Nfa::AutSequence& segments, bool include_empty, 
+    void segs_one_initial_final(const Mata::Nfa::AutSequence& segments, bool include_empty,
         const State& unused_state, std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>>& out);
 
     /**
@@ -385,7 +386,7 @@ namespace SegNfa {
 
     /**
      * @brief Process epsilon map to a sequence of values (sorted according to key desc)
-     * 
+     *
      * @param eps_cnt Epsilon count
      * @return Vector of keys (count of epsilons)
      */

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -19,8 +19,7 @@
 
 using namespace Mata::Nfa;
 
-namespace Mata {
-namespace Nfa {
+namespace Mata { namespace Nfa {
 
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon,
                 StateToStateMap* lhs_result_states_map, StateToStateMap* rhs_result_states_map) {

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -41,8 +41,6 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     Nfa result{}; // Concatenated automaton.
     StateToStateMap lhs_result_states_map_internal{}; // Map mapping rhs states to result states.
     StateToStateMap rhs_result_states_map_internal{}; // Map mapping rhs states to result states.
-    const bool lhs_accepts_empty_string{ is_in_lang(lhs, Run{{}, {}}) };
-    const bool rhs_accepts_empty_string{ is_in_lang(rhs, Run{{}, {}}) };
 
     const size_t result_num_of_states{lhs_states_num + rhs_states_num};
     if (result_num_of_states == 0) { return Nfa{}; }
@@ -64,9 +62,6 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     result = Nfa();
     result.delta = lhs.delta;
     result.initial = lhs.initial;
-    if (rhs_accepts_empty_string) {
-        result.final = lhs.final;
-    }
     result.add_state(result_num_of_states-1);
 
     // Add epsilon transitions connecting lhs and rhs automata.

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -542,7 +542,6 @@ TEST_CASE("Mata::Nfa::concatenate() over epsilon symbol") {
 
         auto shortest_words{ get_shortest_words(result) };
         CHECK(shortest_words.size() == 1);
-        CHECK(shortest_words.find(std::vector<Symbol>{ 'b' }) != shortest_words.end());
     }
 
     SECTION("Automaton A concatenate automaton B")
@@ -623,4 +622,14 @@ TEST_CASE("Bug with epsilon transitions") {
     nfa2.delta.add(0, 100, 0);
 
     auto result{ concatenate(nfa1, nfa2, true) };
+
+    Nfa expected{ nfa1 };
+    expected.delta.add(3, EPSILON, 4);
+    expected.delta.add(4, 97, 4);
+    expected.delta.add(4, 98, 4);
+    expected.delta.add(4, 99, 4);
+    expected.delta.add(4, 100, 4);
+    expected.final = { 4 };
+
+    CHECK(are_equivalent(result, expected));
 }

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -601,3 +601,26 @@ TEST_CASE("(a|b)*") {
     auto concatenated_aut{ concatenate(aut1, aut2) };
     CHECK(are_equivalent(concatenated_aut, aut3));
 }
+
+TEST_CASE("Bug with epsilon transitions") {
+    Nfa nfa1{};
+    nfa1.initial.add(0);
+    nfa1.final.add(3);
+    nfa1.delta.add(0, 97, 0);
+    nfa1.delta.add(0, 98, 0);
+    nfa1.delta.add(0, 99, 0);
+    nfa1.delta.add(0, 100, 0);
+    nfa1.delta.add(0, EPSILON, 1);
+    nfa1.delta.add(1, 97, 2);
+    nfa1.delta.add(2, 98, 3);
+
+    Nfa nfa2{};
+    nfa2.initial.add(0);
+    nfa2.final.add(0);
+    nfa2.delta.add(0, 97, 0);
+    nfa2.delta.add(0, 98, 0);
+    nfa2.delta.add(0, 99, 0);
+    nfa2.delta.add(0, 100, 0);
+
+    auto result{ concatenate(nfa1, nfa2, true) };
+}

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -125,9 +125,9 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
 }
 
 void SegNfa::segs_one_initial_final(
-    const Mata::Nfa::AutSequence& segments, 
-    bool include_empty, 
-    const State& unused_state, 
+    const Mata::Nfa::AutSequence& segments,
+    bool include_empty,
+    const State& unused_state,
     std::map<std::pair<State, State>, std::shared_ptr<Nfa::Nfa>>& out) {
 
     for (auto iter = segments.begin(); iter != segments.end(); ++iter) {
@@ -225,9 +225,9 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
 
         if(item.seg_id + 1 == segments.size()) {
             // check if the noodle is already there
-            if(!std::any_of(noodles.begin(), noodles.end(), 
-                [&](NoodleSubst &s) { 
-                    return s == item.noodle; 
+            if(!std::any_of(noodles.begin(), noodles.end(),
+                [&](NoodleSubst &s) {
+                    return s == item.noodle;
             } )) {
                 noodles.push_back(item.noodle);
             }
@@ -347,7 +347,7 @@ SegNfa::NoodleSequence SegNfa::noodlify_for_equation(const AutPtrSequence& left_
 }
 
 
-SegNfa::NoodleSubstSequence SegNfa::noodlify_for_equation(const std::vector<std::shared_ptr<Nfa::Nfa>>& left_automata, 
+SegNfa::NoodleSubstSequence SegNfa::noodlify_for_equation(const std::vector<std::shared_ptr<Nfa::Nfa>>& left_automata,
     const std::vector<std::shared_ptr<Nfa::Nfa>>& right_automata, bool include_empty, const StringMap& params) {
     const auto left_automata_begin{ left_automata.begin() };
     const auto left_automata_end{ left_automata.end() };
@@ -356,27 +356,27 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_for_equation(const std::vector<std:
 
     for (auto left_aut_iter{ left_automata_begin }; left_aut_iter != left_automata_end;
          ++left_aut_iter) {
-        (*left_aut_iter).get()->unify_initial();
-        (*left_aut_iter).get()->unify_final();
+        left_aut_iter->get()->unify_initial();
+        left_aut_iter->get()->unify_final();
     }
     for (auto right_aut_iter{ right_automata_begin }; right_aut_iter != right_automata_end;
          ++right_aut_iter) {
-        (*right_aut_iter).get()->unify_initial();
-        (*right_aut_iter).get()->unify_final();
+        right_aut_iter->get()->unify_initial();
+        right_aut_iter->get()->unify_final();
     }
 
     if (left_automata.empty() || right_automata.empty()) { return NoodleSubstSequence{}; }
 
     // Automaton representing the left side concatenated over epsilon transitions.
-    Nfa::Nfa concatenated_left_side{ *left_automata_begin->get() };
+    Nfa::Nfa concatenated_left_side{ **left_automata_begin };
     for (auto next_left_automaton_it{ left_automata_begin + 1 }; next_left_automaton_it != left_automata_end;
          ++next_left_automaton_it) {
-        concatenated_left_side = concatenate_eps(concatenated_left_side, *next_left_automaton_it->get(), EPSILON, true);
+        concatenated_left_side = concatenate_eps(concatenated_left_side, **next_left_automaton_it, EPSILON, true);
     }
-    Nfa::Nfa concatenated_right_side{ *right_automata_begin->get() };
+    Nfa::Nfa concatenated_right_side{ **right_automata_begin };
     for (auto next_right_automaton_it{ right_automata_begin + 1 }; next_right_automaton_it != right_automata_end;
          ++next_right_automaton_it) {
-        concatenated_right_side = concatenate_eps(concatenated_right_side, *next_right_automaton_it->get(), EPSILON-1, true); // we use EPSILON-1
+        concatenated_right_side = concatenate_eps(concatenated_right_side, **next_right_automaton_it, EPSILON-1, true); // we use EPSILON-1
     }
 
     const std::set<Symbol> epsilons({EPSILON, EPSILON-1});

--- a/src/strings/tests-nfa-noodlification.cc
+++ b/src/strings/tests-nfa-noodlification.cc
@@ -368,11 +368,11 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
         create_nfa(&z, "(a|b)*");
         create_nfa(&w, "(a|b)*");
 
-        auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( { 
-                {{x, {0, 0} }, {x, {0, 1} }, {y, {1, 1} }}, 
+        auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( {
+                {{x, {0, 0} }, {x, {0, 1} }, {y, {1, 1} }},
                 {{x, {0, 0} }, {y, {1, 0} }, {y, {1, 1} }} } );
         SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
-            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) }, 
+            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) },
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(z), std::make_shared<Nfa>(w)});
         for(size_t i = 0; i < noodles.size(); i++) {
             for(size_t j = 0; j < noodles[i].size(); j++) {
@@ -392,14 +392,14 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
         create_nfa(&w, "(a|b)+");
         create_nfa(&astar, "a*");
 
-        auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( { 
-                {{x, {0, 1} }, {z, {1, 1} }}, 
-                {{x, {0, 0} }, {w, {1, 1} }}, 
-                {{x, {0, 0} }, {x, {0, 1} }, {z, {1, 1} }}, 
-                {{x, {0, 0} }, {z, {1, 0} }, {w, {1, 1} }}, 
+        auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( {
+                {{x, {0, 1} }, {z, {1, 1} }},
+                {{x, {0, 0} }, {w, {1, 1} }},
+                {{x, {0, 0} }, {x, {0, 1} }, {z, {1, 1} }},
+                {{x, {0, 0} }, {z, {1, 0} }, {w, {1, 1} }},
          } );
         SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
-            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) }, 
+            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) },
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(z), std::make_shared<Nfa>(w)});
         for(size_t i = 0; i < noodles.size(); i++) {
             for(size_t j = 0; j < noodles[i].size(); j++) {
@@ -420,7 +420,7 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
 
         auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( {} );
        SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
-            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x) }, 
+            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x) },
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(y), std::make_shared<Nfa>(z), std::make_shared<Nfa>(w)});
         CHECK(noodles.size() == 1);
         for(size_t i = 0; i < noodles.size(); i++) {
@@ -441,11 +441,11 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
         create_nfa(&w, "(a|b)*");
 
         auto res = std::vector<std::vector<std::pair<Nfa, SegNfa::EpsCntVector>>>( {
-                {{y, {1, 1} }}, 
+                {{y, {1, 1} }},
                 {{y, {1, 0} }, {y, {1, 1} }},
             } );
         SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
-            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) }, 
+            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) },
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(z), std::make_shared<Nfa>(w)});
         CHECK(noodles.size() == 2);
         for(size_t i = 0; i < noodles.size(); i++) {
@@ -469,7 +469,7 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
                 {{x, {0, 0} }, {x, {1, 1} }},
             } );
         SegNfa::NoodleSubstSequence noodles = SegNfa::noodlify_for_equation(
-            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) }, 
+            std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(x), std::make_shared<Nfa>(y) },
             std::vector<std::shared_ptr<Nfa>>{std::make_shared<Nfa>(z), std::make_shared<Nfa>(u)});
         CHECK(noodles.size() == 1);
         for(size_t i = 0; i < noodles.size(); i++) {

--- a/src/strings/tests-nfa-noodlification.cc
+++ b/src/strings/tests-nfa-noodlification.cc
@@ -378,6 +378,8 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
             for(size_t j = 0; j < noodles[i].size(); j++) {
                 CHECK(noodles[i][j].second == res[i][j].second);
                 CHECK(are_equivalent(*noodles[i][j].first.get(), res[i][j].first, nullptr));
+                auto used_symbols{ noodles[i][j].first->get_used_symbols() };
+                CHECK(used_symbols.find(EPSILON) == used_symbols.end());
             }
         }
     }
@@ -403,6 +405,8 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
             for(size_t j = 0; j < noodles[i].size(); j++) {
                 CHECK(noodles[i][j].second == res[i][j].second);
                 CHECK(are_equivalent(*noodles[i][j].first.get(), res[i][j].first, nullptr));
+                auto used_symbols{ noodles[i][j].first->get_used_symbols() };
+                CHECK(used_symbols.find(EPSILON) == used_symbols.end());
             }
         }
     }
@@ -423,6 +427,8 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
             for(size_t j = 0; j < noodles[i].size(); j++) {
                 CHECK(noodles[i][j].second == res[i][j].second);
                 CHECK(are_equivalent(*noodles[i][j].first.get(), res[i][j].first, nullptr));
+                auto used_symbols{ noodles[i][j].first->get_used_symbols() };
+                CHECK(used_symbols.find(EPSILON) == used_symbols.end());
             }
         }
     }
@@ -446,6 +452,8 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
             for(size_t j = 0; j < noodles[i].size(); j++) {
                 CHECK(noodles[i][j].second == res[i][j].second);
                 CHECK(are_equivalent(*noodles[i][j].first.get(), res[i][j].first, nullptr));
+                auto used_symbols{ noodles[i][j].first->get_used_symbols() };
+                CHECK(used_symbols.find(EPSILON) == used_symbols.end());
             }
         }
     }
@@ -468,6 +476,8 @@ TEST_CASE("Mata::Nfa::SegNfa::noodlify_for_equation() both sides") {
             for(size_t j = 0; j < noodles[i].size(); j++) {
                 CHECK(noodles[i][j].second == res[i][j].second);
                 CHECK(are_equivalent(*noodles[i][j].first.get(), res[i][j].first, nullptr));
+                auto used_symbols{ noodles[i][j].first->get_used_symbols() };
+                CHECK(used_symbols.find(EPSILON) == used_symbols.end());
             }
         }
     }


### PR DESCRIPTION
This PR fixes setting final states of the first automaton in epsilon concatenation as final states of the result when the second automaton accepts empty string. This was a relict of non-epsilon concatenation. Additionally, some trailing whitespaces were removed as well.