### PR TITLE
construct of bit nfa directly from parser

### DIFF
--- a/examples/example05-parsing-bv-nfa.cc
+++ b/examples/example05-parsing-bv-nfa.cc
@@ -1,0 +1,44 @@
+// example5.cc - parsing a NFA from file
+
+#include <mata/nfa.hh>
+#include <mata/inter-aut.hh>
+#include <iostream>
+#include <fstream>
+
+using namespace Mata::Nfa;
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        std::cerr << "Input file missing\n";
+        return EXIT_FAILURE;
+    }
+
+    std::string filename = argv[1];
+
+    std::fstream fs(filename, std::ios::in);
+    if (!fs) {
+        std::cerr << "Could not open file \'" << filename << "'\n";
+        return EXIT_FAILURE;
+    }
+
+    Mata::Parser::Parsed parsed;
+    Nfa aut;
+    Mata::StringToSymbolMap stsm;
+    try {
+        parsed = Mata::Parser::parse_mf(fs, true);
+        fs.close();
+
+        Mata::OnTheFlyAlphabet alph;
+        aut = construct(parsed[0], &alph);
+    }
+    catch (const std::exception& ex) {
+        fs.close();
+        std::cerr << "libMATA error: " << ex.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+
+    aut.print_to_DOT(std::cout);
+    return EXIT_SUCCESS;
+}

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1346,7 +1346,7 @@ Nfa Mata::Nfa::construct(
         {
             State state = get_state_name(str);
             aut.initial.add(state);
-            if (!nonfinal.count(str)) {
+            if (!nonfinal.count(str) && !nonfinal.empty()) {
                 aut.final.add(state);
             }
         }
@@ -1374,7 +1374,7 @@ Nfa Mata::Nfa::construct(
         }
 
         State src_state = get_state_name(body_line[0]);
-        if (!nonfinal.count(body_line[0])) {
+        if (!nonfinal.count(body_line[0]) && !nonfinal.empty()) {
             aut.final.add(get_state_name(body_line[0]));
         }
 
@@ -1384,7 +1384,7 @@ Nfa Mata::Nfa::construct(
         }
         Symbol symbol = alphabet->translate_symb(sym);
 
-        if (!nonfinal.count(body_line[body_line.size()-1])) {
+        if (!nonfinal.count(body_line[body_line.size()-1]) && !nonfinal.empty()) {
             aut.final.add(get_state_name(body_line[body_line.size() - 1]));
         }
         State tgt_state = get_state_name(body_line[body_line.size()-1]);


### PR DESCRIPTION
This PR is **NOT** intended for merge. It is a guide how to bypass intermedia automaton and construct directly from parsed section from `Parser`. 

- It is NOT properly tested
- It contains changes in `construct` of `Nfa` to load final states in negated form and bitvectors on edges. Bitvectors are converted to symbols by taking the whole string and saying that it is a symbol.
- PR also provide example of use of the `construct` functions.