### PR TITLE
Create new alphabet class: Enumerated alphabet

### DIFF
--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -181,6 +181,14 @@ namespace Mata {
      *
      * Therefore, calling member functions @c get_complement() and @c get_alphabet_symbols() makes sense in the context
      *  of @c EnumAlphabet and the functions give the expected results.
+     *
+     *  Example:
+     *  ```cpp
+     *  Alphabet alph{ EnumAlphabet{ 0, 4, 6, 8, 9 } };
+     *  CHECK(alph.translate_symb("6") == 6);
+     *  CHECK_THROWS(alph.translate_symb("5")); // Throws an exception about an unknown symbol.
+     *  CHECK(alph.get_complement({ Util::OrdVector<Symbol>{ 0, 6, 9 } }) == Util::OrdVector<Symbol>{ 4, 8 });
+     *  ```
      */
     class EnumAlphabet : public Alphabet {
     public:

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -115,6 +115,9 @@ namespace Mata {
                 Symbol symbol;
                 std::istringstream stream{ symb };
                 stream >> symbol;
+                if (stream.fail() || !stream.eof()) {
+                    throw std::runtime_error("Cannot translate string '" + symb + "' to symbol.");
+                }
                 return symbol;
             }
 
@@ -231,10 +234,14 @@ namespace Mata {
             Symbol symbol;
             std::istringstream stream{ str };
             stream >> symbol;
-            return symbol;
+            if (stream.fail() || !stream.eof()) {
+                throw std::runtime_error("Cannot translate string '" + str + "' to symbol.");
+            }
+            if (m_symbols.find(symbol) == m_symbols.end()) {
+                throw std::runtime_error("Unknown symbol'" + str + "' to be translated to Symbol.");
+            }
 
-            // TODO: How can the user specify to throw exceptions when we encounter an unknown symbol? How to specify that
-            //  the alphabet should have only the previously fixed symbols?
+            return symbol;
         }
 
         std::vector<Symbol> translate_word(const std::vector<std::string>& word) const override {

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -187,7 +187,7 @@ namespace Mata {
 
         Util::OrdVector<Symbol> get_alphabet_symbols() const override { return m_symbols; }
         Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const override {
-            return m_symbols.difference(Util::OrdVector<Symbol>{ symbols });
+            return m_symbols.difference(symbols);
         }
 
         std::string reverse_translate_symbol(const Symbol symbol) const override {

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -64,7 +64,7 @@ namespace Mata {
             } // }}}
 
             /// complement of a set of symbols wrt the alphabet
-            virtual Util::OrdVector<Symbol> get_complement(const std::set<Symbol> &symbols) const { // {{{
+            virtual Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const { // {{{
                 (void) symbols;
                 throw std::runtime_error("Unimplemented");
             } // }}}
@@ -126,7 +126,7 @@ namespace Mata {
                 throw std::runtime_error("Nonsensical use of get_alphabet_symbols() on IntAlphabet.");
             }
 
-            Util::OrdVector<Symbol> get_complement(const std::set<Symbol> &symbols) const override {
+            Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const override {
                 (void) symbols;
                 throw std::runtime_error("Nonsensical use of get_complement() on IntAlphabet.");
             }
@@ -186,7 +186,7 @@ namespace Mata {
         EnumAlphabet(EnumAlphabet&& rhs) = default;
 
         Util::OrdVector<Symbol> get_alphabet_symbols() const override { return m_symbols; }
-        Util::OrdVector<Symbol> get_complement(const std::set<Symbol>& symbols) const override {
+        Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const override {
             return m_symbols.difference(Util::OrdVector<Symbol>{ symbols });
         }
 
@@ -227,8 +227,7 @@ namespace Mata {
 
         EnumAlphabet(std::initializer_list<std::string> l) : EnumAlphabet(l.begin(), l.end()) {}
 
-        Symbol translate_symb(const std::string& str) override
-        {
+        Symbol translate_symb(const std::string& str) override {
             Symbol symbol;
             std::istringstream stream{ str };
             stream >> symbol;
@@ -311,10 +310,10 @@ namespace Mata {
         }
     }; // class EnumAlphabet.
 
-/**
- * An alphabet constructed 'on the fly'.
- * Should be use anytime the automata have a specific names for the symbols.
- */
+    /**
+     * An alphabet constructed 'on the fly'.
+     * Should be use anytime the automata have a specific names for the symbols.
+     */
     class OnTheFlyAlphabet : public Alphabet {
     public:
         using InsertionResult = std::pair<StringToSymbolMap::const_iterator, bool>; ///< Result of the insertion of a new symbol.
@@ -334,7 +333,7 @@ namespace Mata {
                 : symbol_map(), next_symbol_value(init_symbol) { add_symbols_from(symbol_names); }
 
         Util::OrdVector<Symbol> get_alphabet_symbols() const override;
-        Util::OrdVector<Symbol> get_complement(const std::set<Symbol>& symbols) const override;
+        Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const override;
 
         std::string reverse_translate_symbol(const Symbol symbol) const override {
             for (const auto& symbol_mapping: symbol_map) {

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -202,7 +202,7 @@ namespace Mata {
 
     public:
         /**
-         * @brief Expand alphabet by symbols from the passed @p symbol_names.
+         * @brief Expand alphabet by symbols from the passed @p symbols.
          *
          * Adding a symbol name which already exists will throw an exception.
          * @param[in] symbols Vector of symbols to add.

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -64,8 +64,8 @@ namespace Mata {
             } // }}}
 
             /// complement of a set of symbols wrt the alphabet
-            virtual std::list<Symbol> get_complement(const std::set<Symbol> &syms) const { // {{{
-                (void) syms;
+            virtual Util::OrdVector<Symbol> get_complement(const std::set<Symbol> &symbols) const { // {{{
+                (void) symbols;
                 throw std::runtime_error("Unimplemented");
             } // }}}
 
@@ -126,9 +126,9 @@ namespace Mata {
                 throw std::runtime_error("Nonsensical use of get_alphabet_symbols() on IntAlphabet.");
             }
 
-            std::list<Symbol> get_complement(const std::set<Symbol> &syms) const override {
-                (void) syms;
-                throw std::runtime_error("Nonsensical use of get_alphabet_symbols() on IntAlphabet.");
+            Util::OrdVector<Symbol> get_complement(const std::set<Symbol> &symbols) const override {
+                (void) symbols;
+                throw std::runtime_error("Nonsensical use of get_complement() on IntAlphabet.");
             }
 
             IntAlphabet(const IntAlphabet &) = default;
@@ -192,7 +192,7 @@ namespace Mata {
                 : symbol_map(), next_symbol_value(init_symbol) { add_symbols_from(symbol_names); }
 
         Util::OrdVector<Symbol> get_alphabet_symbols() const override;
-        std::list<Symbol> get_complement(const std::set<Symbol>& syms) const override;
+        Util::OrdVector<Symbol> get_complement(const std::set<Symbol>& symbols) const override;
 
         std::string reverse_translate_symbol(const Symbol symbol) const override {
             for (const auto& symbol_mapping: symbol_map) {

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -234,7 +234,7 @@ struct Post : private Util::OrdVector<Move> {
     // is adding this non-const version ok?
     inline Move& back() { return Util::OrdVector<Move>::back(); }
 
-    inline void resize(size_t size) override { Util::OrdVector<Move>::resize(size); }
+    inline void reserve(size_t size) override { Util::OrdVector<Move>::reserve(size); }
 
     void remove(const Move& m)  { Util::OrdVector<Move>::remove(m); }
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -543,7 +543,7 @@ public:
      * @param[in] num_of_states Number of states for which to preallocate Delta.
      */
     explicit Nfa(const unsigned long num_of_states, const StateSet& initial_states = StateSet{},
-                 const StateSet& final_states = StateSet{}, Alphabet* alphabet = new IntAlphabet())
+                 const StateSet& final_states = StateSet{}, Alphabet* alphabet = nullptr)
         : delta(num_of_states), initial(initial_states), final(final_states), alphabet(alphabet), m_num_of_requested_states(0) {}
 
     /**
@@ -882,7 +882,7 @@ public:
      *
      * The value of the already existing symbols will NOT be overwritten.
      */
-    void add_symbols_to(OnTheFlyAlphabet& alphabet);
+    void add_symbols_to(OnTheFlyAlphabet& alphabet) const;
 }; // struct Nfa.
 
 /**

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -327,9 +327,16 @@ public:   // Public methods
      */
     inline void remove(Key k) {
         assert(vectorIsSorted());
-        auto found_values_range = std::equal_range(vec_.begin(), vec_.end(), k);
-        vec_.erase(found_values_range.first, found_values_range.second);
-        assert(vectorIsSorted());
+        auto found_value_it = std::lower_bound(vec_.begin(), vec_.end(), k);
+        if (found_value_it != vec_.end()) {
+            if (*found_value_it == k) {
+                vec_.erase(found_value_it);
+                assert(vectorIsSorted());
+                return;
+            }
+        }
+
+        throw std::runtime_error("Key is not in OrdVector.");
     }
 
     virtual inline bool empty() const { return vec_.empty(); }

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -124,6 +124,8 @@ public:   // Public methods
         Util::sort_and_rmdupl(vec_);
     }
 
+    explicit OrdVector(const std::set<Key>& set): vec_{ set.begin(), set.end() } { Util::sort_and_rmdupl(vec_); }
+
     OrdVector(std::initializer_list<Key> list) :
         vec_(list)
     {

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -194,8 +194,8 @@ public:   // Public methods
         vec_.emplace_back(x);
     }
 
-    virtual inline void resize(size_t  size) {
-        vec_.resize(size);
+    virtual inline void reserve(size_t  size) {
+        vec_.reserve(size);
     }
 
     virtual inline void erase(const_iterator first, const_iterator last) {

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -255,8 +255,7 @@ public:   // Public methods
         assert(vectorIsSorted());
         assert(vec.vectorIsSorted());
 
-        OrdVector result = this->Union(vec);
-        vec_ = result.vec_;
+        vec_ = OrdVector::Union(*this, vec).vec_;
 
         // Assertions
         assert(vectorIsSorted());
@@ -288,121 +287,11 @@ public:   // Public methods
      * @param rhs Other vector with symbols to be excluded.
      * @return @c this minus @p rhs.
      */
-    OrdVector difference(const OrdVector& rhs) const {
-        assert(vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+    OrdVector difference(const OrdVector& rhs) const { return difference(*this, rhs); }
 
-        OrdVector result{};
-        auto lhs_it{ vec_.begin() };
-        auto rhs_it{ rhs.begin() };
+    OrdVector intersection(const OrdVector& rhs) const { return intersection(*this, rhs); }
 
-        while ((lhs_it != vec_.end())) {
-            if (rhs_it == rhs.end()) {
-                result.push_back(*lhs_it);
-                ++lhs_it;
-            } else if (*lhs_it == *rhs_it) {
-                ++lhs_it;
-                ++rhs_it;
-            } else if (*lhs_it < *rhs_it) {
-                result.push_back(*lhs_it);
-                ++lhs_it;
-            } else if (*lhs_it > *rhs_it) {
-                ++rhs_it;
-            }
-        }
-
-        assert(result.vectorIsSorted());
-        return result;
-    }
-
-    OrdVector intersection(const OrdVector& rhs) const
-    {
-        // Assertions
-        assert(vectorIsSorted());
-        assert(rhs.vectorIsSorted());
-
-        VectorType newVector{};
-
-        auto lhsIt = vec_.begin();
-        auto rhsIt = rhs.vec_.begin();
-
-        while ((lhsIt != vec_.end()) && (rhsIt != rhs.vec_.end()))
-        {	// until we get to the end of both vectors
-            if (*lhsIt == *rhsIt)
-            {
-                newVector.push_back(*lhsIt);
-
-                ++lhsIt;
-                ++rhsIt;
-            }
-            else if (*lhsIt < *rhsIt)
-            {
-                ++lhsIt;
-            }
-            else if (*rhsIt < *lhsIt)
-            {
-                ++rhsIt;
-            }
-        }
-
-        OrdVector result(newVector);
-
-        // Assertions
-        assert(result.vectorIsSorted());
-
-        return result;
-    }
-
-    OrdVector Union(const OrdVector& rhs) const {
-        // Assertions
-        assert(vectorIsSorted());
-        assert(rhs.vectorIsSorted());
-
-        VectorType newVector;
-
-        auto lhsIt = vec_.begin();
-        auto rhsIt = rhs.vec_.begin();
-
-        while ((lhsIt != vec_.end()) || (rhsIt != rhs.vec_.end()))
-        {	// until we get to the end of both vectors
-            if (lhsIt == vec_.end())
-            {	// if we are finished with the left-hand side vector
-                newVector.push_back(*rhsIt);
-                ++rhsIt;
-            }
-            else if (rhsIt == rhs.vec_.end())
-            {	// if we are finished with the right-hand side vector
-                newVector.push_back(*lhsIt);
-                ++lhsIt;
-            }
-            else
-            {
-                if (*lhsIt < *rhsIt)
-                {
-                    newVector.push_back(*lhsIt);
-                    ++lhsIt;
-                }
-                else if (*rhsIt < *lhsIt)
-                {
-                    newVector.push_back(*rhsIt);
-                    ++rhsIt;
-                }
-                else
-                {	// in case they are equal
-                    newVector.push_back(*rhsIt);
-                    ++rhsIt;
-                    ++lhsIt;
-                }
-            }
-        }
-
-        OrdVector result(newVector);
-
-        // Assertions
-        assert(result.vectorIsSorted());
-
-        return result;
-    }
+    OrdVector Union(const OrdVector& rhs) const { return Union(*this, rhs); }
 
     //TODO: this code of find was duplicated, not nice.
     // Replacing the original code by std function, but keeping the original here commented, it was nice, might be even better.
@@ -568,6 +457,94 @@ public:   // Public methods
 
     // Renames numbers in the vector according to the renaming, q becomes renaming[q].
    void rename(const std::vector<Key> & renaming) { Util::rename(vec_,renaming); }
+
+
+    static OrdVector difference(const OrdVector& lhs, const OrdVector& rhs) {
+        assert(lhs.vectorIsSorted());
+        assert(rhs.vectorIsSorted());
+
+        OrdVector result{};
+        auto lhs_it{ lhs.begin() };
+        auto rhs_it{ rhs.begin() };
+
+        while ((lhs_it != lhs.end())) {
+            if (rhs_it == rhs.end()) {
+                result.push_back(*lhs_it);
+                ++lhs_it;
+            } else if (*lhs_it == *rhs_it) {
+                ++lhs_it;
+                ++rhs_it;
+            } else if (*lhs_it < *rhs_it) {
+                result.push_back(*lhs_it);
+                ++lhs_it;
+            } else if (*lhs_it > *rhs_it) {
+                ++rhs_it;
+            }
+        }
+
+        assert(result.vectorIsSorted());
+        return result;
+    }
+
+    static OrdVector Union(const OrdVector& lhs, const OrdVector& rhs) {
+        assert(lhs.vectorIsSorted());
+        assert(rhs.vectorIsSorted());
+
+        OrdVector result;
+
+        auto lhs_it = lhs.begin();
+        auto rhs_it = rhs.vec_.begin();
+
+        while ((lhs_it != lhs.end()) || (rhs_it != rhs.end())) { // Until we get to the end of both vectors.
+            if (lhs_it == lhs.end()) { // If we are finished with the left-hand side vector.
+                result.push_back(*rhs_it);
+                ++rhs_it;
+            } else if (rhs_it == rhs.end()) { // If we are finished with the right-hand side vector.
+                result.push_back(*lhs_it);
+                ++lhs_it;
+            } else {
+                if (*lhs_it < *rhs_it) {
+                    result.push_back(*lhs_it);
+                    ++lhs_it;
+                } else if (*rhs_it < *lhs_it) {
+                    result.push_back(*rhs_it);
+                    ++rhs_it;
+                } else { // In case they are equal.
+                    result.push_back(*rhs_it);
+                    ++rhs_it;
+                    ++lhs_it;
+                }
+            }
+        }
+
+        assert(result.vectorIsSorted());
+        return result;
+    }
+
+    static OrdVector intersection(const OrdVector& lhs, const OrdVector& rhs) {
+        assert(lhs.vectorIsSorted());
+        assert(rhs.vectorIsSorted());
+
+        OrdVector result{};
+
+        auto lhs_it = lhs.begin();
+        auto rhs_it = rhs.vec_.begin();
+
+        while ((lhs_it != lhs.end()) && (rhs_it != rhs.end())) {	// Until we get to the end of both vectors.
+            if (*lhs_it == *rhs_it) {
+                result.push_back(*lhs_it);
+                ++lhs_it;
+                ++rhs_it;
+            } else if (*lhs_it < *rhs_it) {
+                ++lhs_it;
+            } else if (*rhs_it < *lhs_it) {
+                ++rhs_it;
+            }
+        }
+
+        assert(result.vectorIsSorted());
+        return result;
+    }
 }; // Class OrdVector.
 
 } // Namespace Mata::Util.

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -281,6 +281,38 @@ public:   // Public methods
         return 0;
     }
 
+    /**
+     * Compute set difference as @c this minus @p rhs.
+     * @param rhs Other vector with symbols to be excluded.
+     * @return @c this minus @p rhs.
+     */
+    OrdVector difference(const OrdVector& rhs) const {
+        assert(vectorIsSorted());
+        assert(rhs.vectorIsSorted());
+
+        OrdVector result{};
+        auto lhs_it{ vec_.begin() };
+        auto rhs_it{ rhs.begin() };
+
+        while ((lhs_it != vec_.end())) {
+            if (rhs_it == rhs.end()) {
+                result.push_back(*lhs_it);
+                ++lhs_it;
+            } else if (*lhs_it == *rhs_it) {
+                ++lhs_it;
+                ++rhs_it;
+            } else if (*lhs_it < *rhs_it) {
+                result.push_back(*lhs_it);
+                ++lhs_it;
+            } else if (*lhs_it > *rhs_it) {
+                ++rhs_it;
+            }
+        }
+
+        assert(result.vectorIsSorted());
+        return result;
+    }
+
     OrdVector intersection(const OrdVector& rhs) const
     {
         // Assertions
@@ -319,9 +351,7 @@ public:   // Public methods
         return result;
     }
 
-    //TODO: why are some method names capitalised?
-    OrdVector Union(const OrdVector& rhs) const
-    {
+    OrdVector Union(const OrdVector& rhs) const {
         // Assertions
         assert(vectorIsSorted());
         assert(rhs.vectorIsSorted());

--- a/include/mata/util.hh
+++ b/include/mata/util.hh
@@ -454,7 +454,7 @@ void defragment(Vector & vec, const std::vector<Index> & renaming) {
             vec[i] = std::move(vec[renaming[i]]);
         }
     }
-    vec.resize(i);
+        vec.reserve(i);
 }
 
 //In a vector of numbers, rename the numbers according to the renaming: renaming[old_name]=new_name
@@ -480,7 +480,7 @@ void filter_indexes(Vector & vec, F && is_staying) {
             last++;
         }
     }
-    vec.resize(last);
+    vec.reserve(last);
 }
 
 template<class Vector, typename F>
@@ -496,7 +496,7 @@ void filter(Vector & vec, F && is_staying) {
             last++;
         }
     }
-    vec.resize(last);
+    vec.reserve(last);
 }
 
     template<class Vector>
@@ -511,7 +511,7 @@ void filter(Vector & vec, F && is_staying) {
 
         // remove duplicates
         auto it = std::unique(vec.begin(), vec.end());
-        vec.resize(it - vec.begin());
+        vec.reserve(it - vec.begin());
     }
 }
 }

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -26,21 +26,14 @@ Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
     return result;
 } // OnTheFlyAlphabet::get_alphabet_symbols.
 
-std::list<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& syms) const {
-    std::list<Symbol> result;
-    // TODO: Could be optimized.
-    std::set<Symbol> symbols_alphabet;
+Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& symbols) const {
+    Mata::Util::OrdVector<Symbol> symbols_alphabet{};
+    symbols_alphabet.resize(symbol_map.size());
     for (const auto& str_sym_pair : symbol_map) {
         symbols_alphabet.insert(str_sym_pair.second);
     }
-
-    std::set_difference(
-            symbols_alphabet.begin(), symbols_alphabet.end(),
-            syms.begin(), syms.end(),
-            std::inserter(result, result.end()));
-    return result;
-} // OnTheFlyAlphabet::get_complement.
-
+    return symbols_alphabet.difference(Mata::Util::OrdVector<Symbol>{ symbols });
+}
 
 void OnTheFlyAlphabet::add_symbols_from(const StringToSymbolMap& new_symbol_map) {
     for (const auto& symbol_binding: new_symbol_map) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -26,13 +26,13 @@ Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
     return result;
 } // OnTheFlyAlphabet::get_alphabet_symbols.
 
-Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& symbols) const {
+Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const Mata::Util::OrdVector<Symbol>& symbols) const {
     Mata::Util::OrdVector<Symbol> symbols_alphabet{};
     symbols_alphabet.reserve(symbol_map.size());
     for (const auto& str_sym_pair : symbol_map) {
         symbols_alphabet.insert(str_sym_pair.second);
     }
-    return symbols_alphabet.difference(Mata::Util::OrdVector<Symbol>{ symbols });
+    return symbols_alphabet.difference(symbols);
 }
 
 void OnTheFlyAlphabet::add_symbols_from(const StringToSymbolMap& new_symbol_map) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -28,7 +28,7 @@ Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
 
 Mata::Util::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const std::set<Symbol>& symbols) const {
     Mata::Util::OrdVector<Symbol> symbols_alphabet{};
-    symbols_alphabet.resize(symbol_map.size());
+    symbols_alphabet.reserve(symbol_map.size());
     for (const auto& str_sym_pair : symbol_map) {
         symbols_alphabet.insert(str_sym_pair.second);
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -710,7 +710,7 @@ bool Mata::Nfa::make_complete(
 
     auto num_of_states = aut.size();
     for (State state = 0; state < num_of_states; ++state) {
-        std::set<Symbol> used_symbols;
+        std::set<Symbol> used_symbols{};
         for (auto const &move : aut.delta[state]) {
             used_symbols.insert(move.symbol);
         }
@@ -1953,7 +1953,7 @@ void Mata::Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alpha
     }
 }
 
-void Nfa::add_symbols_to(OnTheFlyAlphabet& alphabet) {
+void Nfa::add_symbols_to(OnTheFlyAlphabet& alphabet) const {
     size_t aut_num_of_states{size() };
     for (Mata::Nfa::State state{ 0 }; state < aut_num_of_states; ++state) {
         for (const auto& state_transitions: delta[state]) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -710,7 +710,7 @@ bool Mata::Nfa::make_complete(
 
     auto num_of_states = aut.size();
     for (State state = 0; state < num_of_states; ++state) {
-        std::set<Symbol> used_symbols{};
+        OrdVector<Symbol> used_symbols{};
         for (auto const &move : aut.delta[state]) {
             used_symbols.insert(move.symbol);
         }

--- a/src/tests-alphabet.cc
+++ b/src/tests-alphabet.cc
@@ -72,16 +72,16 @@ TEST_CASE("Mata::EnumAlphabet") {
     CHECK(!alphabet.is_equal(alphabet2));
     CHECK(alphabet.get_complement({}).empty());
 
-    CHECK(alphabet.add_new_symbol(1));
-    CHECK(alphabet.add_new_symbol(1));
+    CHECK_NOTHROW(alphabet.add_new_symbol(1));
+    CHECK_NOTHROW(alphabet.add_new_symbol(1));
 
     CHECK(alphabet.get_alphabet_symbols() == OrdVector<Symbol>{ 1 });
     CHECK(alphabet.get_number_of_symbols() == 1);
     CHECK(alphabet.get_next_value() == 2);
     CHECK(alphabet.get_complement({}) == OrdVector<Symbol>{ 1 });
 
-    CHECK(alphabet.add_new_symbol(2));
-    CHECK(alphabet.add_new_symbol(3));
+    CHECK_NOTHROW(alphabet.add_new_symbol(2));
+    CHECK_NOTHROW(alphabet.add_new_symbol(3));
 
     CHECK(alphabet.get_alphabet_symbols() == OrdVector<Symbol>{ 1, 2, 3 });
     CHECK(alphabet.get_number_of_symbols() == 3);

--- a/src/tests-alphabet.cc
+++ b/src/tests-alphabet.cc
@@ -1,0 +1,93 @@
+// TODO: Some header.
+
+#include <unordered_set>
+
+#include "../3rdparty/catch.hpp"
+
+#include <mata/alphabet.hh>
+#include <mata/nfa.hh>
+#include <mata/nfa-algorithms.hh>
+
+using namespace Mata;
+using namespace Mata::Nfa::Algorithms;
+using namespace Mata::Nfa;
+using namespace Mata::Util;
+using namespace Mata::Parser;
+using IntAlphabet = Mata::IntAlphabet;
+using OnTheFlyAlphabet = Mata::OnTheFlyAlphabet;
+
+using Word = std::vector<Symbol>;
+
+template<class T> void unused(const T &) {}
+
+TEST_CASE("Mata::IntAlphabet") {
+    auto alphabet1 = IntAlphabet();
+    auto alphabet2 = IntAlphabet();
+    CHECK(alphabet1.is_equal(alphabet2));
+
+    auto& alphabet3 = alphabet2;
+    CHECK(alphabet3.is_equal(&alphabet1));
+    const auto& alphabet4 = alphabet2;
+    CHECK(alphabet4.is_equal(alphabet1));
+
+    OnTheFlyAlphabet different_alphabet{};
+    OnTheFlyAlphabet different_alphabet2{};
+    CHECK(!alphabet1.is_equal(different_alphabet));
+    CHECK(!different_alphabet.is_equal(different_alphabet2));
+    CHECK(different_alphabet.is_equal(&different_alphabet));
+}
+
+TEST_CASE("Mata::OnTheFlyAlphabet::add_symbols_from()") {
+    OnTheFlyAlphabet alphabet{};
+    StringToSymbolMap symbol_map{ { "a", 4 }, { "b", 2 }, { "c", 10 } };
+    alphabet.add_symbols_from(symbol_map);
+
+    auto symbols{alphabet.get_alphabet_symbols() };
+    Mata::Util::OrdVector<Symbol> expected{ 4, 2, 10 };
+    CHECK(symbols == expected);
+    CHECK(alphabet.get_next_value() == 11);
+    CHECK(alphabet.get_symbol_map() == symbol_map);
+
+    symbol_map["a"] = 6;
+    symbol_map["e"] = 7;
+    alphabet.add_symbols_from(symbol_map);
+
+    symbols = alphabet.get_alphabet_symbols();
+    expected = Mata::Util::OrdVector<Symbol>{ 7, 4, 2, 10 };
+    CHECK(symbols == expected);
+    CHECK(alphabet.get_next_value() == 11);
+    CHECK(alphabet.get_symbol_map() == StringToSymbolMap{
+        { "a", 4 }, { "b", 2 }, { "c", 10 }, { "e", 7 }
+    });
+}
+
+TEST_CASE("Mata::EnumAlphabet") {
+    EnumAlphabet alphabet{};
+    EnumAlphabet alphabet2{ 1, 2, 3, 4, 5 };
+
+    CHECK(alphabet.get_alphabet_symbols().empty());
+    CHECK(alphabet.get_number_of_symbols() == 0);
+    CHECK(alphabet.get_next_value() == 0);
+    CHECK(alphabet.is_equal(alphabet));
+    CHECK(!alphabet.is_equal(alphabet2));
+    CHECK(alphabet.get_complement({}).empty());
+
+    CHECK(alphabet.add_new_symbol(1));
+    CHECK(alphabet.add_new_symbol(1));
+
+    CHECK(alphabet.get_alphabet_symbols() == OrdVector<Symbol>{ 1 });
+    CHECK(alphabet.get_number_of_symbols() == 1);
+    CHECK(alphabet.get_next_value() == 2);
+    CHECK(alphabet.get_complement({}) == OrdVector<Symbol>{ 1 });
+
+    CHECK(alphabet.add_new_symbol(2));
+    CHECK(alphabet.add_new_symbol(3));
+
+    CHECK(alphabet.get_alphabet_symbols() == OrdVector<Symbol>{ 1, 2, 3 });
+    CHECK(alphabet.get_number_of_symbols() == 3);
+    CHECK(alphabet.get_next_value() == 4);
+    CHECK(alphabet.get_complement({ 2 }) == OrdVector<Symbol>{ 1, 3 });
+
+    CHECK_NOTHROW(alphabet.add_symbols_from(alphabet2));
+    CHECK(alphabet.get_alphabet_symbols() == alphabet2.get_alphabet_symbols());
+}

--- a/src/tests-alphabet.cc
+++ b/src/tests-alphabet.cc
@@ -90,4 +90,9 @@ TEST_CASE("Mata::EnumAlphabet") {
 
     CHECK_NOTHROW(alphabet.add_symbols_from(alphabet2));
     CHECK(alphabet.get_alphabet_symbols() == alphabet2.get_alphabet_symbols());
+
+    CHECK_THROWS(alphabet.translate_symb("3414"));
+    CHECK(alphabet.translate_symb("1") == 1);
+    CHECK_THROWS(alphabet.translate_symb("3414not a number"));
+    CHECK_THROWS(alphabet.translate_symb("not a number"));
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(tests
 		number-predicate.cc
 		synchronized-iterator.cc
 		main.cc
+		alphabet.cc
 		parser.cc
 		re2parser.cc
 		mintermization.cc

--- a/tests/alphabet.cc
+++ b/tests/alphabet.cc
@@ -4,9 +4,9 @@
 
 #include "../3rdparty/catch.hpp"
 
-#include <mata/alphabet.hh>
-#include <mata/nfa.hh>
-#include <mata/nfa-algorithms.hh>
+#include "mata/alphabet.hh"
+#include "mata/nfa.hh"
+#include "mata/nfa-algorithms.hh"
 
 using namespace Mata;
 using namespace Mata::Nfa::Algorithms;

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -71,23 +71,6 @@ TEST_CASE("Mata::Nfa::Trans::operator<<")
 } // }}}
 */
 
-TEST_CASE("Mata::Nfa::IntAlphabet") {
-    auto alphabet1 = IntAlphabet();
-    auto alphabet2 = IntAlphabet();
-    CHECK(alphabet1.is_equal(alphabet2));
-
-    auto& alphabet3 = alphabet2;
-    CHECK(alphabet3.is_equal(&alphabet1));
-    const auto& alphabet4 = alphabet2;
-    CHECK(alphabet4.is_equal(alphabet1));
-
-    OnTheFlyAlphabet different_alphabet{};
-    OnTheFlyAlphabet different_alphabet2{};
-    CHECK(!alphabet1.is_equal(different_alphabet));
-    CHECK(!different_alphabet.is_equal(different_alphabet2));
-    CHECK(different_alphabet.is_equal(&different_alphabet));
-}
-
 TEST_CASE("Mata::Nfa::create_alphabet()") {
     Nfa a{1};
     a.delta.add(0, 'a', 0);
@@ -105,30 +88,6 @@ TEST_CASE("Mata::Nfa::create_alphabet()") {
 
     //Mata::Nfa::create_alphabet(1, 3, 4); // Will not compile: '1', '3', '4' are not of the required type.
     //Mata::Nfa::create_alphabet(a, b, 4); // Will not compile: '4' is not of the required type.
-}
-
-TEST_CASE("Mata::Nfa::OnTheFlyAlphabet::add_symbols_from()") {
-    OnTheFlyAlphabet alphabet{};
-    StringToSymbolMap symbol_map{ { "a", 4 }, { "b", 2 }, { "c", 10 } };
-    alphabet.add_symbols_from(symbol_map);
-
-    auto symbols{alphabet.get_alphabet_symbols() };
-    Mata::Util::OrdVector<Symbol> expected{ 4, 2, 10 };
-    CHECK(symbols == expected);
-    CHECK(alphabet.get_next_value() == 11);
-    CHECK(alphabet.get_symbol_map() == symbol_map);
-
-    symbol_map["a"] = 6;
-	symbol_map["e"] = 7;
-    alphabet.add_symbols_from(symbol_map);
-
-    symbols = alphabet.get_alphabet_symbols();
-	expected = Mata::Util::OrdVector<Symbol>{ 7, 4, 2, 10 };
-    CHECK(symbols == expected);
-    CHECK(alphabet.get_next_value() == 11);
-    CHECK(alphabet.get_symbol_map() == StringToSymbolMap{
-		{ "a", 4 }, { "b", 2 }, { "c", 10 }, { "e", 7 }
-	});
 }
 
 TEST_CASE("Mata::Nfa::Nfa::delta.add()/delta.contains()")

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -22,6 +22,22 @@
 
 using namespace Mata::Util;
 
+TEST_CASE("Mata::Util::OrdVector::remove()") {
+    using OrdVectorT = OrdVector<int>;
+    OrdVectorT set{ 1, 2, 3, 4, 6 };
+    set.remove(3);
+    CHECK(set == OrdVectorT{ 1, 2, 4, 6 });
+    set.remove(4);
+    CHECK(set == OrdVectorT{ 1, 2, 6 });
+    CHECK_THROWS(set.remove(5));
+    set.remove(2);
+    CHECK(set == OrdVectorT{ 1, 6 });
+    set.remove(1);
+    set.remove(6);
+    CHECK(set.empty());
+    CHECK_THROWS(set.remove(0));
+}
+
 TEST_CASE("Mata::Util::OrdVector::intersection(}")
 {
     using OrdVectorT = OrdVector<int>;

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -57,3 +57,41 @@ TEST_CASE("Mata::Util::OrdVector::intersection(}")
         REQUIRE(set1.intersection(set2).empty());
     }
 }
+
+TEST_CASE("Mata::Util::OrdVector::difference()") {
+    using OrdVectorT = OrdVector<int>;
+    OrdVectorT set1{};
+    OrdVectorT set2{};
+
+    SECTION("Empty sets") {
+        CHECK(set1.difference(set2).empty());
+    }
+
+    SECTION("Empty rhs set") {
+        set1 = { 1, 2, 3 };
+        CHECK(set1.difference(set2) == set1);
+    }
+
+    SECTION("Empty lhs set") {
+        set2 = { 1, 2, 3 };
+        CHECK(set1.difference(set2).empty());
+    }
+
+    SECTION("filled sets") {
+        set1 = { 1, 2, 3 };
+        set2 = { 1, 2, 3 };
+        CHECK(set1.difference(set2).empty());
+
+        set1 = { 1, 2, 3 };
+        set2 = { 1, 3 };
+        CHECK(set1.difference(set2) == Mata::Util::OrdVector<int>{ 2 });
+
+        set1 = { 1, 3 };
+        set2 = { 1, 2, 3 };
+        CHECK(set1.difference(set2).empty());
+
+        set1 = { 1, 2, 3 };
+        set2 = { 3 };
+        CHECK(set1.difference(set2) == Mata::Util::OrdVector<int>{ 1, 2 });
+    }
+}


### PR DESCRIPTION
This PR implements an enumerated alphabet class, `Mata::EnumAlphabet`, which holds a set of symbols, behaving like `Mata::IntAlphabet`, only working with a limited set of symbols instead of presumably the whole `Mata::Symbol` value range.

In order for the enumerated alphabet class (and its methods) to work, this PR implements some support functions and fixes inconsistencies in `Mata::Util::OrdVector` which `Mata:EnumAlphabet` depends on.

Resolves #199.
