### PR TITLE
Add minimization during complement + rewrote complete computation (and some minor fixes)

### DIFF
--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -318,7 +318,7 @@ cdef extern from "mata/nfa-plumbing.hh" namespace "Mata::Nfa::Plumbing":
     cdef void uni(CNfa*, CNfa&, CNfa&)
     cdef void intersection(CNfa*, CNfa&, CNfa&, bool, umap[pair[State, State], State]*)
     cdef void concatenate(CNfa*, CNfa&, CNfa&, bool, StateToStateMap*, StateToStateMap*)
-    cdef void complement(CNfa*, CNfa&, CAlphabet&, StringMap&, umap[StateSet, State]*) except +
+    cdef void complement(CNfa*, CNfa&, CAlphabet&, StringMap&) except +
     cdef void make_complete(CNfa*, CAlphabet&, State) except +
     cdef void revert(CNfa*, CNfa&)
     cdef void remove_epsilon(CNfa*, CNfa&, Symbol) except +

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -868,40 +868,18 @@ cdef class Nfa:
         return noodle_segments
 
     @classmethod
-    def complement_with_subset_map(cls, Nfa lhs, Alphabet alphabet, params = None):
-        """Performs complement of lhs
-
-        :param Nfa lhs: complemented automaton
-        :param OnTheFlyAlphabet alphabet: alphabet of the lhs
-        :param dict params: additional params
-        :return: complemented automaton, map of subsets to states
-        """
-        result = Nfa()
-        params = params or {'algorithm': 'classical'}
-        cdef umap[StateSet, State] subset_map
-        mata.complement(
-            result.thisptr.get(),
-            dereference(lhs.thisptr.get()),
-            <CAlphabet&>dereference(alphabet.as_base()),
-            {
-                k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
-                for k, v in params.items()
-            },
-            &subset_map
-        )
-        return result, subset_map_to_dictionary(subset_map)
-
-    @classmethod
     def complement(cls, Nfa lhs, Alphabet alphabet, params = None):
         """Performs complement of lhs
 
         :param Nfa lhs: complemented automaton
         :param OnTheFlyAlphabet alphabet: alphabet of the lhs
         :param dict params: additional params
+          - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
+          - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
         :return: complemented automaton
         """
         result = Nfa()
-        params = params or {'algorithm': 'classical'}
+        params = params or {'algorithm': 'classical', 'minimize': 'false'}
         mata.complement(
             result.thisptr.get(),
             dereference(lhs.thisptr.get()),
@@ -910,7 +888,6 @@ cdef class Nfa:
                 k.encode('utf-8'): v.encode('utf-8') if isinstance(v, str) else v
                 for k, v in params.items()
             },
