### PR TITLE
Remove construct parsed section function

### DIFF
--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -1273,12 +1273,6 @@ inline Run encode_word(
 
 /** Loads an automaton from Parsed object */
 Nfa construct(
-        const Mata::Parser::ParsedSection&   parsec,
-        Alphabet*                            alphabet,
-        StringToStateMap*                    state_map = nullptr);
-
-/** Loads an automaton from Parsed object */
-Nfa construct(
         const Mata::IntermediateAut&         inter_aut,
         Alphabet*                            alphabet,
         StringToStateMap*                    state_map = nullptr);

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -347,6 +347,8 @@ namespace
             aut.automaton_type = Mata::IntermediateAut::AutomatonType::NFA;
         } else if (section.type.find("AFA") != std::string::npos) {
             aut.automaton_type = Mata::IntermediateAut::AutomatonType::AFA;
+        } else {
+            throw std::runtime_error(std::string(__FUNCTION__) + ": expecting type specification");
         }
         aut.alphabet_type = get_alphabet_type(section.type);
 

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -617,31 +617,31 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 
 	SECTION("construct an empty automaton")
 	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
+		parsec.type = Mata::Nfa::TYPE_NFA + "-explicit";
 
-		aut = construct(parsec);
+		aut = construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0]);
 
 		REQUIRE(is_lang_empty(aut));
 	}
 
 	SECTION("construct a simple non-empty automaton accepting the empty word")
 	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
+		parsec.type = Mata::Nfa::TYPE_NFA + "-explicit";
 		parsec.dict.insert({"Initial", {"q1"}});
 		parsec.dict.insert({"Final", {"q1"}});
 
-		aut = construct(parsec);
+		aut = construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0]);
 
 		REQUIRE(!is_lang_empty(aut));
 	}
 
 	SECTION("construct an automaton with more than one initial/final states")
 	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
+		parsec.type = Mata::Nfa::TYPE_NFA + "-explicit";
 		parsec.dict.insert({"Initial", {"q1", "q2"}});
 		parsec.dict.insert({"Final", {"q1", "q2", "q3"}});
 
-		aut = construct(parsec);
+		aut = construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0]);
 
 		REQUIRE(aut.initial.size() == 2);
 		REQUIRE(aut.final.size() == 3);
@@ -649,12 +649,12 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 
 	SECTION("construct a simple non-empty automaton accepting only the word 'a'")
 	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
+		parsec.type = Mata::Nfa::TYPE_NFA + "-explicit";
 		parsec.dict.insert({"Initial", {"q1"}});
 		parsec.dict.insert({"Final", {"q2"}});
 		parsec.body = { {"q1", "a", "q2"} };
 
-		aut = construct(parsec, &symbol_map);
+		aut = construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0], &symbol_map);
 
 		Run cex;
 		REQUIRE(!is_lang_empty(aut, &cex));
@@ -667,7 +667,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 
 	SECTION("construct a more complicated non-empty automaton")
 	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
+		parsec.type = Mata::Nfa::TYPE_NFA + "-explicit";
 		parsec.dict.insert({"Initial", {"q1", "q3"}});
 		parsec.dict.insert({"Final", {"q5"}});
 		parsec.body.push_back({"q1", "a", "q3"});
@@ -686,7 +686,7 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 		parsec.body.push_back({"q5", "a", "q5"});
 		parsec.body.push_back({"q5", "c", "q9"});
 
-		aut = construct(parsec, &symbol_map);
+		aut = construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0], &symbol_map);
 
 		// some samples
 		REQUIRE(is_in_lang(aut, encode_word(symbol_map, {"b", "a"})));
@@ -700,37 +700,17 @@ TEST_CASE("Mata::Nfa::construct() correct calls")
 	}
 } // }}}
 
