### PR TITLE
Parsing of an initial formula of an AFA - simple tests

### DIFF
--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -640,7 +640,7 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
         StringToStateMap state_map;
         construct(&aut, inter_aut, &symbol_map, &state_map);
 
-		// Two initial nodes {q1} and {q2}
+        // Two initial nodes {q1} and {q2}
         REQUIRE(aut.initialstates.size() == 2);
 		REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
     }
@@ -662,7 +662,7 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
         StringToStateMap state_map;
         construct(&aut, inter_aut, &symbol_map, &state_map);
 
-		// One initial node {q1, q2}
+        // One initial node {q1, q2}
         REQUIRE(aut.initialstates.size() == 1);
 		REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
     }
@@ -689,7 +689,6 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
 		CHECK(aut.finalstates.count(state_map.at("4")));
 
     }
-   
 
 } // }}}
 

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -642,7 +642,7 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
 
         // Two initial nodes {q1} and {q2}
         REQUIRE(aut.initialstates.size() == 2);
-		REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+        REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
     }
     
     SECTION("AFA with a simple initial formula, just conjunction")
@@ -664,7 +664,7 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
 
         // One initial node {q1, q2}
         REQUIRE(aut.initialstates.size() == 1);
-		REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
+        REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
     }
 
     SECTION("AFA final states from multiple negations")

--- a/src/afa/tests-afa.cc
+++ b/src/afa/tests-afa.cc
@@ -622,6 +622,50 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
         ++it;
         REQUIRE(it->count(state_map["QC0_0"]));
     }
+    
+    SECTION("AFA with a simple initial formula, just disjunction")
+    {
+        std::string file =
+                "@AFA-explicit\n"
+                "%Initial q1 | q2\n"
+                "%Final !q0 & !q1 & !q2 & !q3\n"
+                "q0 a1\n"
+                "q1 a2 & (q2 & q3)\n"
+                "q2 a2 & (q0 & q3)\n"
+                "q3 a1 & (q0 | q2)\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+        StringToStateMap state_map;
+        construct(&aut, inter_aut, &symbol_map, &state_map);
+
+		// Two initial nodes {q1} and {q2}
+        REQUIRE(aut.initialstates.size() == 2);
+		REQUIRE(!antichain_concrete_forward_emptiness_test_new(aut));
+    }
+    
+    SECTION("AFA with a simple initial formula, just conjunction")
+    {
+        std::string file =
+                "@AFA-explicit\n"
+                "%Initial q1 & q2\n"
+                "%Final !q0 & !q1 & !q2 & !q3\n"
+                "q0 a1\n"
+                "q1 a2 & (q2 & q3)\n"
+                "q2 a2 & (q0 & q3)\n"
+                "q3 a1 & (q0 | q2)\n";
+
+        const auto auts = Mata::IntermediateAut::parse_from_mf(parse_mf(file));
+        inter_aut = auts[0];
+
+        StringToStateMap state_map;
+        construct(&aut, inter_aut, &symbol_map, &state_map);
+
+		// One initial node {q1, q2}
+        REQUIRE(aut.initialstates.size() == 1);
+		REQUIRE(antichain_concrete_forward_emptiness_test_new(aut));
+    }
 
     SECTION("AFA final states from multiple negations")
     {
@@ -645,6 +689,7 @@ TEST_CASE("Mata::Afa::construct() from IntermediateAut correct calls")
 		CHECK(aut.finalstates.count(state_map.at("4")));
 
     }
+   
 
 } // }}}
 


### PR DESCRIPTION
I've added two simple tests which were requested in PR #191 but I did not managed to add it before merging. Both tests parse the same AFA, the only difference is in the initial formula. The first one consists of a simple disjunction, the second one consists of a simple conjunction. This difference affects the result of the emptiness test.