### PR TITLE
Fix minor issues in tests-performance

### DIFF
--- a/tests-performance/README.md
+++ b/tests-performance/README.md
@@ -24,6 +24,8 @@
 1. Copy one of the `template*.cc` files with boilerplate code.
 2. Find comment `HERE COMES YOUR CODE THAT YOU WANT TO PROFILE` and fill your code.
 3. Run `make` from `src` or compile your binary.
+ * By default, `Makefile` looks up source build dir (either `../../build`, `../../cmake-build-debug` or `../../cmake-build-release`).
+ Run `make BUILD_DIR="..."` to pass different build directory.
 4. Run `callgrind` or custom profile on the binary.
 5. Note, you can use one of the scripts (`scripts/run_callgrind.sh` or `scripts/run_massif.sh`)
 
@@ -32,6 +34,8 @@
 1. Copy one of the `template*.cc` files with boilerplate code.
 2. Find comment `HERE COMES YOUR CODE THAT YOU WANT TO PROFILE` and fill your code.
 3. Run `make` from `src` or compile your binary.
+* By default, `Makefile` looks up source build dir (either `../../build`, `../../cmake-build-debug` or `../../cmake-build-release`).
+  Run `make BUILD_DIR="..."` to pass different build directory.
 4. Add the new binary to the `jobs.yaml` as follows:
 5. Note, you can use one of the scripts (`scripts/run_callgrind.sh` or `scripts/run_massif.sh`)
  

--- a/tests-performance/src/Makefile
+++ b/tests-performance/src/Makefile
@@ -14,9 +14,20 @@ CFLAGS=-std=c++17 \
   -fdiagnostics-show-option \
   -g
 
+INCLUDE_DIR=../../include
+THIRD_PARTY_DIR=../../3rdparty
+BUILD_DIR=$(shell \
+	if [ -d "../../cmake-build-release" ]; then \
+		echo "../../cmake-build-release"; \
+	elif [ -d "../../cmake-build-debug" ]; then \
+		echo "../../cmake-build-debug"; \
+	else \
+		echo "../../build"; \
+	fi \
+)
 
-INCLUDE=-I../../include -I../../3rdparty/simlib/include -I../../3rdparty/re2/include -I ../../3rdparty -I ../../3rdparty/cudd/cudd
-LIBS_ADD=-L../../build/src -L../../build/3rdparty/re2 -L../../build/3rdparty/simlib -L../../build/3rdparty/cudd
+INCLUDE=-I$(INCLUDE_DIR) -I$(THIRD_PARTY_DIR)/simlib/include -I$(THIRD_PARTY_DIR)/re2/include -I $(THIRD_PARTY_DIR) -I $(THIRD_PARTY_DIR)/cudd/cudd
+LIBS_ADD=-L$(BUILD_DIR)/src -L$(BUILD_DIR)/3rdparty/re2 -L$(BUILD_DIR)/3rdparty/simlib -L$(BUILD_DIR)/3rdparty/cudd
 LIBS=-lmata -lsimlib -lre2 -lcudd
 
 
@@ -24,7 +35,7 @@ LIBS=-lmata -lsimlib -lre2 -lcudd
 
 .PHONY: all clean
 
-all: $(patsubst %.cc,%,$(wildcard *.cc)) ../../build/src/libmata.a
+all: $(patsubst %.cc,%,$(wildcard *.cc)) $(BUILD_DIR)/src/libmata.a
 
 %: %.cc
 	g++ $(CFLAGS) $(INCLUDE) $(LIBS_ADD) $< $(LIBS) -o ../bin/$@

--- a/tests-performance/src/Makefile
+++ b/tests-performance/src/Makefile
@@ -16,9 +16,7 @@ CFLAGS=-std=c++17 \
 
 
 INCLUDE=-I../../include -I../../3rdparty/simlib/include -I../../3rdparty/re2/include -I ../../3rdparty -I ../../3rdparty/cudd/cudd
-
-LIBS_ADD=-L../../build/src -L../../build/3rdparty/re2 -L../../build/3rdparty/simlib -L../../build/3rdparty/cudd/lib
-
+LIBS_ADD=-L../../build/src -L../../build/3rdparty/re2 -L../../build/3rdparty/simlib -L../../build/3rdparty/cudd
 LIBS=-lmata -lsimlib -lre2 -lcudd
 
 

--- a/tests-performance/src/Makefile
+++ b/tests-performance/src/Makefile
@@ -16,7 +16,7 @@ CFLAGS=-std=c++17 \
 
 INCLUDE_DIR=../../include
 THIRD_PARTY_DIR=../../3rdparty
-BUILD_DIR=$(shell \
+BUILD_DIR := $(shell \
 	if [ -d "../../cmake-build-release" ]; then \
 		echo "../../cmake-build-release"; \
 	elif [ -d "../../cmake-build-debug" ]; then \


### PR DESCRIPTION
This PR fixes few minor issues:
  * After previous PR, the compilation was broken because of `libcudd`. This PR fixes this.
  * Adds lookup of build dir for people who use cmake.
  * Documents better how to build, if you have different directory.