-TEST_CASE("Mata::Nfa::construct() invalid calls")
-{ // {{{
+TEST_CASE("Mata::Nfa::construct() invalid calls") {
 	Nfa aut;
 	Mata::Parser::ParsedSection parsec;
 
-	SECTION("construct() call with invalid ParsedSection object")
-	{
-		parsec.type = "FA";
+	SECTION("construct() call with invalid ParsedSection object") {
+		parsec.type = "FA-explicit";
 
-		CHECK_THROWS_WITH(construct(parsec),
+		CHECK_THROWS_WITH(construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0]),
 			Catch::Contains("expecting type"));
 	}
-
-	SECTION("construct() call with an epsilon transition")
-	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
-		parsec.body = { {"q1", "q2"} };
-
-		CHECK_THROWS_WITH(construct(parsec),
-			Catch::Contains("Epsilon transition"));
-	}
-
-	SECTION("construct() call with a nonsense transition")
-	{
-		parsec.type = Mata::Nfa::TYPE_NFA;
-		parsec.body = { {"q1", "a", "q2", "q3"} };
-
-		CHECK_THROWS_WITH(construct(&aut, parsec),
-			Catch::Contains("Invalid transition"));
-	}
-} // }}}
+}
 
 TEST_CASE("Mata::Nfa::construct() from IntermediateAut correct calls")
 { // {{{

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -27,641 +27,641 @@ using namespace Mata::Util;
 
 TEST_CASE("correct use of Mata::Parser::parse_mf_section()")
 { // {{{
-	ParsedSection parsec;
+    ParsedSection parsec;
 
-	SECTION("empty file")
-	{
-		std::string file =
-			"";
+    SECTION("empty file")
+    {
+        std::string file =
+            "";
 
-		parsec = parse_mf_section(file);
-		REQUIRE(parsec.empty());
-	}
+        parsec = parse_mf_section(file);
+        REQUIRE(parsec.empty());
+    }
 
-	SECTION("empty section")
-	{
-		std::string file =
-			"@Type\n";
+    SECTION("empty section")
+    {
+        std::string file =
+            "@Type\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		REQUIRE(parsec.dict.empty());
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        REQUIRE(parsec.dict.empty());
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("file with some keys")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1\n"
-			"%key2\n";
+    SECTION("file with some keys")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1\n"
+            "%key2\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		REQUIRE(haskey(parsec.dict, "key1"));
-		REQUIRE(parsec.dict.at("key1").empty());
-		REQUIRE(haskey(parsec.dict, "key2"));
-		REQUIRE(parsec.dict.at("key2").empty());
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        REQUIRE(haskey(parsec.dict, "key1"));
+        REQUIRE(parsec.dict.at("key1").empty());
+        REQUIRE(haskey(parsec.dict, "key2"));
+        REQUIRE(parsec.dict.at("key2").empty());
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("file with some keys and values")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 value1\n"
-			"%key2\n"
-			"%key3 value3\n";
+    SECTION("file with some keys and values")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 value1\n"
+            "%key2\n"
+            "%key3 value3\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value1");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->empty());
-		ref = &parsec.dict.at("key3");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value3");
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value1");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->empty());
+        ref = &parsec.dict.at("key3");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value3");
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("file with multiple values for some keys")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1     value1.1  value1.2 value1.3			value1.4\n"
-			"%key2\n";
+    SECTION("file with multiple values for some keys")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1     value1.1  value1.2 value1.3			value1.4\n"
+            "%key2\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 4);
-		REQUIRE((*ref)[0] == "value1.1");
-		REQUIRE((*ref)[1] == "value1.2");
-		REQUIRE((*ref)[2] == "value1.3");
-		REQUIRE((*ref)[3] == "value1.4");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->empty());
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 4);
+        REQUIRE((*ref)[0] == "value1.1");
+        REQUIRE((*ref)[1] == "value1.2");
+        REQUIRE((*ref)[2] == "value1.3");
+        REQUIRE((*ref)[3] == "value1.4");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->empty());
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("file with some transitions")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 value1\n"
-			"%key2 value2.1 value2.2     \n"
-			"a\n"
-			"b0 b1 b2 b3		b4    b5";
+    SECTION("file with some transitions")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 value1\n"
+            "%key2 value2.1 value2.2     \n"
+            "a\n"
+            "b0 b1 b2 b3		b4    b5";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value1");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->size() == 2);
-		REQUIRE((*ref)[0] == "value2.1");
-		REQUIRE((*ref)[1] == "value2.2");
-		REQUIRE(parsec.body.size() == 2);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 1);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[1].size() == 6);
-		REQUIRE(body[1][0] == "b0");
-		REQUIRE(body[1][1] == "b1");
-		REQUIRE(body[1][2] == "b2");
-		REQUIRE(body[1][3] == "b3");
-		REQUIRE(body[1][4] == "b4");
-		REQUIRE(body[1][5] == "b5");
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value1");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->size() == 2);
+        REQUIRE((*ref)[0] == "value2.1");
+        REQUIRE((*ref)[1] == "value2.2");
+        REQUIRE(parsec.body.size() == 2);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 1);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[1].size() == 6);
+        REQUIRE(body[1][0] == "b0");
+        REQUIRE(body[1][1] == "b1");
+        REQUIRE(body[1][2] == "b2");
+        REQUIRE(body[1][3] == "b3");
+        REQUIRE(body[1][4] == "b4");
+        REQUIRE(body[1][5] == "b5");
+    }
 
