### PR TITLE
Getting rid of  remaining warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CLANG_WARNINGS
         -Winconsistent-missing-override
         -Wgnu-anonymous-struct
         -Wnested-anon-types
+        -Wno-system-headers
         )
 
 ##############################################################################

--- a/include/mata/ord-vector.hh
+++ b/include/mata/ord-vector.hh
@@ -187,7 +187,7 @@ public:
         }
 
         vec_.resize(vec_.size() + 1);
-        std::copy_backward(vec_.begin() + first, vec_.end() - 1, vec_.end());
+        std::copy_backward(vec_.begin() + static_cast<long>(first), vec_.end() - 1, vec_.end());
 
         // insert the new element
         vec_[first] = x;

--- a/include/mata/synchronized-iterator.hh
+++ b/include/mata/synchronized-iterator.hh
@@ -58,7 +58,7 @@ public:
     std::vector<Iterator> ends{};
 
     /// @param size Number of elements to reserve up-front for positions and ends.
-    explicit SynchronizedIterator(const int size = 0) {
+    explicit SynchronizedIterator(const size_t size = 0) {
         positions.reserve(size);
         ends.reserve(size);
     };
@@ -80,7 +80,7 @@ public:
      * Though they should keep the allocated space.
      * @param size Number of elements to reserve up-front for positions and ends.
      */
-    void reset(const int size = 0) {
+    void reset(const size_t size = 0) {
         positions.clear();
         ends.clear();
         if (size > 0) {
@@ -169,9 +169,9 @@ public:
         return this->positions;
     };
 
-    explicit SynchronizedUniversalIterator(const int size=0) : SynchronizedIterator<Iterator>(size) {};
+    explicit SynchronizedUniversalIterator(const size_t size=0) : SynchronizedIterator<Iterator>(size) {};
 
-    void reset(const int size = 0) {
+    void reset(const size_t size = 0) {
         SynchronizedIterator < Iterator > ::reset(size);
         this->synchronized_at_current_minimum = false;
     };
@@ -271,11 +271,11 @@ public:
         this->ends.emplace_back(end);
     }
 
-    explicit SynchronizedExistentialIterator(const int size=0) : SynchronizedIterator<Iterator>(size) {
+    explicit SynchronizedExistentialIterator(const size_t size=0) : SynchronizedIterator<Iterator>(size) {
         this->currently_synchronized.reserve(size);
     }
 
-    void reset(const int size = 0) {
+    void reset(const size_t size = 0) {
         SynchronizedIterator < Iterator > ::reset(size);
         if (size > 0) {
             this->currently_synchronized.reserve(size);

--- a/include/mata/util.hh
+++ b/include/mata/util.hh
@@ -580,7 +580,7 @@ void filter(Vector & vec, F && is_staying) {
 
         // remove duplicates
         auto it = std::unique(vec.begin(), vec.end());
-        vec.reserve(it - vec.begin());
+        vec.reserve(static_cast<unsigned long>(it - vec.begin()));
     }
 }
 }

--- a/include/mata/util.hh
+++ b/include/mata/util.hh
@@ -580,7 +580,7 @@ void filter(Vector & vec, F && is_staying) {
 
         // remove duplicates
         auto it = std::unique(vec.begin(), vec.end());
-        vec.reserve(static_cast<unsigned long>(it - vec.begin()));
+        vec.reserve(static_cast<size_t>(it - vec.begin()));
     }
 }
 }

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -14,6 +14,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+
+// NOTE: AFA implementation is in an unmaintained state at the moment.
+// We hide warnings from the AFA implementation until we rewrite the whole AFA module from scratch.
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wreturn-type"

--- a/src/afa/afa.cc
+++ b/src/afa/afa.cc
@@ -14,6 +14,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wreturn-type"
+#pragma clang diagnostic ignored "-Wstring-conversion"
 
 #include <algorithm>
 #include <list>
@@ -1189,3 +1193,5 @@ namespace std {
         return accum;
     }
 }
+
+#pragma clang diagnostic pop

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -417,7 +417,7 @@ TEST_CASE("correct use of Mata::Parser::parse_mf_section()")
 		REQUIRE(ref->size() == 0);
 
 		// check what remains
-		std::string remains = stream.str().substr(stream.tellg());
+		std::string remains = stream.str().substr(static_cast<unsigned long>(stream.tellg()));
 		REQUIRE("@Type2\n%key2\n" == remains);
 	}
 } // parse_mf_section correct }}}

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -417,7 +417,7 @@ TEST_CASE("correct use of Mata::Parser::parse_mf_section()")
 		REQUIRE(ref->size() == 0);
 
 		// check what remains
-		std::string remains = stream.str().substr(static_cast<unsigned long>(stream.tellg()));
+		std::string remains = stream.str().substr(static_cast<size_t>(stream.tellg()));
 		REQUIRE("@Type2\n%key2\n" == remains);
 	}
 } // parse_mf_section correct }}}


### PR DESCRIPTION
- somewhat solved few remainning warnings originating in our mata code, someone who can program should check, not too many changes
- switched of warnings from afa by pragma in aha.hh, we will probably not maintain it anyway
- have not managed to switch off warnings from re2. It should be doable through marking it as SYSTEM and for clang also adding this flag -Wno-system-headers, but does not work ... any idea?