### PR TITLE
Remove member variables for number of states

### DIFF
--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -182,7 +182,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void clear()
         bool empty()
         void resize(size_t)
-        size_t post_size()
+        size_t posts_size()
         void defragment()
         void add(CTrans) except +
         void add(State, Symbol, State) except +

--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -182,7 +182,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         void clear()
         bool empty()
         void resize(size_t)
-        size_t posts_size()
+        size_t num_of_states()
         void defragment()
         void add(CTrans) except +
         void add(State, Symbol, State) except +

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -350,9 +350,9 @@ public:
     }
 
     /**
-     * @return Number of states with outgoing transitions.
+     * @return Number of states in the whole Delta, including both source and target states.
      */
-    size_t posts_size() const { return posts.size(); }
+    size_t num_of_states() const { return posts.size(); }
 
     void add(State state_from, Symbol symbol, State state_to);
     void add(const Trans& trans) { add(trans.src, trans.symb, trans.tgt); }
@@ -501,7 +501,7 @@ public:
      * Clear transitions but keep the automata states.
      */
     void clear_transitions() {
-        const size_t delta_size = delta.posts_size();
+        const size_t delta_size = delta.num_of_states();
         for (size_t i = 0; i < delta_size; ++i) {
             delta.get_mutable_post(i) = Post();
         }
@@ -522,7 +522,7 @@ public:
      * @return The requested @p state.
      */
     State add_state(State state) {
-        if (state >= delta.posts_size()) {
+        if (state >= delta.num_of_states()) {
             delta.increase_size(state + 1);
         }
         return state;
@@ -537,7 +537,7 @@ public:
      size_t size() const {
         return std::max({ static_cast<unsigned long>(initial.domain_size()),
                           static_cast<unsigned long>(final.domain_size()),
-                          static_cast<unsigned long>(delta.posts_size()) });
+                          static_cast<unsigned long>(delta.num_of_states()) });
     }
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -245,7 +245,7 @@ public:
  */
 struct Delta {
 private:
-    std::vector<Post> post;
+    std::vector<Post> posts;
 
     /// Number of actual states occurring in the transition relation.
     ///
@@ -257,11 +257,11 @@ private:
 public:
     inline static const Post empty_post; //when post[q] is not allocated, then delta[q] returns this.
 
-    Delta() : post(), m_num_of_states(0) {}
-    explicit Delta(size_t n) : post(), m_num_of_states(n) {}
+    Delta() : posts(), m_num_of_states(0) {}
+    explicit Delta(size_t n) : posts(), m_num_of_states(n) {}
 
     void reserve(size_t n) {
-        post.reserve(n);
+        posts.reserve(n);
         if (n > m_num_of_states) {
             m_num_of_states = n;
         }
@@ -284,16 +284,16 @@ public:
     // But it feels fragile, before doing something like that, better think and talk to people.
     Post & get_mutable_post(State q)
     {
-        if (q >= post.size()) {
-            Util::reserve_on_insert(post,q);
+        if (q >= posts.size()) {
+            Util::reserve_on_insert(posts, q);
             const size_t new_size{ q + 1 };
-            post.resize(new_size);
+            posts.resize(new_size);
             if (new_size > m_num_of_states) {
                 m_num_of_states = new_size;
             }
         }
 
-        return post[q];
+        return posts[q];
     };
 
     // TODO: why do we have the code of all these methods in the header file? Should we move it out?
@@ -301,13 +301,13 @@ public:
     std::vector<State> defragment(Util::NumberPredicate<State> & is_staying) {
         //first, indexes of post are filtered (places of to be removed states are taken by states on their right)
         size_t move_index{ 0 };
-        post.erase(
-            std::remove_if(post.begin(), post.end(), [&](Post& _post) -> bool {
+        posts.erase(
+            std::remove_if(posts.begin(), posts.end(), [&](Post& _post) -> bool {
                 size_t prev{ move_index };
                 ++move_index;
                 return !is_staying[prev];
             }),
-            post.end()
+            posts.end()
         );
 
         //get renaming of current states to new numbers:
@@ -322,7 +322,7 @@ public:
 
         //this iterates through every post and ever, filters and renames states,
         //and finally removes moves that became empty from the post.
-        for (State q=0,size=post.size();q<size;++q) {
+        for (State q=0,size=posts.size(); q < size; ++q) {
             //should we have a function Post::transform(Lambda) for this?
             Post & p = get_mutable_post(q);
             for (auto move = p.begin(); move < p.end(); ++move) {
@@ -343,7 +343,7 @@ public:
         }
 
         //TODO: this is bad. m_num_of_states should be named differently and it should be the number of states, so that 0 means no states and 1 means at least state 0.
-        if (post.size() > 0)
+        if (posts.size() > 0)
             m_num_of_states = find_max_state()+1;
         else
             m_num_of_states = 0;
@@ -353,34 +353,30 @@ public:
     };
 
     // Get a constant reference to the post of a state. No side effects.
-    const Post & operator[] (State q) const
-    {
-        if (q >= post.size())
+    const Post & operator[] (State q) const {
+        if (q >= posts.size())
             return empty_post;
         else
-            return post[q];
+            return posts[q];
     };
 
-    void emplace_back() {
-        post.emplace_back();
-        if (post.size() > m_num_of_states) { ++m_num_of_states; }
-    }
+    void emplace_back() { posts.emplace_back(); }
 
     void clear()
     {
-        post.clear();
+        posts.clear();
         m_num_of_states = 0;
     }
 
     void increase_size(size_t n)
     {
-        assert(n >= post.size());
-        post.resize(n);
-        if (post.size() > m_num_of_states)
-            m_num_of_states = post.size();
+        assert(n >= posts.size());
+        posts.resize(n);
+        if (posts.size() > m_num_of_states)
+            m_num_of_states = posts.size();
     }
 
-    size_t post_size() const { return post.size(); }
+    size_t post_size() const { return posts.size(); }
 
     void add(State state_from, Symbol symbol, State state_to);
     void add(const Trans& trans) { add(trans.src, trans.symb, trans.tgt); }
@@ -459,12 +455,12 @@ public:
 
     struct const_iterator cbegin() const
     {
-        return const_iterator(post);
+        return const_iterator(posts);
     }
 
     struct const_iterator cend() const
     {
-        return const_iterator(post, true);
+        return const_iterator(posts, true);
     }
 
     struct const_iterator begin() const

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -563,20 +563,26 @@ public:
         final.clear();
     }
 
-    // this is exact equality of automata, including state numbering (so even stronger than isomorphism)
-    // essentially only useful for testing purposes
+    /**
+     * @brief Check if @c this is exactly identical to @p aut.
+     *
+     * This is exact equality of automata, including state numbering (so even stronger than isomorphism),
+     *  essentially only useful for testing purposes.
+     * @return True if automata are exactly identical, false otherwise.
+     */
     bool is_identical(const Nfa & aut) {
-        std::vector<Trans> thisTrans;
-        for (auto trans: *this) thisTrans.push_back(trans);
-        std::vector<Trans> autTrans;
-        for (auto trans: aut) autTrans.push_back(trans);
+        if (Util::OrdVector<State>(initial.get_elements()) != Util::OrdVector<State>(aut.initial.get_elements())) {
+            return false;
+        }
+        if (Util::OrdVector<State>(final.get_elements()) != Util::OrdVector<State>(aut.final.get_elements())) {
+            return false;
+        }
 
-
-        bool init = Util::OrdVector<State>(initial.get_elements()) == Util::OrdVector<State>(aut.initial.get_elements());
-        bool fin = Util::OrdVector<State>(final.get_elements()) == Util::OrdVector<State>(aut.final.get_elements());
-        bool trans = thisTrans == autTrans;
-
-        return (init && fin && trans);
+        std::vector<Trans> this_trans;
+        for (auto trans: *this) { this_trans.push_back(trans); }
+        std::vector<Trans> aut_trans;
+        for (auto trans: aut) { aut_trans.push_back(trans); }
+        return this_trans == aut_trans;
     };
 
     /**

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -23,9 +23,6 @@
 
 // MATA headers
 #include <mata/afa.hh>
-#include <mata/nfa.hh>
-#include <mata/util.hh>
-#include <mata/closed-set.hh>
 
 using std::tie;
 

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -1153,12 +1153,8 @@ TEST_CASE("Mata::Nfa::complement()")
 
 		cmpl = complement(aut, alph, {{"algorithm", "classical"},
                                     {"minimize", "false"}});
-
-		REQUIRE(is_in_lang(cmpl, { }));
-		REQUIRE(cmpl.initial.size() == 1);
-		REQUIRE(cmpl.final.size() == 1);
-		REQUIRE(cmpl.delta.empty());
-		REQUIRE(*cmpl.initial.begin() == *cmpl.final.begin());
+        Nfa empty_string_nfa{ Mata::Nfa::create_sigma_star_nfa(&alph) };
+        CHECK(Mata::Nfa::are_equivalent(cmpl, empty_string_nfa));
 	}
 
 	SECTION("empty automaton")
@@ -1174,17 +1170,8 @@ TEST_CASE("Mata::Nfa::complement()")
 		REQUIRE(is_in_lang(cmpl, Mata::Nfa::Run{{ alph["a"], alph["a"]}, {}}));
 		REQUIRE(is_in_lang(cmpl, Mata::Nfa::Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
 
-		// TODO: consider removing the structural tests (in case a more}
-		// sophisticated complementation algorithm is used)
-		REQUIRE(cmpl.initial.size() == 1);
-		REQUIRE(cmpl.final.size() == 1);
-
-		State init_state = *cmpl.initial.begin();
-		State fin_state = *cmpl.final.begin();
-		REQUIRE(init_state == fin_state);
-		REQUIRE(cmpl.get_moves_from(init_state).size() == 2);
-		REQUIRE(cmpl.delta.contains(init_state, alph["a"], init_state));
-		REQUIRE(cmpl.delta.contains(init_state, alph["b"], init_state));
+        Nfa sigma_star_nfa{ Mata::Nfa::create_sigma_star_nfa(&alph) };
+        CHECK(Mata::Nfa::are_equivalent(cmpl, sigma_star_nfa));
 	}
 
 	SECTION("empty automaton accepting epsilon, empty alphabet")
@@ -1196,10 +1183,7 @@ TEST_CASE("Mata::Nfa::complement()")
 		cmpl = complement(aut, alph, {{"algorithm", "classical"},
                                     {"minimize", "false"}});
 
-		REQUIRE(!is_in_lang(cmpl, { }));
-		REQUIRE(cmpl.initial.size() == 1);
-		REQUIRE(cmpl.final.size() == 0);
-		REQUIRE(cmpl.delta.empty());
+		CHECK(is_lang_empty(cmpl));
 	}
 
 	SECTION("empty automaton accepting epsilon")
@@ -1263,12 +1247,8 @@ TEST_CASE("Mata::Nfa::complement()")
 
 		cmpl = complement(aut, alph, {{"algorithm", "classical"},
                                     {"minimize", "true"}});
-
-		REQUIRE(is_in_lang(cmpl, { }));
-		REQUIRE(cmpl.initial.size() == 1);
-		REQUIRE(cmpl.final.size() == 1);
-		REQUIRE(cmpl.delta.empty());
-		REQUIRE(*cmpl.initial.begin() == *cmpl.final.begin());
+        Nfa empty_string_nfa{ Mata::Nfa::create_sigma_star_nfa(&alph) };
+        CHECK(Mata::Nfa::are_equivalent(empty_string_nfa, cmpl));
 	}
 
 	SECTION("empty automaton, minimization")
@@ -1284,15 +1264,8 @@ TEST_CASE("Mata::Nfa::complement()")
 		REQUIRE(is_in_lang(cmpl, Mata::Nfa::Run{{ alph["a"], alph["a"]}, {}}));
 		REQUIRE(is_in_lang(cmpl, Mata::Nfa::Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
 
-		REQUIRE(cmpl.initial.size() == 1);
-		REQUIRE(cmpl.final.size() == 1);
-
-		State init_state = *cmpl.initial.begin();
-		State fin_state = *cmpl.final.begin();
-		REQUIRE(init_state == fin_state);
-		REQUIRE(cmpl.get_moves_from(init_state).size() == 2);
-		REQUIRE(cmpl.delta.contains(init_state, alph["a"], init_state));
-		REQUIRE(cmpl.delta.contains(init_state, alph["b"], init_state));
+        Nfa sigma_star_nfa{ Mata::Nfa::create_sigma_star_nfa(&alph) };
+        CHECK(Mata::Nfa::are_equivalent(sigma_star_nfa, cmpl));
 	}
 
 	SECTION("minimization vs no minimization")

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -28,17 +28,6 @@ using Word = std::vector<Symbol>;
 
 template<class T> void unused(const T &) {}
 
-//TODO: we have already a method for this in nfa.hh - has_not_transitions, right?
-bool nothing_in_trans(const Nfa& nfa)
-{
-    bool all_empty = true;
-    for (size_t i = 0; i < nfa.size(); ++i) {
-        all_empty &= nfa.delta[i].empty();
-    }
-
-    return all_empty;
-}
-
 TEST_CASE("Mata::Nfa::size()") {
     Nfa nfa{};
     CHECK(nfa.size() == 0);
@@ -128,7 +117,7 @@ TEST_CASE("Mata::Nfa::Nfa iteration")
 	}
 
     const size_t state_num = 'r'+1;
-    aut.add_state(state_num-1);
+    aut.delta.increase_size(state_num);
 
 	SECTION("a non-empty automaton")
 	{
@@ -521,7 +510,7 @@ TEST_CASE("Mata::Nfa::determinize()")
 		result = determinize(aut);
 
 		REQUIRE(result.final.empty());
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
         CHECK(is_lang_empty(result));
 	}
 
@@ -533,7 +522,7 @@ TEST_CASE("Mata::Nfa::determinize()")
 
 		REQUIRE(result.initial[subset_map[{1}]]);
 		REQUIRE(result.final[subset_map[{1}]]);
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
 	}
 
 	SECTION("simple automaton 2")
@@ -1065,7 +1054,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 
 		REQUIRE(aut.initial.empty());
 		REQUIRE(aut.final.empty());
-		REQUIRE(nothing_in_trans(aut));
+		REQUIRE(aut.delta.empty());
 	}
 
 	SECTION("empty automaton")
@@ -1091,7 +1080,7 @@ TEST_CASE("Mata::Nfa::make_complete()")
 		REQUIRE(aut.initial.size() == 1);
 		REQUIRE(*aut.initial.begin() == 1);
 		REQUIRE(aut.final.empty());
-		REQUIRE(nothing_in_trans(aut));
+		REQUIRE(aut.delta.empty());
 	}
 
 	SECTION("one-state automaton")
@@ -1168,7 +1157,7 @@ TEST_CASE("Mata::Nfa::complement()")
 		REQUIRE(is_in_lang(cmpl, { }));
 		REQUIRE(cmpl.initial.size() == 1);
 		REQUIRE(cmpl.final.size() == 1);
-		REQUIRE(nothing_in_trans(cmpl));
+		REQUIRE(cmpl.delta.empty());
 		REQUIRE(*cmpl.initial.begin() == *cmpl.final.begin());
 	}
 
@@ -1210,7 +1199,7 @@ TEST_CASE("Mata::Nfa::complement()")
 		REQUIRE(!is_in_lang(cmpl, { }));
 		REQUIRE(cmpl.initial.size() == 1);
 		REQUIRE(cmpl.final.size() == 0);
-		REQUIRE(nothing_in_trans(cmpl));
+		REQUIRE(cmpl.delta.empty());
 	}
 
 	SECTION("empty automaton accepting epsilon")
@@ -1278,7 +1267,7 @@ TEST_CASE("Mata::Nfa::complement()")
 		REQUIRE(is_in_lang(cmpl, { }));
 		REQUIRE(cmpl.initial.size() == 1);
 		REQUIRE(cmpl.final.size() == 1);
-		REQUIRE(nothing_in_trans(cmpl));
+		REQUIRE(cmpl.delta.empty());
 		REQUIRE(*cmpl.initial.begin() == *cmpl.final.begin());
 	}
 
@@ -1920,7 +1909,7 @@ TEST_CASE("Mata::Nfa::revert()")
 	{
 		Nfa result = revert(aut);
 
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
 		REQUIRE(result.initial.size() == 0);
 		REQUIRE(result.final.size() == 0);
 	}
@@ -1935,7 +1924,7 @@ TEST_CASE("Mata::Nfa::revert()")
 
 		Nfa result = revert(aut);
 
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
 		REQUIRE(result.initial[2]);
 		REQUIRE(result.initial[5]);
 		REQUIRE(result.final[1]);
@@ -2303,7 +2292,7 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 	{
 		Nfa result = reduce(aut, false, &state_map);
 
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
 		REQUIRE(result.initial.empty());
 		REQUIRE(result.final.empty());
 	}
@@ -2316,7 +2305,7 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
         aut.final.add(2);
 		Nfa result = reduce(aut, false, &state_map);
 
-		REQUIRE(nothing_in_trans(result));
+		REQUIRE(result.delta.empty());
 		REQUIRE(result.initial[state_map[1]]);
 		REQUIRE(result.final[state_map[2]]);
 		REQUIRE(result.size() == 2);
@@ -2536,11 +2525,11 @@ TEST_CASE("Mata::Nfa::get_trans_as_sequence(}")
     TransSequence expected{};
 
     aut.delta.add(1, 2, 3);
-    expected.push_back(Trans{1, 2, 3});
+    expected.emplace_back(1, 2, 3);
     aut.delta.add(1, 3, 4);
-    expected.push_back(Trans{1, 3, 4});
+    expected.emplace_back(1, 3, 4);
     aut.delta.add(2, 3, 4);
-    expected.push_back(Trans{2, 3, 4});
+    expected.emplace_back(2, 3, 4);
 
 
     REQUIRE(aut.get_trans_as_sequence() == expected);


### PR DESCRIPTION
This PR removes the member variables representing the number of requested states in `class Nfa` and the number of states present in `Delta`.

It was decided that we will represent the number of states in an automaton with a union of initial, final and delta states, where delta states mean the number of allocated `Post`. Each state used in delta (either as a source or a target state) will have allocated its `Post` in delta. Therefore, the number of allocated `Post` in delta corresponds to the number of states in the whole delta (both source and target states).

Furthermore, this PR renames member variable `post` of type vector of `Post` to `posts` which now correctly explains, that the variable holds, indeed, multiple `Post` classes, not just one `Post`. This was a typo done in the past, and it seems that no one noticed.

`Mata::Nfa::Delta::posts_size()` now represents the number of states in the whole delta, including both source and target states. Therefore, the function does no longer need to have a unique name different from the number of states in delta. This function was renamed previously to `posts_size()` only because it represented only the number of source states. Now, when it represents the number of all states in delta again, it can be renamed back to its original meaning.

Resolves #189 and #167.