-	SECTION("file with transitions and line break")
-	{
-		std::string file =
-		        "@Type\n"
-		        "%key1 value1\n"
-		        "%key2 value2.1 value2.2     \n"
-		        "a\\\n"
-		        "b";
+    SECTION("file with transitions and line break")
+    {
+        std::string file =
+                "@Type\n"
+                "%key1 value1\n"
+                "%key2 value2.1 value2.2     \n"
+                "a\\\n"
+                "b";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value1");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->size() == 2);
-		REQUIRE((*ref)[0] == "value2.1");
-		REQUIRE((*ref)[1] == "value2.2");
-		REQUIRE(parsec.body.size() == 1);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 2);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[0][1] == "b");
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value1");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->size() == 2);
+        REQUIRE((*ref)[0] == "value2.1");
+        REQUIRE((*ref)[1] == "value2.2");
+        REQUIRE(parsec.body.size() == 1);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 2);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[0][1] == "b");
+    }
 
-	SECTION("file with transitions and line break")
-	{
-		std::string file =
-		        "@Type\n"
-		        "%key1 value1\n"
-		        "a x & !b&c|(a& !b)";
+    SECTION("file with transitions and line break")
+    {
+        std::string file =
+                "@Type\n"
+                "%key1 value1\n"
+                "a x & !b&c|(a& !b)";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value1");
-		REQUIRE(parsec.body.size() == 1);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 14);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[0][1] == "x");
-		REQUIRE(body[0][2] == "&");
-		REQUIRE(body[0][3] == "!");
-		REQUIRE(body[0][4] == "b");
-		REQUIRE(body[0][5] == "&");
-		REQUIRE(body[0][6] == "c");
-		REQUIRE(body[0][7] == "|");
-		REQUIRE(body[0][8] == "(");
-		REQUIRE(body[0][9] == "a");
-		REQUIRE(body[0][10] == "&");
-		REQUIRE(body[0][11] == "!");
-		REQUIRE(body[0][12] == "b");
-		REQUIRE(body[0][13] == ")");
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value1");
+        REQUIRE(parsec.body.size() == 1);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 14);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[0][1] == "x");
+        REQUIRE(body[0][2] == "&");
+        REQUIRE(body[0][3] == "!");
+        REQUIRE(body[0][4] == "b");
+        REQUIRE(body[0][5] == "&");
+        REQUIRE(body[0][6] == "c");
+        REQUIRE(body[0][7] == "|");
+        REQUIRE(body[0][8] == "(");
+        REQUIRE(body[0][9] == "a");
+        REQUIRE(body[0][10] == "&");
+        REQUIRE(body[0][11] == "!");
+        REQUIRE(body[0][12] == "b");
+        REQUIRE(body[0][13] == ")");
+    }
 
-	SECTION("file with comments and whitespaces")
-	{
-		std::string file =
-			"     \n"
-			"\n"
-			"	\n"
-			"# a comment\n"
-			"    #another comment\n"
-			"#\n"
-			"     @Ty#pe      \n"
-			"# some commment\n"
-			"%key1 value1#comment#comment2\n"
-			"   %key2 value2.1 # value2.2     \n"
-			"\t\n"
-			"a\n"
-			"   b0 b1 #b2";
+    SECTION("file with comments and whitespaces")
+    {
+        std::string file =
+            "     \n"
+            "\n"
+            "	\n"
+            "# a comment\n"
+            "    #another comment\n"
+            "#\n"
+            "     @Ty#pe      \n"
+            "# some commment\n"
+            "%key1 value1#comment#comment2\n"
+            "   %key2 value2.1 # value2.2     \n"
+            "\t\n"
+            "a\n"
+            "   b0 b1 #b2";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Ty" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value1");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value2.1");
-		REQUIRE(parsec.body.size() == 2);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 1);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[1].size() == 2);
-		REQUIRE(body[1][0] == "b0");
-		REQUIRE(body[1][1] == "b1");
-	}
+        REQUIRE("Ty" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value1");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value2.1");
+        REQUIRE(parsec.body.size() == 2);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 1);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[1].size() == 2);
+        REQUIRE(body[1][0] == "b0");
+        REQUIRE(body[1][1] == "b1");
+    }
 
