### PR TITLE
Util refactorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ VERSION
 
 .DS_Store
 .vscode/
+.venv
+bindings/python/libmata.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(libMATA)
 
+set(CMAKE_CXX_STANDARD 17)
+
 # 3rd party modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 # Enable fancy colours

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <mata/util.hh>
+#include <mata/ord-vector.hh>
 
 namespace Mata {
         using Symbol = unsigned long;

--- a/include/mata/number-predicate.hh
+++ b/include/mata/number-predicate.hh
@@ -8,378 +8,377 @@
 #include <vector>
 #include <mata/ord-vector.hh>
 
-namespace Mata {
-    namespace Util {
+namespace Mata::Util {
 
-        /**
-         * A sort of enhanced boolean array,
-         * implementing a set of numbers, aka a unary predicate over numbers, that provides a constant test and update.
-         * A number that is explicitly added is in the set, all the other numbers are implicitly not in the set.
-         *
-         * Besides a vector of bools (predicate), it can also be asked to maintain a vector of elements (elements).
-         * To keep constant test and set, new elements are pushed back to the vector but remove does not modify the vector.
-         * Hence, after a remove, the vector contains a superset of the true elements.
-         * Superset is still useful, to iterate through true elements, iterate through the vector and test membership in the bool array.
-         * tracking_elements indicates that elements are tracked in the vector of elements as described above.
-         * elements_are_exact indicates that the vector of elements contains the exact set of true elements.
-         * INVARIANT:
-         *  tracking_elements -> elements contains a superset of the true elements
-         *  elements_are_exact -> elements contain exactly the true elements
-         *
-         * predicate.size() is referred to as "the size of the domain". Ideally, the "domain" would not be visible form the outside,
-         * but the size of the domain is going to be used to determine the number of states in the nfa automaton :(.
-         * This is somewhat ugly, but don't know how else to do it efficiently (computing true maximum would be costly).
-         */
-        template <class Number> class OrdVector;
+template <class Number> class OrdVector;
 
-        template<typename Number>
-        class NumberPredicate {
-        private:
-            mutable std::vector<bool> predicate = {};
-            mutable std::vector <Number> elements = {};
-            mutable bool elements_are_exact = true;
-            mutable bool tracking_elements = true;
-            //TODO: if it is never used with tracking_elements = false, then we can remove that and simplify.
+/**
+ * A sort of enhanced boolean array,
+ * implementing a set of numbers, aka a unary predicate over numbers, that provides a constant test and update.
+ * A number that is explicitly added is in the set, all the other numbers are implicitly not in the set.
+ *
+ * Besides a vector of bools (predicate), it can also be asked to maintain a vector of elements (elements).
+ * To keep constant test and set, new elements are pushed back to the vector but remove does not modify the vector.
+ * Hence, after a remove, the vector contains a superset of the true elements.
+ * Superset is still useful, to iterate through true elements, iterate through the vector and test membership in the bool array.
+ * tracking_elements indicates that elements are tracked in the vector of elements as described above.
+ * elements_are_exact indicates that the vector of elements contains the exact set of true elements.
+ * INVARIANT:
+ *  tracking_elements -> elements contains a superset of the true elements
+ *  elements_are_exact -> elements contain exactly the true elements
+ *
+ * predicate.size() is referred to as "the size of the domain". Ideally, the "domain" would not be visible form the outside,
+ * but the size of the domain is going to be used to determine the number of states in the nfa automaton :(.
+ * This is somewhat ugly, but don't know how else to do it efficiently (computing true maximum would be costly).
+ */
+template<typename Number> class NumberPredicate {
+private:
+    mutable std::vector<bool> predicate = {};
+    mutable std::vector <Number> elements = {};
+    mutable bool elements_are_exact = true;
+    mutable bool tracking_elements = true;
+    //TODO: if it is never used with tracking_elements = false, then we can remove that and simplify.
 
-            using const_iterator = typename std::vector<Number>::const_iterator;
+    using const_iterator = typename std::vector<Number>::const_iterator;
 
-            /**
-             * assuming that elements contain a superset of the true elements, prune them (in situ)
-             */
-            void prune_elements() const {
-                Number new_pos = 0;
-                for (Number orig_pos = 0; orig_pos < elements.size(); ++orig_pos) {
-                    if (predicate[elements[orig_pos]]) {
-                        elements[new_pos] = elements[orig_pos];
-                        ++new_pos;
-                    }
-                }
-                elements.resize(new_pos);
-                elements_are_exact = true;
+    /**
+     * assuming that elements contain a superset of the true elements, prune them (in situ)
+     */
+    void prune_elements() const {
+        Number new_pos = 0;
+        for (Number orig_pos = 0; orig_pos < elements.size(); ++orig_pos) {
+            if (predicate[elements[orig_pos]]) {
+                elements[new_pos] = elements[orig_pos];
+                ++new_pos;
             }
+        }
+        elements.resize(new_pos);
+        elements_are_exact = true;
+    }
 
-            /**
-             * assuming nothing, compute the true elements from scratch
-             */
-            void compute_elements() const {
-                elements.clear();
-                for (Number q = 0, size=predicate.size(); q < size; ++q) {
-                    if (predicate[q])
-                        elements.push_back(q);
-                }
-                elements_are_exact = true;
+    /**
+     * assuming nothing, compute the true elements from scratch
+     */
+    void compute_elements() const {
+        elements.clear();
+        for (Number q = 0, size=predicate.size(); q < size; ++q) {
+            if (predicate[q])
+                elements.push_back(q);
+        }
+        elements_are_exact = true;
+    }
+
+    /**
+     * calls prune_elements or compute_elements based on the state of the indicator variables
+     */
+    void update_elements() const {
+        if (!elements_are_exact) {
+            if (!tracking_elements) {
+                compute_elements();
+            } else {
+                prune_elements();
             }
+        }
+    }
 
-            /**
-             * calls prune_elements or compute_elements based on the state of the indicator variables
-             */
-            void update_elements() const {
-                if (!elements_are_exact) {
-                    if (!tracking_elements) {
-                        compute_elements();
-                    } else {
-                        prune_elements();
-                    }
-                }
+public:
+    NumberPredicate(bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {};
+
+    NumberPredicate(std::initializer_list <Number> list, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
+        for (auto q: list)
+            add(q);
+    }
+
+    NumberPredicate(std::vector <Number> list, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
+        add(list);
+    }
+
+    NumberPredicate(Mata::Util::OrdVector<Number> vec, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
+        for (auto q: vec)
+            add(q);
+    }
+
+    template <class InputIterator>
+    NumberPredicate(InputIterator first, InputIterator last)
+    {
+        while (first < last) {
+            add(*first);
+            ++first;
+        }
+    }
+
+    /*
+     * Note that it extends predicate if q is out of its current domain.
+     */
+    void add(Number q) {
+        if (predicate.size() <= q)
+            predicate.resize(q+1,false);
+        if (tracking_elements) {
+            Number q_was_there = predicate[q];
+            predicate[q] = true;
+            if (!q_was_there) {
+                elements.push_back(q);
             }
+        } else {
+            predicate[q] = true;
+            elements_are_exact = false;
+        }
+    }
 
-        public:
-            NumberPredicate(bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {};
+    void remove(Number q) {
+        elements_are_exact = false;
+        if (q < predicate.size() && predicate[q]) {
+            predicate[q] = false;
+        }
+    }
 
-            NumberPredicate(std::initializer_list <Number> list, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
-                for (auto q: list)
-                    add(q);
+    void add(const std::vector <Number> &elems) {
+        for (Number q: elems)
+            add(q);
+    }
+
+    void remove(const std::vector <Number> &elems) {
+        for (Number q: elems)
+            remove(q);
+    }
+
+    /**
+     * start tracking elements (might require updating them to establish the invariant)
+     */
+    void track_elements() {
+        if (!tracking_elements) {
+            update_elements();
+            tracking_elements = true;
+        }
+    }
+
+    void dont_track_elements() {
+        tracking_elements = false;
+    }
+
+    /**
+     * @return True if predicate for @p q is set. False otherwise (even if q is out of range of the predicate).
+     */
+    bool operator[](Number q) const {
+        if (q < predicate.size())
+            return predicate[q];
+        else
+            return false;
+    }
+
+    /**
+     * This is the number of the true elements, not the size of any data structure.
+     */
+    Number size() const {
+        if (elements_are_exact)
+            return elements.size();
+        if (tracking_elements) {
+            prune_elements();
+            return elements.size();
+        } else {
+            Number cnt = 0;
+            for (Number q = 0, size = predicate.size(); q < size; ++q) {
+                if (predicate[q])
+                    cnt++;
             }
+            return cnt;
+        }
+    }
 
-            NumberPredicate(std::vector <Number> list, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
-                add(list);
+    /*
+     * Clears the set of true elements. Does not clear the predicate, only sets it false everywhere.
+     */
+    void clear() {
+        if (tracking_elements)
+            for (size_t i = 0, size = elements.size(); i < size; i++)
+                predicate[elements[i]] = false;
+        else
+            //for (size_t i = 0, size = predicate.size(); i < size; i++)
+            //    predicate[i] = false;
+            // Vysvetlete mi, co dela to && nize a zaplatim obed.
+            for (auto && i : predicate)
+                i = false;
+        elements.clear();
+        elements_are_exact = true;
+    }
+
+    void reserve(Number n) {
+        predicate.reserve(n);
+        if (tracking_elements) {
+            elements.reserve(n);
+        }
+    }
+
+    //TODO: or negate()?
+    void flip(Number q) {
+        if (this[q])
+            add(q);
+        else
+            remove(q);
+    }
+
+    /*
+     * Complements the set with respect to a given number of elements = the maximum number + 1.
+     * Should be somewhat efficient.
+     */
+    void complement(Number domain_size) {
+        Number old_domain_size = predicate.size();
+        predicate.reserve(domain_size);
+        Number to_flip = std::min(domain_size,old_domain_size);
+        for (Number q = 0; q < to_flip; ++q) {
+             predicate[q] = !predicate[q];
+        }
+        if (domain_size > old_domain_size)
+            for (Number q = old_domain_size; q < domain_size; ++q) {
+                predicate.push_back(true);
             }
-
-            NumberPredicate(Mata::Util::OrdVector<Number> vec, bool track_elements = true) : elements_are_exact(true), tracking_elements(track_elements) {
-                for (auto q: vec)
-                    add(q);
+        else if (domain_size < old_domain_size)
+            for (Number q = domain_size; q < old_domain_size; ++q) {
+                predicate[q]=false;
             }
+        if (tracking_elements) {
+            compute_elements();
+        }
+    }
 
-            template <class InputIterator>
-            NumberPredicate(InputIterator first, InputIterator last)
-            {
-                while (first < last) {
-                    add(*first);
-                    ++first;
-                }
+    /*
+     * Iterators to iterate through the true elements. No order can be assumed.
+     */
+    inline const_iterator begin() const {
+        update_elements();
+        return elements.begin();
+    }
+
+    inline const_iterator end() const {
+        update_elements();
+        return elements.end();
+    }
+
+    inline const_iterator cbegin() const {
+        update_elements();
+        return elements.cbegin();
+    }
+
+    inline const_iterator cend() const {
+        update_elements();
+        return elements.cend();
+    }
+
+    inline const_iterator begin() {
+        update_elements();
+        return elements.begin();
+    }
+
+    inline const_iterator end() {
+        update_elements();
+        return elements.end();
+    }
+
+    const std::vector <Number> &get_elements() const {
+        update_elements();
+        return elements;
+    }
+
+    bool are_disjoint(const NumberPredicate<Number> &other) const {
+        //return std::all_of(begin(),end(),[&other](Number x) {return !other[x];});//Vau!
+        for (auto q: *this)
+            if (other[q])
+                return false;
+        return true;
+    }
+
+    bool empty() const {
+        return (size() == 0);
+    }
+
+    // This is supposed to return something not smaller than the largest element in the set
+    // the easiest is to return the size of the predicate, roughly, the largest element ever inserted.
+    Number domain_size() const {
+        return predicate.size();
+    }
+
+    // truncates the domain to the maximal element (so the elements stay the same)
+    // this could be needed in defragmentation of nfa
+    void truncate_domain() {
+        if (predicate.empty())
+            return;
+        else if (predicate[predicate.size()])
+            return;
+
+        Number max;
+        if (tracking_elements) {
+            update_elements();
+            // if empty, max would be something strange
+            if (elements.empty()) {
+                predicate.resize(0);
+                return;
             }
+            else
+                max = *std::max_element(elements.begin(), elements.end());
+        }
+        else {
+            // one needs to be careful, Number can be unsigned, empty predicate would cause 0-1 below
+            for (max = predicate.size()-1; max >= 0; --max)
+                if (predicate[max])
+                    break;
+        }
 
-            /*
-             * Note that it extends predicate if q is out of its current domain.
-             */
-            void add(Number q) {
-                if (predicate.size() <= q)
-                    predicate.resize(q+1,false);
-                if (tracking_elements) {
-                    Number q_was_there = predicate[q];
-                    predicate[q] = true;
-                    if (!q_was_there) {
-                        elements.push_back(q);
-                    }
-                } else {
-                    predicate[q] = true;
-                    elements_are_exact = false;
-                }
-            }
+        predicate.resize(max+1);
+    }
 
-            void remove(Number q) {
-                elements_are_exact = false;
-                if (q < predicate.size() && predicate[q]) {
-                    predicate[q] = false;
-                }
-            }
+    /**
+     * Renames numbers in predicate according to the given @renaming. If a number is not present in @renaming
+     * it is renamed to base + offset value. Rationalization for this is that base should e.g.,
+     * higher than number of states in Nfa delta so we rename the initial or final states not presented in delta
+     * to numbers just after delta. Offset is then increased after encountering each of such states
+     * not presented in delta.
+     */
+    void rename(const std::vector<Number>& renaming, const Number base = 0) {
+        if (renaming.empty())
+            return; // nothing to rename
 
-            void add(const std::vector <Number> &elems) {
-                for (Number q: elems)
-                    add(q);
-            }
+        Number offset = 0;
+        std::vector<Number> single_states_renaming;
 
-            void remove(const std::vector <Number> &elems) {
-                for (Number q: elems)
-                    remove(q);
-            }
+        update_elements();
 
-            /**
-             * start tracking elements (might require updating them to establish the invariant)
-             */
-            void track_elements() {
-                if (!tracking_elements) {
-                    update_elements();
-                    tracking_elements = true;
-                }
-            }
-
-            void dont_track_elements() {
-                tracking_elements = false;
-            }
-
-            /**
-             * @return True if predicate for @p q is set. False otherwise (even if q is out of range of the predicate).
-             */
-            bool operator[](Number q) const {
-                if (q < predicate.size())
-                    return predicate[q];
-                else
-                    return false;
-            }
-
-            /**
-             * This is the number of the true elements, not the size of any data structure.
-             */
-            Number size() const {
-                if (elements_are_exact)
-                    return elements.size();
-                if (tracking_elements) {
-                    prune_elements();
-                    return elements.size();
-                } else {
-                    Number cnt = 0;
-                    for (Number q = 0, size = predicate.size(); q < size; ++q) {
-                        if (predicate[q])
-                            cnt++;
-                    }
-                    return cnt;
-                }
-            }
-
-            /*
-             * Clears the set of true elements. Does not clear the predicate, only sets it false everywhere.
-             */
-            void clear() {
-                if (tracking_elements)
-                    for (size_t i = 0, size = elements.size(); i < size; i++)
-                        predicate[elements[i]] = false;
-                else
-                    //for (size_t i = 0, size = predicate.size(); i < size; i++)
-                    //    predicate[i] = false;
-                    // Vysvetlete mi, co dela to && nize a zaplatim obed.
-                    for (auto && i : predicate)
-                        i = false;
-                elements.clear();
-                elements_are_exact = true;
-            }
-
-            void reserve(Number n) {
-                predicate.reserve(n);
-                if (tracking_elements) {
-                    elements.reserve(n);
-                }
-            }
-
-            //TODO: or negate()?
-            void flip(Number q) {
-                if (this[q])
-                    add(q);
-                else
-                    remove(q);
-            }
-
-            /*
-             * Complements the set with respect to a given number of elements = the maximum number + 1.
-             * Should be somewhat efficient.
-             */
-            void complement(Number domain_size) {
-                Number old_domain_size = predicate.size();
-                predicate.reserve(domain_size);
-                Number to_flip = std::min(domain_size,old_domain_size);
-                for (Number q = 0; q < to_flip; ++q) {
-                     predicate[q] = !predicate[q];
-                }
-                if (domain_size > old_domain_size)
-                    for (Number q = old_domain_size; q < domain_size; ++q) {
-                        predicate.push_back(true);
-                    }
-                else if (domain_size < old_domain_size)
-                    for (Number q = domain_size; q < old_domain_size; ++q) {
-                        predicate[q]=false;
-                    }
-                if (tracking_elements) {
-                    compute_elements();
-                }
-            }
-
-            /*
-             * Iterators to iterate through the true elements. No order can be assumed.
-             */
-            inline const_iterator begin() const {
-                update_elements();
-                return elements.begin();
-            }
-
-            inline const_iterator end() const {
-                update_elements();
-                return elements.end();
-            }
-
-            inline const_iterator cbegin() const {
-                update_elements();
-                return elements.cbegin();
-            }
-
-            inline const_iterator cend() const {
-                update_elements();
-                return elements.cend();
-            }
-
-            inline const_iterator begin() {
-                update_elements();
-                return elements.begin();
-            }
-
-            inline const_iterator end() {
-                update_elements();
-                return elements.end();
-            }
-
-            const std::vector <Number> &get_elements() const {
-                update_elements();
-                return elements;
-            }
-
-            bool are_disjoint(const NumberPredicate<Number> &other) const {
-                //return std::all_of(begin(),end(),[&other](Number x) {return !other[x];});//Vau!
-                for (auto q: *this)
-                    if (other[q])
-                        return false;
-                return true;
-            }
-
-            bool empty() const {
-                return (size() == 0);
-            }
-
-            // This is supposed to return something not smaller than the largest element in the set
-            // the easiest is to return the size of the predicate, roughly, the largest element ever inserted.
-            Number domain_size() const {
-                return predicate.size();
-            }
-
-            // truncates the domain to the maximal element (so the elements stay the same)
-            // this could be needed in defragmentation of nfa
-            void truncate_domain() {
-                if (predicate.empty())
-                    return;
-                else if (predicate[predicate.size()])
-                    return;
-
-                Number max;
-                if (tracking_elements) {
-                    update_elements();
-                    // if empty, max would be something strange
-                    if (elements.empty()) {
-                        predicate.resize(0);
-                        return;
-                    }
-                    else
-                        max = *std::max_element(elements.begin(), elements.end());
-                }
-                else {
-                    // one needs to be careful, Number can be unsigned, empty predicate would cause 0-1 below
-                    for (max = predicate.size()-1; max >= 0; --max)
-                        if (predicate[max])
-                            break;
-                }
-
-                predicate.resize(max+1);
-            }
-
-            /**
-             * Renames numbers in predicate according to the given @renaming. If a number is not present in @renaming
-             * it is renamed to base + offset value. Rationalization for this is that base should e.g.,
-             * higher than number of states in Nfa delta so we rename the initial or final states not presented in delta
-             * to numbers just after delta. Offset is then increased after encountering each of such states
-             * not presented in delta.
-             */
-            void rename(const std::vector<Number>& renaming, const Number base = 0) {
-                if (renaming.empty())
-                    return; // nothing to rename
-
-                Number offset = 0;
-                std::vector<Number> single_states_renaming;
-
-                update_elements();
-
-                auto max_or_default = [](const std::vector<Number>& container, Number def) {
-                    auto max_it = std::max_element(container.begin(), container.end());
-                    return (max_it == container.end() ? def : *max_it);
-                };
-
-                std::vector<Number> new_elements;
-                std::vector<bool> new_predicate(std::max(max_or_default(elements, 0)+1, max_or_default(renaming, 0)+1));
-
-                for (const Number& number : elements) {
-                    if (number < renaming.size()) { // number is renamed by provided vector
-                        new_elements.push_back(renaming[number]);
-                        if (predicate[number])
-                            new_predicate[renaming[number]] = true;
-                    }
-                    else { // number not defined in provided vector, needs to be renamed by this function
-                        if (number >= single_states_renaming.size()) {
-                            single_states_renaming.resize(number + 1);
-                            single_states_renaming[number] = base + offset;
-                            ++offset;
-                        }
-
-                        new_elements.push_back(single_states_renaming[number]);
-                        if (predicate[number])
-                            new_predicate[single_states_renaming[number]] = true;
-                    }
-                }
-
-                elements = new_elements;
-                predicate = new_predicate;
-            }
+        auto max_or_default = [](const std::vector<Number>& container, Number def) {
+            auto max_it = std::max_element(container.begin(), container.end());
+            return (max_it == container.end() ? def : *max_it);
         };
-    }
 
-    template <typename Number>
-    bool are_disjoint(Util::NumberPredicate<Number> lhs, Util::NumberPredicate<Number> rhs) {
-        return lhs.are_disjoint(rhs);
+        std::vector<Number> new_elements;
+        std::vector<bool> new_predicate(std::max(max_or_default(elements, 0)+1, max_or_default(renaming, 0)+1));
+
+        for (const Number& number : elements) {
+            if (number < renaming.size()) { // number is renamed by provided vector
+                new_elements.push_back(renaming[number]);
+                if (predicate[number])
+                    new_predicate[renaming[number]] = true;
+            }
+            else { // number not defined in provided vector, needs to be renamed by this function
+                if (number >= single_states_renaming.size()) {
+                    single_states_renaming.resize(number + 1);
+                    single_states_renaming[number] = base + offset;
+                    ++offset;
+                }
+
+                new_elements.push_back(single_states_renaming[number]);
+                if (predicate[number])
+                    new_predicate[single_states_renaming[number]] = true;
+            }
+        }
+
+        elements = new_elements;
+        predicate = new_predicate;
     }
+};
+
+template <typename Number>
+bool are_disjoint(Mata::Util::NumberPredicate<Number> lhs, Mata::Util::NumberPredicate<Number> rhs) {
+    return lhs.are_disjoint(rhs);
 }
-#endif //LIBMATA_NUMBER_PREDICATE_HH
+
+} // Namespace Mata::Util.
+
+#endif // LIBMATA_NUMBER_PREDICATE_HH

--- a/include/mata/number-predicate.hh
+++ b/include/mata/number-predicate.hh
@@ -377,5 +377,9 @@ namespace Mata {
         };
     }
 
+    template <typename Number>
+    bool are_disjoint(Util::NumberPredicate<Number> lhs, Util::NumberPredicate<Number> rhs) {
+        return lhs.are_disjoint(rhs);
+    }
 }
 #endif //LIBMATA_NUMBER_PREDICATE_HH

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -17,13 +17,37 @@
 #include <cassert>
 
 #include <mata/number-predicate.hh>
+#include <mata/util.hh>
 
 // insert the class into proper namespace
 namespace Mata
 {
     namespace Util
     {
-        template <class Number> class NumberPredicate;
+        template<typename Number>
+        bool are_disjoint(Mata::Util::OrdVector<Number> lhs, NumberPredicate<Number> rhs) {
+            for (auto q: lhs) {
+                if (rhs[q]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        template <class T>
+        bool are_disjoint(const Util::OrdVector<T>& lhs, const Util::OrdVector<T>& rhs)
+        { // {{{
+            auto itLhs = lhs.begin();
+            auto itRhs = rhs.begin();
+            while (itLhs != lhs.end() && itRhs != rhs.end()) {
+                if (*itLhs == *itRhs) { return false; }
+                else if (*itLhs < *itRhs) { ++itLhs; }
+                else {++itRhs; }
+            }
+            return true;
+        } // }}}
+
+template <class Number> class NumberPredicate;
 
         template <
             class Key
@@ -481,7 +505,7 @@ public:   // Public methods
     {
         // Assertions
         assert(vectorIsSorted());
-        
+
         return vec_.back();
     }
 

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -8,10 +8,9 @@
  *
  *****************************************************************************/
 
-#ifndef _MATA_ORD_VECTOR_HH_
-#define _MATA_ORD_VECTOR_HH_
+#ifndef MATA_ORD_VECTOR_HH_
+#define MATA_ORD_VECTOR_HH_
 
-// Standard library headers
 #include <vector>
 #include <algorithm>
 #include <cassert>
@@ -19,82 +18,67 @@
 #include <mata/number-predicate.hh>
 #include <mata/util.hh>
 
-// insert the class into proper namespace
-namespace Mata
+namespace {
+/**
+ * @brief  Converts an object to string
+ *
+ * Static method for conversion of an object of any class with the << output
+ * operator into a string
+ *
+ * @param[in]  n  The object for the conversion
+ *
+ * @returns  The string representation of the object
+ */
+template <typename T>
+static std::string ToString(const T& n)
 {
-    namespace Util
-    {
-        template<typename Number>
-        bool are_disjoint(Mata::Util::OrdVector<Number> lhs, NumberPredicate<Number> rhs) {
-            for (auto q: lhs) {
-                if (rhs[q]) {
-                    return false;
-                }
-            }
-            return true;
-        }
+    // the output stream for the string
+    std::ostringstream oss;
+    // insert the object into the stream
+    oss << n;
+    // return the string
+    return oss.str();
+}
 
-        template <class T>
-        bool are_disjoint(const Util::OrdVector<T>& lhs, const Util::OrdVector<T>& rhs)
-        { // {{{
-            auto itLhs = lhs.begin();
-            auto itRhs = rhs.begin();
-            while (itLhs != lhs.end() && itRhs != rhs.end()) {
-                if (*itLhs == *itRhs) { return false; }
-                else if (*itLhs < *itRhs) { ++itLhs; }
-                else {++itRhs; }
-            }
-            return true;
-        } // }}}
+} // Anonymous namespace.
+
+namespace Mata::Util {
 
 template <class Number> class NumberPredicate;
+template <class Key> class OrdVector;
 
-        template <
-            class Key
-        >
-        class OrdVector;
-
-        template <class Key>
-        bool is_sorted(std::vector<Key> vec)
-        {
-            for (auto itVec = vec.cbegin() + 1; itVec < vec.cend(); ++itVec)
-            {	// check that the vector is sorted
-                if (!(*(itVec - 1) < *itVec))
-                {	// in case there is an unordered pair (or there is one element twice)
-                    return false;
-                }
-            }
-
-            return true;
+template<typename Number> bool are_disjoint(OrdVector<Number> lhs, NumberPredicate<Number> rhs) {
+    for (auto q: lhs) {
+        if (rhs[q]) {
+            return false;
         }
     }
+    return true;
 }
 
-namespace
-{
-    /**
-     * @brief  Converts an object to string
-     *
-     * Static method for conversion of an object of any class with the << output
-     * operator into a string
-     *
-     * @param[in]  n  The object for the conversion
-     *
-     * @returns  The string representation of the object
-     */
-    template <typename T>
-    static std::string ToString(const T& n)
-    {
-        // the output stream for the string
-        std::ostringstream oss;
-        // insert the object into the stream
-        oss << n;
-        // return the string
-        return oss.str();
+template <class T>
+bool are_disjoint(const Util::OrdVector<T>& lhs, const Util::OrdVector<T>& rhs) {
+    auto itLhs = lhs.begin();
+    auto itRhs = rhs.begin();
+    while (itLhs != lhs.end() && itRhs != rhs.end()) {
+        if (*itLhs == *itRhs) { return false; }
+        else if (*itLhs < *itRhs) { ++itLhs; }
+        else { ++itRhs; }
+    }
+    return true;
+}
+
+template <class Key> bool is_sorted(std::vector<Key> vec) {
+    for (auto itVec = vec.cbegin() + 1; itVec < vec.cend(); ++itVec)
+    {	// check that the vector is sorted
+        if (!(*(itVec - 1) < *itVec))
+        {	// in case there is an unordered pair (or there is one element twice)
+            return false;
+        }
     }
 
+    return true;
 }
-
 
 /**
  * @brief  Implementation of a set using ordered vector
@@ -105,12 +89,7 @@ namespace
  * @tparam  Key  Key type: type of the elements contained in the container.
  *               Each elements in a set is also its key.
  */
-template
-<
-    class Key
->
-class Mata::Util::OrdVector
-{
+template<class Key> class OrdVector {
 private:  // Private data types
     using VectorType = std::vector<Key>;
 
@@ -653,7 +632,9 @@ public:   // Public methods
 
         return true;
     }
-};
+}; // Class OrdVector.
+
+} // Namespace Mata::Util.
 
 namespace std {
     template <class Key>
@@ -666,4 +647,4 @@ namespace std {
     };
 }
 
-#endif
+#endif // MATA_ORD_VECTOR_HH_.

--- a/include/mata/util.hh
+++ b/include/mata/util.hh
@@ -28,8 +28,6 @@
 #include <stack>
 #include <unordered_map>
 #include <vector>
-#include <mata/ord-vector.hh>
-#include <mata/number-predicate.hh>
 
 /// macro for debug outputs
 #define PRINT_VERBOSE_LVL(lvl, title, x) {\
@@ -60,19 +58,6 @@ extern unsigned LOG_VERBOSITY;
 namespace Util
 {
 
-template <typename Number>
-bool are_disjoint(NumberPredicate<Number> lhs, NumberPredicate<Number> rhs) {
-    return lhs.are_disjoint(rhs);
-}
-
-template <typename Number>
-bool are_disjoint(Mata::Util::OrdVector<Number> lhs, NumberPredicate<Number> rhs) {
-    for (auto q: lhs)
-        if (rhs[q])
-            return false;
-    return true;
-}
-
 /** Are two sets disjoint? */
 template <class T>
 bool are_disjoint(const std::set<T>& lhs, const std::set<T>& rhs)
@@ -87,22 +72,6 @@ bool are_disjoint(const std::set<T>& lhs, const std::set<T>& rhs)
 	}
 
 	return true;
-} // }}}
-
-
-template <class T>
-bool are_disjoint(const Util::OrdVector<T>& lhs, const Util::OrdVector<T>& rhs)
-{ // {{{
-    auto itLhs = lhs.begin();
-    auto itRhs = rhs.begin();
-    while (itLhs != lhs.end() && itRhs != rhs.end())
-    {
-        if (*itLhs == *itRhs) { return false; }
-        else if (*itLhs < *itRhs) { ++itLhs; }
-        else {++itRhs; }
-    }
-
-    return true;
 } // }}}
 
 /** Is there an element in a container? */
@@ -426,7 +395,7 @@ std::string to_string(const A& value)
 
 namespace Mata
 {
-namespace util
+namespace Util
 {
 
 // Taken from

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(CMAKE_COLOR_MAKEFILE ON)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 17)
 
 project(libmata)
 

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -29,7 +29,7 @@
 
 using std::tie;
 
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Afa;
 
 const std::string Mata::Afa::TYPE_AFA = "AFA";

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -6,7 +6,7 @@
 
 #include <mata/afa.hh>
 using namespace Mata::Afa;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 
 TEST_CASE("Mata::Afa::Trans::operator<<")

--- a/src/nfa/tests-nfa-concatenation.cc
+++ b/src/nfa/tests-nfa-concatenation.cc
@@ -26,7 +26,7 @@
 
 using namespace Mata::Nfa;
 using namespace Mata::Strings;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 
 using Symbol = Mata::Symbol;

--- a/src/nfa/tests-nfa-intersection.cc
+++ b/src/nfa/tests-nfa-intersection.cc
@@ -23,7 +23,7 @@
 #include <mata/nfa.hh>
 
 using namespace Mata::Nfa;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 
 // Some common automata {{{

--- a/src/rra/tests-rrt.cc
+++ b/src/rra/tests-rrt.cc
@@ -4,7 +4,7 @@
 
 #include <mata/rrt.hh>
 using namespace Mata::Rrt;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 
 using GuardType = Mata::Rrt::Trans::Guard::GuardType;

--- a/src/strings/tests-nfa-noodlification.cc
+++ b/src/strings/tests-nfa-noodlification.cc
@@ -10,7 +10,7 @@
 
 using namespace Mata::Nfa;
 using namespace Mata::Strings;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 using namespace Mata::RE2Parser;
 

--- a/src/strings/tests-nfa-segmentation.cc
+++ b/src/strings/tests-nfa-segmentation.cc
@@ -25,7 +25,7 @@
 
 using namespace Mata::Nfa;
 using namespace Mata::Strings;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 using Symbol = Mata::Symbol;
 

--- a/src/strings/tests-nfa-string-solving.cc
+++ b/src/strings/tests-nfa-string-solving.cc
@@ -26,7 +26,7 @@
 using namespace Mata::Nfa;
 using namespace Mata::Strings;
 using namespace Mata::Strings::SegNfa;
-using namespace Mata::util;
+using namespace Mata::Util;
 using namespace Mata::Parser;
 using namespace Mata::RE2Parser;
 

--- a/src/tests-ord-vector.cc
+++ b/src/tests-ord-vector.cc
@@ -20,7 +20,6 @@
 #include <mata/util.hh>
 #include <mata/ord-vector.hh>
 
-using namespace Mata::util;
 using namespace Mata::Util;
 
 TEST_CASE("Mata::Util::OrdVector::intersection(}")


### PR DESCRIPTION
This PR refactors `Mata::Util` namespace, especially classes `Mata::Util::OrdVector` and `Mata::Util::NumberPredicate`. This PR lays foundation to the upcoming optimizations of vector insertions.

Overloaded functions `Mata::Util::are_disjoint()` are moved to their corresponding header files to break unneeded dependency on `ord-vector.hh` and `number-predicate.hh`. This makes `util.h` the most general header file in the project (standing at the top of the include hierarchy). Furthermore, the PR moves C++ standard specification to the root `CMakeLists.txt`.

I advise the reviewers to review commit by commit instead of trying to work out the whole diff.