### PR TITLE
Eps lang check

### DIFF
--- a/include/mata/nfa-strings.hh
+++ b/include/mata/nfa-strings.hh
@@ -119,6 +119,14 @@ namespace Strings {
      */
     std::set<std::pair<int, int>> get_word_lengths(const Nfa::Nfa& aut);
 
+    /**
+     * @brief Checks if the automaton @p nfa accepts only a single word \eps. 
+     * 
+     * @param nfa Input automaton
+     * @return true iff L(nfa) = {\eps}
+     */
+    bool is_lang_eps(const Nfa::Nfa& nfa);
+
 /**
  * Operations on segment automata.
  */

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -578,7 +578,7 @@ public:
      * @param[out] state_map Mapping of trimmed states to new states.
      * @return Trimmed automaton.
      */
-    Nfa get_trimmed_automaton(StateToStateMap* state_map = nullptr);
+    Nfa get_trimmed_automaton(StateToStateMap* state_map = nullptr) const;
 
     // FIXME: Resolve this comment and delete it.
     /* Lukas: the above is nice. The good thing is that access to [q] is constant,

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -539,7 +539,7 @@ void Nfa::trim(StateToStateMap* state_map)
     }
 }
 
-Nfa Nfa::get_trimmed_automaton(StateToStateMap* state_map) {
+Nfa Nfa::get_trimmed_automaton(StateToStateMap* state_map) const {
     if (initial.empty() || final.empty()) { return Nfa{}; }
 
     StateToStateMap tmp_state_map{};

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -198,3 +198,14 @@ std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& au
 
     return ret;
 }
+
+bool Mata::Strings::is_lang_eps(const Nfa::Nfa& aut) {
+    Nfa::Nfa tr_aut = aut.get_trimmed_automaton();
+    for(const auto& ini : tr_aut.initial) {
+        if(!tr_aut.final[ini])
+            return false;
+        if(tr_aut.delta[ini].size() > 0)
+            return false;
+    }
+    return true;
+}

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -201,6 +201,8 @@ std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& au
 
 bool Mata::Strings::is_lang_eps(const Nfa::Nfa& aut) {
     Nfa::Nfa tr_aut = aut.get_trimmed_automaton();
+    if(tr_aut.initial.size() == 0)
+        return false;
     for(const auto& ini : tr_aut.initial) {
         if(!tr_aut.final[ini])
             return false;

--- a/src/strings/tests-nfa-string-solving.cc
+++ b/src/strings/tests-nfa-string-solving.cc
@@ -276,4 +276,9 @@ TEST_CASE("Mata::Strings::is_lang_eps()") {
         create_nfa(&x, "");
         CHECK(is_lang_eps(x));
     }
+
+    SECTION("basic 3") {
+        Nfa x;
+        CHECK(!is_lang_eps(x));
+    }
 }

--- a/src/strings/tests-nfa-string-solving.cc
+++ b/src/strings/tests-nfa-string-solving.cc
@@ -262,3 +262,18 @@ TEST_CASE("Mata::Strings::get_lengths()") {
         }));
     }
 }
+
+TEST_CASE("Mata::Strings::is_lang_eps()") {
+     
+    SECTION("basic") {
+        Nfa x;
+        create_nfa(&x, "(abcde)*");
+        CHECK(!is_lang_eps(x));
+    }
+
+    SECTION("basic 2") {
+        Nfa x;
+        create_nfa(&x, "");
+        CHECK(is_lang_eps(x));
+    }
+}


### PR DESCRIPTION
This PR introduces a function `is_lang_eps` for checking whether the language of the given automaton contains only epsilon word.