### PR TITLE
Fix infinite looping when input is missing trailing newline

### DIFF
--- a/AUTOMATAFORMAT.md
+++ b/AUTOMATAFORMAT.md
@@ -4,7 +4,8 @@
 * The format is **line**-based. Lines can be connected by `\`.
 * Lines are parsed into tokens. Tokens are delimited by white spaces, the format is **white space sensitive** with exception of formulas in transitions where expressions could be written without white spaces separating tokens.
 * A file contains **sections** starting with a line of the form `@<SECTION-TYPE>`, containing an automaton or, in theory, anything. We will start with one section per file, containing an automaton, but it is obviously extensible to more sections and more kinds of things.
-* In automata sections, non-empty lines are **key-value lines** of the form `%<KEY> [VALUE]`, **transition lines**, or **comment lines** starting with `#`. Several key-value lines with the same key mean that the key is mapped to the set of values, an occurence without a value marks that the `KEY` is defined. 
+* In automata sections, non-empty lines are **key-value lines** of the form `%<KEY> [VALUE]`, **transition lines**, 
+  or **comment lines** starting with `#`. Several key-value lines with the same key mean that the key is mapped to the set of values, an occurrence without a value marks that the `KEY` is defined. 
 * Besides white spaces and the end of line, the following are **characters with special meaning**: `&`,`|`,`!`,`@`,`(`,`)`,`%`,`"`,`\`,`#` `[`,`]`,`a`,`q`,`n`,`t`,`f`.
   * `&`,`|`,`!`,`(`,`)` are logical operators used in Boolean formulas.
   * `[`,`]`,`-`,`^` enclose character classes, such as `[abcd-h]`, `[^abcd-h]`.

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -250,8 +250,7 @@ Parsed Mata::Parser::parse_mf(
 { // {{{
 	Parsed result;
 
-	while (input)
-	{
+	while (input.good()) {
 		ParsedSection parsec = parse_mf_section(input, keepQuotes);
 		if (!parsec.empty())
 		{

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -20,6 +20,7 @@
 
 #include "mata/parser.hh"
 #include "mata/util.hh"
+#include "mata/nfa.hh"
 
 using namespace Mata::Parser;
 using namespace Mata::Util;
@@ -420,6 +421,23 @@ TEST_CASE("correct use of Mata::Parser::parse_mf_section()")
 		std::string remains = stream.str().substr(static_cast<size_t>(stream.tellg()));
 		REQUIRE("@Type2\n%key2\n" == remains);
 	}
+
+    SECTION("Correctly parse with missing newline at the end of the file") {
+        std::string file =
+        "@NFA-explicit\n"
+        "%Alphabet-auto\n"
+        "%Initial q0\n"
+        "%Final q0\n"
+        "q0 0 q0";
+        std::istringstream stream(file);
+        Mata::Nfa::Nfa aut = Mata::Nfa::construct(Mata::IntermediateAut::parse_from_mf(parse_mf(file))[0]);
+        CHECK(aut.initial.size() == 1);
+        CHECK(aut.initial.contains(0));
+        CHECK(aut.final.size() == 1);
+        CHECK(aut.initial.contains(0));
+        CHECK(aut.delta.contains(0, 0, 0) == 1);
+        CHECK(aut.delta.size() == 1);
+    }
 } // parse_mf_section correct }}}
 
 


### PR DESCRIPTION
This PR should fix infinite looping over sections in Mata format when the input stream does not have a trailing newline at the end of the file.