-	SECTION("using double quotes and escaping for names")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 \"value 1\"\n"
-			"%key2 \"value2.1\" value2 2 \"value 2 3\"\n"
-			"%key3 \"val#1\"    # test\n"
-			"a \"\"\n"
-			"%key4 \"val 1   \" \n"
-			"%key5\n"
-			"b0 \"b 1\" c d\n"
-			"\"%key6\"\n"
-			"%key7\n"
-			"c 0 \"\\\"he's so cool,\\\" he said \\/\" c d\n"
-			"\"a\"\n"
-			"\"\"\n"
-			"'\n"
-			"q a q'";
+    SECTION("using double quotes and escaping for names")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 \"value 1\"\n"
+            "%key2 \"value2.1\" value2 2 \"value 2 3\"\n"
+            "%key3 \"val#1\"    # test\n"
+            "a \"\"\n"
+            "%key4 \"val 1   \" \n"
+            "%key5\n"
+            "b0 \"b 1\" c d\n"
+            "\"%key6\"\n"
+            "%key7\n"
+            "c 0 \"\\\"he's so cool,\\\" he said \\/\" c d\n"
+            "\"a\"\n"
+            "\"\"\n"
+            "'\n"
+            "q a q'";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value 1");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->size() == 4);
-		REQUIRE((*ref)[0] == "value2.1");
-		REQUIRE((*ref)[1] == "value2");
-		REQUIRE((*ref)[2] == "2");
-		REQUIRE((*ref)[3] == "value 2 3");
-		ref = &parsec.dict.at("key3");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "val#1");
-		ref = &parsec.dict.at("key4");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "val 1   ");
-		ref = &parsec.dict.at("key5");
-		REQUIRE(ref->size() == 0);
-		ref = &parsec.dict.at("key7");
-		REQUIRE(ref->size() == 0);
-		REQUIRE(parsec.body.size() == 8);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 2);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[0][1] == "");
-		REQUIRE(body[1].size() == 4);
-		REQUIRE(body[1][0] == "b0");
-		REQUIRE(body[1][1] == "b 1");
-		REQUIRE(body[1][2] == "c");
-		REQUIRE(body[1][3] == "d");
-		REQUIRE(body[2].size() == 1);
-		REQUIRE(body[2][0] == "%key6");
-		REQUIRE(body[3].size() == 5);
-		REQUIRE(body[3][0] == "c");
-		REQUIRE(body[3][1] == "0");
-		REQUIRE(body[3][2] == "\"he's so cool,\" he said \\/");
-		REQUIRE(body[3][3] == "c");
-		REQUIRE(body[3][4] == "d");
-		REQUIRE(body[4].size() == 1);
-		REQUIRE(body[4][0] == "a");
-		REQUIRE(body[5].size() == 1);
-		REQUIRE(body[5][0] == "");
-		REQUIRE(body[6].size() == 1);
-		REQUIRE(body[6][0] == "'");
-		REQUIRE(body[7].size() == 3);
-		REQUIRE(body[7][0] == "q");
-		REQUIRE(body[7][1] == "a");
-		REQUIRE(body[7][2] == "q'");
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value 1");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->size() == 4);
+        REQUIRE((*ref)[0] == "value2.1");
+        REQUIRE((*ref)[1] == "value2");
+        REQUIRE((*ref)[2] == "2");
+        REQUIRE((*ref)[3] == "value 2 3");
+        ref = &parsec.dict.at("key3");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "val#1");
+        ref = &parsec.dict.at("key4");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "val 1   ");
+        ref = &parsec.dict.at("key5");
+        REQUIRE(ref->size() == 0);
+        ref = &parsec.dict.at("key7");
+        REQUIRE(ref->size() == 0);
+        REQUIRE(parsec.body.size() == 8);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 2);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[0][1] == "");
+        REQUIRE(body[1].size() == 4);
+        REQUIRE(body[1][0] == "b0");
+        REQUIRE(body[1][1] == "b 1");
+        REQUIRE(body[1][2] == "c");
+        REQUIRE(body[1][3] == "d");
+        REQUIRE(body[2].size() == 1);
+        REQUIRE(body[2][0] == "%key6");
+        REQUIRE(body[3].size() == 5);
+        REQUIRE(body[3][0] == "c");
+        REQUIRE(body[3][1] == "0");
+        REQUIRE(body[3][2] == "\"he's so cool,\" he said \\/");
+        REQUIRE(body[3][3] == "c");
+        REQUIRE(body[3][4] == "d");
+        REQUIRE(body[4].size() == 1);
+        REQUIRE(body[4][0] == "a");
+        REQUIRE(body[5].size() == 1);
+        REQUIRE(body[5][0] == "");
+        REQUIRE(body[6].size() == 1);
+        REQUIRE(body[6][0] == "'");
+        REQUIRE(body[7].size() == 3);
+        REQUIRE(body[7][0] == "q");
+        REQUIRE(body[7][1] == "a");
+        REQUIRE(body[7][2] == "q'");
+    }
 
