### PR TITLE
AFA parsing fixed

### DIFF
--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -177,12 +177,12 @@ struct ClosedSet
         friend std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs)
         {
             std::string strType = "TYPE: ";
-            strType += cs.get_type() == upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
+            strType += cs.type() == upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
             strType += "\n";
             std::string strInterval = "INTERVAL: " + std::to_string(cs.get_min()) + 
 			" - " + std::to_string(cs.get_max()) + "\n";
             std::string strValues = "ANTICHAIN: {";
-            for(auto node : cs.get_antichain())
+            for(auto node : cs.antichain())
             {
                 strValues += "{";
                 for(auto state : node)

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -1031,11 +1031,13 @@ Afa Mata::Afa::construct(
 
     const FormulaGraph* init_graph = &inter_aut.initial_formula;
     if (is_node_operator(init_graph->node, FormulaNode::AND)) { // initial formula is just conjunction
+    	Node initial_node;
         for (const auto& str : init_graph->collect_node_names())
         {
             State state = get_state_name(str);
-            aut.add_initial(state);
+            initial_node.insert(state);
         }
+        aut.add_initial(initial_node);
     } else { // initial formula is dnf
         while (is_node_operator(init_graph->node, FormulaNode::OR))
         {  // Processes each clause separately


### PR DESCRIPTION
The previous version parsed initial formulae of an AFA incorrectly. If the initial formula consisted of states connected only by conjunctions (q1 & q2 & ... & qn), it was parsed as if the states were connected by disjunctions (q1 | q2 | ... | qn). This pull requests fixes this issue.