### PR TITLE
Parse NFAs from Mata format easily

### DIFF
--- a/include/mata/nfa/builder.hh
+++ b/include/mata/nfa/builder.hh
@@ -5,6 +5,8 @@
 
 #include "nfa.hh"
 
+#include <filesystem>
+
 using namespace Mata::Nfa;
 
 /**
@@ -64,6 +66,30 @@ Nfa construct(const ParsedObject& parsed, Mata::StringToSymbolMap* symbol_map = 
     return aut;
 } // construct().
 
+/**
+ * Parse NFA from the mata format in an input stream.
+ *
+ * @param nfa_stream Input stream containing NFA in mata format.
+ * @throws std::runtime_error Parsing of NFA fails.
+ */
+Nfa parse_from_mata(std::istream& nfa_stream);
+
+/**
+ * Parse NFA from the mata format in a string.
+ *
+ * @param nfa_stream String containing NFA in mata format.
+ * @throws std::runtime_error Parsing of NFA fails.
+ */
+Nfa parse_from_mata(const std::string& nfa_in_mata);
+
+/**
+ * Parse NFA from the mata format in a file.
+ *
+ * @param nfa_stream Path to the file containing NFA in mata format.
+ * @throws std::runtime_error @p nfa_file does not exist.
+ * @throws std::runtime_error Parsing of NFA fails.
+ */
+Nfa parse_from_mata(const std::filesystem::path& nfa_file);
 
 } // namespace Mata::Nfa::Builder.
 

--- a/src/nfa/builder.cc
+++ b/src/nfa/builder.cc
@@ -212,10 +212,12 @@ Nfa Builder::parse_from_mata(std::istream& nfa_stream) {
     const std::string nfa_str = "NFA";
     Parser::Parsed parsed{ Parser::parse_mf(nfa_stream) };
     if (parsed.size() != 1) {
-        throw std::runtime_error("The number of sections in the input file is not 1\n");
+        throw std::runtime_error("The number of sections in the input file is '" + std::to_string(parsed.size())
+            + "'. Required is '1'.\n");
     }
-    if (parsed[0].type.compare(0, nfa_str.length(), nfa_str) != 0) {
-        throw std::runtime_error("The type of input automaton is not NFA\n");
+    const std::string automaton_type{ parsed[0].type };
+    if (automaton_type.compare(0, nfa_str.length(), nfa_str) != 0) {
+        throw std::runtime_error("The type of input automaton is '" + automaton_type + "'. Required is 'NFA'\n");
     }
     IntAlphabet alphabet;
     return construct(IntermediateAut::parse_from_mf(parsed)[0], &alphabet);

--- a/src/nfa/builder.cc
+++ b/src/nfa/builder.cc
@@ -217,7 +217,8 @@ Nfa Builder::parse_from_mata(std::istream& nfa_stream) {
     if (parsed[0].type.compare(0, nfa_str.length(), nfa_str) != 0) {
         throw std::runtime_error("The type of input automaton is not NFA\n");
     }
-    return construct(IntermediateAut::parse_from_mf(parsed)[0]);
+    IntAlphabet alphabet;
+    return construct(IntermediateAut::parse_from_mf(parsed)[0], &alphabet);
 }
 
 Nfa Builder::parse_from_mata(const std::filesystem::path& nfa_file) {

--- a/tests-performance/src/unary-operations.cc
+++ b/tests-performance/src/unary-operations.cc
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
         Mata::Mintermization mintermization;
         auto mintermized = mintermization.mintermize(inter_auts);
         assert(mintermized.size() == 1);
-        aut = construct(mintermized[0], &stsm);
+        aut = Mata::Nfa::Builder::construct(mintermized[0], &stsm);
     }
     catch (const std::exception& ex) {
         fs.close();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,13 +30,14 @@ add_executable(tests
 		mintermization.cc
 		afa/afa.cc
 		nfa/nfa.cc
+		nfa/builder.cc
 		nfa/nfa-concatenation.cc
 		nfa/nfa-intersection.cc
 		nfa/nfa-profiling.cc
 		strings/nfa-noodlification.cc
 		strings/nfa-segmentation.cc
 		strings/nfa-string-solving.cc
-		)
+)
 
 target_link_libraries(tests libmata re2 simlib cudd)
 

--- a/tests/example-automata/nfa/simple.mata
+++ b/tests/example-automata/nfa/simple.mata
@@ -1,7 +1,0 @@
-@NFA-explicit
-%Alphabet-auto
-%Initial q0
-%Final q1
-q0 0 q0
-q0 1 q1
-q1 2 q0

--- a/tests/example-automata/nfa/simple.mata
+++ b/tests/example-automata/nfa/simple.mata
@@ -1,0 +1,7 @@
+@NFA-explicit
+%Alphabet-auto
+%Initial q0
+%Final q1
+q0 0 q0
+q0 1 q1
+q1 2 q0

--- a/tests/nfa/builder.cc
+++ b/tests/nfa/builder.cc
@@ -1,0 +1,41 @@
+// TODO: some header
+
+#include <unordered_set>
+
+#include "../3rdparty/catch.hpp"
+
+#include "mata/nfa/nfa.hh"
+#include "mata/nfa/builder.hh"
+
+using Symbol = Mata::Symbol;
+using IntAlphabet = Mata::IntAlphabet;
+using OnTheFlyAlphabet = Mata::OnTheFlyAlphabet;
+using StringToSymbolMap = Mata::StringToSymbolMap;
+
+using Word = std::vector<Symbol>;
+
+TEST_CASE("parse_from_mata()") {
+    Delta delta;
+    delta.add(0, 0, 0);
+    delta.add(0, 1, 1);
+    delta.add(1, 2, 0);
+    Nfa nfa{ delta, { 0 }, { 1 } };
+
+    SECTION("from string") {
+        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa.print_to_mata()) };
+        CHECK(are_equivalent(parsed, nfa));
+    }
+
+    SECTION("from stream") {
+        std::stringstream nfa_stream;
+        nfa.print_to_mata(nfa_stream);
+        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_stream) };
+        CHECK(are_equivalent(parsed, nfa));
+    }
+
+    SECTION("from file") {
+        std::filesystem::path nfa_file{ "./tests/example-automata/nfa/simple.mata" };
+        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_file) };
+        CHECK(are_equivalent(parsed, nfa));
+    }
+}