-	SECTION("file with newlines among keys")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 value1.1 value1.2   # comment\n"
-			"%key1    value1.3\n"
-			"%key2\n"
-			"%key3 \"value3\"";
+    SECTION("file with newlines among keys")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 value1.1 value1.2   # comment\n"
+            "%key1    value1.3\n"
+            "%key2\n"
+            "%key3 \"value3\"";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 3);
-		REQUIRE((*ref)[0] == "value1.1");
-		REQUIRE((*ref)[1] == "value1.2");
-		REQUIRE((*ref)[2] == "value1.3");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->empty());
-		ref = &parsec.dict.at("key3");
-		REQUIRE(ref->size() == 1);
-		REQUIRE((*ref)[0] == "value3");
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 3);
+        REQUIRE((*ref)[0] == "value1.1");
+        REQUIRE((*ref)[1] == "value1.2");
+        REQUIRE((*ref)[2] == "value1.3");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->empty());
+        ref = &parsec.dict.at("key3");
+        REQUIRE(ref->size() == 1);
+        REQUIRE((*ref)[0] == "value3");
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("special characters inside quoted strings")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1     \"value@1\"  \"value@2\"#new\n"
-			"%key2     \"value%1\"  (\"value%2\")\n";
+    SECTION("special characters inside quoted strings")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1     \"value@1\"  \"value@2\"#new\n"
+            "%key2     \"value%1\"  (\"value%2\")\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 2);
-		REQUIRE((*ref)[0] == "value@1");
-		REQUIRE((*ref)[1] == "value@2");
-		ref = &parsec.dict.at("key2");
-		REQUIRE(ref->size() == 4);
-		REQUIRE((*ref)[0] == "value%1");
-		REQUIRE((*ref)[1] == "(");
-		REQUIRE((*ref)[2] == "value%2");
-		REQUIRE((*ref)[3] == ")");
-		REQUIRE(parsec.body.empty());
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 2);
+        REQUIRE((*ref)[0] == "value@1");
+        REQUIRE((*ref)[1] == "value@2");
+        ref = &parsec.dict.at("key2");
+        REQUIRE(ref->size() == 4);
+        REQUIRE((*ref)[0] == "value%1");
+        REQUIRE((*ref)[1] == "(");
+        REQUIRE((*ref)[2] == "value%2");
+        REQUIRE((*ref)[3] == ")");
+        REQUIRE(parsec.body.empty());
+    }
 
-	SECTION("file with no keys")
-	{
-		std::string file =
-			"@Type\n"
-			"a b c\n";
+    SECTION("file with no keys")
+    {
+        std::string file =
+            "@Type\n"
+            "a b c\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		REQUIRE(parsec.body.size() == 1);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 3);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[0][1] == "b");
-		REQUIRE(body[0][2] == "c");
-	}
+        REQUIRE("Type" == parsec.type);
+        REQUIRE(parsec.body.size() == 1);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 3);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[0][1] == "b");
+        REQUIRE(body[0][2] == "c");
+    }
 
-	SECTION("correct handling of parentheses")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 (a b)\n"
-			"a (b   c  d)(e\n";
+    SECTION("correct handling of parentheses")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 (a b)\n"
+            "a (b   c  d)(e\n";
 
-		parsec = parse_mf_section(file);
+        parsec = parse_mf_section(file);
 
