### PR TITLE
Unify each automaton only once

### DIFF
--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1591,7 +1591,8 @@ void Nfa::unify_final() {
     if (final.empty() || final.size() == 1) { return; }
     const State new_final_state{ add_state() };
     for (const auto& orig_final_state: final) {
-        for (const auto& transitions: get_transitions_to(orig_final_state)) {
+        const auto transitions_to{ get_transitions_to(orig_final_state) };
+        for (const auto& transitions: transitions_to) {
             delta.add(transitions.src, transitions.symb, new_final_state);
         }
         if (initial[orig_final_state]) { initial.add(new_final_state); }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1575,7 +1575,8 @@ Mata::Util::OrdVector<Symbol> Nfa::get_used_symbols() const {
     if (initial.empty() || initial.size() == 1) { return; }
     const State new_initial_state{add_state() };
     for (const auto& orig_initial_state: initial) {
-        for (const auto& transitions: get_moves_from(orig_initial_state)) {
+        const auto moves{ get_moves_from(orig_initial_state) };
+        for (const auto& transitions: moves) {
             for (const State state_to: transitions.targets) {
                 delta.add(new_initial_state, transitions.symbol, state_to);
             }

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -2934,6 +2934,16 @@ TEST_CASE("Mata::Nfa::Nfa::unify_(initial/final)()") {
         CHECK(nfa.delta.contains(4, 'b', 1));
         CHECK(nfa.delta.contains(1, 'c', 1));
     }
+
+    SECTION("Bug: NFA with empty string unifying initial/final repeatedly") {
+        Nfa aut;
+        Mata::RE2Parser::create_nfa(&aut, "a*b*");
+        for (size_t i{ 0 }; i < 8; ++i) {
+            aut.unify_initial();
+            aut.unify_final();
+        }
+        CHECK(true); // Check that the program does not seg fault.
+    }
 }
 
 TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {


### PR DESCRIPTION
This PR fixes noodlification and `unify_{initial, final}()` so that each automaton is unified only once.