### PR TITLE
Complement over precomputed symbols

### DIFF
--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -21,10 +21,6 @@
 #include <mata/nfa.hh>
 #include <mata/simlib/util/binary_relation.hh>
 
-namespace Mata {
-
-namespace Nfa {
-
 /**
  * Concrete NFA implementations of algorithms, such as complement, inclusion, or universality checking.
  *
@@ -41,8 +37,7 @@ namespace Nfa {
  *   4. Intersection/concatenation with epsilon transitions, or,
  *   5. Computing relation.
  */
-namespace Algorithms {
-
+namespace Mata::Nfa::Algorithms {
     /**
      * Brzozowski minimization of automata (revert -> determinize -> revert -> determinize).
      * @param[in] aut Automaton to be minimized.
@@ -149,8 +144,6 @@ namespace Algorithms {
          */
         Nfa concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& epsilon, bool use_epsilon = false,
                         StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
-} // Algorithms
-} // Nfa
-}
+} // Namespace Mata::Nfa::Algorithms.
 
-#endif // MATA_NFA_INTERNALS_HH
+#endif // MATA_NFA_INTERNALS_HH_

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -49,7 +49,7 @@ namespace Mata::Nfa::Algorithms {
      * Complement implemented by determization, adding sink state and making automaton complete. Then it adds
      * final states which were non final in the original automaton.
      * @param[in] aut Automaton to be complemented.
-     * @param[in] symbols Symbols to needed to make the automaton complete.
+     * @param[in] symbols Symbols needed to make the automaton complete.
      * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (brzozowski) minimization
      * @return Complemented automaton.
      */

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -68,11 +68,7 @@ namespace Mata::Nfa::Algorithms {
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
      */
-    bool is_included_naive(
-            const Nfa&             smaller,
-            const Nfa&             bigger,
-            const Alphabet* const  alphabet = nullptr,
-            Run*                   cex = nullptr);
+    bool is_included_naive(const Nfa& smaller, const Nfa& bigger, const Alphabet* alphabet = nullptr, Run* cex = nullptr);
 
     /**
      * Inclusion implemented by antichain algorithms.
@@ -83,11 +79,7 @@ namespace Mata::Nfa::Algorithms {
      * @return True if smaller language is included,
      * i.e., if the final intersection of smaller complement of bigger is empty.
      */
-    bool is_included_antichains(
-            const Nfa&             smaller,
-            const Nfa&             bigger,
-            const Alphabet* const  alphabet = nullptr,
-            Run*                   cex = nullptr);
+    bool is_included_antichains(const Nfa& smaller, const Nfa& bigger, const Alphabet*  alphabet = nullptr, Run* cex = nullptr);
 
     /**
      * Universality check implemented by checking emptiness of complemented automaton

--- a/include/mata/nfa-algorithms.hh
+++ b/include/mata/nfa-algorithms.hh
@@ -49,14 +49,12 @@ namespace Mata::Nfa::Algorithms {
      * Complement implemented by determization, adding sink state and making automaton complete. Then it adds
      * final states which were non final in the original automaton.
      * @param[in] aut Automaton to be complemented.
-     * @param[in] alphabet Alphabet is needed for making the automaton complete.
+     * @param[in] symbols Symbols to needed to make the automaton complete.
      * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (brzozowski) minimization
      * @return Complemented automaton.
      */
-    Nfa complement_classical(
-            const Nfa&         aut,
-            const Alphabet&    alphabet,
-            bool minimize_during_determinization = false);
+    Nfa complement_classical(const Nfa& aut, const Mata::Util::OrdVector<Symbol>& symbols,
+                             bool minimize_during_determinization = false);
 
     /**
      * Inclusion implemented by complementation of bigger automaton, intersecting it with smaller and then
@@ -120,7 +118,7 @@ namespace Mata::Nfa::Algorithms {
          * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
          */
         Nfa intersection_eps(const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon, const std::set<Symbol>& epsilons,
-                        std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr);
+            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr);
 
         /**
          * @brief Concatenate two NFAs.
@@ -135,7 +133,7 @@ namespace Mata::Nfa::Algorithms {
          * @return Concatenated automaton.
          */
         Nfa concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& epsilon, bool use_epsilon = false,
-                        StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
+            StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 } // Namespace Mata::Nfa::Algorithms.
 
 #endif // MATA_NFA_INTERNALS_HH_

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1016,11 +1016,12 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs,
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
                 StateToStateMap* lhs_result_states_map = nullptr, StateToStateMap* rhs_result_states_map = nullptr);
 
-
 /**
+ * Make @c aut complete in place.
+ *
  * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
- * on transitions from given state) to @p sink_state. If @p sink_state does not belong to the automaton, it is added to it,
- * but only in the case that some transition to @p sink_state was added.
+ *  on transitions from given state) to @p sink_state. If @p sink_state does not belong to the automaton, it is added to
+ *  it, but only in the case that some transition to @p sink_state was added.
  * In the case that @p aut does not contain any states, this function does nothing.
  *
  * @param[in] aut Automaton to make complete.
@@ -1028,10 +1029,26 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
  * @param[in] sink_state The state into which new transitions are added.
  * @return True if some new transition was added to the automaton.
  */
