### PR TITLE
Improve trim performance

### DIFF
--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -42,7 +42,7 @@
 namespace Mata::Nfa {
 extern const std::string TYPE_NFA;
 
-using State = unsigned;
+using State = unsigned long;
 using StateSet = Mata::Util::OrdVector<State>;
 
 template<typename T> using Set = Mata::Util::OrdVector<T>;

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -243,6 +243,8 @@ struct Post : private Util::OrdVector<Move> {
 
     const std::vector<Move>& ToVector() const { return Util::OrdVector<Move>::ToVector(); }
 
+    inline void erase(const_iterator first, const_iterator last) { Util::OrdVector<Move>::erase(first, last); }
+
     //Could we somehow use the && thingy here? It is supposed to be faster?
     template<typename F>
     inline void filter(F && is_staying) {

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -216,6 +216,10 @@ public:   // Public methods
         vec_.resize(size);
     }
 
+    virtual inline void erase(const_iterator first, const_iterator last) {
+        vec_.erase(first, last);
+    }
+
     virtual void insert(const Key& x)
     {
         reserve_on_insert(vec_);

--- a/include/mata/util.hh
+++ b/include/mata/util.hh
@@ -469,6 +469,7 @@ void rename(Vector & vec, const std::vector<Index> & renaming) {
 
 template<class Vector, typename F>
 void filter_indexes(Vector & vec, F && is_staying) {
+    // TODO: Rewrite with erase and remove_if.
     size_t last = 0;
     for (size_t i = 0,size = vec.size();i < size; ++i)
     {
@@ -484,6 +485,7 @@ void filter_indexes(Vector & vec, F && is_staying) {
 
 template<class Vector, typename F>
 void filter(Vector & vec, F && is_staying) {
+    // TODO: Rewrite with erase and remove_if.
     size_t last = 0;
     for (size_t i = 0,size = vec.size();i < size; ++i)
     {


### PR DESCRIPTION
This PR improves trim performance by using the idiomatic `erase(remove_if())` pattern.

Furthermore, the PR reverts `Mata::Nfa::State` back to `unsigned long` as `unsinged` caused a bug where the standard hashing function for `std::pair<State, State>` starts to allocate GBs of memory. (We are not sure if it was the hashing function which caused it, but the program was forcefully stopped multiple times at this hashing function invocation during the above-mentioned memory allocation).