### PR TITLE
Fix warnings

### DIFF
--- a/3rdparty/args.hxx
+++ b/3rdparty/args.hxx
@@ -1586,7 +1586,7 @@ namespace args
     {
         private:
             T value;
-            Reader reader;
+            Reader reader{};
 
         public:
 

--- a/3rdparty/cudd/cplusplus/cuddObj.cc
+++ b/3rdparty/cudd/cplusplus/cuddObj.cc
@@ -185,6 +185,21 @@ DD::DD(const DD &from) {
 
 } // DD::DD
 
+DD& DD::operator=(const DD& other) {
+    if (this != &other) {
+        this->p = other.p;
+        if (this->node) { Cudd_Deref(this->node); }
+        this->node = other.node;
+        if (this->node) {
+            Cudd_Ref(this->node);
+            if (this->p->verbose) {
+                cout << "Copy DD assignment for node " << hex << node << dec <<
+                     " ref = " << Cudd_Regular(node)->ref << "\n";
+            }
+        }
+    }
+    return *this;
+} // DD::operator=
 
 DD::~DD() {}
 

--- a/3rdparty/cudd/include/mata/cudd/cuddObj.hh
+++ b/3rdparty/cudd/include/mata/cudd/cuddObj.hh
@@ -92,7 +92,11 @@ protected:
     DD(Capsule *cap, DdNode *ddNode);
     DD(Cudd const & manager, DdNode *ddNode);
     DD(const DD &from);
+    DD(DD&& from) = default;
     ~DD();
+
+    DD& operator=(const DD& other) = default;
+    DD& operator=(DD&& other) = default;
 public:
     // This operator should be declared explicit, but there are still too many
     // compilers out there that do not support this C++11 feature.

--- a/3rdparty/cudd/include/mata/cudd/cuddObj.hh
+++ b/3rdparty/cudd/include/mata/cudd/cuddObj.hh
@@ -92,11 +92,9 @@ protected:
     DD(Capsule *cap, DdNode *ddNode);
     DD(Cudd const & manager, DdNode *ddNode);
     DD(const DD &from);
-    DD(DD&&) = default;
     ~DD();
 
-    DD& operator=(const DD& other) = default;
-    DD& operator=(DD&& other) = default;
+    DD& operator=(const DD& other);
 public:
     // This operator should be declared explicit, but there are still too many
     // compilers out there that do not support this C++11 feature.

--- a/3rdparty/cudd/include/mata/cudd/cuddObj.hh
+++ b/3rdparty/cudd/include/mata/cudd/cuddObj.hh
@@ -92,7 +92,7 @@ protected:
     DD(Capsule *cap, DdNode *ddNode);
     DD(Cudd const & manager, DdNode *ddNode);
     DD(const DD &from);
-    DD(DD&& from) = default;
+    DD(DD&&) = default;
     ~DD();
 
     DD& operator=(const DD& other) = default;

--- a/3rdparty/cudd/util/cpu_stats.c
+++ b/3rdparty/cudd/util/cpu_stats.c
@@ -62,7 +62,6 @@
 
 */
 
-#define _BSD_SOURCE
 #include "util.h"
 
 #if HAVE_SYS_TIME_H == 1

--- a/3rdparty/re2/re2/re2.h
+++ b/3rdparty/re2/re2/re2.h
@@ -232,6 +232,7 @@ class RE2 {
   // We convert user-passed pointers into special Arg objects
   class Options;
 
+  RE2() = default;
   ~RE2();
 
   // If RE2 could not be created properly, returns an error string.
@@ -372,19 +373,19 @@ class RE2 {
  private:
 
   std::string pattern_;         // string regular expression
-  re2::Regexp* entire_regexp_;  // parsed regular expression
-  const std::string* error_;    // error indicator (or points to empty string)
+  re2::Regexp* entire_regexp_{};  // parsed regular expression
+  const std::string* error_{};    // error indicator (or points to empty string)
   std::string error_arg_;       // fragment of regexp showing error
   std::string prefix_;          // required prefix (before suffix_regexp_)
-  re2::Regexp* suffix_regexp_;  // parsed regular expression, prefix_ removed
-  re2::Prog* prog_;             // compiled program for regexp
+  re2::Regexp* suffix_regexp_{};  // parsed regular expression, prefix_ removed
+  re2::Prog* prog_{};             // compiled program for regexp
 
   // Reverse Prog for DFA execution only
-  mutable re2::Prog* rprog_;
+  mutable re2::Prog* rprog_{};
   // Map from capture names to indices
-  mutable const std::map<std::string, int>* named_groups_;
+  mutable const std::map<std::string, int>* named_groups_{};
   // Map from capture indices to names
-  mutable const std::map<int, std::string>* group_names_;
+  mutable const std::map<int, std::string>* group_names_{};
 
   RE2(const RE2&) = delete;
   RE2& operator=(const RE2&) = delete;

--- a/3rdparty/re2/re2/regexp.h
+++ b/3rdparty/re2/re2/regexp.h
@@ -209,7 +209,7 @@ class RegexpStatus {
 
  private:
   RegexpStatusCode code_;  // Kind of error
-  StringPiece error_arg_;  // Piece of regexp containing syntax error.
+  StringPiece error_arg_{};  // Piece of regexp containing syntax error.
   std::string* tmp_;       // Temporary storage, possibly where error_arg_ is.
 
   RegexpStatus(const RegexpStatus&) = delete;

--- a/3rdparty/re2/re2/sparse_array.h
+++ b/3rdparty/re2/re2/sparse_array.h
@@ -306,7 +306,7 @@ bool SparseArray<Value>::has_index(int i) const {
     return false;
   }
   // Unsigned comparison avoids checking sparse_[i] < 0.
-  return (uint32_t)sparse_[i] < (uint32_t)size_ &&
+  return static_cast<uint32_t>(sparse_[i]) < static_cast<uint32_t>(size_) &&
          dense_[sparse_[i]].index_ == i;
 }
 

--- a/3rdparty/re2/re2/sparse_set.h
+++ b/3rdparty/re2/re2/sparse_set.h
@@ -189,7 +189,7 @@ bool SparseSetT<Value>::contains(int i) const {
     return false;
   }
   // Unsigned comparison avoids checking sparse_[i] < 0.
-  return (uint32_t)sparse_[i] < (uint32_t)size_ &&
+  return static_cast<uint32_t>(sparse_[i]) < static_cast<uint32_t>(size_) &&
          dense_[sparse_[i]] == i;
 }
 

--- a/3rdparty/re2/util/logging.h
+++ b/3rdparty/re2/util/logging.h
@@ -65,7 +65,7 @@ class LogMessage {
 
  private:
   bool flushed_;
-  std::ostringstream str_;
+  std::ostringstream str_{};
 
   LogMessage(const LogMessage&) = delete;
   LogMessage& operator=(const LogMessage&) = delete;

--- a/3rdparty/simlib/include/mata/simlib/explicit_lts.hh
+++ b/3rdparty/simlib/include/mata/simlib/explicit_lts.hh
@@ -21,7 +21,7 @@ namespace Simlib { class ExplicitLTS; }
 
 class Simlib::ExplicitLTS {
 
-	size_t states_;
+	size_t states_{};
 	size_t transitions_;
 	std::vector<
 		std::pair<

--- a/3rdparty/simlib/include/mata/simlib/util/smart_set.hh
+++ b/3rdparty/simlib/include/mata/simlib/util/smart_set.hh
@@ -51,8 +51,7 @@ private:
 	};
 
 	GCC_DIAG_OFF(effc++)
-	class Iterator : public std::iterator<std::input_iterator_tag, Key>
-	{
+	class Iterator {
 	GCC_DIAG_ON(effc++)
 
 	private:
@@ -60,8 +59,13 @@ private:
 		const Element* element_;
 
 	public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = int;
+        using difference_type = int;
+        using pointer = int*;
+        using reference = int&;
 
-		explicit Iterator(const Element* element) :
+        explicit Iterator(const Element* element) :
 			element_(element)
 		{ }
 

--- a/3rdparty/simlib/include/mata/simlib/util/splitting_relation.hh
+++ b/3rdparty/simlib/include/mata/simlib/util/splitting_relation.hh
@@ -128,8 +128,13 @@ class Simlib::Util::SplittingRelation {
 public:
 
 	GCC_DIAG_OFF(effc++)
-	struct IteratorBase : public std::iterator<std::input_iterator_tag, size_t> {
+	struct IteratorBase {
 	GCC_DIAG_ON(effc++)
+        using iterator_category = std::input_iterator_tag;
+        using value_type = int;
+        using difference_type = int;
+        using pointer = int*;
+        using reference = int&;
 
 		Element* el_;
 

--- a/3rdparty/simlib/src/explicit_lts_sim.cc
+++ b/3rdparty/simlib/src/explicit_lts_sim.cc
@@ -150,6 +150,11 @@ public:
 		} while (states != this->states_);
 	}
 
+    Block(Block&) = default;
+
+    Block& operator=(const Block&) = delete;
+    Block& operator=(Block&&) = delete;
+
 	void move_to_tmp(StateListElem* elem)
 	{
 		this->tmp_.push_back(elem);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.25.0)
 project(libMATA)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -120,9 +120,9 @@ enable_testing()
 # Process subdirectories
 add_subdirectory(src)
 add_subdirectory(cli)
-add_subdirectory(3rdparty/re2 SYSTEM)
-add_subdirectory(3rdparty/simlib SYSTEM)
-add_subdirectory(3rdparty/cudd SYSTEM)
+add_subdirectory(3rdparty/re2 EXCLUDE_FROM_ALL SYSTEM)
+add_subdirectory(3rdparty/simlib EXCLUDE_FROM_ALL SYSTEM)
+add_subdirectory(3rdparty/cudd EXCLUDE_FROM_ALL SYSTEM)
 add_subdirectory(tests)
 
 install(TARGETS libmata ARCHIVE DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,41 @@ endif()
 option(USE_CLANG "build with clang" OFF)
 # option(USE_CLANG "build with clang" ON)
 
+# Common compiler flags.
+set(COMMON_COMPILER_FLAGS
+        -fms-extensions
+        -fdiagnostics-show-option
+        -fPIC
+        -fno-strict-aliasing
+        )
+
+# Common warnings compiler flags.
+set(COMMON_WARNINGS
+        -Wextra
+        -Wall
+        -Wfloat-equal
+        -Wctor-dtor-privacy
+        -Weffc++
+        -Woverloaded-virtual
+        -Wold-style-cast
+        -Wunused-parameter
+        -Wsign-compare
+        -Wunused-parameter
+
+        -Wpedantic
+        #-pedantic-errors
+
+        -Wconversion
+        #-Wsign-conversion
+        -Wreturn-type
+        )
+# Clang-specific warnings compiler flags.
+set(CLANG_WARNINGS
+        -Winconsistent-missing-override
+        -Wgnu-anonymous-struct
+        -Wnested-anon-types
+        )
+
 ##############################################################################
 #                                DEPENDENCIES
 ##############################################################################
@@ -85,9 +120,9 @@ enable_testing()
 # Process subdirectories
 add_subdirectory(src)
 add_subdirectory(cli)
-add_subdirectory(3rdparty/re2)
-add_subdirectory(3rdparty/simlib)
-add_subdirectory(3rdparty/cudd)
+add_subdirectory(3rdparty/re2 SYSTEM)
+add_subdirectory(3rdparty/simlib SYSTEM)
+add_subdirectory(3rdparty/cudd SYSTEM)
 add_subdirectory(tests)
 
 install(TARGETS libmata ARCHIVE DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,8 @@ set(COMMON_WARNINGS
         -Wunused-parameter
         -Wsign-compare
         -Wunused-parameter
-
-        -Wpedantic
+        #-Wpedantic
         #-pedantic-errors
-
         -Wconversion
         #-Wsign-conversion
         -Wreturn-type

--- a/bindings/python/libmata.pxd
+++ b/bindings/python/libmata.pxd
@@ -333,7 +333,7 @@ cdef extern from "mata/nfa-strings.hh" namespace "Mata::Strings::SegNfa":
     cdef cppclass CSegmentation "Mata::Strings::SegNfa::Segmentation":
         CSegmentation(CNfa&, cset[Symbol]) except +
 
-        ctypedef unsigned EpsilonDepth
+        ctypedef size_t EpsilonDepth
         ctypedef umap[EpsilonDepth, TransitionSequence] EpsilonDepthTransitions
 
         EpsilonDepthTransitions get_epsilon_depths()

--- a/bindings/python/libmata.pyx
+++ b/bindings/python/libmata.pyx
@@ -1660,7 +1660,7 @@ cdef class Segmentation:
 
         :return: Map of depths to lists of ε-transitions.
         """
-        cdef umap[unsigned, vector[CTrans]] c_epsilon_transitions = self.thisptr.get_epsilon_depths()
+        cdef umap[size_t, vector[CTrans]] c_epsilon_transitions = self.thisptr.get_epsilon_depths()
         result = {}
         for epsilon_depth_pair in c_epsilon_transitions:
             for trans in epsilon_depth_pair.second:

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -3,26 +3,6 @@ set(CMAKE_COLOR_MAKEFILE ON)
 
 project(mata-cli)
 
-# Flags
-set(cxx_compiler_flags
-  -pedantic-errors
-  -Wextra
-  -Wall
-  -Wfloat-equal
-  -fdiagnostics-show-option
-  -std=c++11
-  -Wctor-dtor-privacy
-  -Weffc++
-  -fPIC
-  -fno-strict-aliasing
-  -Woverloaded-virtual
-  -Wold-style-cast
-)
-
-foreach(flag ${cxx_compiler_flags})
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-endforeach()
-
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
 endif()
@@ -41,3 +21,15 @@ add_executable(mata-code
 )
 
 target_link_libraries(mata-code libmata)
+
+# Add common compile warnings.
+target_compile_options(libmata PRIVATE "$<$<CONFIG:DEBUG>:${COMMON_WARNINGS}>")
+target_compile_options(libmata PRIVATE "$<$<CONFIG:RELEASE>:${COMMON_WARNINGS}>")
+
+# Optionally, also add Clang-specific warnings.
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") # Using regular Clang or AppleClang.
+	target_compile_options(libmata PRIVATE "$<$<CONFIG:DEBUG>:${CLANG_WARNINGS}>")
+	target_compile_options(libmata PRIVATE "$<$<CONFIG:RELEASE>:${CLANG_WARNINGS}>")
+endif()
+
+target_compile_options(libmata PRIVATE "${COMMON_COMPILER_FLAGS}")

--- a/cli/mata-code.cc
+++ b/cli/mata-code.cc
@@ -36,11 +36,11 @@ int main(int argc, const char* argv[])
 	try {
 		arg_parser.ParseCLI(argc, argv);
 	}
-	catch (args::Help) {
+	catch (const args::Help&) {
 		std::cout << arg_parser;
 		return EXIT_SUCCESS;
 	}
-	catch (args::Error e) {
+	catch (const args::Error& e) {
 		std::cerr << e.what() << std::endl;
 		return EXIT_FAILURE;
 	}

--- a/include/mata/afa.hh
+++ b/include/mata/afa.hh
@@ -197,7 +197,7 @@ public:
     } // }}}
     bool has_initial(Node node) const
     { // {{{
-        return StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1, initialstates).contains(node);
+        return StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, initialstates).contains(node);
     } // }}}
     void add_final(State state) { this->finalstates.insert(state); }
     void add_final(const std::vector<State> vec)
@@ -276,10 +276,10 @@ public:
     StateClosedSet get_initial_nodes() const;
 
     StateClosedSet get_non_initial_nodes() const {
-        return StateClosedSet{ upward_closed_set, 0, transitionrelation.size()-1, initialstates }.complement();
+        return StateClosedSet{ ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, initialstates }.complement();
     };
     StateClosedSet get_final_nodes() const {
-        return { downward_closed_set, 0, transitionrelation.size()-1, finalstates };
+        return { ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1, finalstates };
     };
 
     /**

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -186,7 +186,7 @@ public:
         return m_symbols.difference(symbols);
     }
 
-    std::string reverse_translate_symbol(const Symbol symbol) const override;
+    std::string reverse_translate_symbol(Symbol symbol) const override;
 
 private:
     EnumAlphabet& operator=(const EnumAlphabet& rhs);
@@ -283,7 +283,7 @@ public:
     Util::OrdVector<Symbol> get_alphabet_symbols() const override;
     Util::OrdVector<Symbol> get_complement(const Util::OrdVector<Symbol>& symbols) const override;
 
-    std::string reverse_translate_symbol(const Symbol symbol) const override;
+    std::string reverse_translate_symbol(Symbol symbol) const override;
 
 private:
     OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs);
@@ -314,7 +314,7 @@ public:
 
     Symbol translate_symb(const std::string& str) override;
 
-    virtual std::vector<Symbol> translate_word(const std::vector<std::string>& word) const;
+    virtual std::vector<Symbol> translate_word(const std::vector<std::string>& word) const override;
 
     /**
      * @brief Add new symbol to the alphabet with the value of @c next_symbol_value.

--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -77,6 +77,9 @@ template<typename T> using OrdVec = Mata::Util::OrdVector<T>;
 // A closed set could be upward-closed or downward-closed.
 enum class ClosedSetType { upward_closed_set, downward_closed_set };
 
+template <typename T> struct ClosedSet;
+template <typename T> std::ostream& operator<<(std::ostream& os, const ClosedSet<T>& cs);
+
 /**
  * @brief Closed set.
  *
@@ -164,7 +167,7 @@ struct ClosedSet {
         } // operator<= }}}
 
         // Text representation of a closed set
-        friend std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs);
+        friend std::ostream& operator<< <> (std::ostream& os, const ClosedSet<T>& cs);
 
         bool is_upward_closed() const { return type_ == ClosedSetType::upward_closed_set; };
         bool is_downward_closed() const { return type_ == ClosedSetType::downward_closed_set; };
@@ -196,7 +199,7 @@ struct ClosedSet {
 }; // class ClosedSet.
 
 template<typename T>
-std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs) {
+std::ostream& operator<<(std::ostream& os, const ClosedSet<T>& cs) {
     std::string strType = "TYPE: ";
     strType += cs.type() == ClosedSetType::upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
     strType += "\n";

--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -75,7 +75,7 @@ namespace Mata {
 template<typename T> using OrdVec = Mata::Util::OrdVector<T>;
 
 // A closed set could be upward-closed or downward-closed.
-enum ClosedSetType {upward_closed_set, downward_closed_set};
+enum class ClosedSetType { upward_closed_set, downward_closed_set };
 
 /**
  * @brief Closed set.
@@ -91,7 +91,7 @@ struct ClosedSet {
 
     private:
 
-       ClosedSetType type_{upward_closed_set}; // upward_closed or downward_closed sets
+       ClosedSetType type_{ ClosedSetType::upward_closed_set }; // upward_closed or downward_closed sets.
        T min_val_;
        T max_val_;
        Nodes antichain_{};
@@ -102,7 +102,7 @@ struct ClosedSet {
        ClosedSet() : type_(), min_val_(), max_val_(), antichain_() { }
 
        // inserting a single value of the datatype T
-       ClosedSet(ClosedSetType type, T min_val, T max_val, T value)
+       ClosedSet(const ClosedSetType type, const T& min_val, const T& max_val, const T& value)
            : type_(type), min_val_(min_val), max_val_(max_val), antichain_(Nodes(value)) {
            assert(min_val <= max_val);
            assert(min_val <= value && value <= max_val);
@@ -166,8 +166,8 @@ struct ClosedSet {
         // Text representation of a closed set
         friend std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs);
 
-        bool is_upward_closed() const {return type_ == upward_closed_set;};
-        bool is_downward_closed() const {return type_ == downward_closed_set;};
+        bool is_upward_closed() const { return type_ == ClosedSetType::upward_closed_set; };
+        bool is_downward_closed() const { return type_ == ClosedSetType::downward_closed_set; };
 
         ClosedSetType type() {return type_;}
         const ClosedSetType type() const {return type_;}
@@ -198,7 +198,7 @@ struct ClosedSet {
 template<typename T>
 std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs) {
     std::string strType = "TYPE: ";
-    strType += cs.type() == upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
+    strType += cs.type() == ClosedSetType::upward_closed_set ? "UPWARD CLOSED" : "DOWNWARD CLOSED";
     strType += "\n";
     std::string strInterval = "INTERVAL: " + std::to_string(cs.get_min()) + " - " + std::to_string(cs.get_max()) + "\n";
     std::string strValues = "ANTICHAIN: {";
@@ -221,14 +221,14 @@ std::ostream& operator<<(std::ostream& os, const ClosedSet<T> cs) {
 */
 template <typename T>
 bool ClosedSet<T>::contains(Node node) const {
-    if(type_ == upward_closed_set) {
+    if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element : antichain_) {
             if(element.IsSubsetOf(node)) {
                 return true;
             }
         }
     }
-    else if(type_ == downward_closed_set) {
+    else if(type_ == ClosedSetType::downward_closed_set) {
         for(auto element : antichain_) {
             if(node.IsSubsetOf(element)) {
                 return true;
@@ -300,7 +300,7 @@ void ClosedSet<T>::insert(Node node) {
     // antichain {{0, 1}, {2}}. If we add {0} to the closed set, the element {0, 1}
     // needs to be erased from the antichain since the set {{0}, {0, 1}, {2}} contains
     // <=-comparable elements and the result should be upward-closed.
-    if(type_ == upward_closed_set) {
+    if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element : antichain_) {
             if(node.IsSubsetOf(element)) {
                 to_erase.insert(element);
@@ -314,7 +314,7 @@ void ClosedSet<T>::insert(Node node) {
     // antichain {{0, 1}, {2}}. If we add {1, 2} to the closed set, the element {2}
     // needs to be erased from the antichain since the set {{0}, {1, 2}, {2}} contains
     // <=-comparable elements and the result should be downward-closed.
-    else if(type_ == downward_closed_set) {
+    else if(type_ == ClosedSetType::downward_closed_set) {
         for(auto element : antichain_) {
             if(element.IsSubsetOf(node)) {
                 to_erase.insert(element);
@@ -357,7 +357,7 @@ ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const {
 
     // Iterates through all the tuples from Antichan1 X Antichan2
     // and creates an union of them
-    if(type_ == upward_closed_set) {
+    if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element1 : antichain_) {
             for(auto element2 : rhs.antichain()) {
                result.insert(element1.Union(element2));
@@ -367,7 +367,7 @@ ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const {
 
     // Iterates through all the tuples from Antichan1 X Antichan2
     // and creates an intersection of them
-    if(type_ == downward_closed_set) {
+    if(type_ == ClosedSetType::downward_closed_set) {
         for(auto element1 : antichain_) {
             for(auto element2 : rhs.antichain()) {
                result.insert(element1.intersection(element2));
@@ -387,13 +387,13 @@ template <typename T>
 ClosedSet<T> ClosedSet<T>::complement() const {
     // The complement of an upward-closed set is
     // always downward-closed and vice versa.
-    ClosedSetType new_type = upward_closed_set;
-    if(type_ == upward_closed_set) {
-        new_type = downward_closed_set;
+    ClosedSetType new_type = ClosedSetType::upward_closed_set;
+    if(type_ == ClosedSetType::upward_closed_set) {
+        new_type = ClosedSetType::downward_closed_set;
     }
     ClosedSet<T> result = ClosedSet(new_type, get_min(), get_max(), antichain());
 
-    if(type_ == upward_closed_set) {
+    if(type_ == ClosedSetType::upward_closed_set) {
         // Initially, a complement contains all possible elements
         // which will be then (possibly) removed.
         Node initialValues{};
@@ -411,13 +411,13 @@ ClosedSet<T> ClosedSet<T>::complement() const {
         // The result will be an intersection of all downward-closed sets
         // created using this procedure.
         for(const auto& element : antichain()) {
-            ClosedSet preparingAntichain(downward_closed_set, get_min(), get_max());
-            for(int i = 0; i <= max_val_; ++i) {
+            ClosedSet preparingAntichain(ClosedSetType::downward_closed_set, get_min(), get_max());
+            for(int i = 0; i <= static_cast<int>(max_val_); ++i) {
                 if(!element.count(i)) {
                     continue;
                 }
                 Node candidates{};
-                for(int j = 0; j <= max_val_; ++j) {
+                for(int j = 0; j <= static_cast<int>(max_val_); ++j) {
                     if(i!=j) {
                         candidates.insert(j);
                     }
@@ -428,7 +428,7 @@ ClosedSet<T> ClosedSet<T>::complement() const {
         }
     }
 
-    else if(type_ == downward_closed_set) {
+    else if(type_ == ClosedSetType::downward_closed_set) {
         // Initially, a complement contains all possible elements
         // which will be then (possibly) removed.
         result.insert(Node());
@@ -441,7 +441,7 @@ ClosedSet<T> ClosedSet<T>::complement() const {
         // The result will be an intersection of all upward-closed sets
         // created using this procedure.
         for(Node element : antichain()) {
-            ClosedSet preparingAntichain(upward_closed_set, min_val_, max_val_);
+            ClosedSet preparingAntichain(ClosedSetType::upward_closed_set, min_val_, max_val_);
             for(T i = min_val_; i <= max_val_; ++i) {
                 Node candidates{i};
                 if(!element.count(i)) {

--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -415,12 +415,13 @@ ClosedSet<T> ClosedSet<T>::complement() const {
         // created using this procedure.
         for(const auto& element : antichain()) {
             ClosedSet preparingAntichain(ClosedSetType::downward_closed_set, get_min(), get_max());
-            for(int i = 0; i <= static_cast<int>(max_val_); ++i) {
+            const int max_val{ static_cast<int>(max_val_) };
+            for(int i = 0; i <= max_val; ++i) {
                 if(!element.count(i)) {
                     continue;
                 }
                 Node candidates{};
-                for(int j = 0; j <= static_cast<int>(max_val_); ++j) {
+                for(int j = 0; j <= max_val; ++j) {
                     if(i!=j) {
                         candidates.insert(j);
                     }

--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -112,14 +112,14 @@ struct ClosedSet {
        }
 
        // inserting a single vector of the datatype T
-       ClosedSet(ClosedSetType type, T min_val, T max_val, Node node)
+       ClosedSet(ClosedSetType type, const T& min_val, const T& max_val, const Node& node)
            : type_(type), min_val_(min_val), max_val_(max_val), antichain_(Node(node)) {
            assert(min_val <= max_val);
            assert(in_interval(node));
        }
 
        // inserting a whole antichain
-       ClosedSet(ClosedSetType type, T min_val, T max_val, Nodes antichain = Nodes())
+       ClosedSet(const ClosedSetType type, const T& min_val, const T& max_val, const Nodes& antichain = Nodes())
            : type_(type), min_val_(min_val), max_val_(max_val) {
            assert(min_val <= max_val);
            insert(antichain);
@@ -129,7 +129,7 @@ struct ClosedSet {
 
        // Two closed sets are equivalent iff their type, borders
        // and corresponding antichains are the same
-       bool operator==(ClosedSet<T> rhs) const
+       bool operator==(const ClosedSet<T>& rhs) const
         { // {{{
             return type_ == rhs.type && min_val_ == rhs.min_val &&
             max_val_ == rhs.max_val && antichain_ == rhs.antichain;
@@ -137,7 +137,7 @@ struct ClosedSet {
 
        // Two closed sets are not equivalent iff their type,
        // borders or corresponding antichains differ
-       bool operator!=(ClosedSet<T> rhs) const
+       bool operator!=(const ClosedSet<T>& rhs) const
         { // {{{
             return type_ != rhs.type_ || min_val_ != rhs.min_val_ ||
             max_val_ != rhs.max_val_ || antichain_ != rhs.antichain_;
@@ -147,7 +147,7 @@ struct ClosedSet {
         // it is a subset of the other one
         // It is not possible to perform <=-comparisons accros upward- and downward-closed
         // sets, each argument has to be upward- or downward-closed set
-        bool operator<=(ClosedSet<T> rhs) const
+        bool operator<=(const ClosedSet<T>& rhs) const
         { // {{{
             assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
             "Types and borders of given closed sets must be the same to perform their <=-comparison.");
@@ -159,7 +159,7 @@ struct ClosedSet {
         // It is not possible to perform <=-comparisons of accros upward-
         // and downward-closed sets, each argument
         // has to be upward- or downward-closed set
-        bool operator>=(ClosedSet<T> rhs) const
+        bool operator>=(const ClosedSet<T>& rhs) const
         { // {{{
             assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
             "Types and borders of given closed sets must be the same to perform their <=-comparison.");
@@ -172,29 +172,29 @@ struct ClosedSet {
         bool is_upward_closed() const { return type_ == ClosedSetType::upward_closed_set; };
         bool is_downward_closed() const { return type_ == ClosedSetType::downward_closed_set; };
 
-        ClosedSetType type() {return type_;}
-        const ClosedSetType type() const {return type_;}
+        ClosedSetType type() { return type_; }
+        ClosedSetType type() const { return type_; }
 
-        Nodes antichain() {return antichain_;}
-        const Nodes antichain() const {return antichain_;}
+        Nodes antichain() { return antichain_;}
+        Nodes antichain() const { return antichain_; }
 
-        T get_min() {return min_val_;}
-        const T get_min() const {return min_val_;}
+        T get_min() { return min_val_; }
+        T get_min() const { return min_val_; }
 
-        T get_max() {return max_val_;}
-        const T get_max() const {return max_val_;}
+        T get_max() { return max_val_; }
+        T get_max() const { return max_val_; }
 
-        bool contains (Node node) const;
-        bool contains (Nodes nodes) const;
+        bool contains (const Node& node) const;
+        bool contains (const Nodes& nodes) const;
 
-        bool in_interval (Node node) const;
+        bool in_interval (const Node& node) const;
 
-        void insert(T el) {insert(Node(el));};
-        void insert(Node node);
-        void insert(Nodes nodes) {for(auto node : nodes) insert(node);};
+        void insert(const T& el) { insert(Node(el)); }
+        void insert(const Node& node);
+        void insert(const Nodes& nodes) {for (const auto& node: nodes) insert(node); }
 
-        ClosedSet Union (const ClosedSet rhs) const;
-        ClosedSet intersection (const ClosedSet rhs) const;
+        ClosedSet Union (const ClosedSet& rhs) const;
+        ClosedSet intersection (const ClosedSet& rhs) const;
         ClosedSet complement () const;
 }; // class ClosedSet.
 
@@ -223,7 +223,7 @@ std::ostream& operator<<(std::ostream& os, const ClosedSet<T>& cs) {
 * @return true iff the given ordered vector belongs to the current closed set
 */
 template <typename T>
-bool ClosedSet<T>::contains(Node node) const {
+bool ClosedSet<T>::contains(const Node& node) const {
     if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element : antichain_) {
             if(element.IsSubsetOf(node)) {
@@ -248,7 +248,7 @@ bool ClosedSet<T>::contains(Node node) const {
 * @return true iff the given ordered vector of ordered vectors belongs to the current closed set
 */
 template <typename T>
-bool ClosedSet<T>::contains(Nodes nodes) const {
+bool ClosedSet<T>::contains(const Nodes& nodes) const {
     for(auto node : nodes) {
         if(!contains(node)) {
             return false;
@@ -264,7 +264,7 @@ bool ClosedSet<T>::contains(Nodes nodes) const {
 * @return true iff the given ordered vector respects the borders
 */
 template <typename T>
-bool ClosedSet<T>::in_interval(Node node) const {
+bool ClosedSet<T>::in_interval(const Node& node) const {
     for(auto value : node) {
         if(value < min_val_ || value > max_val_) {
             return false;
@@ -279,7 +279,7 @@ bool ClosedSet<T>::in_interval(Node node) const {
 * @param node a given node which will be added to the closed set
 */
 template <typename T>
-void ClosedSet<T>::insert(Node node) {
+void ClosedSet<T>::insert(const Node& node) {
     assert(in_interval(node) && "Each element of the given node has to respect " &&
     "the carrier of the closed set.");
     // If the closed set is empty, the antichain could be simply changed
@@ -339,7 +339,7 @@ void ClosedSet<T>::insert(Node node) {
 * @return an union of the given closed sets
 */
 template <typename T>
-ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const {
+ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T>& rhs) const {
     assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
     "Types and borders of given closed sets must be the same to compute their union.");
     ClosedSet<T> result(type_, min_val_, max_val_, antichain_);
@@ -353,7 +353,7 @@ ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T> rhs) const {
 * @return an intersection of the given closed sets
 */
 template <typename T>
-ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T> rhs) const {
+ClosedSet<T> ClosedSet<T>::intersection(const ClosedSet<T>& rhs) const {
     assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
     "Types and borders of given closed sets must be the same to compute their union.");
     ClosedSet<T> result(type_, min_val_, max_val_);

--- a/include/mata/closed-set.hh
+++ b/include/mata/closed-set.hh
@@ -415,14 +415,13 @@ ClosedSet<T> ClosedSet<T>::complement() const {
         // created using this procedure.
         for(const auto& element : antichain()) {
             ClosedSet preparingAntichain(ClosedSetType::downward_closed_set, get_min(), get_max());
-            const int max_val{ static_cast<int>(max_val_) };
-            for(int i = 0; i <= max_val; ++i) {
+            for(T i = 0; i <= max_val_; ++i) {
                 if(!element.count(i)) {
                     continue;
                 }
                 Node candidates{};
-                for(int j = 0; j <= max_val; ++j) {
-                    if(i!=j) {
+                for(T j = 0; j <= max_val_; ++j) {
+                    if(i != j) {
                         candidates.insert(j);
                     }
                 }

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -107,6 +107,9 @@ public:
 
     FormulaNode(const FormulaNode& n)
         : type(n.type), raw(n.raw), name(n.name), operator_type(n.operator_type), operand_type(n.operand_type) {}
+
+    FormulaNode& operator=(const FormulaNode& other) = default;
+    FormulaNode& operator=(FormulaNode&& other) = default;
 };
 
 /**
@@ -120,9 +123,12 @@ struct FormulaGraph {
     FormulaNode node;
     std::vector<FormulaGraph> children;
 
-    FormulaGraph() : node(), children() {}
+    FormulaGraph() = default;
     FormulaGraph(const FormulaNode& n) : node(n), children() {}
     FormulaGraph(const FormulaGraph& g) : node(g.node), children(g.children) {}
+
+    FormulaGraph& operator=(const Mata::FormulaGraph& other) = default;
+    FormulaGraph& operator=(Mata::FormulaGraph&& other) noexcept = default;
 
     std::unordered_set<std::string> collect_node_names() const;
     void print_tree(std::ostream& os) const;
@@ -135,6 +141,7 @@ struct FormulaGraph {
  * states. The formulas are represented as tree where nodes are either operands or operators.
  */
 struct IntermediateAut {
+public:
     /**
      * Type of automaton. So far we support nondeterministic finite automata (NFA) and
      * alternating finite automata (AFA)
@@ -172,7 +179,6 @@ struct IntermediateAut {
         INTERVALS
     };
 
-public:
     Naming state_naming = Naming::MARKED;
     Naming symbol_naming = Naming::MARKED;
     Naming node_naming = Naming::MARKED;

--- a/include/mata/inter-aut.hh
+++ b/include/mata/inter-aut.hh
@@ -120,8 +120,8 @@ public:
  * and q1 and s2 being children nodes of the root.
  */
 struct FormulaGraph {
-    FormulaNode node;
-    std::vector<FormulaGraph> children;
+    FormulaNode node{};
+    std::vector<FormulaGraph> children{};
 
     FormulaGraph() = default;
     FormulaGraph(const FormulaNode& n) : node(n), children() {}
@@ -182,16 +182,16 @@ public:
     Naming state_naming = Naming::MARKED;
     Naming symbol_naming = Naming::MARKED;
     Naming node_naming = Naming::MARKED;
-    AlphabetType alphabet_type;
-    AutomatonType automaton_type;
+    AlphabetType alphabet_type{};
+    AutomatonType automaton_type{};
 
     // The vectors represent the given sets when enumeration is used.
-    std::vector<std::string> states_names;
-    std::vector<std::string> symbols_names;
-    std::vector<std::string> nodes_names;
+    std::vector<std::string> states_names{};
+    std::vector<std::string> symbols_names{};
+    std::vector<std::string> nodes_names{};
 
-    FormulaGraph initial_formula;
-    FormulaGraph final_formula;
+    FormulaGraph initial_formula{};
+    FormulaGraph final_formula{};
 
     bool initial_enumerated = false;
     bool final_enumerated = false;
@@ -200,7 +200,7 @@ public:
      * Transitions are pairs where the first member is left-hand side of transition (i.e., a state)
      * and the second item is a graph representing transition formula (which can contain symbols, nodes, and states).
      */
-    struct std::vector<std::pair<FormulaNode, FormulaGraph>> transitions;
+    struct std::vector<std::pair<FormulaNode, FormulaGraph>> transitions{};
 
     /**
      * Returns symbolic part of transition. That may be just a symbol or bitvector formula.

--- a/include/mata/mintermization.hh
+++ b/include/mata/mintermization.hh
@@ -29,7 +29,7 @@ private: // data types
         enum class TYPE {NOTHING_E, BDD_E};
 
         TYPE type;
-        BDD val;
+        BDD val{};
 
         explicit OptionalBdd(TYPE t) : type(t) {}
         explicit OptionalBdd(const BDD& bdd) : type(TYPE::BDD_E), val(bdd) {}
@@ -43,11 +43,11 @@ private: // data types
     using DisjunctStatesPair = std::pair<const FormulaGraph *, const FormulaGraph *>;
 
 private: // private data members
-    Cudd bdd_mng; // Manager of BDDs from lib cubdd, it allocates and manages BDDs.
-    std::unordered_map<std::string, BDD> symbol_to_bddvar;
-    std::unordered_map<const FormulaGraph *, BDD> trans_to_bddvar;
-    std::unordered_map<const FormulaNode*, std::vector<DisjunctStatesPair>> lhs_to_disjuncts_and_states;
-    std::unordered_set<BDD> bdds; // bdds created from transitions
+    Cudd bdd_mng{}; // Manager of BDDs from lib cubdd, it allocates and manages BDDs.
+    std::unordered_map<std::string, BDD> symbol_to_bddvar{};
+    std::unordered_map<const FormulaGraph *, BDD> trans_to_bddvar{};
+    std::unordered_map<const FormulaNode*, std::vector<DisjunctStatesPair>> lhs_to_disjuncts_and_states{};
+    std::unordered_set<BDD> bdds{}; // bdds created from transitions
 
 private:
     void trans_to_bdd_nfa(const IntermediateAut& aut);

--- a/include/mata/mintermization.hh
+++ b/include/mata/mintermization.hh
@@ -28,9 +28,10 @@ private: // data types
     struct OptionalBdd {
         enum class TYPE {NOTHING_E, BDD_E};
 
-        TYPE type;
+        TYPE type{};
         BDD val{};
 
+        OptionalBdd() = default;
         explicit OptionalBdd(TYPE t) : type(t) {}
         explicit OptionalBdd(const BDD& bdd) : type(TYPE::BDD_E), val(bdd) {}
         OptionalBdd(TYPE t, const BDD& bdd) : type(t), val(bdd) {}
@@ -57,17 +58,17 @@ public:
     /**
      * Takes a set of BDDs and build a minterm tree over it.
      * The leaves of BDDs, which are minterms of input set, are returned
-     * @param bdds BDDs for which minterms are computed
+     * @param source_bdds BDDs for which minterms are computed
      * @return Computed minterms
      */
-    std::unordered_set<BDD> compute_minterms(const std::unordered_set<BDD>& bdds);
+    std::unordered_set<BDD> compute_minterms(const std::unordered_set<BDD>& source_bdds);
 
     /**
      * Transforms a graph representing formula at transition to bdd.
      * @param graph Graph to be transformed
      * @return Resulting BDD
      */
-    const BDD graph_to_bdd_nfa(const FormulaGraph& graph);
+    BDD graph_to_bdd_nfa(const FormulaGraph& graph);
 
     /**
      * Transforms a graph representing formula at transition to bdd.
@@ -76,7 +77,7 @@ public:
      * @param graph Graph to be transformed
      * @return Resulting BDD
      */
-    const OptionalBdd graph_to_bdd_afa(const FormulaGraph& graph);
+    OptionalBdd graph_to_bdd_afa(const FormulaGraph& graph);
 
     /**
      * Method mintermizes given automaton which has bitvector alphabet.

--- a/include/mata/nfa-strings.hh
+++ b/include/mata/nfa-strings.hh
@@ -165,7 +165,7 @@ using EpsCntVector = std::vector<unsigned>;
 */
 class Segmentation {
 public:
-    using EpsilonDepth = unsigned; ///< Depth of ε-transitions.
+    using EpsilonDepth = size_t; ///< Depth of ε-transitions.
     /// Dictionary of lists of ε-transitions grouped by their depth.
     /// For each depth 'i' we have 'depths[i]' which contains a list of ε-transitions of depth 'i'.
     using EpsilonDepthTransitions = std::unordered_map<EpsilonDepth, TransSequence>;

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -59,8 +59,8 @@ template<typename T> using Set = Mata::Util::OrdVector<T>;
 
 using WordSet = std::set<std::vector<Symbol>>;
 struct Run {
-    std::vector<Symbol> word; ///< A finite-length word.
-    std::vector<State> path; ///< A finite-length path through automaton.
+    std::vector<Symbol> word{}; ///< A finite-length word.
+    std::vector<State> path{}; ///< A finite-length path through automaton.
 };
 
 using StringToStateMap = std::unordered_map<std::string, State>;

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -82,10 +82,11 @@ using StringMap = std::unordered_map<std::string, std::string>;
  * maybe something else is needed for the more complex maps*/
 
 struct Limits {
-    static const State maxState = std::numeric_limits<State>::max();
-    static const State minState = std::numeric_limits<State>::min();
-    static const Symbol maxSymbol = std::numeric_limits<Symbol>::max();
-    static const Symbol minSymbol = std::numeric_limits<Symbol>::min();
+public:
+    static const State min_state = std::numeric_limits<State>::min();
+    static const State max_state = std::numeric_limits<State>::max();
+    static const Symbol min_symbol = std::numeric_limits<Symbol>::min();
+    static const Symbol max_symbol = std::numeric_limits<Symbol>::max();
 };
 
 /*TODO: Ideally remove functions using this struct as a parameter.
@@ -337,7 +338,7 @@ private:
 bool operator==(const Delta::const_iterator& a, const Delta::const_iterator& b);
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
-constexpr Symbol EPSILON = Limits::maxSymbol;
+constexpr Symbol EPSILON = Limits::max_symbol;
 
 /**
  * A struct representing an NFA.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -174,7 +174,7 @@ public:
     size_t size() const { return targets.size(); }
 
     void insert(State s);
-    void insert(StateSet states);
+    void insert(const StateSet& states);
 
     // THIS BREAKS THE SORTEDNESS INVARIANT,
     // dangerous,

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -299,7 +299,7 @@ public:
         bool is_end;
 
     public:
-        using iterator_category = std::forward_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
         using value_type = int;
         using difference_type = int;
         using pointer = int*;
@@ -522,8 +522,12 @@ public:
      */
     void remove_epsilon(Symbol epsilon = EPSILON);
 
-    /// Number of transitions; contains linear time complexity.
-    size_t get_num_of_trans() const { return std::distance(delta.begin(), delta.end()); }
+    /**
+     * @brief Get a number of transitions in the whole automaton.
+     *
+     * The operation has constant time complexity.
+     */
+    size_t get_num_of_trans() const { return static_cast<size_t>(std::distance(delta.begin(), delta.end())); }
 
     /**
      * Get transitions as a sequence of @c Trans.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -182,7 +182,7 @@ public:
 
     void remove(State s) { targets.remove(s); }
 
-    const std::vector<State>::iterator find(State s) const { targets.find(s); }
+    std::vector<State>::const_iterator find(State s) const { return targets.find(s); }
     std::vector<State>::iterator find(State s) { return targets.find(s); }
 };
 

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -293,11 +293,17 @@ public:
     private:
         const std::vector<Post>& post;
         size_t current_state;
-        Post::const_iterator post_iterator;
-        StateSet::const_iterator targets_position;
+        Post::const_iterator post_iterator{};
+        StateSet::const_iterator targets_position{};
         bool is_end;
 
     public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = int;
+        using difference_type = int;
+        using pointer = int*;
+        using reference = int&;
+
         explicit const_iterator(const std::vector<Post>& post_p, bool ise = false);
 
         const_iterator(const std::vector<Post>& post_p, size_t as,
@@ -327,6 +333,8 @@ public:
 private:
     State find_max_state();
 }; // struct Delta.
+
+bool operator==(const Delta::const_iterator& a, const Delta::const_iterator& b);
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = Limits::maxSymbol;
@@ -480,7 +488,7 @@ public:
     StateSet get_useful_states_old() const;
 
     //I just want to return something as constant reference to the thing, without copying anything, how?
-    const Util::NumberPredicate<State> get_useful_states() const;
+    Util::NumberPredicate<State> get_useful_states() const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
@@ -513,7 +521,8 @@ public:
      */
     void remove_epsilon(Symbol epsilon = EPSILON);
 
-    size_t get_num_of_trans() const; ///< Number of transitions; contains linear time complexity.
+    /// Number of transitions; contains linear time complexity.
+    size_t get_num_of_trans() const { return std::distance(delta.begin(), delta.end()); }
 
     /**
      * Get transitions as a sequence of @c Trans.

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -199,7 +199,6 @@ public:
     using super::begin, super::end, super::cbegin, super::cend;
     using super::OrdVector;
     using super::operator=;
-    using super::find;
     using super::insert;
     using super::reserve;
     using super::remove;
@@ -211,6 +210,10 @@ public:
     // is adding non-const version as well ok?
     using super::back;
     using super::filter;
+
+    using super::find;
+    iterator find(const Symbol symbol) { return super::find({ symbol, {} }); }
+    const_iterator find(const Symbol symbol) const { return super::find({ symbol, {} }); }
 }; // struct Post.
 
 /**
@@ -245,12 +248,11 @@ public:
     // Namely, it allocates the post of the state if it was not allocated yet. This in turn may cause that
     // the entire post data structure is re-allocated, iterators to it get invalidated ...
     // Use the constant [] operator below if possible.
-    // Or, to prevent the side effect form happening, one might want to make sure that posts of all states in the automaton
+    // Or, to prevent the side effect from happening, one might want to make sure that posts of all states in the automaton
     // are allocated, e.g., write an NFA method that allocate delta for all states of the NFA.
     // But it feels fragile, before doing something like that, better think and talk to people.
     Post& get_mutable_post(State q);
 
-    // TODO: why do we have the code of all these methods in the header file? Should we move it out?
     // TODO: Explain what is returned from this method.
     std::vector<State> defragment(Util::NumberPredicate<State> & is_staying);
 
@@ -356,7 +358,7 @@ public:
     explicit Nfa(Delta delta = {}, Util::NumberPredicate<State> initial_states = {},
                  Util::NumberPredicate<State> final_states = {}, Alphabet* alphabet = nullptr)
         : delta(std::move(delta)), initial(std::move(initial_states)), final(std::move(final_states)), alphabet(alphabet) {}
-        
+
     /**
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
      *

--- a/include/mata/number-predicate.hh
+++ b/include/mata/number-predicate.hh
@@ -89,8 +89,8 @@ private:
     }
 
 public:
-    NumberPredicate(Number size,bool val,bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), predicate(size, val) {
+    NumberPredicate(Number size, bool val, bool track_elements = true)
+        : predicate(size, val), elements_are_exact(true), tracking_elements(track_elements) {
         if (tracking_elements && val) {
             elements.reserve(size);
             for (Number e = 0;e<size;++e)
@@ -100,35 +100,29 @@ public:
             cardinality = 0;
         else
             cardinality = size;
-    };
-
-    NumberPredicate(bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), cardinality(0) {};
-
-    NumberPredicate(std::initializer_list <Number> list, bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), cardinality(0) {
-        for (auto q: list)
-            add(q);
     }
 
-    NumberPredicate(std::vector <Number> list, bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), cardinality(0) {
-        add(list);
+    NumberPredicate() = default;
+    explicit NumberPredicate(const bool track_elements) : tracking_elements(track_elements) {}
+    NumberPredicate(std::initializer_list<Number> list, bool track_elements = true)
+        : tracking_elements(track_elements) {
+        for (const auto& q: list) { add(q); }
     }
 
-    NumberPredicate(const std::vector<bool> & bv, bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), cardinality(0) {
+    explicit NumberPredicate(const std::vector<Number>& list, const bool track_elements = true)
+        : tracking_elements(track_elements) { add(list); }
+
+    explicit NumberPredicate(const std::vector<bool>& bv, bool track_elements = true)
+        : tracking_elements(track_elements) {
         predicate.reserve(bv.size());
         for (size_t i = 0;i<bv.size();i++) {
-            if (bv[i])
-                add(i);
+            if (bv[i]) { add(i); }
         }
     }
 
-    explicit NumberPredicate(Mata::Util::OrdVector<Number> vec, bool track_elements = true)
-        : elements_are_exact(true), tracking_elements(track_elements), cardinality(0) {
-        for (auto q: vec)
-            add(q);
+    explicit NumberPredicate(const Mata::Util::OrdVector<Number>& vec, bool track_elements = true)
+        : tracking_elements(track_elements) {
+        for (const auto& q: vec) { add(q); }
     }
 
     NumberPredicate(const NumberPredicate<Number>& rhs) = default;

--- a/include/mata/parser.hh
+++ b/include/mata/parser.hh
@@ -47,9 +47,6 @@ struct ParsedSection {
 	/// Is the section empty?
 	bool empty() const { return type.empty() && dict.empty() && body.empty(); }
 
-	/// Output stream operator
-	friend std::ostream& operator<<(std::ostream& os, const ParsedSection& parsec);
-
 	/// Equality operator
 	bool operator==(const ParsedSection& rhs) const;
 	bool operator!=(const ParsedSection& rhs) const { return !(*this == rhs); }
@@ -80,5 +77,10 @@ ParsedSection parse_mf_section(const std::string& input, bool keepQuotes = false
 void init();
 
 } // namespace Mata::Parser.
+
+namespace std {
+    /// Output stream operator
+    std::ostream& operator<<(std::ostream& os, const Mata::Parser::ParsedSection& parsec);
+}
 
 #endif /* MATA_PARSER_HH_ */

--- a/include/mata/re2parser.hh
+++ b/include/mata/re2parser.hh
@@ -26,8 +26,8 @@
  * Currently supported automata types are NFA and AFA.
  */
 namespace Mata::Parser {
-    void create_nfa(Nfa::Nfa* nfa, const std::string &pattern, bool use_epsilon = false, int epsilon_value = 306,
-                    bool use_reduction = true);
+    void create_nfa(Nfa::Nfa* nfa, const std::string &pattern, bool use_epsilon = false, Mata::Symbol epsilon_value = 306,
+                    bool use_reduce = true);
 }
 
 #endif // MATA_RE2PARSER_HH

--- a/include/mata/synchronized-iterator.hh
+++ b/include/mata/synchronized-iterator.hh
@@ -54,8 +54,8 @@ namespace Mata::Util {
 template<typename Iterator> class SynchronizedIterator {
 public:
 
-    std::vector<Iterator> positions;
-    std::vector<Iterator> ends;
+    std::vector<Iterator> positions{};
+    std::vector<Iterator> ends{};
 
     /// @param size Number of elements to reserve up-front for positions and ends.
     explicit SynchronizedIterator(const int size = 0) {
@@ -68,7 +68,7 @@ public:
      * Calling after advance breaks the iterator.
      * Specifies begin and end of one vector, to initialise before the iteration starts.
      */
-    virtual void push_back (const Iterator &begin, const Iterator &end) {
+    virtual void push_back(const Iterator& begin, const Iterator& end) {
         // Btw, I don't know what I am doing with the const & parameter passing,
         // begin is actually incremented in advance ...? But tests do pass ...
         this->positions.emplace_back(begin);
@@ -90,8 +90,10 @@ public:
     };
 
     virtual bool advance() = 0;
-    virtual const std::vector<Iterator> get_current() = 0;
-};
+    virtual std::vector<Iterator> get_current() = 0;
+
+    virtual ~SynchronizedIterator() = default;
+}; // class SynchronizedIterator.
 
 
 
@@ -160,7 +162,7 @@ public:
     }
 
     /// Returns the vector of current positions.
-    const std::vector<Iterator> get_current() {
+    std::vector<Iterator> get_current() {
         // How to return so that things don't get copied?
         // Or maybe we should return a copy of positions anyway, to prevent a side effect of advance?
         // Instead of returning a vector, we could also provide iterators through the result.
@@ -173,15 +175,13 @@ public:
         SynchronizedIterator < Iterator > ::reset(size);
         this->synchronized_at_current_minimum = false;
     };
-};
+}; // class SynchronizedUniversalIterator.
 
 template<typename Iterator>
 class SynchronizedExistentialIterator : public SynchronizedIterator<Iterator> {
 public:
-
-    std::vector<Iterator> currently_synchronized; // Positions that are currently synchronized.
-
-    Iterator next_minimum; // the value we should synchronise on after the first next call of advance().
+    std::vector<Iterator> currently_synchronized{}; // Positions that are currently synchronized.
+    Iterator next_minimum{}; // The value we should synchronise on after the first next call of advance().
 
     bool is_synchronized() { return !currently_synchronized.empty(); }
 
@@ -250,7 +250,7 @@ public:
      * Beware, thy will be ordered differently from how there were input into the iterator.
      * This is due to swapping of the emptied positions with positions at the end.
      */
-    const std::vector<Iterator> get_current() { return this->currently_synchronized; };
+    std::vector<Iterator> get_current() { return this->currently_synchronized; };
 
     void push_back (const Iterator &begin, const Iterator &end) {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,32 +6,6 @@ project(libmata)
 # Export compile commands to be used with YouCompleteMe
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Flags
-set(cxx_compiler_flags
-  -Wextra
-  -Wall
-  -Wfloat-equal
-  -fms-extensions
-  -fdiagnostics-show-option
-  -Wctor-dtor-privacy
-  -Weffc++
-  -fPIC
-  -fno-strict-aliasing
-  -Woverloaded-virtual
-  -Wold-style-cast
-)
-
-foreach(flag ${cxx_compiler_flags})
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-endforeach()
-
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	# using regular Clang or AppleClang
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wgnu-anonymous-struct")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnested-anon-types")
-endif()
-
 # if DEBUG, also test coverage
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
@@ -75,12 +49,24 @@ set_target_properties(libmata PROPERTIES
   CLEAN_DIRECT_OUTPUT 1
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 	target_link_libraries(libmata pthread)
 endif()
 
 add_dependencies(libmata cudd re2 simlib)
 target_link_libraries(libmata simlib cudd)
+
+# Add common compile warnings.
+target_compile_options(libmata PRIVATE "$<$<CONFIG:DEBUG>:${COMMON_WARNINGS}>")
+target_compile_options(libmata PRIVATE "$<$<CONFIG:RELEASE>:${COMMON_WARNINGS}>")
+
+# Optionally, also add Clang-specific warnings.
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang") # Using regular Clang or AppleClang.
+	target_compile_options(libmata PRIVATE "$<$<CONFIG:DEBUG>:${CLANG_WARNINGS}>")
+	target_compile_options(libmata PRIVATE "$<$<CONFIG:RELEASE>:${CLANG_WARNINGS}>")
+endif()
+
+target_compile_options(libmata PRIVATE "${COMMON_COMPILER_FLAGS}")
 
 add_custom_command(TARGET libmata POST_BUILD
 		COMMAND ${CMAKE_SOURCE_DIR}/merge_static_libraries.sh libcombined.a ${CMAKE_BINARY_DIR}/src/libmata.a

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -570,6 +570,7 @@ bool Mata::Afa::are_state_disjoint(const Afa& lhs, const Afa& rhs)
 
   // TODO
   assert(false);
+  return {};
 } // are_disjoint }}}
 
 
@@ -578,13 +579,13 @@ void Mata::Afa::union_norename(
 	const Afa&  lhs,
 	const Afa&  rhs)
 { // {{{
-	assert(nullptr != result);
+    assert(nullptr != result);
 
-  assert(&lhs);
-  assert(&rhs);
+    assert(&lhs);
+    assert(&rhs);
 
-  // TODO
-  assert(false);
+    // TODO
+    assert(false);
 } // union_norename }}}
 
 
@@ -597,6 +598,7 @@ Afa Mata::Afa::union_rename(
 
   // TODO
   assert(false);
+  return {};
 } // union_rename }}}
 
 
@@ -607,6 +609,7 @@ bool Mata::Afa::is_lang_empty(const Afa& aut, Path* cex)
 
   // TODO
   assert(false);
+  return {};
 } // is_lang_empty }}}
 
 
@@ -619,6 +622,7 @@ bool Mata::Afa::is_lang_empty_cex(const Afa& aut, Word* cex)
 
   // TODO
   assert(false);
+  return {};
 } // is_lang_empty_cex }}}
 
 /** This function decides whether the given automaton is empty using
@@ -1156,6 +1160,7 @@ bool Mata::Afa::is_complete(const Afa& aut, const Alphabet& alphabet)
 
   // TODO
   assert(false);
+  return {};
 } // is_complete }}}
 
 bool Mata::Afa::accepts_epsilon(const Afa& aut) {

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -58,7 +58,7 @@ void Afa::add_trans(const Trans& trans)
 			// Before the dst nodes are added to the transition, we want to get rid
 			// of redundant clauses. For example, in context of the formula
 			// (1 || (1 && 2)), the clause (1 && 2) could be deleted
-			auto cl = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1, transVec.dst);
+			auto cl = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, transVec.dst);
 			cl.insert(trans.dst);
 			transVec.dst = cl.antichain();	
 			return;
@@ -227,7 +227,7 @@ State Afa::add_new_state() {
 */
 StateClosedSet Afa::post(State state, Symbol symb) const
 {
-	return StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1, 
+	return StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1,
 	get_trans_from_state(state, symb).dst);
 } // post }}}
 
@@ -244,7 +244,7 @@ StateClosedSet Afa::post(State state, Symbol symb) const
 StateClosedSet Afa::post(Node node, Symbol symb) const
 {
 	// initially, the result is empty
-	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
 	if(node.empty())
 	{
 		result.insert(node);
@@ -280,8 +280,8 @@ StateClosedSet Afa::post(Node node, Symbol symb) const
 StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 {
 	// initially, the result is empty
-	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1);
-	for(auto node : nodes)
+	StateClosedSet result = StateClosedSet{ ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1 };
+	for(const auto& node : nodes)
 	{
 		result.insert(post(node, symb).antichain());
 	}
@@ -299,7 +299,7 @@ StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 */
 StateClosedSet Afa::post(StateClosedSet closed_set, Symbol symb) const
 {
-	assert(closed_set.type() == Mata::upward_closed_set && "The predicate transformer " &&
+	assert(closed_set.type() == Mata::ClosedSetType::upward_closed_set && "The predicate transformer " &&
 	" post can be computed only over upward-closed sets.");
 	return post(closed_set.antichain(), symb);
 } // post }}}
@@ -318,9 +318,9 @@ StateClosedSet Afa::post(Node node) const
 {
 	if(node.empty())
 	{
-		return StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1, Nodes{Node{}});
+		return StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, Nodes{Node{}});
 	}
-	StateClosedSet result = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
 
 	// It is sufficient to access the first element of the node
 	// to collect all required symbols of the alphabet. If there is another symbol used
@@ -345,7 +345,7 @@ StateClosedSet Afa::post(Node node) const
 */
 StateClosedSet Afa::post(Nodes nodes) const
 {
-	StateClosedSet result(upward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
 	for(auto node : nodes)
 	{
 		result.insert(post(node).antichain());
@@ -366,7 +366,7 @@ StateClosedSet Afa::post(Nodes nodes) const
 */
 StateClosedSet Afa::post(StateClosedSet closed_set) const 
 {
-	assert(closed_set.type() == Mata::upward_closed_set && "The predicate transformer " &&
+	assert(closed_set.type() == Mata::ClosedSetType::upward_closed_set && "The predicate transformer " &&
 	" post can be computed only over upward-closed sets.");
 	return post(closed_set.antichain());
 };
@@ -443,7 +443,7 @@ StateClosedSet Afa::pre(Node node, Symbol symb) const
 			}
 		}
 	}
-	return StateClosedSet(downward_closed_set, 0, transitionrelation.size()-1, result);
+	return StateClosedSet(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1, result);
 } // pre }}}
 
 /** This function takes a set of nodes and a symbol and returns all the nodes
@@ -456,7 +456,7 @@ StateClosedSet Afa::pre(Node node, Symbol symb) const
 */
 StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
 {
-	StateClosedSet result(downward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1);
 	for(auto node : nodes)
 	{
 		result = result.Union(pre(node, symb));
@@ -472,7 +472,7 @@ StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
 */
 StateClosedSet Afa::pre(StateClosedSet closed_set, Symbol symb) const
 {
-	assert(closed_set.type() == downward_closed_set && "The predicate transformer " &&
+	assert(closed_set.type() == ClosedSetType::downward_closed_set && "The predicate transformer " &&
 	"pre can be computed only over downward-closed sets.");
 	return pre(closed_set.antichain(), symb);
 } // pre }}}
@@ -487,9 +487,9 @@ StateClosedSet Afa::pre(Node node) const
 {
 	if(node.empty())
 	{
-		return StateClosedSet(downward_closed_set, 0, transitionrelation.size()-1, Nodes{Node{}});
+		return StateClosedSet(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1, Nodes{Node{}});
 	}
-	StateClosedSet result(downward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1);
 
 	// It is sufficient to access the first element of the node
 	// to collect all required symbols of the alphabet. If there is another symbol used
@@ -511,7 +511,7 @@ StateClosedSet Afa::pre(Node node) const
 */
 StateClosedSet Afa::pre(Nodes nodes) const
 {
-	StateClosedSet result(downward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1);
 	for(auto node : nodes)
 	{
 		result.insert(pre(node).antichain());
@@ -544,7 +544,7 @@ size_t Afa::trans_size() const
 } // trans_size() }}}
 
 StateClosedSet Afa::get_non_final_nodes() const {
-	StateClosedSet result(upward_closed_set, 0, transitionrelation.size()-1);
+	StateClosedSet result(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
 	auto transSize = transitionrelation.size();
 	for(State state = 0; state < transSize; ++state)
 	{
@@ -557,7 +557,7 @@ StateClosedSet Afa::get_non_final_nodes() const {
 }
 
 StateClosedSet Afa::get_initial_nodes() const {
-    StateClosedSet result = StateClosedSet(upward_closed_set, 0, transitionrelation.size()-1);
+    StateClosedSet result = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
     for(const auto& node : initialstates)
     {
         result.insert(node);
@@ -644,7 +644,7 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_old(const Afa& aut)
     // We will perform each operation directly over antichains.
     // Note that the fixed point always exists so the while loop always terminates.
     StateClosedSet goal = aut.get_non_final_nodes();
-    StateClosedSet current = StateClosedSet(upward_closed_set, 0, aut.get_num_of_states()-1);
+    StateClosedSet current = StateClosedSet(ClosedSetType::upward_closed_set, 0, aut.get_num_of_states()-1);
     StateClosedSet next = aut.get_initial_nodes();
 
     while(current != next)
@@ -717,7 +717,7 @@ bool Mata::Afa::antichain_concrete_backward_emptiness_test_old(const Afa& aut)
 	// We will perform each operation directly over antichains
 	// Note that the fixed point always exists so the while loop always terminates
 	StateClosedSet goal = aut.get_non_initial_nodes();
-	StateClosedSet current = StateClosedSet(downward_closed_set, 0, aut.get_num_of_states()-1);
+	StateClosedSet current = StateClosedSet(ClosedSetType::downward_closed_set, 0, aut.get_num_of_states()-1);
 	StateClosedSet next = aut.get_final_nodes();
 
 	while(current != next)
@@ -955,14 +955,11 @@ Afa Mata::Afa::construct(
 
 	for (const auto& body_line : parsec.body) {
 		if (body_line.size() < 2) {
-			// clean up
-      clean_up();
+            clean_up();
 
-      throw std::runtime_error("Invalid transition: " +
-        std::to_string(body_line));
+            throw std::runtime_error("Invalid transition: " + std::to_string(body_line));
 		}
 
-		State src_state = get_state_name(body_line[0]);
     std::string formula;
     for (size_t i = 1; i < body_line.size(); ++i) {
       formula += body_line[i] + " ";

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -31,10 +31,9 @@ using namespace Mata::Afa;
 
 const std::string Mata::Afa::TYPE_AFA = "AFA";
 
-std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::Trans& trans)
-{ // {{{
-	std::string result = "(" + std::to_string(trans.src) + ", " 
-                       + std::to_string(trans.symb) + ", " 
+std::ostream& std::operator<<(std::ostream& os, const Mata::Afa::Trans& trans) {
+	std::string result = "(" + std::to_string(trans.src) + ", "
+                       + std::to_string(trans.symb) + ", "
                        + std::to_string(trans.dst) + ")";
 	return os << result;
 } // operator<<(ostream, Trans) }}}
@@ -60,10 +59,10 @@ void Afa::add_trans(const Trans& trans)
 			// (1 || (1 && 2)), the clause (1 && 2) could be deleted
 			auto cl = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, transVec.dst);
 			cl.insert(trans.dst);
-			transVec.dst = cl.antichain();	
+			transVec.dst = cl.antichain();
 			return;
 		}
-	}    
+	}
 
 	// If there is no result, a new transition will be created
 	transitionrelation[trans.src].push_back(trans);
@@ -81,7 +80,7 @@ std::vector<Trans> Afa::get_trans_from_state(State state) const
 	assert(state < transitionrelation.size() &&
 	"It is not possible to perform transitions from an non-existing state.");
 	std::vector<Trans> result = std::vector<Trans>();
-	for(auto transition : transitionrelation[state])
+	for(const auto& transition : transitionrelation[state])
 	{
 		result.push_back(transition);
 	}
@@ -107,7 +106,7 @@ Trans Afa::get_trans_from_state(State state, Symbol symbol) const
 			return transition;
 		}
 	}
-	return Trans(state, symbol, Nodes());
+    return { state, symbol, Nodes{} };
 }
 
 
@@ -126,17 +125,17 @@ void Afa::add_inverse_trans(const Trans& trans)
 		// If there is already a memory cell which corresponds to the current dst node and a
 		// transition symbol, we have to find it and add the 'src' state to the corresponding
 		// result_node vector. Let us recall that the inverse transition datatype is a vector
-		// of vectors of tuples (symbol, vector_of_inverse_results). Each InverseResult is 
+		// of vectors of tuples (symbol, vector_of_inverse_results). Each InverseResult is
 		// a tuple (result_node, precondition). If there exists such a tuple, where
 		// the precondition corresponds to the current dst node, we can simply add the current
 		// 'src' state to the result_node. Since the corresponding tuple (result_node,
 		// precondition) would be identical for all states of the current node, we can store it
-		// to the memory only once. For this purpose, we choose the minimal element from 
+		// to the memory only once. For this purpose, we choose the minimal element from
 		// the current node. Then, it is sufficient to choose the minimal element of the dst
-		// node and look if there exists such a tuple (result_node, precondition), where 
+		// node and look if there exists such a tuple (result_node, precondition), where
 		// precondition == dst node in context of the current symbol.
 		//
-		// Example: We have transitions (0, a, {0, 1}), (0, b, {1}). 
+		// Example: We have transitions (0, a, {0, 1}), (0, b, {1}).
 		// The inverse transition data structure looks like this:
 		//
 		// 0 -> {('a', {(result_node:{0}, precondition:{0, 1})})}
@@ -147,7 +146,7 @@ void Afa::add_inverse_trans(const Trans& trans)
 		// of the dst node {0, 1}, access the corresponding element of the inverse transition
 		// relation and look if there exists a tuple (result_node, precondition),
 		// where precondition == {0, 1}.  If so, we add 1 to the result_node. The result:
-		//	
+		//
 		// 0 -> {('a', {(result_node:{0, 1}, precondition:{0, 1})})}
 		// 1 -> {('a', {}),
 		//      ('b', {(result_node:{0}, precondition:{1})})}
@@ -177,12 +176,10 @@ void Afa::add_inverse_trans(const Trans& trans)
 
 		// If there is no tuple (symbol, vector_of_pointers) in context of the current
 		// state and symbol because the symbol has not been used yet, we need to create it
-		if(perform_inverse_trans(storeTo, trans.symb).empty())
-		{
-			inverseTransRelation[storeTo].push_back
-			(InverseTrans(trans.src, trans.symb, InverseResults(trans.src, node)));
+		if(perform_inverse_trans(storeTo, trans.symb).empty()) {
+			inverseTransRelation[storeTo].emplace_back(trans.src, trans.symb, InverseResults(trans.src, node));
 			continue;
-		} 
+		}
 
 		// Otherwise, we need to find the appropriate tuple (symbol, inverse_results)
 		// and store the inverse result to the vector of inverse results
@@ -190,7 +187,7 @@ void Afa::add_inverse_trans(const Trans& trans)
 		{
 			if(transVec.symb == trans.symb)
 			{
-			    transVec.inverseResults.push_back(InverseResults(trans.src, node));
+			    transVec.inverseResults.emplace_back(trans.src, node);
 			    break;
 			}
 		}
@@ -218,21 +215,19 @@ State Afa::add_new_state() {
 //***************************************************
 
 /** This function takes a single state and a symbol and returns all the nodes
-* which are accessible from the node {state} in one step using the given symbol. 
+* which are accessible from the node {state} in one step using the given symbol.
 * The output will be represented as a ClosedSet to omit the neccessity
 * to explicitly return all the proper nodes. The result is always an upward closed set!
 * @param state a source state
 * @param symb a symbol used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(State state, Symbol symb) const
-{
-	return StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1,
-	get_trans_from_state(state, symb).dst);
-} // post }}}
+StateClosedSet Afa::post(const State state, const Symbol symb) const {
+	return { ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1, get_trans_from_state(state, symb).dst };
+}
 
 /** This function takes a single node and a symbol and returns all the nodes
-* which are accessible from the node in one step using the given symbol. 
+* which are accessible from the node in one step using the given symbol.
 * The output will be represented as a ClosedSet to omit the neccessity
 * to explicitly return all the proper nodes. We will perform a transition
 * for each state of the given node and then, we perform an intersection
@@ -241,7 +236,7 @@ StateClosedSet Afa::post(State state, Symbol symb) const
 * @param symb a symbol used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(Node node, Symbol symb) const
+StateClosedSet Afa::post(const Node& node, const Symbol symb) const
 {
 	// initially, the result is empty
 	StateClosedSet result = StateClosedSet(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
@@ -251,7 +246,7 @@ StateClosedSet Afa::post(Node node, Symbol symb) const
 		return result;
 	}
 
-	// we get the first result without any changes and then, we will 
+	// we get the first result without any changes and then, we will
 	// perform several intersections over it
 	bool used = false;
 	for(auto state : node)
@@ -277,7 +272,7 @@ StateClosedSet Afa::post(Node node, Symbol symb) const
 * @param symb a symbol used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
+StateClosedSet Afa::post(const Nodes& nodes, const Symbol symb) const
 {
 	// initially, the result is empty
 	StateClosedSet result = StateClosedSet{ ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1 };
@@ -288,8 +283,8 @@ StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 	return result;
 } // post }}}
 
-/** This function allows us to perform post directly over the closed set. 
-* The output will be represented as a ClosedSet to omit the neccessity to 
+/** This function allows us to perform post directly over the closed set.
+* The output will be represented as a ClosedSet to omit the neccessity to
 * explicitly return all the proper nodes. We will perform a transition for
 * each node of the antichain of the given set of nodes and then we perform
 * an union over these subresults. The result is always an upward closed set!
@@ -297,7 +292,7 @@ StateClosedSet Afa::post(Nodes nodes, Symbol symb) const
 * @param symb a symbol used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(StateClosedSet closed_set, Symbol symb) const
+StateClosedSet Afa::post(const StateClosedSet& closed_set, const Symbol symb) const
 {
 	assert(closed_set.type() == Mata::ClosedSetType::upward_closed_set && "The predicate transformer " &&
 	" post can be computed only over upward-closed sets.");
@@ -305,16 +300,16 @@ StateClosedSet Afa::post(StateClosedSet closed_set, Symbol symb) const
 } // post }}}
 
 
-/** This function takes a single node and and returns all the nodes which are 
+/** This function takes a single node and and returns all the nodes which are
 * accessible from the node in one step using any symbol. The output will be
-* represented as a ClosedSet to omit the neccessity to explicitly return all 
-* the proper nodes. We will perform a transition for each state of the given 
+* represented as a ClosedSet to omit the neccessity to explicitly return all
+* the proper nodes. We will perform a transition for each state of the given
 * node and then, we perform an intersection over these subresults.
 * The result is always an upward closed set!
 * @param node a source set of states
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(Node node) const
+StateClosedSet Afa::post(const Node& node) const
 {
 	if(node.empty())
 	{
@@ -327,15 +322,15 @@ StateClosedSet Afa::post(Node node) const
 	// in context of another state of the node, it won't affect the result. The result for
 	// such symbol will be empty since it is not used in context of all states
 	// stored in the node
-	for(auto transVec : transitionrelation[*(node.begin())])
+	for(const auto& transVec : transitionrelation[*(node.begin())])
 	{
 		result.insert(post(node, transVec.symb).antichain());
 	}
 	return result;
 } // post }}}
 
-/** This function allows us to perfom "post" and use the whole alphabet 
-* to perform individual transitions. The output will be represented as 
+/** This function allows us to perfom "post" and use the whole alphabet
+* to perform individual transitions. The output will be represented as
 * a ClosedSet to omit the neccessity to explicitly return all the proper nodes.
 * We will perform a transition for each node of the antichain of the given set
 * of nodes and then we perform an union over these subresults.
@@ -343,10 +338,10 @@ StateClosedSet Afa::post(Node node) const
 * @param nodes a set of sets of nodes used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(Nodes nodes) const
+StateClosedSet Afa::post(const Nodes& nodes) const
 {
 	StateClosedSet result(ClosedSetType::upward_closed_set, 0, transitionrelation.size()-1);
-	for(auto node : nodes)
+	for(const auto& node : nodes)
 	{
 		result.insert(post(node).antichain());
 	}
@@ -354,17 +349,17 @@ StateClosedSet Afa::post(Nodes nodes) const
 } // post }}}
 
 
-/** This function allows us to perfom "post" and use the whole alphabet 
-* to perform individual transitions directly over the closed set. 
+/** This function allows us to perfom "post" and use the whole alphabet
+* to perform individual transitions directly over the closed set.
 * The output will be represented as a ClosedSet to omit the neccessity to
-* explicitly return all the proper nodes. We will perform a transition 
+* explicitly return all the proper nodes. We will perform a transition
 * for each node of the antichain of the given set
 * of nodes and then we perform an union over these subresults.
 * The result is always an upward closed set!
 * @param nodes a set of sets of nodes used to perform a transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::post(StateClosedSet closed_set) const 
+StateClosedSet Afa::post(const StateClosedSet& closed_set) const
 {
 	assert(closed_set.type() == Mata::ClosedSetType::upward_closed_set && "The predicate transformer " &&
 	" post can be computed only over upward-closed sets.");
@@ -389,16 +384,16 @@ StateClosedSet Afa::post(StateClosedSet closed_set) const
 * @param symb a symbol used to perform an inverse transition
 * @return a vector of the inverse results
 */
-std::vector<InverseResults> Afa::perform_inverse_trans(State src, Symbol symb) const
+std::vector<InverseResults> Afa::perform_inverse_trans(const State src, const Symbol symb) const
 {
-	for(auto element : this->inverseTransRelation[src])
+	for(const auto& element : this->inverseTransRelation[src])
 	{
 		if(element.symb == symb)
 		{
 		    return element.inverseResults;
 		}
 	}
-	return std::vector<InverseResults>();
+	return {};
 }  // perform_inverse_trans }}}
 
 /** This function inspects an inverse transition relation and returns a vector
@@ -409,7 +404,7 @@ std::vector<InverseResults> Afa::perform_inverse_trans(State src, Symbol symb) c
 * @param symb a symbol used to perform an inverse transition
 * @return a vector of the inverse results
 */
-std::vector<InverseResults> Afa::perform_inverse_trans(Node node, Symbol symb) const
+std::vector<InverseResults> Afa::perform_inverse_trans(const Node& node, Symbol symb) const
 {
 	std::vector<InverseResults> result{};
 	for(auto state : node)
@@ -429,11 +424,11 @@ std::vector<InverseResults> Afa::perform_inverse_trans(Node node, Symbol symb) c
 * @param symb a symbol used to perform an inverse transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::pre(Node node, Symbol symb) const
+StateClosedSet Afa::pre(const Node& node, Symbol symb) const
 {
 	std::vector<InverseResults> candidates = perform_inverse_trans(node, symb);
 	Node result{};
-	for(auto candidate : candidates)
+	for(const auto& candidate : candidates)
 	{
 		if(candidate.precondition.IsSubsetOf(node))
 		{
@@ -443,7 +438,7 @@ StateClosedSet Afa::pre(Node node, Symbol symb) const
 			}
 		}
 	}
-	return StateClosedSet(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1, result);
+	return { ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1, result };
 } // pre }}}
 
 /** This function takes a set of nodes and a symbol and returns all the nodes
@@ -454,10 +449,10 @@ StateClosedSet Afa::pre(Node node, Symbol symb) const
 * @param symb a symbol used to perform an inverse transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
+StateClosedSet Afa::pre(const Nodes& nodes, Symbol symb) const
 {
 	StateClosedSet result(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1);
-	for(auto node : nodes)
+	for(const auto& node : nodes)
 	{
 		result = result.Union(pre(node, symb));
 	}
@@ -470,7 +465,7 @@ StateClosedSet Afa::pre(Nodes nodes, Symbol symb) const
 * @param symb a symbol used to perform an inverse transition
 * @return closed set of nodes
 */
-StateClosedSet Afa::pre(StateClosedSet closed_set, Symbol symb) const
+StateClosedSet Afa::pre(const StateClosedSet& closed_set, const Symbol symb) const
 {
 	assert(closed_set.type() == ClosedSetType::downward_closed_set && "The predicate transformer " &&
 	"pre can be computed only over downward-closed sets.");
@@ -478,12 +473,12 @@ StateClosedSet Afa::pre(StateClosedSet closed_set, Symbol symb) const
 } // pre }}}
 
 /** This function allows us to perfom pre over a node and use the whole
-* alphabet to perform individual transitions. The result is always 
+* alphabet to perform individual transitions. The result is always
 * a downward closed set!
 * @param node a set of states
 * @return closed set of nodes
 */
-StateClosedSet Afa::pre(Node node) const
+StateClosedSet Afa::pre(const Node& node) const
 {
 	if(node.empty())
 	{
@@ -496,7 +491,7 @@ StateClosedSet Afa::pre(Node node) const
 	// in context of another state of the node, it won't affect the result. The result for
 	// such symbol will be empty since it is not used in context of all states
 	// stored in the node
-	for(auto transVec : inverseTransRelation[*(node.begin())])
+	for(const auto& transVec : inverseTransRelation[*(node.begin())])
 	{
 		result.insert(pre(node, transVec.symb).antichain());
 	}
@@ -504,18 +499,14 @@ StateClosedSet Afa::pre(Node node) const
 } // pre }}}
 
 /** This function allows us to perfom pre over a set of nodes and use
-* the whole alphabet to perform individual transitions 
+* the whole alphabet to perform individual transitions
 * The result is always a downward closed set!
 * @param nodes a set of sets of states
 * @return closed set of nodes
 */
-StateClosedSet Afa::pre(Nodes nodes) const
-{
-	StateClosedSet result(ClosedSetType::downward_closed_set, 0, transitionrelation.size()-1);
-	for(auto node : nodes)
-	{
-		result.insert(pre(node).antichain());
-	}
+StateClosedSet Afa::pre(const Nodes& nodes) const {
+	StateClosedSet result{ ClosedSetType::downward_closed_set, 0, transitionrelation.size() - 1 };
+	for(const auto& node : nodes) { result.insert(pre(node).antichain()); }
 	return result;
 } // pre }}}
 
@@ -525,7 +516,7 @@ StateClosedSet Afa::pre(Nodes nodes) const
 bool Afa::has_trans(const Trans& trans) const
 { // {{{
 	Nodes res = get_trans_from_state(trans.src, trans.symb).dst;
-	if(res.size() && res.IsSubsetOf(trans.dst))
+	if(!res.empty() && res.IsSubsetOf(trans.dst))
 	{
 		return true;
 	}
@@ -536,7 +527,7 @@ bool Afa::has_trans(const Trans& trans) const
 size_t Afa::trans_size() const
 { // {{{
 	size_t result = 0;
-	for(auto state : transitionrelation)
+	for(const auto& state : transitionrelation)
 	{
 		result += state.size();
 	}
@@ -630,7 +621,7 @@ bool Mata::Afa::is_lang_empty_cex(const Afa& aut, Word* cex)
   assert(false);
 } // is_lang_empty_cex }}}
 
-/** This function decides whether the given automaton is empty using 
+/** This function decides whether the given automaton is empty using
 * an antichain-based emptiness test working in the concrete domain
 * in the forward fashion
 * @param aut a given automaton
@@ -659,7 +650,7 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_old(const Afa& aut)
     return true;
 }
 
-/** This function decides whether the given automaton is empty using 
+/** This function decides whether the given automaton is empty using
 * an antichain-based emptiness test working in the concrete domain
 * in the forward fashion
 * @param aut a given automaton
@@ -671,7 +662,7 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_new(const Afa& aut)
 	StateClosedSet result = aut.get_initial_nodes();
 	std::set<Node> processed = std::set<Node>();
 	std::vector<Node> worklist = std::vector<Node>();
-	for(Node node : aut.get_initial_nodes().antichain())
+	for(const Node& node : aut.get_initial_nodes().antichain())
 	{
 		worklist.push_back(node);
 	}
@@ -681,13 +672,13 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_new(const Afa& aut)
 		return false;
 	}
 
-	while(!worklist.empty()) 
+	while(!worklist.empty())
 	{
 		Node current = worklist.back();
 		worklist.pop_back();
 		auto post_current = aut.post(current);
 		result = result.Union(post_current);
-		for(Node node : post_current.antichain())
+		for(const Node& node : post_current.antichain())
 		{
 			if(!goal.contains(node))
 			{
@@ -703,7 +694,7 @@ bool Mata::Afa::antichain_concrete_forward_emptiness_test_new(const Afa& aut)
 	return true;
 }
 
-/** This function decides whether the given automaton is empty using 
+/** This function decides whether the given automaton is empty using
 * an antichain-based emptiness test working in the concrete domain
 * in the backward fashion
 * @param aut a given automaton
@@ -733,7 +724,7 @@ bool Mata::Afa::antichain_concrete_backward_emptiness_test_old(const Afa& aut)
 }
 
 
-/** This function decides whether the given automaton is empty using 
+/** This function decides whether the given automaton is empty using
 * an antichain-based emptiness test working in the concrete domain
 * in the backward fashion
 * @param aut a given automaton
@@ -745,7 +736,7 @@ bool Mata::Afa::antichain_concrete_backward_emptiness_test_new(const Afa& aut)
 	StateClosedSet result = aut.get_final_nodes();
 	std::set<Node> processed = std::set<Node>();
 	std::vector<Node> worklist = std::vector<Node>();
-	for(Node node : aut.get_final_nodes().antichain())
+	for(const Node& node : aut.get_final_nodes().antichain())
 	{
 		worklist.push_back(node);
 	}
@@ -755,13 +746,13 @@ bool Mata::Afa::antichain_concrete_backward_emptiness_test_new(const Afa& aut)
 		return false;
 	}
 
-	while(!worklist.empty()) 
+	while(!worklist.empty())
 	{
 		Node current = worklist.back();
 		worklist.pop_back();
 		auto pre_current = aut.pre(current);
 		result = result.Union(pre_current);
-		for(Node node : pre_current.antichain())
+		for(const Node& node : pre_current.antichain())
 		{
 			if(!goal.contains(node))
 			{
@@ -842,7 +833,7 @@ Mata::Parser::ParsedSection Mata::Afa::serialize(
 			if (!bsp.first) { throw std::runtime_error("cannot translate state " + std::to_string(s)); }
 			if(!first) {init_res += " & ";}
 			init_res += bsp.second;
-			first = false;		
+			first = false;
 		}
 		init_res += " )";
 		init_states.push_back(init_res);
@@ -967,7 +958,7 @@ Afa Mata::Afa::construct(
 
 	// TODO: Transform a positive Boolean formula from the string format
 	// to the inner representation (src state, symbol on transition, ordered
-	// vector of ordered vectors of states which corresponds to the formula in DNF) 
+	// vector of ordered vectors of states which corresponds to the formula in DNF)
 	// Call the "add_trans" and "add_inverse_trans" functions over the
 	// parsed formula to add it do the automaton
 
@@ -1044,7 +1035,7 @@ Afa Mata::Afa::construct(
                    "Clause should be conjunction or single state");
             // Conjunction is the right son of initent node
             Node initial_node;
-            for (const auto s : init_graph->children[1].collect_node_names())
+            for (const auto& s : init_graph->children[1].collect_node_names())
                 initial_node.insert(get_state_name(s));
             aut.add_initial(initial_node);
 
@@ -1055,7 +1046,7 @@ Afa Mata::Afa::construct(
                is_node_operator(init_graph->node, FormulaNode::OperatorType::AND) ||
                        "Remaining clause should be conjunction or single element");
         Node initial_node;
-        for (const auto s : init_graph->collect_node_names())
+        for (const auto& s : init_graph->collect_node_names())
             initial_node.insert(get_state_name(s));
         aut.add_initial(initial_node);
     }

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -226,12 +226,13 @@ namespace {
                     opstack.pop_back();
                     break;
                 case Mata::FormulaNode::Type::OPERATOR:
-                    for (int j = opstack.size()-1; j >= 0; --j) {
-                        assert(!opstack[j].is_operand());
-                        if (opstack[j].is_leftpar())
+                    for (int j = static_cast<int>(opstack.size())-1; j >= 0; --j) {
+                        size_t j_size_t{ static_cast<size_t>(j) };
+                        assert(!opstack[j_size_t].is_operand());
+                        if (opstack[j_size_t].is_leftpar())
                             break;
-                        if (lower_precedence(node.operator_type, opstack[j].operator_type)) {
-                            output.push_back(opstack[j]);
+                        if (lower_precedence(node.operator_type, opstack[j_size_t].operator_type)) {
+                            output.push_back(opstack[j_size_t]);
                             opstack.erase(opstack.begin()+j);
                         }
                     }

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -51,6 +51,7 @@ namespace {
 
         assert(false && "Unknown naming type - a naming type should be always defined correctly otherwise it is"
                         "impossible to parse automaton correctly");
+        return {};
     }
 
     Mata::IntermediateAut::AlphabetType get_alphabet_type(const std::string &type)
@@ -68,6 +69,7 @@ namespace {
 
         assert(false && "Unknown alphabet type - an alphabet type should be always defined correctly otherwise it is"
                         "impossible to parse automaton correctly");
+        return {};
     }
 
     bool is_naming_marker(const Mata::IntermediateAut::Naming naming)
@@ -247,11 +249,13 @@ namespace {
             opstack.pop_back();
         }
 
+        #ifndef NDEBUG
         for (const auto& node : output) {
             assert(node.is_operator() || (node.name != "!" && node.name != "&" && node.name != "|"));
             assert(node.is_leftpar() || node.name != "(");
             assert(node.is_rightpar() || node.name != ")");
         }
+        #endif // #ifndef NDEBUG.
 
         return output;
     }
@@ -460,11 +464,13 @@ void Mata::IntermediateAut::parse_transition(Mata::IntermediateAut &aut, const s
     } else
         postfix = infix_to_postfix(aut, rhs);
 
+    #ifndef NDEBUG
     for (const auto& node : postfix) {
         assert(node.is_operator() || (node.name != "!" && node.name != "&" && node.name != "|"));
         assert(node.is_leftpar() || node.name != "(");
         assert(node.is_rightpar() || node.name != ")");
     }
+    #endif // #ifndef NDEBUG.
     const Mata::FormulaGraph graph = postfix_to_graph(postfix);
 
     aut.transitions.emplace_back(lhs, graph);

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -418,7 +418,7 @@ size_t Mata::IntermediateAut::get_number_of_disjuncts() const
             for (const auto &ch: gr->children)
                 stack.push_back(&ch);
         }
-        res += std::max(trans_disjuncts, (size_t) 1);
+        res += std::max(trans_disjuncts, 1ul);
     }
 
     return res;
@@ -466,7 +466,7 @@ void Mata::IntermediateAut::parse_transition(Mata::IntermediateAut &aut, const s
     }
     const Mata::FormulaGraph graph = postfix_to_graph(postfix);
 
-    aut.transitions.push_back(std::pair<Mata::FormulaNode,Mata::FormulaGraph>(lhs, graph));
+    aut.transitions.emplace_back(lhs, graph);
 }
 
 std::unordered_set<std::string> Mata::FormulaGraph::collect_node_names() const
@@ -474,7 +474,7 @@ std::unordered_set<std::string> Mata::FormulaGraph::collect_node_names() const
     std::unordered_set<std::string> res;
     std::vector<const Mata::FormulaGraph *> stack;
 
-    stack.push_back(reinterpret_cast<const FormulaGraph *const>(&(this->node)));
+    stack.push_back(reinterpret_cast<const FormulaGraph*>(&(this->node)));
     while (!stack.empty()) {
         const FormulaGraph* g = stack.back();
         assert(g != nullptr);

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1189,6 +1189,7 @@ Mata::Parser::ParsedSection Mata::Nfa::serialize(
         const StateToStringMap*   state_map) {
     (void)aut; (void)symbol_map; (void)state_map;
     assert(false);
+    return {};
 }
 
 bool Mata::Nfa::is_lang_empty(const Nfa& aut, Run* cex)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -35,6 +35,11 @@ using StateBoolArray = std::vector<bool>; ///< Bool array for states in the auto
 
 const std::string Mata::Nfa::TYPE_NFA = "NFA";
 
+const State Limits::min_state;
+const State Limits::max_state;
+const Symbol Limits::min_symbol;
+const Symbol Limits::max_symbol;
+
 namespace {
     Simlib::Util::BinaryRelation compute_fw_direct_simulation(const Nfa& aut) {
         Symbol maxSymbol = 0;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1188,7 +1188,7 @@ Mata::Parser::ParsedSection Mata::Nfa::serialize(
         const SymbolToStringMap*  symbol_map,
         const StateToStringMap*   state_map) {
     (void)aut; (void)symbol_map; (void)state_map;
-    assert(false);
+    assert(false && "Unimplemented.");
     return {};
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -1928,7 +1928,7 @@ Mata::Util::NumberPredicate<Symbol> Nfa::get_used_symbols_np() const {
             symbols.add(move.symbol);
         }
     }
-    //TODO: is it neccessary toreturn ordered vector? Would the number predicate suffice?
+    //TODO: is it necessary to return ordered vector? Would the number predicate suffice?
     return symbols;
 }
 
@@ -1970,8 +1970,8 @@ Symbol Nfa::get_max_symbol() const {
  void Nfa::unify_initial() {
     if (initial.empty() || initial.size() == 1) { return; }
     const State new_initial_state{add_state() };
-    for (const auto& orig_initial_state: initial) {
-        const auto moves{ get_moves_from(orig_initial_state) };
+    for (const State orig_initial_state: initial) {
+        const Post& moves{ get_moves_from(orig_initial_state) };
         for (const auto& transitions: moves) {
             for (const State state_to: transitions.targets) {
                 delta.add(new_initial_state, transitions.symbol, state_to);
@@ -1998,9 +1998,10 @@ void Nfa::unify_final() {
 }
 
 void Mata::Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
-    size_t nfa_num_of_states{nfa.size() };
+    const size_t nfa_num_of_states{ nfa.size() };
     for (Mata::Nfa::State state{ 0 }; state < nfa_num_of_states; ++state) {
-        for (const auto state_transitions: nfa.delta) {
+        // TODO: Rewrite to not create 'Trans' instances and iterate over same symbols all the time.
+        for (const Trans& state_transitions: nfa.delta) {
             alphabet.update_next_symbol_value(state_transitions.symb);
             alphabet.try_add_new_symbol(std::to_string(state_transitions.symb), state_transitions.symb);
         }
@@ -2038,7 +2039,7 @@ void Nfa::clear_transitions() {
 
 State Nfa::add_state() {
     const size_t num_of_states{ size() };
-    delta.increase_size(num_of_states + 1 );
+    delta.increase_size(num_of_states + 1);
     return num_of_states;
 }
 
@@ -2185,7 +2186,7 @@ void Move::insert(State s) {
     }
 }
 
-void Move::insert(StateSet states) {
+void Move::insert(const StateSet& states) {
     for (State s : states) {
         insert(s);
     }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -419,7 +419,7 @@ bool Mata::Parser::ParsedSection::operator==(const ParsedSection& rhs) const {
         this->body == rhs.body;
 }
 
-std::ostream& Mata::Parser::operator<<(std::ostream& os, const ParsedSection& parsec) {
+std::ostream& std::operator<<(std::ostream& os, const ParsedSection& parsec) {
     os << "@" << parsec.type << "\n";
     for (const auto& string_list_pair : parsec.dict) {
         os << "%" << string_list_pair.first;

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -91,11 +91,11 @@ std::string get_token_from_line(std::istream& input, bool* quoted)
 				} else if ('#' == ch) { // clear the rest of the line
 					std::string aux;
 					std::getline(input, aux);
-					return std::string();
+					return {};
 				} else if ('(' == ch || ')' == ch) {
 					return std::to_string(static_cast<char>(ch));
 				} else {
-					result += ch;
+					result += static_cast<char>(ch);
 					state = TokenizerState::UNQUOTED;
 				}
 				break;
@@ -109,8 +109,7 @@ std::string get_token_from_line(std::istream& input, bool* quoted)
 				} else if ('"' == ch) {
 					std::string context;
 					std::getline(input, context);
-					throw std::runtime_error("misplaced quotes: " + result + "_\"_" +
-						context);
+					throw std::runtime_error("misplaced quotes: " + result + "_\"_" + context);
 				} else if ('(' == ch || ')' == ch) {
 					input.unget();
 					return result;
@@ -121,7 +120,7 @@ std::string get_token_from_line(std::istream& input, bool* quoted)
 						static_cast<char>(ch) + "\' in string \"" + result +
 						static_cast<char>(ch) + context + "\"");
 				} else {
-					result += ch;
+					result += static_cast<char>(ch);
 				}
 				break;
 			}
@@ -140,12 +139,12 @@ std::string get_token_from_line(std::istream& input, bool* quoted)
 					return result;
 				} else if ('\\' == ch) {
 					state = TokenizerState::QUOTED_ESCAPE;
-				} else { result += ch; }
+				} else { result += static_cast<char>(ch); }
 				break;
 			}
 			case TokenizerState::QUOTED_ESCAPE: {
 				if ('"' != ch) { result += '\\'; }
-				result += ch;
+				result += static_cast<char>(ch);
 				state = TokenizerState::QUOTED;
 				break;
 			}
@@ -179,7 +178,7 @@ std::vector<std::pair<std::string, bool>> tokenize_line(const std::string& line)
 		std::string token = get_token_from_line(stream, &quoted);
 		if (!quoted && token.empty()) { break; }
 
-		result.push_back({ token, quoted });
+		result.emplace_back(token, quoted);
 
 		if (!first && !quoted)
 		{
@@ -200,7 +199,7 @@ std::vector<std::pair<std::string, bool>> tokenize_line(const std::string& line)
 	return result;
 } // tokenize_line(string) }}}
 
-std::vector<std::pair<std::string, bool>> split_tokens(std::vector<std::pair<std::string, bool>> tokens)
+std::vector<std::pair<std::string, bool>> split_tokens(const std::vector<std::pair<std::string, bool>>& tokens)
 { // {{{
     std::vector<std::pair<std::string, bool>> result;
     for (const auto& token : tokens) {
@@ -218,8 +217,8 @@ std::vector<std::pair<std::string, bool>> split_tokens(std::vector<std::pair<std
 
                 // there is token before logical operator (this is case of binary operators, e.g., a&b)
                 if (!token_candidate.empty())
-                    result.push_back(std::make_pair(token_candidate, false));
-                result.push_back(std::make_pair(std::string(1,token_string[i]), false));
+                    result.emplace_back(token_candidate, false);
+                result.emplace_back(std::string(1,token_string[i]), false);
                 last_operator = i+1;
             }
         }
@@ -228,9 +227,7 @@ std::vector<std::pair<std::string, bool>> split_tokens(std::vector<std::pair<std
         if (last_operator == 0) {
             result.push_back(token);
         } else if (last_operator != length){ // operator was not last, we need parse rest of token
-            result.push_back(std::make_pair(
-                    token_string.substr(last_operator, length-last_operator), false));
-        }
+            result.emplace_back(token_string.substr(last_operator, length-last_operator), false); }
     }
 
     return result;
@@ -376,7 +373,7 @@ ParsedSection Mata::Parser::parse_mf_section(
 			std::vector<std::string>& val_list = it->second;
 			std::transform(token_line.begin() + 1, token_line.end(),
 				std::back_inserter(val_list),
-				[](const std::pair<std::string, bool> token) { return token.first; });
+				[](const std::pair<std::string, bool>& token) { return token.first; });
 		} else {
 			BodyLine stripped_token_line;
 			std::transform(token_line.begin(), token_line.end(),

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -197,9 +197,9 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
     const auto& epsilon_depths_map{ segmentation.get_epsilon_depth_trans_map() };
 
     struct SegItem {
-        NoodleSubst noodle;
-        State fin;
-        size_t seg_id;
+        NoodleSubst noodle{};
+        State fin{};
+        size_t seg_id{};
     };
 
     NoodleSubstSequence noodles{};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,32 +4,6 @@ set(CMAKE_COLOR_MAKEFILE ON)
 # Export compile commands to be used with YouCompleteMe
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Flags
-set(cxx_compiler_flags
-  -Wextra
-  -Wall
-  -Wfloat-equal
-  -fms-extensions
-  -fdiagnostics-show-option
-  -Wctor-dtor-privacy
-  -Weffc++
-  -fPIC
-  -fno-strict-aliasing
-  -Woverloaded-virtual
-  -Wold-style-cast
-)
-
-foreach(flag ${cxx_compiler_flags})
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-endforeach()
-
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	# using regular Clang or AppleClang
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wgnu-anonymous-struct")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnested-anon-types")
-endif()
-
 # if DEBUG, also test coverage
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
@@ -65,6 +39,19 @@ add_executable(tests
 )
 
 target_link_libraries(tests libmata re2 simlib cudd)
+
+# Add common compile warnings.
+target_compile_options(tests PRIVATE "$<$<CONFIG:DEBUG>:${COMMON_WARNINGS}>")
+target_compile_options(tests PRIVATE "$<$<CONFIG:RELEASE>:${COMMON_WARNINGS}>")
+
+# Optionally, also add Clang-specific warnings.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang") # Using regular Clang or AppleClang.
+	target_compile_options(tests PRIVATE "$<$<CONFIG:DEBUG>:${CLANG_WARNINGS}>")
+    target_compile_options(tests PRIVATE "$<$<CONFIG:RELEASE>:${CLANG_WARNINGS}>")
+endif()
+
+target_compile_options(tests PRIVATE "${COMMON_COMPILER_FLAGS}")
+
 include(Catch)
 catch_discover_tests(tests)
 add_custom_command(

--- a/tests/afa/afa.cc
+++ b/tests/afa/afa.cc
@@ -19,11 +19,11 @@ TEST_CASE("Mata::Afa::Trans::operator<<")
 
 TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 { // {{{
-	StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 2, Nodes());
-	StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 10, 20, Nodes());
+	StateClosedSet c1 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes());
+	StateClosedSet c2 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 10, 20, Nodes());
 
-	REQUIRE(c1.type() == Mata::upward_closed_set);
-	REQUIRE(c2.type() == Mata::downward_closed_set);
+	REQUIRE(c1.type() == Mata::ClosedSetType::upward_closed_set);
+	REQUIRE(c2.type() == Mata::ClosedSetType::downward_closed_set);
 	REQUIRE(c1.type() != c2.type());
 	REQUIRE(c1.antichain().size() == 0);
 	REQUIRE(c2.antichain().size() == 0);
@@ -32,8 +32,8 @@ TEST_CASE("Mata::Afa::ClosedSet creating closed sets")
 
 TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 { // {{{
-	StateClosedSet c1 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
-	StateClosedSet c2 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
+	StateClosedSet c1 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes());
+	StateClosedSet c2 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes());
 
 	REQUIRE(!c1.contains(Node{0}));
 	REQUIRE(!c2.contains(Node{0}));
@@ -52,8 +52,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	REQUIRE(!c1.contains(Node{}));
 	REQUIRE(c2.contains(Node{}));
 
-	StateClosedSet c3 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
-	StateClosedSet c4 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	StateClosedSet c3 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes{Node{0, 1}});
+	StateClosedSet c4 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
 
 	REQUIRE(c3.Union(c4).contains(Node{0, 1}));
 	REQUIRE(c3.Union(c4).contains(Node{0, 3}));
@@ -65,8 +65,8 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	REQUIRE(!c3.Union(c4).contains(Node{}));
 	REQUIRE(!c3.intersection(c4).contains(Node{}));
 
-	StateClosedSet c5 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
-	StateClosedSet c6 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	StateClosedSet c5 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes{Node{0, 1}});
+	StateClosedSet c6 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
 
 	REQUIRE(c5.Union(c6).contains(Node{0, 1}));
 	REQUIRE(c5.Union(c6).contains(Node{0, 3}));
@@ -81,7 +81,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	REQUIRE(std::to_string(c5.Union(c6).antichain()) == "{ { 0, 1}, { 0, 3}}");
 	REQUIRE(std::to_string(c5.intersection(c6).antichain()) == "{ { 0}}");
 
-	StateClosedSet c7 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	StateClosedSet c7 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes{Node{0, 3}});
 	c7.insert(Node{0});
 	REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 3}}");
 	c7.insert(Node{0, 2});
@@ -89,7 +89,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	c7.insert(Node{0, 2, 3});
 	REQUIRE(std::to_string(c7.antichain()) == "{ { 0, 2, 3}}");
 
-	StateClosedSet c8 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
+	StateClosedSet c8 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes{Node{0, 3}});
 	c8.insert(Node{0, 1, 3});
 	REQUIRE(std::to_string(c8.antichain()) == "{ { 0, 3}}");
 	c8.insert(Node{0, 2});
@@ -97,7 +97,7 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	c8.insert(Node{0});
 	REQUIRE(std::to_string(c8.antichain()) == "{ { 0}}");
 
-	StateClosedSet c9 = StateClosedSet(Mata::upward_closed_set, 0, 4, Nodes());
+	StateClosedSet c9 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 4, Nodes());
 
 	c9.insert(Node{1, 4});
 	c9.insert(Node{1, 2, 3});
@@ -108,28 +108,28 @@ TEST_CASE("Mata::Afa::ClosedSet operation over closed sets")
 	REQUIRE(c9.complement().complement().antichain() == Nodes{{1, 4}, {1, 2, 3}});
 	REQUIRE(!(c9.complement().complement().antichain() == Nodes{{0, 1, 4}, {1, 2, 3}}));
 
-	StateClosedSet c10 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
+	StateClosedSet c10 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes());
 
 	c10.insert(Node{1, 2});
 	c10.insert(Node{2, 3});
 
 	REQUIRE(c10.complement().antichain() == Nodes{{0}, {1, 3}});
 
-	REQUIRE(c10.type() == Mata::downward_closed_set);
+	REQUIRE(c10.type() == Mata::ClosedSetType::downward_closed_set);
 	c10 = c10.complement();
-	REQUIRE(c10.type() == Mata::upward_closed_set);
+	REQUIRE(c10.type() == Mata::ClosedSetType::upward_closed_set);
 
-	StateClosedSet c11 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
+	StateClosedSet c11 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes());
 	REQUIRE(c11.complement().antichain() == Nodes{{}});
 
-	StateClosedSet c12 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
+	StateClosedSet c12 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes());
 	REQUIRE(c12.complement().antichain() == Nodes{{0, 1, 2, 3}});
 
-	StateClosedSet c13 = StateClosedSet(Mata::downward_closed_set, 0, 3, Nodes());
+	StateClosedSet c13 = StateClosedSet(Mata::ClosedSetType::downward_closed_set, 0, 3, Nodes());
 	c13.insert(Node{0, 1, 2, 3});
 	REQUIRE(c13.complement().antichain() == Nodes{});
 
-	StateClosedSet c14 = StateClosedSet(Mata::upward_closed_set, 0, 3, Nodes());
+	StateClosedSet c14 = StateClosedSet(Mata::ClosedSetType::upward_closed_set, 0, 3, Nodes());
 	c14.insert(Node{0, 1, 2, 3});
 	REQUIRE(c14.complement().antichain() == Nodes{{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}});
 
@@ -218,37 +218,37 @@ TEST_CASE("Mata::Afa transition test")
 	REQUIRE(std::to_string(aut.post(Node{0}, 0).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
 	REQUIRE(std::to_string(aut.post(0, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.post(Node{0}, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
 	REQUIRE(std::to_string(aut.post(1, 0).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(Node{1}, 0).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 0).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{}");
 
 	REQUIRE(std::to_string(aut.post(1, 1).antichain()) == "{ { 0}, { 1, 2}}");
 	REQUIRE(std::to_string(aut.post(Node{1}, 1).antichain()) == "{ { 0}, { 1, 2}}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{1}}, 1).antichain()) == "{ { 0}, { 1, 2}}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}, { 1, 2}}");
 
 	REQUIRE(std::to_string(aut.post(2, 0).antichain()) == "{ { 0, 1}, { 2}}");
 	REQUIRE(std::to_string(aut.post(Node{2}, 0).antichain()) == "{ { 0, 1}, { 2}}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 0).antichain()) == "{ { 0, 1}, { 2}}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 0, 1}, { 2}}");
 
 	REQUIRE(std::to_string(aut.post(2, 1).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(Node{2}, 1).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(Nodes{Node{2}}, 1).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(StateClosedSet
-	(Mata::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
+	(Mata::ClosedSetType::upward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{}");
 
 	REQUIRE(std::to_string(aut.post(Node{0, 1}, 0).antichain()) == "{}");
 	REQUIRE(std::to_string(aut.post(Node{0, 2}, 0).antichain()) == "{ { 0, 1}, { 0, 2}}");
@@ -285,38 +285,38 @@ TEST_CASE("Mata::Afa inverse transition test")
 	REQUIRE(std::to_string(aut.pre(Node{0}, 0).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 0).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{0}}), 0).antichain()) == "{ { 0}}");
 
 	REQUIRE(std::to_string(aut.pre(1, 0).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(Node{1}, 0).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 0).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{1}}), 0).antichain()) == "{ {}}");
 
 	REQUIRE(std::to_string(aut.pre(2, 0).antichain()) == "{ { 2}}");
 	REQUIRE(std::to_string(aut.pre(Node{2}, 0).antichain()) == "{ { 2}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 0).antichain()) == "{ { 2}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{2}}), 0).antichain()) == "{ { 2}}");
 
 
 	REQUIRE(std::to_string(aut.pre(0, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.pre(Node{0}, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{0}}, 1).antichain()) == "{ { 1}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{0}}), 1).antichain()) == "{ { 1}}");
 
 	REQUIRE(std::to_string(aut.pre(1, 1).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.pre(Node{1}, 1).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{1}}, 1).antichain()) == "{ { 0}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{1}}), 1).antichain()) == "{ { 0}}");
 
 	REQUIRE(std::to_string(aut.pre(2, 1).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(Node{2}, 1).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(Nodes{Node{2}}, 1).antichain()) == "{ {}}");
 	REQUIRE(std::to_string(aut.pre(StateClosedSet
-	(Mata::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
+	(Mata::ClosedSetType::downward_closed_set, 0, 2, Nodes{Node{2}}), 1).antichain()) == "{ {}}");
 
 
 	REQUIRE(std::to_string(aut.pre(Node{0, 1}, 0).antichain()) == "{ { 0, 2}}");

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2347,7 +2347,7 @@ TEST_CASE("Mata::Nfa::reduce_size_by_simulation()")
 	{
 		aut.delta.add(0, 'a', 1);
 		aut.initial = { 0 };
-		Nfa result = reduce(aut, &state_map);
+		Nfa result = reduce(aut, true, &state_map);
 		CHECK(Mata::Nfa::are_equivalent(result, aut));
 	}
 }

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -925,7 +925,7 @@ TEST_CASE("parsing automata to intermediate representation")
         parsed = parse_mf(file);
         try {
             Mata::IntermediateAut::parse_from_mf(parsed);
-        } catch (std::runtime_error e) {
+        } catch (const std::runtime_error& e) {
             exception = true;
         }
 

--- a/tests/strings/nfa-string-solving.cc
+++ b/tests/strings/nfa-string-solving.cc
@@ -327,7 +327,7 @@ TEST_CASE("Mata::Nfa::create_single_word_nfa()") {
         SECTION("Simple word with alphabet") {
             std::vector<std::string> word{ "zero", "one", "two", "three", "four", "five" };
             Mata::OnTheFlyAlphabet alphabet{};
-            for (unsigned long symbol{ 0 }; symbol < word.size(); ++symbol) {
+            for (Mata::Symbol symbol{ 0 }; symbol < word.size(); ++symbol) {
                 alphabet.add_new_symbol(word[symbol], symbol);
             }
             auto nfa{ Mata::Strings::create_single_word_nfa(word) };


### PR DESCRIPTION
This PR fixes the code so no warnings are displayed. The purpose of this PR is to allow easier error fixing and producing more quality code. We will be able to actually see the new warnings and fix them as we introduce new features (or you better be able to run fast if you introduce new warnings in your PRs from now on). 

Some changes with default initialization simply replace an undefined behaviour we are being warned about by a defined, but maybe nonsensical value. That still has the same effect, however: the value should never be used in any case. More thorough fixes for these kinds of potential bugs may come in future.

I also modified a few places in external libraries in order to suppress warnings brought by including their header files. Note that I did not fix warnings introduced by external libraries during their compilation. I only fixed warnings generated by compilation of Mata library itself. 

The PR also refactors specifying compiler warnings flags in CMake which allow for a more unified and optionally more granular specification of said flags.