-bool make_complete(
-        Nfa&             aut,
-        const Alphabet&  alphabet,
-        State            sink_state);
+bool make_complete(Nfa& aut, const Alphabet& alphabet, State sink_state);
+
+/**
+ * Make @c aut complete in place.
+ *
+ * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur
+ *  on transitions from given state) to @p sink_state. If @p sink_state does not belong to the automaton, it is added to
+ *  it, but only in the case that some transition to @p sink_state was added.
+ * In the case that @p aut does not contain any states, this function does nothing.
+ *
+ * This overloaded version is a more efficient version which does not need to compute the set of symbols to complete to
+ *  from the alphabet. Prefer this version when you already have the set of symbols precomputed or plan to complete
+ *  multiple automata over the same set of symbols.
+ *
+ * @param[in] aut Automaton to make complete.
+ * @param[in] symbols Symbols to compute missing symbols from.
+ * @param[in] sink_state The state into which new transitions are added.
+ * @return True if some new transition was added to the automaton.
+ */
+bool make_complete(Nfa& aut, const Util::OrdVector<Symbol>& symbols, State sink_state);
 
 /**
  * For each state 0,...,aut.size()-1, add transitions with "missing" symbols from @p alphabet (symbols that do not occur

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1076,11 +1076,27 @@ inline bool make_complete(
  * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
  * @return Complemented automaton.
  */
-Nfa complement(
-        const Nfa&         aut,
-        const Alphabet&    alphabet,
-        const StringMap&  params = {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+Nfa complement(const Nfa& aut, const Alphabet& alphabet,
+    const StringMap& params = {{"algorithm", "classical"}, {"minimize", "false"}});
+
+/**
+ * @brief Compute automaton accepting complement of @p aut.
+ *
+ * This overloaded version complements over an already created ordered set of @p symbols instead of an alphabet.
+ * This is a more efficient solution in case you already have @p symbols precomputed or want to complement multiple
+ *  automata over the same set of @c symbols: the function does not need to compute the ordered set of symbols from
+ *  the alphabet again (and for each automaton).
+ *
+ * @param[in] aut Automaton whose complement to compute.
+ * @param[in] symbols Symbols to complement over.
+ * @param[in] params Optional parameters to control the complementation algorithm:
+ * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
+ * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * @return Complemented automaton.
+ */
+Nfa complement(const Nfa& aut, const Util::OrdVector<Symbol>& symbols,
+   const StringMap& params = {{"algorithm", "classical"}, {"minimize", "false"}});
+
 /**
  * @brief Compute minimal deterministic automaton.
  *

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -701,29 +701,28 @@ bool Mata::Nfa::are_state_disjoint(const Nfa& lhs, const Nfa& rhs)
     return true;
 } // are_disjoint }}}
 
-bool Mata::Nfa::make_complete(
-        Nfa&             aut,
-        const Alphabet&  alphabet,
-        State            sink_state)
-{
-    bool was_something_added = false;
+bool Mata::Nfa::make_complete(Nfa& aut, const Alphabet& alphabet, State sink_state) {
+    return Mata::Nfa::make_complete(aut, alphabet.get_alphabet_symbols(), sink_state);
+}
 
-    auto num_of_states = aut.size();
+bool Mata::Nfa::make_complete(Nfa& aut, const Mata::Util::OrdVector<Symbol>& symbols, State sink_state) {
+    bool was_something_added{ false };
+
+    size_t num_of_states{ aut.size() };
     for (State state = 0; state < num_of_states; ++state) {
         OrdVector<Symbol> used_symbols{};
         for (auto const &move : aut.delta[state]) {
             used_symbols.insert(move.symbol);
         }
-        auto unused_symbols = alphabet.get_complement(used_symbols);
-        for (Symbol symb : unused_symbols)
-        {
+        Mata::Util::OrdVector<Symbol> unused_symbols{ symbols.difference(used_symbols) };
+        for (Symbol symb : unused_symbols) {
             aut.delta.add(state, symb, sink_state);
             was_something_added = true;
         }
     }
 
     if (was_something_added && num_of_states <= sink_state) {
-        for (Symbol symbol : alphabet.get_alphabet_symbols()) {
+        for (Symbol symbol : symbols) {
             aut.delta.add(sink_state, symbol, sink_state);
         }
     }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -731,13 +731,8 @@ bool Mata::Nfa::make_complete(Nfa& aut, const Mata::Util::OrdVector<Symbol>& sym
 }
 
 //TODO: based on the comments inside, this function needs to be rewritten in a more optimal way.
-Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon)
-{
-    Nfa result;
-
-    result.clear();
-
-    result.add_state(aut.delta.post_size()-1);
+Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
+    Nfa result{ aut.delta.post_size() };
 
     // cannot use multimap, because it can contain multiple occurrences of (a -> a), (a -> a)
     std::unordered_map<State, StateSet> eps_closure;


### PR DESCRIPTION
This PR purpose is to allow complementing over a precomputed set of symbols. In order to allow that, the functions `Mata::Nfa::make_complete()` and `Mata::Nfa::complement()` have to be modified in order to follow the DRY principle.

This PR resolves #201.