### PR TITLE
Create single word nfa

### DIFF
--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -35,6 +35,14 @@ namespace Mata {
             virtual Symbol translate_symb(const std::string &symb) = 0;
 
             /**
+             * Translate sequence of symbol names to sequence of their respective values.
+             */
+            virtual std::vector<Symbol> translate_word(const std::vector<std::string>& word) const {
+                (void)word;
+                throw std::runtime_error("Unimplemented");
+            }
+
+            /**
              * @brief Translate internal @p symbol representation back to its original string name.
              *
              * Throws an exception when the @p symbol is missing in the alphabet.
@@ -246,6 +254,20 @@ namespace Mata {
             //}
 
             //return it->second;
+        }
+
+        virtual std::vector<Symbol> translate_word(const std::vector<std::string>& word) const {
+            const size_t word_size{ word.size() };
+            std::vector<Symbol> symbols;
+            symbols.reserve(word_size);
+            for (size_t i{ 0 }; i < word_size; ++i) {
+                const auto symbol_mapping_it = symbol_map.find(word[i]);
+                if (symbol_mapping_it == symbol_map.end()) {
+                    throw std::runtime_error("Unknown symbol \'" + word[i] + "\'");
+                }
+                symbols.push_back(symbol_mapping_it->second);
+            }
+            return symbols;
         }
 
         /**

--- a/include/mata/nfa-strings.hh
+++ b/include/mata/nfa-strings.hh
@@ -120,12 +120,27 @@ namespace Strings {
     std::set<std::pair<int, int>> get_word_lengths(const Nfa::Nfa& aut);
 
     /**
-     * @brief Checks if the automaton @p nfa accepts only a single word \eps. 
-     * 
+     * @brief Checks if the automaton @p nfa accepts only a single word \eps.
+     *
      * @param nfa Input automaton
      * @return true iff L(nfa) = {\eps}
      */
     bool is_lang_eps(const Nfa::Nfa& nfa);
+
+    /**
+     * Create an automaton accepting only a single @p word.
+     */
+    Nfa::Nfa create_single_word_nfa(const std::vector<Symbol>& word);
+
+    /**
+     * Create an automaton accepting only a single @p word.
+     *
+     * @param word Word to accept.
+     * @param alphabet Alphabet to use in NFA for translating word into symbols. If specified, the alphabet has to contain
+     *  translations for all of the word symbols. If left empty, a new alphabet with only the symbols of the word will be
+     *  created.
+     */
+    Nfa::Nfa create_single_word_nfa(const std::vector<std::string>& word, Alphabet* alphabet = nullptr);
 
 /**
  * Operations on segment automata.

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -149,7 +149,7 @@ void ShortestWordsMap::update_current_words(LengthWordsPair& act, const LengthWo
 
 std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& aut) {
     Nfa::Nfa one_letter;
-    /// if we are interested in lengths of words, it suffices to forget the different symbols on transitions. 
+    /// if we are interested in lengths of words, it suffices to forget the different symbols on transitions.
     /// The lengths of @p aut are hence equivalent to lengths of the NFA taken from @p aut where all symbols on
     /// transitions are renamed to a single symbol (e.g., `a`).
     aut.get_one_letter_aut(one_letter);
@@ -157,7 +157,7 @@ std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& au
     one_letter.trim();
     if(one_letter.size() == 0) {
         return {};
-    } 
+    }
 
     std::set<std::pair<int, int>> ret;
     std::vector<int> handles(one_letter.size(), 0); // initialized to 0
@@ -210,4 +210,27 @@ bool Mata::Strings::is_lang_eps(const Nfa::Nfa& aut) {
             return false;
     }
     return true;
+}
+
+Nfa Mata::Strings::create_single_word_nfa(const std::vector<Mata::Symbol>& word) {
+    const size_t word_size{ word.size() };
+    Nfa::Nfa nfa{ word_size + 1, { 0 }, { word_size } };
+
+    for (State state{ 0 }; state < word_size; ++state) {
+        nfa.delta.add(state, word[state], state + 1);
+    }
+    return nfa;
+}
+
+Nfa Mata::Strings::create_single_word_nfa(const std::vector<std::string>& word, Mata::Alphabet *alphabet) {
+    if (!alphabet) {
+        alphabet = new OnTheFlyAlphabet{ word };
+    }
+    const size_t word_size{ word.size() };
+    Nfa::Nfa nfa{ word_size + 1, { 0 }, { word_size }, alphabet };
+
+    for (State state{ 0 }; state < word_size; ++state) {
+        nfa.delta.add(state, alphabet->translate_symb(word[state]), state + 1);
+    }
+    return nfa;
 }

--- a/src/strings/tests-nfa-string-solving.cc
+++ b/src/strings/tests-nfa-string-solving.cc
@@ -208,7 +208,7 @@ TEST_CASE("Mata::Nfa::get_shortest_words() for profiling", "[.profiling][shortes
 }
 
 TEST_CASE("Mata::Strings::get_lengths()") {
-     
+
     SECTION("basic") {
         Nfa x;
         create_nfa(&x, "(abcde)*");
@@ -256,15 +256,15 @@ TEST_CASE("Mata::Strings::get_lengths()") {
         Nfa x;
         create_nfa(&x, "a(aaaa|aaaaaaa)*");
         CHECK(get_word_lengths(x) == std::set<std::pair<int, int>>({
-            {1,0}, {5,0}, {8,0}, {9,0}, {12,0}, {13,0}, {15,0}, {16,0}, 
-            {17,0}, {19,0}, {20,0}, {21,0}, {22,0}, {23,0}, {24,0}, {25,0}, 
+            {1,0}, {5,0}, {8,0}, {9,0}, {12,0}, {13,0}, {15,0}, {16,0},
+            {17,0}, {19,0}, {20,0}, {21,0}, {22,0}, {23,0}, {24,0}, {25,0},
             {26,1}
         }));
     }
 }
 
 TEST_CASE("Mata::Strings::is_lang_eps()") {
-     
+
     SECTION("basic") {
         Nfa x;
         create_nfa(&x, "(abcde)*");
@@ -280,5 +280,62 @@ TEST_CASE("Mata::Strings::is_lang_eps()") {
     SECTION("basic 3") {
         Nfa x;
         CHECK(!is_lang_eps(x));
+    }
+}
+
+TEST_CASE("Mata::Nfa::create_single_word_nfa()") {
+    SECTION("From numbers") {
+        SECTION("Simple word") {
+            std::vector<Mata::Symbol> word{ 10, 20, 30, 40, 50, 60 };
+            auto nfa{ Mata::Strings::create_single_word_nfa(word) };
+            CHECK(is_in_lang(nfa, { word, {} }));
+            CHECK(nfa.final.size() == 1);
+            CHECK(nfa.initial.size() == 1);
+            CHECK(Mata::Strings::get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(6, 0) });
+        }
+
+        SECTION("Empty string") {
+            std::vector<Mata::Symbol> word{};
+            auto nfa{ Mata::Strings::create_single_word_nfa(word) };
+            CHECK(is_in_lang(nfa, { word, {} }));
+            CHECK(Mata::Strings::is_lang_eps(nfa));
+            CHECK(nfa.final.size() == 1);
+            CHECK(nfa.initial.size() == 1);
+            CHECK(Mata::Strings::get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
+        }
+    }
+
+    SECTION("From symbol names") {
+        SECTION("Simple word") {
+            std::vector<std::string> word{ "zero", "one", "two", "three", "four", "five" };
+            auto nfa{ Mata::Strings::create_single_word_nfa(word) };
+            CHECK(is_in_lang(nfa, { nfa.alphabet->translate_word(word), {} }));
+            CHECK(nfa.final.size() == 1);
+            CHECK(nfa.initial.size() == 1);
+            CHECK(Mata::Strings::get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(6, 0) });
+        }
+
+        SECTION("Empty string") {
+            std::vector<Mata::Symbol> word{};
+            auto nfa{ Mata::Strings::create_single_word_nfa(word) };
+            CHECK(is_in_lang(nfa, { word, {} }));
+            CHECK(Mata::Strings::is_lang_eps(nfa));
+            CHECK(nfa.final.size() == 1);
+            CHECK(nfa.initial.size() == 1);
+            CHECK(Mata::Strings::get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
+        }
+
+        SECTION("Simple word with alphabet") {
+            std::vector<std::string> word{ "zero", "one", "two", "three", "four", "five" };
+            Mata::OnTheFlyAlphabet alphabet{};
+            for (unsigned long symbol{ 0 }; symbol < word.size(); ++symbol) {
+                alphabet.add_new_symbol(word[symbol], symbol);
+            }
+            auto nfa{ Mata::Strings::create_single_word_nfa(word) };
+            CHECK(is_in_lang(nfa, { nfa.alphabet->translate_word(word), {} }));
+            CHECK(nfa.final.size() == 1);
+            CHECK(nfa.initial.size() == 1);
+            CHECK(Mata::Strings::get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(6, 0) });
+        }
     }
 }


### PR DESCRIPTION
This PR adds functions to create an NFA accepting a single word specified as an argument. Furthermore, the PR adds a method to alphabet interface to translate a word according to the symbol mapping in the alphabet.

There are two versions of the `Mata::Strings::create_signle_word_nfa()`. One has as an argument a sequence of symbols, the other one a sequence of symbol names and an optional alphabet argument which would translate the symbol names into their corresponding values.

We should decide whether we want `translate_word()` to be in the abstract `Alphabet` interface. Seeing as there is `translate_symb`, adding `translate_word` would make sense to me.

Fixes #166.