-            NULL
         )
         return result
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -580,11 +580,10 @@ def test_complement(
     alph.translate_symbol("a")
     alph.translate_symbol("b")
 
-    res, subset_map = mata.Nfa.complement_with_subset_map(fa_one_divisible_by_two, alph)
+    res = mata.Nfa.complement(fa_one_divisible_by_two, alph)
     assert not mata.Nfa.is_in_lang(res, [1, 1])
     assert mata.Nfa.is_in_lang(res, [1, 1, 1])
     assert not mata.Nfa.is_in_lang(res, [1, 1, 1, 1])
-    assert subset_map == {(): 3, (0,): 0, (1,): 1, (2,): 2}
 
 
 def test_revert():

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -45,7 +45,8 @@ namespace Algorithms {
     Nfa complement_classical(
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            std::unordered_map<StateSet, State>* subset_map);
+            std::unordered_map<StateSet, State>* subset_map,
+            bool minimize_after_determinization);
 
     /**
      * Complement implemented by determization and making final states which were non final in the original automaton.

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -59,7 +59,7 @@ namespace Algorithms {
      * it checks emptiness of intersection
      * @param[in] smaller Automaton which language should be included in the bigger one
      * @param[in] bigger Automaton which language should include the smaller one
-     * @param[in] alphabet Alphabet of the both automaton
+     * @param[in] alphabet Alphabet of both automata (it is computed automatically, but it is more optimal to set it if you have it)
      * @param[out] cex A potential counterexample word which breaks inclusion
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
@@ -67,14 +67,14 @@ namespace Algorithms {
     bool is_included_naive(
             const Nfa&             smaller,
             const Nfa&             bigger,
-            const Alphabet* const  alphabet,
-            Run*                   cex);
+            const Alphabet* const  alphabet = nullptr,
+            Run*                   cex = nullptr);
 
     /**
      * Inclusion implemented by antichain algorithms.
      * @param[in] smaller Automaton which language should be included in the bigger one
      * @param[in] bigger Automaton which language should include the smaller one
-     * @param[in] alphabet Alphabet of the both automaton
+     * @param[in] alphabet Alphabet of both automata (not needed for antichain algorithm)
      * @param[out] cex A potential counterexample word which breaks inclusion
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
@@ -82,8 +82,8 @@ namespace Algorithms {
     bool is_included_antichains(
             const Nfa&             smaller,
             const Nfa&             bigger,
-            const Alphabet* const  alphabet,
-            Run*                   cex);
+            const Alphabet* const  alphabet = nullptr,
+            Run*                   cex = nullptr);
 
     /**
      * Universality check implemented by checking emptiness of complemented automaton

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -35,40 +35,32 @@ namespace Nfa {
 namespace Algorithms {
 
     /**
+     * Brzozowski minimization of automata (revert -> determinize -> revert -> determinize).
+     * @param[in] aut Automaton to be minimized.
+     * @return Minimized automaton.
+     */
+    Nfa minimize_brzozowski(const Nfa& aut);
+
+    /**
      * Complement implemented by determization, adding sink state and making automaton complete. Then it adds
      * final states which were non final in the original automaton.
-     * @param aut Automaton to be complemented
-     * @param alphabet Alphabet is needed since no symbols needs to be in automaton transitions
-     * @param subset_map Maps states to subsets created during complementation.
-     * @return Complemented automaton
+     * @param[in] aut Automaton to be complemented.
+     * @param[in] alphabet Alphabet is needed for making the automaton complete.
+     * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (brzozowski) minimization
+     * @return Complemented automaton.
      */
     Nfa complement_classical(
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            std::unordered_map<StateSet, State>* subset_map,
-            bool minimize_after_determinization);
-
-    /**
-     * Complement implemented by determization and making final states which were non final in the original automaton.
-     * @param aut Automaton to be complemented
-     * @param alphabet Alphabet is needed since no symbols needs to be in automaton transitions
-     * @param params Determines algorithms properties
-     * @param subset_map Maps states to subsets created during complementation.
-     * @return result Complemented automaton
-     */
-    Nfa complement_naive(
-            const Nfa&         aut,
-            const Alphabet&    alphabet,
-            const StringMap&  params,
-            std::unordered_map<StateSet, State>* subset_map);
+            bool minimize_during_determinization = false);
 
     /**
      * Inclusion implemented by complementation of bigger automaton, intersecting it with smaller and then
      * it checks emptiness of intersection
-     * @param smaller Automaton which language should be included in the bigger one
-     * @param bigger Automaton which language should include the smaller one
-     * @param alphabet Alphabet of the both automaton
-     * @param cex A potential counterexample word which breaks inclusion
+     * @param[in] smaller Automaton which language should be included in the bigger one
+     * @param[in] bigger Automaton which language should include the smaller one
+     * @param[in] alphabet Alphabet of the both automaton
+     * @param[out] cex A potential counterexample word which breaks inclusion
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
      */
@@ -76,16 +68,14 @@ namespace Algorithms {
             const Nfa&             smaller,
             const Nfa&             bigger,
             const Alphabet* const  alphabet,
-            Run*                   cex,
-            const StringMap&  /* params*/);
+            Run*                   cex);
 
     /**
      * Inclusion implemented by antichain algorithms.
-     * @param smaller Automaton which language should be included in the bigger one
-     * @param bigger Automaton which language should include the smaller one
-     * @param alphabet Alphabet of the both automaton
-     * @param cex A potential counterexample word which breaks inclusion
-     * @param params The parameters used in algorithm. E.g., type of simulation relation
+     * @param[in] smaller Automaton which language should be included in the bigger one
+     * @param[in] bigger Automaton which language should include the smaller one
+     * @param[in] alphabet Alphabet of the both automaton
+     * @param[out] cex A potential counterexample word which breaks inclusion
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
      */