-		REQUIRE("Type" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 4);
-		REQUIRE((*ref)[0] == "(");
-		REQUIRE((*ref)[1] == "a");
-		REQUIRE((*ref)[2] == "b");
-		REQUIRE((*ref)[3] == ")");
-		REQUIRE(parsec.body.size() == 1);
-		std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
-		REQUIRE(body[0].size() == 8);
-		REQUIRE(body[0][0] == "a");
-		REQUIRE(body[0][1] == "(");
-		REQUIRE(body[0][2] == "b");
-		REQUIRE(body[0][3] == "c");
-		REQUIRE(body[0][4] == "d");
-		REQUIRE(body[0][5] == ")");
-		REQUIRE(body[0][6] == "(");
-		REQUIRE(body[0][7] == "e");
-	}
+        REQUIRE("Type" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 4);
+        REQUIRE((*ref)[0] == "(");
+        REQUIRE((*ref)[1] == "a");
+        REQUIRE((*ref)[2] == "b");
+        REQUIRE((*ref)[3] == ")");
+        REQUIRE(parsec.body.size() == 1);
+        std::vector<BodyLine> body(parsec.body.begin(), parsec.body.end());
+        REQUIRE(body[0].size() == 8);
+        REQUIRE(body[0][0] == "a");
+        REQUIRE(body[0][1] == "(");
+        REQUIRE(body[0][2] == "b");
+        REQUIRE(body[0][3] == "c");
+        REQUIRE(body[0][4] == "d");
+        REQUIRE(body[0][5] == ")");
+        REQUIRE(body[0][6] == "(");
+        REQUIRE(body[0][7] == "e");
+    }
 
-	SECTION("correct handling of start of another section")
-	{
-		std::string file =
-			"@Type1\n"
-			"%key1\n"
-			"@Type2\n"
-			"%key2\n";
+    SECTION("correct handling of start of another section")
+    {
+        std::string file =
+            "@Type1\n"
+            "%key1\n"
+            "@Type2\n"
+            "%key2\n";
 
-		std::istringstream stream(file);
+        std::istringstream stream(file);
 
-		parsec = parse_mf_section(stream);
+        parsec = parse_mf_section(stream);
 
-		REQUIRE("Type1" == parsec.type);
-		const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
-		REQUIRE(ref->size() == 0);
+        REQUIRE("Type1" == parsec.type);
+        const KeyListStore::mapped_type* ref = &parsec.dict.at("key1");
+        REQUIRE(ref->size() == 0);
 
-		// check what remains
-		std::string remains = stream.str().substr(stream.tellg());
-		REQUIRE("@Type2\n%key2\n" == remains);
-	}
+        // check what remains
+        std::string remains = stream.str().substr(stream.tellg());
+        REQUIRE("@Type2\n%key2\n" == remains);
+    }
 } // parse_mf_section correct }}}
 
 
 TEST_CASE("incorrect use of Mata::Parser::parse_mf_section()")
 { // {{{
-	ParsedSection parsec;
+    ParsedSection parsec;
 
-	SECTION("no type")
-	{
-		std::string file =
-			"@\n"
-			"Type"
-			"%key1\n"
-			"%key2\n";
+    SECTION("no type")
+    {
+        std::string file =
+            "@\n"
+            "Type"
+            "%key1\n"
+            "%key2\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("expecting automaton type"));
-	}
+    }
 
-	SECTION("trailing characters behind @TYPE")
-	{
-		std::string file =
-			"@Type another\n";
+    SECTION("trailing characters behind @TYPE")
+    {
+        std::string file =
+            "@Type another\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("invalid trailing characters"));
-	}
+    }
 
-	SECTION("missing type")
-	{
-		std::string file =
-			"%key1\n"
-			"%key2\n";
+    SECTION("missing type")
+    {
+        std::string file =
+            "%key1\n"
+            "%key2\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("expecting automaton type"));
-	}
+    }
 
-	SECTION("unterminated quote")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 \"value\n";
+    SECTION("unterminated quote")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 \"value\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("missing ending quotes"));
-	}
+    }
 
-	SECTION("unterminated quote 2")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 \"\n";
+    SECTION("unterminated quote 2")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 \"\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("missing ending quotes"));
-	}
+    }
 
