### PR TITLE
Remove NFA iterator

### DIFF
--- a/clean_gcda.sh
+++ b/clean_gcda.sh
@@ -1,2 +1,2 @@
-#/bin/sh
+#!/bin/sh
 find . -name '*.gcda' -delete

--- a/examples/example05-parsing.cc
+++ b/examples/example05-parsing.cc
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 
     Mata::Parser::Parsed parsed;
     Nfa aut;
-    StringToSymbolMap stsm;
+    Mata::StringToSymbolMap stsm;
     try {
         parsed = Mata::Parser::parse_mf(fs, true);
         fs.close();

--- a/examples/example06-mintermization.cc
+++ b/examples/example06-mintermization.cc
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
 
     Mata::Parser::Parsed parsed;
     Nfa aut;
-    StringToSymbolMap stsm;
+    Mata::StringToSymbolMap stsm;
     try {
         parsed = Mata::Parser::parse_mf(fs, true);
         fs.close();

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -859,13 +859,6 @@ public:
     const_iterator begin() const { return const_iterator::for_begin(this); }
     const_iterator end() const { return const_iterator::for_end(this); }
 
-    const Post& operator[](State state) const
-    { // {{{
-        assert(state < size());
-        return delta[state];
-    } // operator[] }}}
-
-
     /**
      * Return all epsilon transitions from epsilon symbol under a given state.
      * @param[in] state State from which are epsilon transitions checked
@@ -1222,8 +1215,8 @@ Nfa revert(const Nfa& aut);
 
 // This revert algorithm is fragile, uses low level accesses to Nfa and static data structures,
 // and it is potentially dangerous when there are used symbols with large numbers (allocates an array indexed by symbols)
-// It is faster assymptoticaly and for somewhat dense automata,
-// the same or a litle bit slower than simple_revert otherwise.
+// It is faster asymptotically and for somewhat dense automata,
+// the same or a little bit slower than simple_revert otherwise.
 // Not affected by pre-reserving vectors.
 Nfa fragile_revert(const Nfa& aut);
 

--- a/include/mata/number-predicate.hh
+++ b/include/mata/number-predicate.hh
@@ -13,8 +13,9 @@ namespace Mata::Util {
 template <class Number> class OrdVector;
 
 /**
- * A sort of enhanced boolean array,
- * implementing a set of numbers, aka a unary predicate over numbers, that provides a constant test and update.
+ * @brief An enhanced boolean array, implementing a set of numbers, aka a unary predicate over numbers, that provides a
+ *  constant test and update.
+ *
  * A number that is explicitly added is in the set, all the other numbers are implicitly not in the set.
  *
  * Besides a vector of bools (predicate), it can also be asked to maintain a vector of elements (elements).

--- a/src/nfa/nfa-inclusion.cc
+++ b/src/nfa/nfa-inclusion.cc
@@ -130,7 +130,7 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
         }
 
         // process transitions leaving smaller_state
-        for (const auto& smaller_move : smaller[smaller_state]) {//TODO: this should become smaller.delta[smaller_state] after refactoring
+        for (const auto& smaller_move : smaller.delta[smaller_state]) {
             const Symbol& smaller_symbol = smaller_move.symbol;
 
             do {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -742,7 +742,7 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
     const size_t num_of_states{aut.size() };
     for (size_t i{ 0 }; i < num_of_states; ++i)
     {
-        for (const auto& trans: aut[i])
+        for (const auto& trans: aut.delta[i])
         { // initialize
             const auto it_ins_pair = eps_closure.insert({i, {i}});
             if (trans.symbol == epsilon)
@@ -758,7 +758,7 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
     while (changed) { // compute the fixpoint
         changed = false;
         for (size_t i=0; i < num_of_states; ++i) {
-            const auto& state_transitions{ aut[i] };
+            const auto& state_transitions{ aut.delta[i] };
             const auto state_symbol_transitions{
                 state_transitions.find(Move{epsilon}) };
             if (state_symbol_transitions != state_transitions.end()) {
@@ -786,7 +786,7 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
         State src_state = state_closure_pair.first;
         for (State eps_cl_state : state_closure_pair.second) { // for every state in its eps cl
             if (aut.final[eps_cl_state]) result.final.add(src_state);
-            for (const auto& symb_set : aut[eps_cl_state]) {
+            for (const auto& symb_set : aut.delta[eps_cl_state]) {
                 if (symb_set.symbol == epsilon) continue;
 
                 // TODO: this could be done more efficiently if we had a better add method
@@ -1003,7 +1003,7 @@ bool Mata::Nfa::is_deterministic(const Nfa& aut)
     const size_t aut_size = aut.size();
     for (size_t i = 0; i < aut_size; ++i)
     {
-        for (const auto& symStates : aut[i])
+        for (const auto& symStates : aut.delta[i])
         {
             if (symStates.size() != 1) { return false; }
         }
@@ -1030,7 +1030,7 @@ bool Mata::Nfa::is_complete(const Nfa& aut, const Alphabet& alphabet)
 
         size_t n = 0;      // counter of symbols
         if (!aut.delta.empty()) {
-            for (const auto &symb_stateset: aut[state]) {
+            for (const auto &symb_stateset: aut.delta[state]) {
                 ++n;
                 if (!haskey(symbs, symb_stateset.symbol)) {
                     throw std::runtime_error(std::to_string(__func__) +
@@ -1168,7 +1168,7 @@ bool Mata::Nfa::is_lang_empty(const Nfa& aut, Run* cex)
         if (aut.delta.empty())
             continue;
 
-        for (const auto& symb_stateset : aut[state])
+        for (const auto& symb_stateset : aut.delta[state])
         {
             for (const auto& tgt_state : symb_stateset.targets)
             {


### PR DESCRIPTION
This PR removes the iterator over NFA. Resolves #238 (AFA does not have `Mata::Afa::Afa::operator[]`).