### PR TITLE
Use post and move variable names for Posts and Moves

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -165,7 +165,7 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
         StateSet get_terminating_states()
         void remove_epsilon(Symbol) except +
         COrdVector[CMove].const_iterator get_epsilon_transitions(State state, Symbol epsilon)
-        COrdVector[CMove].const_iterator get_epsilon_transitions(CPost& state_transitions, Symbol epsilon)
+        COrdVector[CMove].const_iterator get_epsilon_transitions(CPost& post, Symbol epsilon)
         void clear()
         size_t size()
 

--- a/include/mata/mintermization.hh
+++ b/include/mata/mintermization.hh
@@ -46,7 +46,7 @@ private: // data types
 private: // private data members
     Cudd bdd_mng{}; // Manager of BDDs from lib cubdd, it allocates and manages BDDs.
     std::unordered_map<std::string, BDD> symbol_to_bddvar{};
-    std::unordered_map<const FormulaGraph *, BDD> trans_to_bddvar{};
+    std::unordered_map<const FormulaGraph*, BDD> trans_to_bddvar{};
     std::unordered_map<const FormulaNode*, std::vector<DisjunctStatesPair>> lhs_to_disjuncts_and_states{};
     std::unordered_set<BDD> bdds{}; // bdds created from transitions
 

--- a/include/mata/nfa-strings.hh
+++ b/include/mata/nfa-strings.hh
@@ -273,20 +273,20 @@ private:
 
     /**
      * Add states with non-epsilon transitions to the @p worklist.
-     * @param state_transitions[in] Transitions from current state.
+     * @param move[in] Move from current state.
      * @param depth[in] Current depth.
      * @param worklist[out] Worklist of state and depth pairs to process.
      */
