### PR TITLE
Disable code coverage and CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,12 @@ message("-- Default C++ compiler: ${CMAKE_CXX_COMPILER}")
 ##############################################################################
 
 # Include CTest so that sophisticated testing can be done now
-include(CTest)
-enable_testing()
+#include(CTest)
+#enable_testing()
 
 # if(CMAKE_COMPILER_IS_GNUCXX)
-    include(CodeCoverage)
-    setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)
+#    include(CodeCoverage)
+#    setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)
 # endif()
 
 ##############################################################################


### PR DESCRIPTION
As agreed upon in the office today, this PR quickly and temporarily disables code coverage and CTest so that they are not required dependencies of Mata.

They will stay commented out until we rewrite the CMake to make everything unnecessary optional.