--- a/tests/nfa/builder.cc
+++ b/tests/nfa/builder.cc
@@ -1,6 +1,7 @@
 // TODO: some header
 
 #include <unordered_set>
+#include <fstream>
 
 #include "../3rdparty/catch.hpp"
 
@@ -16,26 +17,88 @@ using Word = std::vector<Symbol>;
 
 TEST_CASE("parse_from_mata()") {
     Delta delta;
-    delta.add(0, 0, 0);
-    delta.add(0, 1, 1);
-    delta.add(1, 2, 0);
-    Nfa nfa{ delta, { 0 }, { 1 } };
 
-    SECTION("from string") {
-        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa.print_to_mata()) };
-        CHECK(are_equivalent(parsed, nfa));
+    SECTION("Simple automaton") {
+        delta.add(0, 0, 0);
+        delta.add(0, 1, 1);
+        delta.add(1, 2, 0);
+        Nfa nfa{ delta, { 0 }, { 1 } };
+
+        SECTION("from string") {
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa.print_to_mata()) };
+            CHECK(are_equivalent(parsed, nfa));
+        }
+
+        SECTION("from stream") {
+            std::stringstream nfa_stream;
+            nfa.print_to_mata(nfa_stream);
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_stream) };
+            CHECK(are_equivalent(parsed, nfa));
+        }
+
+        SECTION("from file") {
+            std::filesystem::path nfa_file{ "./temp-test-parse_from_mata-simple_nfa.mata" };
+            std::fstream file{ nfa_file, std::fstream::in | std::fstream::out | std::fstream::trunc};
+            nfa.print_to_mata(file);
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_file) };
+            file.close();
+            std::filesystem::remove(nfa_file);
+
+            CHECK(are_equivalent(parsed, nfa));
+        }
+
     }
 
-    SECTION("from stream") {
-        std::stringstream nfa_stream;
-        nfa.print_to_mata(nfa_stream);
-        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_stream) };
-        CHECK(are_equivalent(parsed, nfa));
-    }
+    SECTION("larger automaton") {
+        Nfa nfa;
+        nfa.initial = { 1, 2, 50 };
+        nfa.delta.add(1, 'a', 2);
+        nfa.delta.add(1, 'a', 3);
+        nfa.delta.add(1, 'b', 4);
+        nfa.delta.add(2, 'a', 2);
+        nfa.delta.add(2, 'b', 2);
+        nfa.delta.add(2, 'a', 3);
+        nfa.delta.add(2, 'b', 4);
+        nfa.delta.add(3, 'b', 4);
+        nfa.delta.add(3, 'c', 7);
+        nfa.delta.add(3, 'b', 2);
+        nfa.delta.add(5, 'c', 3);
+        nfa.delta.add(7, 'a', 8);
+        nfa.delta.add(12, 'b', 15);
+        nfa.delta.add(1, 'b', 40);
+        nfa.delta.add(51, 'z', 42);
+        nfa.final = { 3, 103 };
 
-    SECTION("from file") {
-        std::filesystem::path nfa_file{ "./tests/example-automata/nfa/simple.mata" };
-        Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_file) };
-        CHECK(are_equivalent(parsed, nfa));
+        SECTION("from string") {
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa.print_to_mata()) };
+            parsed.final.contains(103);
+            parsed.initial.contains(50);
+            parsed.delta.contains(51, 'z', 42);
+            CHECK(are_equivalent(parsed, nfa));
+        }
+
+        SECTION("from stream") {
+            std::stringstream nfa_stream;
+            nfa.print_to_mata(nfa_stream);
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_stream) };
+            parsed.final.contains(103);
+            parsed.initial.contains(50);
+            parsed.delta.contains(51, 'z', 42);
+            CHECK(are_equivalent(parsed, nfa));
+        }
+
+        SECTION("from file") {
+            std::filesystem::path nfa_file{ "./temp-test-parse_from_mata-larger_nfa.mata" };
+            std::fstream file{ nfa_file, std::fstream::in | std::fstream::out | std::fstream::trunc };
+            nfa.print_to_mata(file);
+            Nfa parsed{ Mata::Nfa::Builder::parse_from_mata(nfa_file) };
+            file.close();
+            std::filesystem::remove(nfa_file);
+
+            parsed.final.contains(103);
+            parsed.initial.contains(50);
+            parsed.delta.contains(51, 'z', 42);
+            CHECK(are_equivalent(parsed, nfa));
+        }
     }
 }

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -19,7 +19,6 @@ using namespace Mata::Strings;
 using namespace Mata::Nfa::Plumbing;
 using namespace Mata::Util;
 using namespace Mata::Parser;
-using namespace Mata::Parser;
 using Symbol = Mata::Symbol;
 using IntAlphabet = Mata::IntAlphabet;
 using OnTheFlyAlphabet = Mata::OnTheFlyAlphabet;


### PR DESCRIPTION
This PR adds an easy way to parse an NFA from Mata format using a single function instead of about 30 lines of complicated internal parser code.

This function is useful for the interface when one “just wants to parse an NFA, not a multisectional Mata format file with different automata types for each section.”