@@ -93,35 +83,31 @@ namespace Algorithms {
             const Nfa&             smaller,
             const Nfa&             bigger,
             const Alphabet* const  alphabet,
-            Run*                   cex,
-            const StringMap&      params);
+            Run*                   cex);
 
     /**
      * Universality check implemented by checking emptiness of complemented automaton
-     * @param aut Automaton which universality is checked
-     * @param alphabet Alphabet of the automaton
-     * @param cex Counterexample word which eventually breaks the universality
+     * @param[in] aut Automaton which universality is checked
+     * @param[in] alphabet Alphabet of the automaton
+     * @param[out] cex Counterexample word which eventually breaks the universality
      * @return True if the complemented automaton has non empty language, i.e., the original one is not universal
      */
     bool is_universal_naive(
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            Run*               cex,
-            const StringMap&  /* params*/);
+            Run*               cex);
 
     /**
      * Universality checking based on subset construction with antichain.
-     * @param aut Automaton which universality is checked
-     * @param alphabet Alphabet of the automaton
-     * @param cex Counterexample word which eventually breaks the universality
-     * @param params Parameters of the automaton, i.e., simulation relation to be used for antichains
+     * @param[in] aut Automaton which universality is checked
+     * @param[in] alphabet Alphabet of the automaton
+     * @param[out] cex Counterexample word which eventually breaks the universality
      * @return True if the automaton is universal, otherwise false.
      */
     bool is_universal_antichains(
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            Run*              cex,
-            const StringMap&  params);
+            Run*              cex);
 
     Simlib::Util::BinaryRelation compute_relation(
             const Nfa& aut,

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -59,7 +59,7 @@ namespace Algorithms {
      * it checks emptiness of intersection
      * @param[in] smaller Automaton which language should be included in the bigger one
      * @param[in] bigger Automaton which language should include the smaller one
-     * @param[in] alphabet Alphabet of both automata (it is computed automatically, but it is more optimal to set it if you have it)
+     * @param[in] alphabet Alphabet of both automata (it is computed automatically, but it is more efficient to set it if you have it)
      * @param[out] cex A potential counterexample word which breaks inclusion
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.

--- a/include/mata/nfa-plumbing.hh
+++ b/include/mata/nfa-plumbing.hh
@@ -39,10 +39,10 @@ namespace Plumbing {
             Nfa*               result,
             const Nfa&         aut,
             const Alphabet&    alphabet,
-            const StringMap&  params = {{"algorithm", "classical"}},
-            std::unordered_map<StateSet, State> *subset_map = nullptr)
+            const StringMap&  params = {{"algorithm", "classical"},
+                                        {"minimize", "false"}})
     { // {{{
-        *result = complement(aut, alphabet, params, subset_map);
+        *result = complement(aut, alphabet, params);
     } // complement }}}
 
     inline void minimize(Nfa* res, const Nfa &aut)

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -864,23 +864,70 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
                 StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 
 
-/// makes the transition relation complete
-void make_complete(
+/**
+ * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
+ * on transitions from given state) to @p sink_state. If @p sink_state does not belong to the automaton, it is added to it,
+ * but only in the case that some transition to @p sink_state was added.
+ * 
+ * @param[in] aut Automaton to make complete.
+ * @param[in] alphabet Alphabet to use for computing "missing" symbols.
+ * @param[in] sink_state The state into which new transitions are added.
+ * @return True if some new transition was added to the automaton.
+ */
+bool make_complete(
         Nfa&             aut,
         const Alphabet&  alphabet,
         State            sink_state);
 
-/// Co
+/**
+ * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
+ * on transitions from given state) to new sink state (if no new transitions are added, this sink state is not created).
+ * 
+ * @param[in] aut Automaton to make complete.
+ * @param[in] alphabet Alphabet to use for computing "missing" symbols.
+ * @return True if some new transition (and sink state) was added to the automaton.
+ */
+inline bool make_complete(
+        Nfa&             aut,
+        const Alphabet&  alphabet)
+{
+    return make_complete(aut, alphabet, aut.size());
+}
+
+/**
+ * @brief Compute automaton accepting complement of @p aut.
+ * 
+ * @param[in] aut Automaton whose complement to compute.
+ * @param[in] alphabet Alphabet used for complementation.
+ * @param[in] params Optional parameters to control the complementation algorithm:
+ * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
+ * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * @return Complemented automaton.
+ */
 Nfa complement(
         const Nfa&         aut,
         const Alphabet&    alphabet,
         const StringMap&  params = {{"algorithm", "classical"},
-                                    {"minimize", "false"}},
-        std::unordered_map<StateSet, State> *subset_map = nullptr);
+                                    {"minimize", "false"}});
+/**
+ * @brief Compute minimal deterministic automaton.
+ * 
+ * @param[in] aut Automaton whose minimal version to compute.
+ * @param[in] params Optional parameters to control the minimization algorithm:
+ * - "algorithm": "brzozowski"
+ * @return Minimal deterministic automaton.
+ */
+Nfa minimize(
+        const Nfa &aut,
+        const StringMap& params = {{"algorithm", "brzozowski"}});
 