-	SECTION("newlines within names")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 \" value  \n"
-			"   1\"\n"
-			"\"value\n"
-			"\n"
-			"\"\n"
-			"\n"
-			"\"value    # comment\n"
-			"3\"";
+    SECTION("newlines within names")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 \" value  \n"
+            "   1\"\n"
+            "\"value\n"
+            "\n"
+            "\"\n"
+            "\n"
+            "\"value    # comment\n"
+            "3\"";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("missing ending quotes"));
-	}
+    }
 
-	SECTION("quoted strings starting in the middle of strings")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 val\"ue\"\n";
+    SECTION("quoted strings starting in the middle of strings")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 val\"ue\"\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("misplaced quotes"));
-	}
+    }
 
-	SECTION("quoted strings ending in the middle of strings")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 \"val\"ue\n";
+    SECTION("quoted strings ending in the middle of strings")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 \"val\"ue\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("misplaced quotes"));
-	}
+    }
 
-	SECTION("incorrect position of special characters")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 @here";
+    SECTION("incorrect position of special characters")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 @here";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of @TYPE") &&
-			Catch::Contains("@here"));
-	}
+        CHECK_THROWS_WITH(parse_mf_section(file),
+            Catch::Contains("invalid position of @TYPE") &&
+            Catch::Contains("@here"));
+    }
 
-	SECTION("incorrect position of special characters 2")
-	{
-		std::string file =
-			"@Type\n"
-			"q1 @here q2";
+    SECTION("incorrect position of special characters 2")
+    {
+        std::string file =
+            "@Type\n"
+            "q1 @here q2";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of @TYPE") &&
-			Catch::Contains("@here"));
-	}
+        CHECK_THROWS_WITH(parse_mf_section(file),
+            Catch::Contains("invalid position of @TYPE") &&
+            Catch::Contains("@here"));
+    }
 
-	SECTION("incorrect position of special characters 3")
-	{
-		std::string file =
-			"@Type\n"
-			"q1 %here q2";
+    SECTION("incorrect position of special characters 3")
+    {
+        std::string file =
+            "@Type\n"
+            "q1 %here q2";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of %KEY") &&
-			Catch::Contains("%here"));
-	}
+        CHECK_THROWS_WITH(parse_mf_section(file),
+            Catch::Contains("invalid position of %KEY") &&
+            Catch::Contains("%here"));
+    }
 
-	SECTION("incorrect position of special characters 4")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1 %here";
+    SECTION("incorrect position of special characters 4")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1 %here";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of %KEY") &&
-			Catch::Contains("%here"));
-	}
+        CHECK_THROWS_WITH(parse_mf_section(file),
+            Catch::Contains("invalid position of %KEY") &&
+            Catch::Contains("%here"));
+    }
 
-	SECTION("no key name")
-	{
-		std::string file =
-			"@Type\n"
-			"%\n"
-			"%key2\n";
+    SECTION("no key name")
+    {
+        std::string file =
+            "@Type\n"
+            "%\n"
+            "%key2\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("%KEY name missing"));
-	}
+    }
 
-	SECTION("special characters inside strings 1")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1     value@1\n";
+    SECTION("special characters inside strings 1")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1     value@1\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("misplaced character \'@\'"));
-	}
+    }
 
-	SECTION("special characters inside strings 2")
-	{
-		std::string file =
-			"@Type\n"
-			"%key2     value%1\n";
+    SECTION("special characters inside strings 2")
+    {
+        std::string file =
+            "@Type\n"
+            "%key2     value%1\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("misplaced character \'%\'"));
-	}
+    }
 
-	SECTION("special characters inside strings 3")
-	{
-		std::string file =
-			"@Type\n"
-			"%key1     @value\n";
+    SECTION("special characters inside strings 3")
+    {
+        std::string file =
+            "@Type\n"
+            "%key1     @value\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("invalid position of @TYPE"));
-	}
+    }
 
-	SECTION("special characters inside strings 4")
-	{
-		std::string file =
-			"@Type\n"
-			"%key2     %value\n";
+    SECTION("special characters inside strings 4")
+    {
+        std::string file =
+            "@Type\n"
+            "%key2     %value\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("invalid position of %KEY"));
-	}
+    }
 