-    void add_transitions_to_worklist(const StateDepthTuple& state_depth_pair, const Move& state_transitions,
+    void add_transitions_to_worklist(const StateDepthTuple& state_depth_pair, const Move& move,
                                      std::deque<StateDepthTuple>& worklist);
 
     /**
      * Process epsilon transitions for the current state.
      * @param[in] state_depth_pair Current state depth pair.
-     * @param[in] state_transitions Transitions from current state.
+     * @param[in] move Move from current state.
      * @param[out] worklist Worklist of state and depth pairs to process.
      */
-    void handle_epsilon_transitions(const StateDepthTuple& state_depth_pair, const Move& state_transitions,
+    void handle_epsilon_transitions(const StateDepthTuple& state_depth_pair, const Move& move,
                                     std::deque<StateDepthTuple>& worklist);
 
     /**

--- a/include/mata/nfa.hh
+++ b/include/mata/nfa.hh
@@ -700,19 +700,19 @@ public:
 
     /**
      * Return all epsilon transitions from epsilon symbol under given state transitions.
-     * @param[in] state_transitions State transitions from which are epsilon transitions checked.
+     * @param[in] post Post from which are epsilon transitions checked.
      * @param[in] epsilon User can define his favourite epsilon or used default
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    static Post::const_iterator get_epsilon_transitions(const Post& state_transitions, Symbol epsilon = EPSILON);
+    static Post::const_iterator get_epsilon_transitions(const Post& post, Symbol epsilon = EPSILON);
 
     /**
      * @brief Expand alphabet by symbols from this automaton to given alphabet
      *
      * The value of the already existing symbols will NOT be overwritten.
      */
-    void add_symbols_to(OnTheFlyAlphabet& alphabet) const;
+    void add_symbols_to(OnTheFlyAlphabet& target_alphabet) const;
 }; // struct Nfa.
 
 /**

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -119,12 +119,12 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Add rhs transitions to the result.
     for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
     {
-        for (const auto& symbol_transitions: rhs.get_moves_from(rhs_state))
+        for (const Move& move: rhs.get_moves_from(rhs_state))
         {
-            for (const auto& rhs_state_to: symbol_transitions.targets)
+            for (const State& rhs_state_to: move.targets)
             {
                 result.delta.add(rhs_result_states_map_internal[rhs_state],
-                                 symbol_transitions.symbol,
+                                 move.symbol,
                                  rhs_result_states_map_internal[rhs_state_to]);
             }
         }

--- a/src/nfa/nfa-concatenation.cc
+++ b/src/nfa/nfa-concatenation.cc
@@ -119,12 +119,12 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Add rhs transitions to the result.
     for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
     {
-        for (const Move& move: rhs.get_moves_from(rhs_state))
+        for (const Move& rhs_move: rhs.get_moves_from(rhs_state))
         {
-            for (const State& rhs_state_to: move.targets)
+            for (const State& rhs_state_to: rhs_move.targets)
             {
                 result.delta.add(rhs_result_states_map_internal[rhs_state],
-                                 move.symbol,
+                                 rhs_move.symbol,
                                  rhs_result_states_map_internal[rhs_state_to]);
             }
         }

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -34,12 +34,12 @@ void add_product_transition(Nfa& product, std::unordered_map<std::pair<State,Sta
     if (intersection_transition.empty()) { return; }
 
     auto& intersect_state_transitions{ product.delta.get_mutable_post(product_map[pair_to_process]) };
-    auto symbol_transitions_iter{ intersect_state_transitions.find(intersection_transition) };
-    if (symbol_transitions_iter == intersect_state_transitions.end()) {
+    auto move_iter{ intersect_state_transitions.find(intersection_transition) };
+    if (move_iter == intersect_state_transitions.end()) {
         intersect_state_transitions.insert(intersection_transition);
     } else {
         // Product already has some target states for the given symbol from the current product state.
-        symbol_transitions_iter->insert(intersection_transition.targets);
+        move_iter->insert(intersection_transition.targets);
     }
 }
 
@@ -151,9 +151,9 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
             // Add transitions of the current state pair for an epsilon preserving product.
 
             // Check for lhs epsilon transitions.
-            const auto& lhs_state_symbol_transitions{ lhs.delta[pair_to_process.first] };
-            if (!lhs_state_symbol_transitions.empty()) {
-                const auto& lhs_state_last_transitions{ lhs_state_symbol_transitions.back() };
+            const Post& lhs_post{ lhs.delta[pair_to_process.first] };
+            if (!lhs_post.empty()) {
+                const auto& lhs_state_last_transitions{ lhs_post.back() };
                 if (epsilons.find(lhs_state_last_transitions.symbol) != epsilons.end()) {
                     // Compute product for state transitions with lhs state epsilon transition.
                     // Create transition from the pair_to_process to all pairs between states to which first transition
@@ -169,9 +169,9 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
             }
 
             // Check for rhs epsilon transitions in case only rhs has any transitions and add them.
-            const auto& rhs_state_symbol_transitions{ rhs.delta[pair_to_process.second]};
-            if (!rhs_state_symbol_transitions.empty()) {
-                const auto& rhs_state_last_transitions{rhs_state_symbol_transitions.back()};
+            const Post& rhs_post{ rhs.delta[pair_to_process.second]};
+            if (!rhs_post.empty()) {
+                const auto& rhs_state_last_transitions{ rhs_post.back()};
                 if (epsilons.find(rhs_state_last_transitions.symbol) != epsilons.end()) {
                     // Compute product for state transitions with rhs state epsilon transition.
                     // Create transition from the pair_to_process to all pairs between states to which first transition

--- a/src/nfa/nfa-intersection.cc
+++ b/src/nfa/nfa-intersection.cc
@@ -34,12 +34,12 @@ void add_product_transition(Nfa& product, std::unordered_map<std::pair<State,Sta
     if (intersection_transition.empty()) { return; }
 
     auto& intersect_state_transitions{ product.delta.get_mutable_post(product_map[pair_to_process]) };
-    auto move_iter{ intersect_state_transitions.find(intersection_transition) };
-    if (move_iter == intersect_state_transitions.end()) {
+    auto intersection_move_iter{ intersect_state_transitions.find(intersection_transition) };
+    if (intersection_move_iter == intersect_state_transitions.end()) {
         intersect_state_transitions.insert(intersection_transition);
     } else {
         // Product already has some target states for the given symbol from the current product state.
-        move_iter->insert(intersection_transition.targets);
+        intersection_move_iter->insert(intersection_transition.targets);
     }
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -157,9 +157,9 @@ namespace {
             state = worklist.back();
             worklist.pop_back();
 
-            for (const auto& state_transitions: nfa.delta[state])
+            for (const Move& move: nfa.delta[state])
             {
-                for (const State target_state: state_transitions.targets)
+                for (const State target_state: move.targets)
                 {
                     if (!reachable.at(target_state))
                     {
@@ -195,8 +195,8 @@ namespace {
             state = worklist.back();
             worklist.pop_back();
 
-            for (const auto& state_transitions: nfa.delta[state]) {
-                for (const State target_state: state_transitions.targets) {
+            for (const Move& move: nfa.delta[state]) {
+                for (const State target_state: move.targets) {
                     if (states_to_consider[target_state] && !reachable[target_state]) {
                         worklist.push_back(target_state);
                         reachable[target_state] = true;
@@ -275,8 +275,8 @@ namespace {
     void collect_directed_transitions(const Nfa& nfa, const Symbol abstract_symbol, Nfa& digraph) {
         const State num_of_states{nfa.size() };
         for (State src_state{ 0 }; src_state < num_of_states; ++src_state) {
-            for (const auto& symbol_transitions: nfa.delta[src_state]) {
-                for (const State tgt_state: symbol_transitions.targets) {
+            for (const Move& move: nfa.delta[src_state]) {
+                for (const State tgt_state: move.targets) {
                     // Directly try to add the transition. Finding out whether the transition is already in the digraph
                     //  only iterates through transition relation again.
                     digraph.delta.add(src_state, abstract_symbol, tgt_state);
@@ -311,21 +311,21 @@ void Delta::add(State state_from, Symbol symbol, State state_to) {
         posts.resize(max_state + 1);
     }
 
-    Post& state_transitions{ posts[state_from] };
+    Post& post{ posts[state_from] };
 
-    if (state_transitions.empty()) {
-        state_transitions.insert({ symbol, state_to });
-    } else if (state_transitions.back().symbol < symbol) {
-        state_transitions.insert({ symbol, state_to });
+    if (post.empty()) {
+        post.insert({ symbol, state_to });
+    } else if (post.back().symbol < symbol) {
+        post.insert({ symbol, state_to });
     } else {
-        const auto symbol_transitions{ state_transitions.find(Move{ symbol }) };
-        if (symbol_transitions != state_transitions.end()) {
+        const auto move_it{ post.find(symbol) };
+        if (move_it != post.end()) {
             // Add transition with symbol already used on transitions from state_from.
-            symbol_transitions->insert(state_to);
+            move_it->insert(state_to);
         } else {
             // Add transition to a new Move struct with symbol yet unused on transitions from state_from.
-            const Move new_symbol_transitions{ symbol, state_to };
-            state_transitions.insert(new_symbol_transitions);
+            const Move new_move{ symbol, state_to };
+            post.insert(new_move);
         }
     }
 }
@@ -348,10 +348,10 @@ void Delta::add(const State state_from, const Symbol symbol, const StateSet& sta
     } else if (state_transitions.back().symbol < symbol) {
         state_transitions.insert({ symbol, states });
     } else {
-        const auto symbol_transitions{ state_transitions.find(symbol) };
-        if (symbol_transitions != state_transitions.end()) {
+        const auto move_it{ state_transitions.find(symbol) };
+        if (move_it != state_transitions.end()) {
             // Add transition with symbolOnTransition already used on transitions from state_from.
-            symbol_transitions->insert(states);
+            move_it->insert(states);
 
         } else {
             // Add transition to a new Move struct with symbol yet unused on transitions from state_from.
@@ -366,25 +366,25 @@ void Delta::remove(State src, Symbol symb, State tgt) {
         return;
     }
 
-    Post& state_transitions{ posts[src] };
-    if (state_transitions.empty()) {
+    Post& post{ posts[src] };
+    if (post.empty()) {
         throw std::invalid_argument(
                 "Transition [" + std::to_string(src) + ", " + std::to_string(symb) + ", " +
                 std::to_string(tgt) + "] does not exist.");
-    } else if (state_transitions.back().symbol < symb) {
+    } else if (post.back().symbol < symb) {
         throw std::invalid_argument(
                 "Transition [" + std::to_string(src) + ", " + std::to_string(symb) + ", " +
                 std::to_string(tgt) + "] does not exist.");
     } else {
-        const auto symbol_transitions{ state_transitions.find(Move{symb }) };
-        if (symbol_transitions == state_transitions.end()) {
+        const auto move_it{ post.find(symb) };
+        if (move_it == post.end()) {
             throw std::invalid_argument(
                     "Transition [" + std::to_string(src) + ", " + std::to_string(symb) + ", " +
                     std::to_string(tgt) + "] does not exist.");
         } else {
-            symbol_transitions->remove(tgt);
-            if (symbol_transitions->empty()) {
-                posts[src].remove(*symbol_transitions);
+            move_it->remove(tgt);
+            if (move_it->empty()) {
+                posts[src].remove(*move_it);
             }
         }
     }
@@ -403,12 +403,12 @@ bool Delta::contains(State src, Symbol symb, State tgt) const
     if (tl.empty()) {
         return false;
     }
-    auto symbol_transitions{ tl.find(Move{symb} ) };
-    if (symbol_transitions == tl.cend()) {
+    auto move_it{ tl.find(symb) };
+    if (move_it == tl.cend()) {
         return false;
     }
 
-    return symbol_transitions->targets.find(tgt) != symbol_transitions->targets.end();
+    return move_it->targets.find(tgt) != move_it->targets.end();
 }
 
 bool Delta::empty() const
@@ -860,14 +860,14 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
     const size_t num_of_states{aut.size() };
     for (size_t i{ 0 }; i < num_of_states; ++i)
     {
-        for (const auto& trans: aut.delta[i])
+        for (const Move& move: aut.delta[i])
         { // initialize
             const auto it_ins_pair = eps_closure.insert({i, {i}});
-            if (trans.symbol == epsilon)
+            if (move.symbol == epsilon)
             {
                 StateSet& closure = it_ins_pair.first->second;
                 // TODO: Fix possibly insert to OrdVector. Create list already ordered, then merge (do not need to resize each time);
-                closure.insert(trans.targets);
+                closure.insert(move.targets);
             }
         }
     }
@@ -1447,11 +1447,10 @@ TransSequence Nfa::get_transitions_to(State state_to) const {
     TransSequence transitions_to_state{};
     const size_t num_of_states{ delta.num_of_states() };
     for (State state_from{ 0 }; state_from < num_of_states; ++state_from) {
-        for (const auto& symbol_transitions: delta[state_from]) {
-            const auto& symbol_states_to{ symbol_transitions.targets };
-            const auto target_state{ symbol_states_to.find(state_to) };
-            if (target_state != symbol_states_to.end()) {
-                transitions_to_state.emplace_back( state_from, symbol_transitions.symbol, state_to );
+        for (const Move& move: delta[state_from]) {
+            const auto target_state{ move.targets.find(state_to) };
+            if (target_state != move.targets.end()) {
+                transitions_to_state.emplace_back(state_from, move.symbol, state_to );
             }
         }
     }
@@ -1464,11 +1463,11 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
         return res;
     }
 
-    for (const auto state : states) {
-        const auto& state_transitions{delta[state] };
-        const auto state_symbol_transitions{ state_transitions.find(Move{symbol }) };
-        if (state_symbol_transitions != state_transitions.end()) {
-            res.insert(state_symbol_transitions->targets);
+    for (const State state: states) {
+        const Post& post{ delta[state] };
+        const auto move_it{ post.find(symbol) };
+        if (move_it != post.end()) {
+            res.insert(move_it->targets);
         }
     }
     return res;
@@ -1479,19 +1478,19 @@ Post::const_iterator Nfa::Nfa::get_epsilon_transitions(const State state, const 
     return get_epsilon_transitions(get_moves_from(state), epsilon);
 }
 
-Post::const_iterator Nfa::Nfa::get_epsilon_transitions(const Post& state_transitions, const Symbol epsilon) {
-    if (!state_transitions.empty()) {
+Post::const_iterator Nfa::Nfa::get_epsilon_transitions(const Post& post, const Symbol epsilon) {
+    if (!post.empty()) {
         if (epsilon == EPSILON) {
-            const auto& back = state_transitions.back();
+            const auto& back = post.back();
             if (back.symbol == epsilon) {
-                return std::prev(state_transitions.end());
+                return std::prev(post.end());
             }
         } else {
-            return state_transitions.find(Move(epsilon));
+            return post.find(epsilon);
         }
     }
 
-    return state_transitions.end();
+    return post.end();
 }
 
 Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {
@@ -2099,20 +2098,19 @@ void Nfa::unify_final() {
 void Mata::Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
     const size_t nfa_num_of_states{ nfa.size() };
     for (Mata::Nfa::State state{ 0 }; state < nfa_num_of_states; ++state) {
-        // TODO: Rewrite to not create 'Trans' instances and iterate over same symbols all the time.
-        for (const Trans& state_transitions: nfa.delta) {
-            alphabet.update_next_symbol_value(state_transitions.symb);
-            alphabet.try_add_new_symbol(std::to_string(state_transitions.symb), state_transitions.symb);
+        for (const Move& move: nfa.delta[state]) {
+            alphabet.update_next_symbol_value(move.symbol);
+            alphabet.try_add_new_symbol(std::to_string(move.symbol), move.symbol);
         }
     }
 }
 
-void Nfa::add_symbols_to(OnTheFlyAlphabet& alphabet) const {
+void Nfa::add_symbols_to(OnTheFlyAlphabet& target_alphabet) const {
     size_t aut_num_of_states{size() };
     for (Mata::Nfa::State state{ 0 }; state < aut_num_of_states; ++state) {
-        for (const auto& state_transitions: delta[state]) {
-            alphabet.update_next_symbol_value(state_transitions.symbol);
-            alphabet.try_add_new_symbol(std::to_string(state_transitions.symbol), state_transitions.symbol);
+        for (const Move& move: delta[state]) {
+            target_alphabet.update_next_symbol_value(move.symbol);
+            target_alphabet.try_add_new_symbol(std::to_string(move.symbol), move.symbol);
         }
     }
 }

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -209,7 +209,7 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
         SegItem new_item;
         Mata::Nfa::SharedPtrAut seg = segments_one_initial_final[{unused_state, fn}];
         if(seg->final.size() != 1 || seg->get_num_of_trans() > 0) { // L(seg_iter) != {epsilon}
-            new_item.noodle.push_back({seg, def_eps_vector});
+            new_item.noodle.emplace_back(seg, def_eps_vector);
         }
         new_item.seg_id = 0;
         new_item.fin = fn;
@@ -249,7 +249,7 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
                 new_item.seg_id++;
                 // do not include segmets with trivial epsilon language
                 if(seg_iter->second->final.size() != 1 || seg_iter->second->get_num_of_trans() > 0) { // L(seg_iter) != {epsilon}
-                    new_item.noodle.push_back({seg_iter->second, process_eps_map(visited_eps[tr.tgt])});
+                    new_item.noodle.emplace_back(seg_iter->second, process_eps_map(visited_eps[tr.tgt]));
                 }
                 new_item.fin = fn;
                 lifo.push_back(new_item);

--- a/src/strings/nfa-segmentation.cc
+++ b/src/strings/nfa-segmentation.cc
@@ -21,18 +21,13 @@ using namespace Mata::Nfa;
 using namespace Mata::Strings;
 
 void SegNfa::Segmentation::process_state_depth_pair(const StateDepthTuple& state_depth_pair,
-                                                    std::deque<StateDepthTuple>& worklist)
-{
+                                                    std::deque<StateDepthTuple>& worklist) {
     auto outgoing_post{ automaton.delta[state_depth_pair.state] };
-    for (const Move& move: outgoing_post)
-    {
-        if (this->epsilons.find(move.symbol) != this->epsilons.end())
-        {
-            handle_epsilon_transitions(state_depth_pair, move, worklist);
-        }
-        else // Handle other transitions.
-        {
-            add_transitions_to_worklist(state_depth_pair, move, worklist);
+    for (const Move& outgoing_move: outgoing_post) {
+        if (this->epsilons.find(outgoing_move.symbol) != this->epsilons.end()) {
+            handle_epsilon_transitions(state_depth_pair, outgoing_move, worklist);
+        } else { // Handle other transitions.
+            add_transitions_to_worklist(state_depth_pair, outgoing_move, worklist);
         }
     }
 }

--- a/src/strings/nfa-segmentation.cc
+++ b/src/strings/nfa-segmentation.cc
@@ -23,22 +23,22 @@ using namespace Mata::Strings;
 void SegNfa::Segmentation::process_state_depth_pair(const StateDepthTuple& state_depth_pair,
                                                     std::deque<StateDepthTuple>& worklist)
 {
-    auto outgoing_transitions{automaton.get_moves_from(state_depth_pair.state) };
-    for (const auto& state_transitions: outgoing_transitions)
+    auto outgoing_post{ automaton.delta[state_depth_pair.state] };
+    for (const Move& move: outgoing_post)
     {
-        if (this->epsilons.find(state_transitions.symbol) != this->epsilons.end())
+        if (this->epsilons.find(move.symbol) != this->epsilons.end())
         {
-            handle_epsilon_transitions(state_depth_pair, state_transitions, worklist);
+            handle_epsilon_transitions(state_depth_pair, move, worklist);
         }
         else // Handle other transitions.
         {
-            add_transitions_to_worklist(state_depth_pair, state_transitions, worklist);
+            add_transitions_to_worklist(state_depth_pair, move, worklist);
         }
     }
 }
 
 void SegNfa::Segmentation::handle_epsilon_transitions(const StateDepthTuple& state_depth_pair,
-                                                      const Move& state_transitions,
+                                                      const Move& move,
                                                       std::deque<StateDepthTuple>& worklist)
 {
     /// TODO: Maybe we don't need to keep the transitions in both structures
@@ -46,15 +46,15 @@ void SegNfa::Segmentation::handle_epsilon_transitions(const StateDepthTuple& sta
     this->eps_depth_trans_map.insert({ state_depth_pair.depth, {{state_depth_pair.state, TransSequence{}}} });
 
     std::map<Symbol, unsigned> visited_eps_aux(state_depth_pair.eps);
-    visited_eps_aux[state_transitions.symbol]++; 
+    visited_eps_aux[move.symbol]++;
 
-    for (State target_state: state_transitions.targets)
+    for (State target_state: move.targets)
     {
         this->epsilon_depth_transitions[state_depth_pair.depth].push_back(
-                Trans{ state_depth_pair.state, state_transitions.symbol, target_state }
+                Trans{ state_depth_pair.state, move.symbol, target_state }
         );
         this->eps_depth_trans_map[state_depth_pair.depth][state_depth_pair.state].push_back(
-            Trans{ state_depth_pair.state, state_transitions.symbol, target_state }
+            Trans{ state_depth_pair.state, move.symbol, target_state }
         );
         worklist.push_back(StateDepthTuple{ target_state, state_depth_pair.depth + 1, visited_eps_aux });
         this->visited_eps[target_state] = visited_eps_aux;
@@ -62,10 +62,10 @@ void SegNfa::Segmentation::handle_epsilon_transitions(const StateDepthTuple& sta
 }
 
 void SegNfa::Segmentation::add_transitions_to_worklist(const StateDepthTuple& state_depth_pair,
-                                                      const Move& state_transitions,
+                                                      const Move& move,
                                                       std::deque<StateDepthTuple>& worklist)
 {
-    for (State target_state: state_transitions.targets)
+    for (State target_state: move.targets)
     {
         worklist.push_back(StateDepthTuple{ target_state, state_depth_pair.depth, state_depth_pair.eps });
         this->visited_eps[target_state] = state_depth_pair.eps;

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2965,21 +2965,21 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     CHECK(aut.get_epsilon_transitions(5) == aut.get_moves_from(5).end());
     CHECK(aut.get_epsilon_transitions(19) == aut.get_moves_from(19).end());
 
-    auto state_transitions{ aut.delta[0] };
-    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    Post post{ aut.delta[0] };
+    state_eps_trans = aut.get_epsilon_transitions(post);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3 });
-    state_transitions = aut.delta[3];
-    state_eps_trans = aut.get_epsilon_transitions(state_transitions);
+    post = aut.delta[3];
+    state_eps_trans = aut.get_epsilon_transitions(post);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3, 4 });
 
-    state_transitions = aut.get_moves_from(1);
-    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
-    state_transitions = aut.get_moves_from(5);
-    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
-    state_transitions = aut.get_moves_from(19);
-    CHECK(aut.get_epsilon_transitions(state_transitions) == state_transitions.end());
+    post = aut.get_moves_from(1);
+    CHECK(aut.get_epsilon_transitions(post) == post.end());
+    post = aut.get_moves_from(5);
+    CHECK(aut.get_epsilon_transitions(post) == post.end());
+    post = aut.get_moves_from(19);
+    CHECK(aut.get_epsilon_transitions(post) == post.end());
 }
 
 TEST_CASE("Mata::Nfa::Nfa::delta()") {
@@ -3040,6 +3040,6 @@ TEST_CASE("Mata::Nfa:: print_to_mata") {
 	// for parsing output of print_to_mata() we need to use IntAlphabet to get the same alphabet
 	IntAlphabet int_alph;
 	Nfa aut_big_from_mata = construct(Mata::IntermediateAut::parse_from_mf(parse_mf(aut_big_mata))[0], &int_alph);
-	
+
 	CHECK(are_equivalent(aut_big, aut_big_from_mata));
 }


### PR DESCRIPTION
This PR renames variables with `Move` and `Post` to use the unified names `move` and `post` instead of the inconsistent and imprecise `state_transitions`, `symbol_transitions`, `symbol_state_transitions`, `trans`, etc.

This change was requested in our latest meeting.