-Nfa minimize(const Nfa &aut);
-
-/// Determinize an automaton
+/**
+ * @brief Determinize automaton.
+ * 
+ * @param[in] aut Automaton to determinize.
+ * @param[out] subset_map Map that maps sets of states of input automaton to states of determinized automaton.
+ * @return Determinized automaton. 
+ */
 Nfa determinize(
         const Nfa&  aut,
         std::unordered_map<StateSet, State> *subset_map = nullptr);
@@ -891,7 +938,7 @@ Nfa determinize(
  * @param[in] aut Automaton to reduce.
  * @param[in] trim_input Whether to trim the input automaton first or not.
  * @param[out] state_map Mapping of trimmed states to new states.
- * @param params[in] Optional parameters to control the reduction algorithm:
+ * @param[in] params Optional parameters to control the reduction algorithm:
  * - "algorithm": "simulation".
  * @return Reduced automaton.
  */
@@ -919,11 +966,11 @@ inline bool is_universal(
 /**
  * @brief Checks inclusion of languages of two NFAs: @p smaller and @p bigger (smaller <= bigger).
  *
- * @param smaller[in] First automaton to concatenate.
- * @param bigger[in] Second automaton to concatenate.
- * @param cex[out] Counterexample for the inclusion.
- * @param alphabet[in] Alphabet of both NFAs to compute with.
- * @param params[in] Optional parameters to control the equivalence check algorithm:
+ * @param[in] smaller First automaton to concatenate.
+ * @param[in] bigger Second automaton to concatenate.
+ * @param[out] cex Counterexample for the inclusion.
+ * @param[in] alphabet Alphabet of both NFAs to compute with.
+ * @param[in] params Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p smaller is included in @p bigger, false otherwise.
  */
@@ -936,8 +983,13 @@ bool is_included(
 
 /**
  * @brief Checks inclusion of languages of two NFAs: @p smaller and @p bigger (smaller <= bigger).
- * @param params[in] Optional parameters to control the equivalence check algorithm:
+ *
+ * @param[in] smaller First automaton to concatenate.
+ * @param[in] bigger Second automaton to concatenate.
+ * @param[in] alphabet Alphabet of both NFAs to compute with.
+ * @param[in] params Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
+ * @return True if @p smaller is included in @p bigger, false otherwise.
  */
 inline bool is_included(
         const Nfa&             smaller,
@@ -951,10 +1003,10 @@ inline bool is_included(
 /**
  * @brief Perform equivalence check of two NFAs: @p lhs and @p rhs.
  *
- * @param lhs[in] First automaton to concatenate.
- * @param rhs[in] Second automaton to concatenate.
- * @param alphabet[in] Alphabet of both NFAs to compute with.
- * @param params[in] Optional parameters to control the equivalence check algorithm:
+ * @param[in] lhs First automaton to concatenate.
+ * @param[in] rhs Second automaton to concatenate.
+ * @param[in] alphabet Alphabet of both NFAs to compute with.
+ * @param[in] params[ Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
@@ -972,9 +1024,9 @@ bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet,
  * That way, alphabet has to be computed only once, as opposed to the current ad-hoc construction of the alphabet.
  * The use of the alternative with defined alphabet should be preferred.
  *
- * @param lhs[in] First automaton to concatenate.
- * @param rhs[in] Second automaton to concatenate.
- * @param params[in] Optional parameters to control the equivalence check algorithm:
+ * @param[in] lhs First automaton to concatenate.
+ * @param[in] rhs Second automaton to concatenate.
+ * @param[in] params Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -868,6 +868,7 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
  * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
  * on transitions from given state) to @p sink_state. If @p sink_state does not belong to the automaton, it is added to it,
  * but only in the case that some transition to @p sink_state was added.
+ * In the case that @p aut does not contain any states, this function does nothing.
  * 
  * @param[in] aut Automaton to make complete.
  * @param[in] alphabet Alphabet to use for computing "missing" symbols.
@@ -882,6 +883,7 @@ bool make_complete(
 /**
  * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
  * on transitions from given state) to new sink state (if no new transitions are added, this sink state is not created).
+ * In the case that @p aut does not contain any states, this function does nothing.
  * 
  * @param[in] aut Automaton to make complete.
  * @param[in] alphabet Alphabet to use for computing "missing" symbols.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -874,7 +874,8 @@ void make_complete(
 Nfa complement(
         const Nfa&         aut,
         const Alphabet&    alphabet,
-        const StringMap&  params = {{"algorithm", "classical"}},
+        const StringMap&  params = {{"algorithm", "classical"},
+                                    {"minimize", "false"}},
         std::unordered_map<StateSet, State> *subset_map = nullptr);
 
 Nfa minimize(const Nfa &aut);

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -83,16 +83,16 @@ Nfa Mata::Nfa::complement(
 			" received an unknown value of the \"algo\" key: " + str_algo);
 	}
 
-	bool minimize_after_determinization = false;
+	bool minimize_during_determinization = false;
 	if (params.find("minimize") != params.end()) {
 		const std::string& minimize_arg = params.at("minimize");
-		if ("true" == minimize_arg) { minimize_after_determinization = true; }
-		else if ("false" == minimize_arg) { minimize_after_determinization = false; }
+		if ("true" == minimize_arg) { minimize_during_determinization = true; }
+		else if ("false" == minimize_arg) { minimize_during_determinization = false; }
 		else {
 			throw std::runtime_error(std::to_string(__func__) +
 				" received an unknown value of the \"minimize\" key: " + str_algo);
 		}
 	}
 
-	return algo(aut, alphabet, minimize_after_determinization);
+	return algo(aut, alphabet, minimize_during_determinization);
 } // complement

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -31,7 +31,8 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 	State sink_state;
 	if (minimize_during_determinization) {
 		result = minimize_brzozowski(aut); // brzozowski minimization makes it deterministic
-		if (result.final.size() == 0) {
+		if (result.final.size() == 0 && result.initial.size() > 0) {
+			assert(result.initial.size() == 1);
 			// if automaton does not accept anything, then there is only one (initial) state
 			// which can be the sink state (so we do not create unnecessary one)
 			sink_state = *result.initial.begin();

--- a/src/nfa/nfa-complement.cc
+++ b/src/nfa/nfa-complement.cc
@@ -53,7 +53,6 @@ Nfa Mata::Nfa::Algorithms::complement_classical(
 
 	make_complete(result, alphabet, sink_state);
 
-	// FIXME: result.size() resturns domain size of initial/final state sets, which might contain 'deleted' states, so non-existent states become final
 	result.final.complement(result.size());
 
 	return result;

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -27,8 +27,7 @@ bool Mata::Nfa::Algorithms::is_included_naive(
         const Nfa &smaller,
         const Nfa &bigger,
         const Alphabet *const alphabet,//TODO: this should not be needed, likewise for equivalence
-        Run *cex,
-        const StringMap &  /* params*/) { // {{{
+        Run *cex) { // {{{
     Nfa bigger_cmpl;
     if (alphabet == nullptr) {
         bigger_cmpl = complement(bigger, create_alphabet(smaller, bigger));
@@ -47,11 +46,9 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
     const Nfa&             smaller,
     const Nfa&             bigger,
     const Alphabet* const  alphabet, //TODO: this parameter is not used
-    Run*                   cex,
-    const StringMap&      params) //TODO: why is this parameter there?
+    Run*                   cex) //TODO: why is this parameter there?
 { // {{{
     //TODO: what does this do?
-    (void)params;
     (void)alphabet;
 
     using ProdStateType = std::pair<State, StateSet>;
@@ -215,11 +212,10 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
 namespace {
     using AlgoType = decltype(Algorithms::is_included_naive)*;
 
-    bool compute_equivalence(const Nfa &lhs, const Nfa &rhs, const Mata::Alphabet *const alphabet, const StringMap &params,
-                             const AlgoType &algo) {
+    bool compute_equivalence(const Nfa &lhs, const Nfa &rhs, const Mata::Alphabet *const alphabet, const AlgoType &algo) {
         //alphabet should not be needed as input parameter
-        if (algo(lhs, rhs, alphabet, nullptr, params)) {
-            if (algo(rhs, lhs, alphabet, nullptr, params)) {
+        if (algo(lhs, rhs, alphabet, nullptr)) {
+            if (algo(rhs, lhs, alphabet, nullptr)) {
                 return true;
             }
         }
@@ -258,7 +254,7 @@ bool Mata::Nfa::is_included(
         const Alphabet *const alphabet,
         const StringMap &params) { // {{{
     AlgoType algo{set_algorithm(std::to_string(__func__), params)};
-    return algo(smaller, bigger, alphabet, cex, params);
+    return algo(smaller, bigger, alphabet, cex);
 } // is_included }}}
 
 bool Mata::Nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet *alphabet, const StringMap& params)
@@ -269,11 +265,11 @@ bool Mata::Nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet *a
     if (params.at("algorithm") == "naive") {
         if (alphabet == nullptr) {
             const auto computed_alphabet{create_alphabet(lhs, rhs) };
-            return compute_equivalence(lhs, rhs, &computed_alphabet, params, algo);
+            return compute_equivalence(lhs, rhs, &computed_alphabet, algo);
         }
     }
 
-    return compute_equivalence(lhs, rhs, alphabet, params, algo);
+    return compute_equivalence(lhs, rhs, alphabet, algo);
 }
 
 bool Mata::Nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const StringMap& params) {

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -46,7 +46,7 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
     const Nfa&             smaller,
     const Nfa&             bigger,
     const Alphabet* const  alphabet, //TODO: this parameter is not used
-    Run*                   cex) //TODO: why is this parameter there?
+    Run*                   cex)
 { // {{{
     //TODO: what does this do?
     (void)alphabet;

--- a/src/nfa/nfa-universal.cc
+++ b/src/nfa/nfa-universal.cc
@@ -30,8 +30,7 @@ using namespace Mata::Util;
 bool Mata::Nfa::Algorithms::is_universal_naive(
 	const Nfa&         aut,
 	const Alphabet&    alphabet,
-	Run*               cex,
-	const StringMap&  /* params*/)
+	Run*               cex)
 { // {{{
 	Nfa cmpl = complement(aut, alphabet);
 
@@ -43,10 +42,8 @@ bool Mata::Nfa::Algorithms::is_universal_naive(
 bool Mata::Nfa::Algorithms::is_universal_antichains(
 	const Nfa&         aut,
 	const Alphabet&    alphabet,
-	Run*               cex,
-	const StringMap&  params)
+	Run*               cex)
 { // {{{
-	(void)params;
 
 	using WorklistType = std::list<StateSet>;
 	using ProcessedType = std::list<StateSet>;
@@ -171,5 +168,5 @@ bool Mata::Nfa::is_universal(
 			" received an unknown value of the \"algo\" key: " + str_algo);
 	}
 
-	return algo(aut, alphabet, cex, params);
+	return algo(aut, alphabet, cex);
 } // is_universal }}}

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -633,8 +633,8 @@ bool Mata::Nfa::make_complete(
     auto num_of_states = aut.size();
     for (State state = 0; state < num_of_states; ++state) {
         std::set<Symbol> used_symbols;
-        for (auto const &tran : aut.delta[state]) {
-            used_symbols.insert(tran.symbol);
+        for (auto const &move : aut.delta[state]) {
+            used_symbols.insert(move.symbol);
         }
         auto unused_symbols = alphabet.get_complement(used_symbols);
         for (Symbol symb : unused_symbols)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -623,49 +623,34 @@ bool Mata::Nfa::are_state_disjoint(const Nfa& lhs, const Nfa& rhs)
     return true;
 } // are_disjoint }}}
 
-void Mata::Nfa::make_complete(
+bool Mata::Nfa::make_complete(
         Nfa&             aut,
         const Alphabet&  alphabet,
         State            sink_state)
 {
-    std::list<State> worklist(aut.initial.begin(),
-                              aut.initial.end());
-    std::unordered_set<State> processed(aut.initial.begin(),
-                                        aut.initial.end());
+    bool was_something_added = false;
 
-    if (aut.size() <= sink_state) {
-        aut.add_state(sink_state);
-    }
-
-    worklist.push_back(sink_state);
-    processed.insert(sink_state);
-    while (!worklist.empty())
-    {
-        State state = *worklist.begin();
-        worklist.pop_front();
-
+    auto num_of_states = aut.size();
+    for (State state = 0; state < num_of_states; ++state) {
         std::set<Symbol> used_symbols;
-        if (!aut.delta.empty())
-        {
-            for (const auto &symb_stateset: aut[state]) {
-                // TODO: Possibly fix insert.
-                used_symbols.insert(symb_stateset.symbol);
-
-                const StateSet &stateset = symb_stateset.targets;
-                for (const auto &tgt_state: stateset) {
-                    bool inserted;
-                    tie(std::ignore, inserted) = processed.insert(tgt_state);
-                    if (inserted) { worklist.push_back(tgt_state); }
-                }
-            }
+        for (auto const &tran : aut.delta[state]) {
+            used_symbols.insert(tran.symbol);
         }
-
         auto unused_symbols = alphabet.get_complement(used_symbols);
         for (Symbol symb : unused_symbols)
         {
             aut.delta.add(state, symb, sink_state);
+            was_something_added = true;
         }
     }
+
+    if (was_something_added && num_of_states <= sink_state) {
+        for (Symbol symbol : alphabet.get_alphabet_symbols()) {
+            aut.delta.add(sink_state, symbol, sink_state);
+        }
+    }
+
+    return was_something_added;
 }
 
 Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
@@ -964,12 +949,33 @@ bool Mata::Nfa::is_lang_empty(const Nfa& aut, Run* cex)
     return true;
 } // is_lang_empty }}}
 
-Nfa Mata::Nfa::minimize(const Nfa& aut) {
+
+Nfa Mata::Nfa::Algorithms::minimize_brzozowski(const Nfa& aut) {
     //compute the minimal deterministic automaton, Brzozovski algorithm
-    Nfa inverted = revert(aut);
-    Nfa tmp = determinize(inverted);
-    Nfa deter = revert(tmp);
-    return determinize(deter);
+    return determinize(revert(determinize(revert(aut))));
+}
+
+Nfa Mata::Nfa::minimize(
+                const Nfa& aut,
+                const StringMap& params)
+{
+	Nfa result;
+	// setting the default algorithm
+	decltype(Algorithms::minimize_brzozowski)* algo = Algorithms::minimize_brzozowski;
+	if (!haskey(params, "algorithm")) {
+		throw std::runtime_error(std::to_string(__func__) +
+			" requires setting the \"algo\" key in the \"params\" argument; "
+			"received: " + std::to_string(params));
+	}
+
+	const std::string& str_algo = params.at("algorithm");
+	if ("brzozowski" == str_algo) {  /* default */ }
+	else {
+		throw std::runtime_error(std::to_string(__func__) +
+			" received an unknown value of the \"algo\" key: " + str_algo);
+	}
+
+	return algo(aut);
 }
 
 void Nfa::print_to_DOT(std::ostream &outputStream) const {

--- a/src/nfa/tests-nfa.cc
+++ b/src/nfa/tests-nfa.cc
@@ -1245,7 +1245,7 @@ TEST_CASE("Mata::Nfa::complement()")
 		cmpl = complement(aut, alph);
 
 		REQUIRE(is_in_lang(cmpl, { }));
-		REQUIRE(cmpl.initial.size() == 1);
+		REQUIRE(cmpl.initial.size() == 0);
 		REQUIRE(cmpl.final.size() == 1);
 		REQUIRE(nothing_in_trans(cmpl));
 		REQUIRE(*cmpl.initial.begin() == *cmpl.final.begin());
@@ -1279,8 +1279,8 @@ TEST_CASE("Mata::Nfa::complement()")
 	SECTION("empty automaton accepting epsilon, empty alphabet")
 	{
 		OnTheFlyAlphabet alph{};
-		aut.initial = {1};
-		aut.final = {1};
+		aut.initial = {0};
+		aut.final = {0};
 
 		cmpl = complement(aut, alph);
 


### PR DESCRIPTION
This PR adds minimization to computing determinized automaton during complement. I also rewrote `make_complete` so that it "completes" all states, not only those that are reachable (as we have agreed to do). Furthermore, I updated or added some comments for determinization, inclusion and minimization algorithms. I also created one `minimize` function that can select algorithm for minimization (for future) and moved Brzozowski minimization to its own function `minimize_brzozowski`.