-	SECTION("invalid use of quotes")
-	{
-		std::string file =
-			"\"@Type\"\n";
+    SECTION("invalid use of quotes")
+    {
+        std::string file =
+            "\"@Type\"\n";
 
-		CHECK_THROWS_WITH(parse_mf_section(file),
+        CHECK_THROWS_WITH(parse_mf_section(file),
                           Catch::Contains("expecting automaton type"));
-	}
+    }
 } // parse_mf_section incorrect }}}
 
 
 TEST_CASE("correct use of Mata::Parser::parse_mf()")
 { // {{{
-	Parsed parsed;
+    Parsed parsed;
 
-	SECTION("empty file")
-	{
-		std::string file =
-			"";
+    SECTION("empty file")
+    {
+        std::string file =
+            "";
 
-		parsed = parse_mf(file);
+        parsed = parse_mf(file);
 
-		REQUIRE(parsed.empty());
-	}
+        REQUIRE(parsed.empty());
+    }
 
-	SECTION("one section")
-	{
-		std::string file =
-			"@Type1\n"
-			"%key1\n";
+    SECTION("one section")
+    {
+        std::string file =
+            "@Type1\n"
+            "%key1\n";
 
-		parsed = parse_mf(file);
-		REQUIRE(parsed.size() == 1);
-		REQUIRE(parsed[0].type == "Type1");
-		REQUIRE(haskey(parsed[0].dict, "key1"));
-	}
+        parsed = parse_mf(file);
+        REQUIRE(parsed.size() == 1);
+        REQUIRE(parsed[0].type == "Type1");
+        REQUIRE(haskey(parsed[0].dict, "key1"));
+    }
 
-	SECTION("two sections")
-	{
-		std::string file =
-			"@Type1\n"
-			"%key1\n"
-			"@Type2\n"
-			"%key2\n";
+    SECTION("two sections")
+    {
+        std::string file =
+            "@Type1\n"
+            "%key1\n"
+            "@Type2\n"
+            "%key2\n";
 
-		parsed = parse_mf(file);
-		REQUIRE(parsed.size() == 2);
-		REQUIRE(parsed[0].type == "Type1");
-		REQUIRE(haskey(parsed[0].dict, "key1"));
-		REQUIRE(parsed[1].type == "Type2");
-		REQUIRE(haskey(parsed[1].dict, "key2"));
-	}
+        parsed = parse_mf(file);
+        REQUIRE(parsed.size() == 2);
+        REQUIRE(parsed[0].type == "Type1");
+        REQUIRE(haskey(parsed[0].dict, "key1"));
+        REQUIRE(parsed[1].type == "Type2");
+        REQUIRE(haskey(parsed[1].dict, "key2"));
+    }
 } // parse_mf }}}
 
 
@@ -936,9 +936,9 @@ TEST_CASE("parsing automata to intermediate representation")
 
 TEST_CASE("Mata::Parser::ParsedSection::operator<<(ostream&)")
 { // {{{
-	SECTION("aux")
-	{
-		WARN_PRINT("Insufficient testing of Mata::Parser::ParsedSection::operator<<(ostream&)");
-	}
+    SECTION("aux")
+    {
+        WARN_PRINT("Insufficient testing of Mata::Parser::ParsedSection::operator<<(ostream&)");
+    }
 
 } // }}}


### PR DESCRIPTION
This PR removes `Mata::Nfa::construct` function variation using `Mata::Parser::ParsedSection` as intermediate automaton format, as decided in #175. As we have agreed upon, only the variation using `Mata::IntermediateAut` is left.

This decision bring the slight issue of having to parse from Mata format and construct the NFA in the following manner if we get `Mata::Parser::ParsedSection` as an input somewhere.
```cpp
construct(Mata::IntermediateAut::parse_from_mf({ parsec })[0], &symbol_map)
```
Are we OK with that, or do we want to modify this so that you do not have to subscript the output of `Mata::IntermediateAut::parse_from_mf()`? However, if we want to maintain the possibility of having multiple automata in the same file `instances.mf`, we have no other choice. We could maybe implement another function named something like `Mata::Nfa::construct_single()`. It would parse the same object, but produce only one NFA, and otherwise fail when there were multiple automata, for example.

Resolves #175.

Changes in [tests/parser.cc](https://github.com/VeriFIT/mata/compare/remove_construct_parsed_section_function?expand=1#diff-7bf18db16bf31e771eedc3daf8564ee53716f47c2573421ade1e0d09c00ed501) only unify the indentation style to spaces across the whole file. Before, there were tabs and spaces mixed next to each other.