### PR TITLE
Remove class methods from Nfa

### DIFF
--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -44,6 +44,7 @@ may arise during development.
 * [Troubleshooting](#troubleshooting)
   * [An error when importing Python object from other module](#an-error-when-importing-python-object-from-other-module)
   * [A weird error when Cython cannot retype C/C++ object to Python object](#a-weird-error-when-cython-cannot-retype-cc-object-to-python-object)
+  * [An error when Cython cannot find cimported function, even if it is defined](#an-error-when-cython-cannot-find-cimported-function-even-if-it-is-defined)
 * [Quick glossary](#quick-glossary)
 <!-- TOC -->
 
@@ -784,6 +785,40 @@ for c_noodle in c_noodle_segments:
         noodle.append(noodle_segment)
 
     noodle_segments.append(noodle)
+```
+
+## An error when Cython cannot find cimported function, even if it is defined
+
+* **Problem**: You defined some function `f` you wish to use in binding, you implement the function
+  with same name in the binding, but Cython first says, that 
+  you are redefining the function `f` and then says it cannot `cimport` it.
+* **Solution**: You have to explicitly name the function `f` to, e.g.. `c_f`.
+
+* The following is an example of the error.
+ 
+```shell
+warning: libmata/nfa/nfa.pyx:690:0: Overriding cdef method with def method.
+
+Error compiling Cython file:
+------------------------------------------------------------
+...
+:param Nfa lhs: non-deterministic finite automaton
+:return: deterministic finite automaton, subset map
+"""
+result = Nfa()
+cdef umap[StateSet, State] subset_map
+mata_nfa.determinize(result.thisptr.get(), dereference(lhs.thisptr.get()), &subset_map)
+       ^
+------------------------------------------------------------
+
+libmata/nfa/nfa.pyx:687:12: cimported module has no attribute 'determinize'
+```
+
+* An example of the solution is as follows:
+
+```git
+-    cdef void determinize(CNfa*, CNfa&, umap[StateSet, State]*)
++    cdef void c_determinize "Mata::Nfa::Plumbing::determinize" (CNfa*, CNfa&, umap[StateSet, State]*)
 ```
 
 # Quick glossary

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -169,39 +169,39 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         size_t size()
 
     # Automata tests
-    cdef bool is_deterministic(CNfa&)
-    cdef bool is_lang_empty(CNfa&, CRun*)
-    cdef bool is_universal(CNfa&, CAlphabet&, StringMap&) except +
-    cdef bool is_included(CNfa&, CNfa&, CAlphabet*, StringMap&)
-    cdef bool is_included(CNfa&, CNfa&, CRun*, CAlphabet*, StringMap&) except +
-    cdef bool are_equivalent(CNfa&, CNfa&, CAlphabet*, StringMap&)
-    cdef bool are_equivalent(CNfa&, CNfa&, StringMap&)
-    cdef bool is_complete(CNfa&, CAlphabet&) except +
-    cdef bool is_in_lang(CNfa&, CRun&)
-    cdef bool is_prfx_in_lang(CNfa&, CRun&)
+    cdef bool c_is_deterministic "Mata::Nfa::is_deterministic" (CNfa&)
+    cdef bool c_is_lang_empty "Mata::Nfa::is_lang_empty" (CNfa&, CRun*)
+    cdef bool c_is_universal "Mata::Nfa::is_universal" (CNfa&, CAlphabet&, StringMap&) except +
+    cdef bool c_is_included "Mata::Nfa::is_included" (CNfa&, CNfa&, CAlphabet*, StringMap&)
+    cdef bool c_is_included "Mata::Nfa::is_included" (CNfa&, CNfa&, CRun*, CAlphabet*, StringMap&) except +
+    cdef bool c_are_equivalent "Mata::Nfa::are_equivalent" (CNfa&, CNfa&, CAlphabet*, StringMap&)
+    cdef bool c_are_equivalent "Mata::Nfa::are_equivalent" (CNfa&, CNfa&, StringMap&)
+    cdef bool c_is_complete "Mata::Nfa::is_complete" (CNfa&, CAlphabet&) except +
+    cdef bool c_is_in_lang "Mata::Nfa::is_in_lang" (CNfa&, CRun&)
+    cdef bool c_is_prfx_in_lang "Mata::Nfa::is_prfx_in_lang" (CNfa&, CRun&)
 
     # Automata operations
     cdef void compute_fw_direct_simulation(const CNfa&)
 
     # Helper functions
-    cdef pair[CRun, bool] get_word_for_path(CNfa&, CRun&)
-    cdef CRun encode_word(StringToSymbolMap&, vector[string])
+    cdef pair[CRun, bool] c_get_word_for_path "Mata::Nfa::get_word_for_path" (CNfa&, CRun&)
+    cdef CRun c_encode_word "Mata::Nfa::encode_word" (StringToSymbolMap&, vector[string])
 
 cdef extern from "mata/nfa/algorithms.hh" namespace "Mata::Nfa::Algorithms":
-    cdef CBinaryRelation& compute_relation(CNfa&, StringMap&)
+    cdef CBinaryRelation& c_compute_relation "Mata::Nfa::Algorithms::compute_relation" (CNfa&, StringMap&)
 
 cdef extern from "mata/nfa/plumbing.hh" namespace "Mata::Nfa::Plumbing":
     cdef void get_elements(StateSet*, CBoolVector)
-    cdef void determinize(CNfa*, CNfa&, umap[StateSet, State]*)
-    cdef void uni(CNfa*, CNfa&, CNfa&)
-    cdef void intersection(CNfa*, CNfa&, CNfa&, bool, umap[pair[State, State], State]*)
-    cdef void concatenate(CNfa*, CNfa&, CNfa&, bool, StateToStateMap*, StateToStateMap*)
-    cdef void complement(CNfa*, CNfa&, CAlphabet&, StringMap&) except +
-    cdef void make_complete(CNfa*, CAlphabet&, State) except +
-    cdef void revert(CNfa*, CNfa&)
-    cdef void remove_epsilon(CNfa*, CNfa&, Symbol) except +
-    cdef void minimize(CNfa*, CNfa&)
-    cdef void reduce(CNfa*, CNfa&, bool, StateToStateMap*, StringMap&)
+    cdef void c_determinize "Mata::Nfa::Plumbing::determinize" (CNfa*, CNfa&, umap[StateSet, State]*)
+    cdef void c_uni "Mata::Nfa::Plumbing::uni" (CNfa*, CNfa&, CNfa&)
+    cdef void c_intersection "Mata::Nfa::Plumbing::intersection" (CNfa*, CNfa&, CNfa&, bool, umap[pair[State, State], State]*)
+    cdef void c_concatenate "Mata::Nfa::Plumbing::concatenate" (CNfa*, CNfa&, CNfa&, bool, StateToStateMap*, StateToStateMap*)
+    cdef void c_complement "Mata::Nfa::Plumbing::complement" (CNfa*, CNfa&, CAlphabet&, StringMap&) except +
+    cdef void c_make_complete "Mata::Nfa::Plumbing::make_complete" (CNfa*, CAlphabet&, State) except +
+    cdef void c_revert "Mata::Nfa::Plumbing::revert" (CNfa*, CNfa&)
+    cdef void c_remove_epsilon "Mata::Nfa::Plumbing::remove_epsilon" (CNfa*, CNfa&, Symbol) except +
+    cdef void c_minimize "Mata::Nfa::Plumbing::minimize" (CNfa*, CNfa&)
+    cdef void c_reduce "Mata::Nfa::Plumbing::reduce" (CNfa*, CNfa&, bool, StateToStateMap*, StringMap&)
 
 
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -219,12 +219,12 @@ def test_determinisation(nfa_two_states_uni, dfa_one_state_uni):
     Tests determinisation
     """
     lhs = nfa_two_states_uni
-    assert not mata_nfa.Nfa.is_deterministic(lhs)
+    assert not mata_nfa.is_deterministic(lhs)
     rhs = dfa_one_state_uni
-    assert mata_nfa.Nfa.is_deterministic(rhs)
+    assert mata_nfa.is_deterministic(rhs)
 
-    chs, sm_map = mata_nfa.Nfa.determinize_with_subset_map(lhs)
-    assert mata_nfa.Nfa.is_deterministic(chs)
+    chs, sm_map = mata_nfa.determinize_with_subset_map(lhs)
+    assert mata_nfa.is_deterministic(chs)
     assert sm_map == {(0,): 0, (0, 1): 1}
 
 
@@ -239,24 +239,24 @@ def test_forward_reach_states(
 def test_get_word_for_path(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
-    assert mata_nfa.Nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2]) == ([1, 1], True)
-    assert mata_nfa.Nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2, 0]) == ([], False)
-    assert mata_nfa.Nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2, 2]) == ([1, 1, 0], True)
-    assert mata_nfa.Nfa.get_word_for_path(
+    assert mata_nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2]) == ([1, 1], True)
+    assert mata_nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2, 0]) == ([], False)
+    assert mata_nfa.get_word_for_path(fa_one_divisible_by_two, [0, 1, 2, 2]) == ([1, 1, 0], True)
+    assert mata_nfa.get_word_for_path(
         fa_one_divisible_by_four, [0, 1, 2, 3, 4]
     ) == ([1, 1, 1, 1], True)
-    assert mata_nfa.Nfa.get_word_for_path(
+    assert mata_nfa.get_word_for_path(
         fa_one_divisible_by_eight, [0, 1, 2, 3, 4, 5, 6, 7, 8]
     ) == ([1, 1, 1, 1, 1, 1, 1, 1], True)
 
 
 def test_encode_word():
-    assert mata_nfa.Nfa.encode_word({'a': 1, 'b': 2, "c": 0}, "abca") == [1, 2, 0, 1]
+    assert mata_nfa.encode_word({'a': 1, 'b': 2, "c": 0}, "abca") == [1, 2, 0, 1]
 
 
 def test_language_emptiness(fa_one_divisible_by_two):
     cex = mata_nfa.Run()
-    assert not mata_nfa.Nfa.is_lang_empty(fa_one_divisible_by_two, cex)
+    assert not mata_nfa.is_lang_empty(fa_one_divisible_by_two, cex)
     assert cex.path == [0, 1, 2]
     assert cex.word == [1, 1]
 
@@ -266,7 +266,7 @@ def test_language_emptiness(fa_one_divisible_by_two):
     lhs.add_transition(1, 0, 2)
     lhs.add_transition(2, 0, 3)
     cex = mata_nfa.Run()
-    assert mata_nfa.Nfa.is_lang_empty(lhs, cex)
+    assert mata_nfa.is_lang_empty(lhs, cex)
     assert cex.word == []
     assert cex.path == []
 
@@ -275,14 +275,14 @@ def test_universality(fa_one_divisible_by_two):
     alph = alphabets.OnTheFlyAlphabet()
     alph.translate_symbol("a")
     alph.translate_symbol("b")
-    assert mata_nfa.Nfa.is_universal(fa_one_divisible_by_two, alph) == False
+    assert mata_nfa.is_universal(fa_one_divisible_by_two, alph) == False
 
     l = mata_nfa.Nfa(1)
     l.make_initial_state(0)
     l.add_transition(0, 0, 0)
     l.add_transition(0, 1, 0)
     l.make_final_state(0)
-    assert mata_nfa.Nfa.is_universal(l, alph) == True
+    assert mata_nfa.is_universal(l, alph) == True
 
 
 def test_inclusion(
@@ -291,28 +291,28 @@ def test_inclusion(
     alph = alphabets.OnTheFlyAlphabet()
     alph.translate_symbol("a")
     alph.translate_symbol("b")
-    result, cex = mata_nfa.Nfa.is_included_with_cex(fa_one_divisible_by_two, fa_one_divisible_by_four, alph)
+    result, cex = mata_nfa.is_included_with_cex(fa_one_divisible_by_two, fa_one_divisible_by_four, alph)
     assert not result
     assert cex.word == [1, 1]
-    result, cex = mata_nfa.Nfa.is_included_with_cex(fa_one_divisible_by_two, fa_one_divisible_by_four)
+    result, cex = mata_nfa.is_included_with_cex(fa_one_divisible_by_two, fa_one_divisible_by_four)
     assert not result
     assert cex.word == [1, 1]
 
-    result, cex = mata_nfa.Nfa.is_included_with_cex(fa_one_divisible_by_four, fa_one_divisible_by_two, alph)
+    result, cex = mata_nfa.is_included_with_cex(fa_one_divisible_by_four, fa_one_divisible_by_two, alph)
     assert result
     assert cex.word == []
-    result, cex = mata_nfa.Nfa.is_included_with_cex(fa_one_divisible_by_four, fa_one_divisible_by_two)
+    result, cex = mata_nfa.is_included_with_cex(fa_one_divisible_by_four, fa_one_divisible_by_two)
     assert result
     assert cex.word == []
 
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_two, alph)
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four, alph)
-    assert not mata_nfa.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight, alph)
-    assert not mata_nfa.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight, alph)
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_two)
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four)
-    assert not mata_nfa.Nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight)
-    assert not mata_nfa.Nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight)
+    assert mata_nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_two, alph)
+    assert mata_nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four, alph)
+    assert not mata_nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight, alph)
+    assert not mata_nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight, alph)
+    assert mata_nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_two)
+    assert mata_nfa.is_included(fa_one_divisible_by_eight, fa_one_divisible_by_four)
+    assert not mata_nfa.is_included(fa_one_divisible_by_two, fa_one_divisible_by_eight)
+    assert not mata_nfa.is_included(fa_one_divisible_by_four, fa_one_divisible_by_eight)
 
     # Test equivalence of two NFAs.
     smaller = mata_nfa.Nfa(10)
@@ -337,10 +337,10 @@ def test_inclusion(
     bigger.add_transition(13, ord('b'), 15)
     bigger.add_transition(15, ord('b'), 15)
 
-    assert not mata_nfa.Nfa.equivalence_check(smaller, bigger, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
-    assert not mata_nfa.Nfa.equivalence_check(smaller, bigger)
-    assert not mata_nfa.Nfa.equivalence_check(bigger, smaller, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
-    assert not mata_nfa.Nfa.equivalence_check(bigger, smaller)
+    assert not mata_nfa.equivalence_check(smaller, bigger, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
+    assert not mata_nfa.equivalence_check(smaller, bigger)
+    assert not mata_nfa.equivalence_check(bigger, smaller, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
+    assert not mata_nfa.equivalence_check(bigger, smaller)
 
     smaller = mata_nfa.Nfa(10)
     bigger = mata_nfa.Nfa(16)
@@ -350,10 +350,10 @@ def test_inclusion(
     bigger.initial_states = [11]
     bigger.final_states = [11]
 
-    assert mata_nfa.Nfa.equivalence_check(smaller, bigger, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
-    assert mata_nfa.Nfa.equivalence_check(smaller, bigger)
-    assert mata_nfa.Nfa.equivalence_check(bigger, smaller, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
-    assert mata_nfa.Nfa.equivalence_check(bigger, smaller)
+    assert mata_nfa.equivalence_check(smaller, bigger, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
+    assert mata_nfa.equivalence_check(smaller, bigger)
+    assert mata_nfa.equivalence_check(bigger, smaller, alphabets.OnTheFlyAlphabet.from_symbol_map(symbol_map))
+    assert mata_nfa.equivalence_check(bigger, smaller)
 
 
 def test_concatenate():
@@ -367,14 +367,14 @@ def test_concatenate():
     rhs.make_final_state(1)
     rhs.add_transition(0, ord('a'), 1)
 
-    result = mata_nfa.Nfa.concatenate(lhs, rhs)
+    result = mata_nfa.concatenate(lhs, rhs)
 
-    assert not mata_nfa.Nfa.is_lang_empty(result)
+    assert not mata_nfa.is_lang_empty(result)
     shortest_words = mata_strings.get_shortest_words(result)
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
 
-    result = mata_nfa.Nfa.concatenate(lhs, rhs, True)
+    result = mata_nfa.concatenate(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
     assert result.size() == 4
@@ -382,7 +382,7 @@ def test_concatenate():
     assert result.has_transition(1, mata_nfa.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
 
-    result, lhs_map, rhs_map = mata_nfa.Nfa.concatenate_with_result_state_maps(lhs, rhs, True)
+    result, lhs_map, rhs_map = mata_nfa.concatenate_with_result_state_maps(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
     assert result.size() == 4
@@ -397,44 +397,44 @@ def test_completeness(
     alph = alphabets.OnTheFlyAlphabet()
     alph.translate_symbol("a")
     alph.translate_symbol("b")
-    assert mata_nfa.Nfa.is_complete(fa_one_divisible_by_two, alph)
-    assert mata_nfa.Nfa.is_complete(fa_one_divisible_by_four, alph)
-    assert mata_nfa.Nfa.is_complete(fa_one_divisible_by_eight, alph)
+    assert mata_nfa.is_complete(fa_one_divisible_by_two, alph)
+    assert mata_nfa.is_complete(fa_one_divisible_by_four, alph)
+    assert mata_nfa.is_complete(fa_one_divisible_by_eight, alph)
 
     l = mata_nfa.Nfa(1)
     l.make_initial_state(0)
     l.add_transition(0, 0, 0)
-    assert not mata_nfa.Nfa.is_complete(l, alph)
+    assert not mata_nfa.is_complete(l, alph)
     l.add_transition(0, 1, 0)
-    assert mata_nfa.Nfa.is_complete(l, alph)
+    assert mata_nfa.is_complete(l, alph)
 
     r = mata_nfa.Nfa(1)
     r.make_initial_state(0)
     r.add_transition(0, 0, 0)
-    assert not mata_nfa.Nfa.is_complete(r, alph)
-    mata_nfa.Nfa.make_complete(r, 1, alph)
-    assert mata_nfa.Nfa.is_complete(r, alph)
+    assert not mata_nfa.is_complete(r, alph)
+    mata_nfa.make_complete(r, 1, alph)
+    assert mata_nfa.is_complete(r, alph)
 
 
 def test_in_language(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
-    assert mata_nfa.Nfa.is_in_lang(fa_one_divisible_by_two, [1, 1])
-    assert not mata_nfa.Nfa.is_in_lang(fa_one_divisible_by_two, [1, 1, 1])
+    assert mata_nfa.is_in_lang(fa_one_divisible_by_two, [1, 1])
+    assert not mata_nfa.is_in_lang(fa_one_divisible_by_two, [1, 1, 1])
 
-    assert mata_nfa.Nfa.is_prefix_in_lang(fa_one_divisible_by_four, [1, 1, 1, 1, 0])
-    assert not mata_nfa.Nfa.is_prefix_in_lang(fa_one_divisible_by_four, [1, 1, 1, 0, 0])
-    assert not mata_nfa.Nfa.accepts_epsilon(fa_one_divisible_by_four)
+    assert mata_nfa.is_prefix_in_lang(fa_one_divisible_by_four, [1, 1, 1, 1, 0])
+    assert not mata_nfa.is_prefix_in_lang(fa_one_divisible_by_four, [1, 1, 1, 0, 0])
+    assert not mata_nfa.accepts_epsilon(fa_one_divisible_by_four)
 
     lhs = mata_nfa.Nfa(2)
     lhs.make_initial_state(0)
     lhs.add_transition(0, 0, 0)
     lhs.add_transition(0, 1, 1)
-    assert not mata_nfa.Nfa.accepts_epsilon(lhs)
+    assert not mata_nfa.accepts_epsilon(lhs)
     lhs.make_final_state(1)
-    assert not mata_nfa.Nfa.accepts_epsilon(lhs)
+    assert not mata_nfa.accepts_epsilon(lhs)
     lhs.make_final_state(0)
-    assert mata_nfa.Nfa.accepts_epsilon(lhs)
+    assert mata_nfa.accepts_epsilon(lhs)
 
 
 def test_union(
@@ -444,18 +444,18 @@ def test_union(
     alph.translate_symbol("a")
     alph.translate_symbol("b")
 
-    assert mata_nfa.Nfa.is_in_lang(fa_one_divisible_by_two, [1, 1])
-    assert not mata_nfa.Nfa.is_in_lang(fa_one_divisible_by_four, [1, 1])
-    uni = mata_nfa.Nfa.union(fa_one_divisible_by_two, fa_one_divisible_by_four)
-    assert mata_nfa.Nfa.is_in_lang(uni, [1, 1])
-    assert mata_nfa.Nfa.is_in_lang(uni, [1, 1, 1, 1])
-    assert mata_nfa.Nfa.is_in_lang(uni, [1, 1, 1, 1, 1, 1])
-    assert mata_nfa.Nfa.is_in_lang(uni, [1, 1, 1, 1, 1, 1, 1, 1, ])
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_two, uni, alph)
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_four, uni, alph)
+    assert mata_nfa.is_in_lang(fa_one_divisible_by_two, [1, 1])
+    assert not mata_nfa.is_in_lang(fa_one_divisible_by_four, [1, 1])
+    uni = mata_nfa.union(fa_one_divisible_by_two, fa_one_divisible_by_four)
+    assert mata_nfa.is_in_lang(uni, [1, 1])
+    assert mata_nfa.is_in_lang(uni, [1, 1, 1, 1])
+    assert mata_nfa.is_in_lang(uni, [1, 1, 1, 1, 1, 1])
+    assert mata_nfa.is_in_lang(uni, [1, 1, 1, 1, 1, 1, 1, 1, ])
+    assert mata_nfa.is_included(fa_one_divisible_by_two, uni, alph)
+    assert mata_nfa.is_included(fa_one_divisible_by_four, uni, alph)
 
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_two, uni)
-    assert mata_nfa.Nfa.is_included(fa_one_divisible_by_four, uni)
+    assert mata_nfa.is_included(fa_one_divisible_by_two, uni)
+    assert mata_nfa.is_included(fa_one_divisible_by_four, uni)
 
 
 def test_intersection(
@@ -465,16 +465,16 @@ def test_intersection(
     alph.translate_symbol("a")
     alph.translate_symbol("b")
 
-    inter, product_map = mata_nfa.Nfa.intersection_with_product_map(fa_one_divisible_by_two, fa_one_divisible_by_four)
+    inter, product_map = mata_nfa.intersection_with_product_map(fa_one_divisible_by_two, fa_one_divisible_by_four)
 
-    assert not mata_nfa.Nfa.is_in_lang(inter, [1, 1])
-    assert mata_nfa.Nfa.is_in_lang(inter, [1, 1, 1, 1])
-    assert not mata_nfa.Nfa.is_in_lang(inter, [1, 1, 1, 1, 1, 1])
-    assert mata_nfa.Nfa.is_in_lang(inter, [1, 1, 1, 1, 1, 1, 1, 1, ])
-    assert mata_nfa.Nfa.is_included(inter, fa_one_divisible_by_two, alph)
-    assert mata_nfa.Nfa.is_included(inter, fa_one_divisible_by_four, alph)
-    assert mata_nfa.Nfa.is_included(inter, fa_one_divisible_by_two)
-    assert mata_nfa.Nfa.is_included(inter, fa_one_divisible_by_four)
+    assert not mata_nfa.is_in_lang(inter, [1, 1])
+    assert mata_nfa.is_in_lang(inter, [1, 1, 1, 1])
+    assert not mata_nfa.is_in_lang(inter, [1, 1, 1, 1, 1, 1])
+    assert mata_nfa.is_in_lang(inter, [1, 1, 1, 1, 1, 1, 1, 1, ])
+    assert mata_nfa.is_included(inter, fa_one_divisible_by_two, alph)
+    assert mata_nfa.is_included(inter, fa_one_divisible_by_four, alph)
+    assert mata_nfa.is_included(inter, fa_one_divisible_by_two)
+    assert mata_nfa.is_included(inter, fa_one_divisible_by_four)
     assert product_map == {(0, 0): 0, (1, 1): 1, (1, 3): 3, (2, 2): 2, (2, 4): 4}
 
 
@@ -505,7 +505,7 @@ def test_intersection_preserving_epsilon_transitions():
     b.add_transition(6, ord('a'), 9)
     b.add_transition(6, ord('b'), 7)
 
-    result, product_map = mata_nfa.Nfa.intersection_with_product_map(a, b, True)
+    result, product_map = mata_nfa.intersection_with_product_map(a, b, True)
 
     # Check states.
     assert result.size() == 13
@@ -583,10 +583,10 @@ def test_complement(
     alph.translate_symbol("a")
     alph.translate_symbol("b")
 
-    res = mata_nfa.Nfa.complement(fa_one_divisible_by_two, alph)
-    assert not mata_nfa.Nfa.is_in_lang(res, [1, 1])
-    assert mata_nfa.Nfa.is_in_lang(res, [1, 1, 1])
-    assert not mata_nfa.Nfa.is_in_lang(res, [1, 1, 1, 1])
+    res = mata_nfa.complement(fa_one_divisible_by_two, alph)
+    assert not mata_nfa.is_in_lang(res, [1, 1])
+    assert mata_nfa.is_in_lang(res, [1, 1, 1])
+    assert not mata_nfa.is_in_lang(res, [1, 1, 1, 1])
 
 
 def test_revert():
@@ -595,12 +595,12 @@ def test_revert():
     lhs.add_transition(0, 0, 1)
     lhs.add_transition(1, 1, 2)
     lhs.make_final_state(2)
-    assert mata_nfa.Nfa.is_in_lang(lhs, [0, 1])
-    assert not mata_nfa.Nfa.is_in_lang(lhs, [1, 0])
+    assert mata_nfa.is_in_lang(lhs, [0, 1])
+    assert not mata_nfa.is_in_lang(lhs, [1, 0])
 
-    rhs = mata_nfa.Nfa.revert(lhs)
-    assert not mata_nfa.Nfa.is_in_lang(rhs, [0, 1])
-    assert mata_nfa.Nfa.is_in_lang(rhs, [1, 0])
+    rhs = mata_nfa.revert(lhs)
+    assert not mata_nfa.is_in_lang(rhs, [0, 1])
+    assert mata_nfa.is_in_lang(rhs, [1, 0])
 
 
 def test_removing_epsilon():
@@ -611,7 +611,7 @@ def test_removing_epsilon():
     lhs.add_transition(0, 2, 2)
     lhs.make_final_state(2)
 
-    rhs = mata_nfa.Nfa.remove_epsilon(lhs, 2)
+    rhs = mata_nfa.remove_epsilon(lhs, 2)
     assert rhs.has_transition(0, 0, 1)
     assert rhs.has_transition(1, 1, 2)
     assert not rhs.has_transition(0, 2, 2)
@@ -620,11 +620,11 @@ def test_removing_epsilon():
 def test_minimize(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):
-    minimized = mata_nfa.Nfa.minimize(fa_one_divisible_by_two)
+    minimized = mata_nfa.minimize(fa_one_divisible_by_two)
     assert minimized.get_num_of_trans() <= fa_one_divisible_by_two.get_num_of_trans()
-    minimized = mata_nfa.Nfa.minimize(fa_one_divisible_by_four)
+    minimized = mata_nfa.minimize(fa_one_divisible_by_four)
     assert minimized.get_num_of_trans() <= fa_one_divisible_by_four.get_num_of_trans()
-    minimized = mata_nfa.Nfa.minimize(fa_one_divisible_by_eight)
+    minimized = mata_nfa.minimize(fa_one_divisible_by_eight)
     assert minimized.get_num_of_trans() <= fa_one_divisible_by_eight.get_num_of_trans()
 
     lhs = mata_nfa.Nfa(11)
@@ -636,7 +636,7 @@ def test_minimize(
     lhs.make_final_state(10)
     assert lhs.get_num_of_trans() == 11
 
-    minimized = mata_nfa.Nfa.minimize(lhs)
+    minimized = mata_nfa.minimize(lhs)
     assert minimized.get_num_of_trans() == 1
 
 
@@ -691,7 +691,7 @@ def test_trim(prepare_automaton_a):
     assert len(nfa.final_states) == len(old_nfa.final_states)
 
     for word in mata_strings.get_shortest_words(old_nfa):
-        assert mata_nfa.Nfa.is_in_lang(nfa, word)
+        assert mata_nfa.is_in_lang(nfa, word)
 
     nfa.remove_final_state(2)  # '2' is the new final state in the earlier trimmed automaton.
     nfa.trim()
@@ -717,7 +717,7 @@ def test_get_one_letter_automaton(prepare_automaton_a):
 
 def test_simulation(fa_one_divisible_by_four):
     lhs = fa_one_divisible_by_four
-    rel = mata_nfa.Nfa.compute_relation(lhs)
+    rel = mata_nfa.compute_relation(lhs)
     assert rel.size() == 5
     assert rel.to_matrix() == [
         [True, False, False, False, True],
@@ -749,7 +749,7 @@ def test_simulation(fa_one_divisible_by_four):
 
 def test_simulation_other_features(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
-    rel = mata_nfa.Nfa.compute_relation(lhs)
+    rel = mata_nfa.compute_relation(lhs)
     assert rel.to_matrix() == [
         [True, False, True],
         [False, True, False],
@@ -805,7 +805,7 @@ def test_simulation_equivalence():
 
 def test_simulation_indexes(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
-    rel = mata_nfa.Nfa.compute_relation(lhs)
+    rel = mata_nfa.compute_relation(lhs)
     index = rel.build_index()
     assert sorted(index) == [[0, 2], [1], [2]]
     inv_index = rel.build_inverse_index()
@@ -925,7 +925,7 @@ def test_reduce():
     nfa = mata_nfa.Nfa()
 
     # Test the reduction of an empty automaton.
-    result, state_map = mata_nfa.Nfa.reduce_with_state_map(nfa, False)
+    result, state_map = mata_nfa.reduce_with_state_map(nfa, False)
     assert result.get_num_of_trans() == 0
     assert len(result.initial_states) == 0
     assert len(result.final_states) == 0
@@ -934,7 +934,7 @@ def test_reduce():
     nfa.add_state(2)
     nfa.make_initial_state(1)
     nfa.make_final_state(2)
-    result, state_map = mata_nfa.Nfa.reduce_with_state_map(nfa, False)
+    result, state_map = mata_nfa.reduce_with_state_map(nfa, False)
     assert result.get_num_of_trans() == 0
     assert result.size() == 2
     assert result.has_initial_state(state_map[1])
@@ -942,7 +942,7 @@ def test_reduce():
     assert state_map[1] == state_map[0]
     assert state_map[2] != state_map[0]
 
-    result, state_map = mata_nfa.Nfa.reduce_with_state_map(nfa, True)
+    result, state_map = mata_nfa.reduce_with_state_map(nfa, True)
     assert result.get_num_of_trans() == 0
     assert result.size() == 0
 
@@ -966,7 +966,7 @@ def test_reduce():
     nfa.add_transition(9, ord('c'), 0)
     nfa.add_transition(0, ord('a'), 4)
 
-    result, state_map = mata_nfa.Nfa.reduce_with_state_map(nfa, False)
+    result, state_map = mata_nfa.reduce_with_state_map(nfa, False)
     assert result.size() == 6
     assert result.has_initial_state(state_map[1])
     assert result.has_initial_state(state_map[2])
@@ -1043,13 +1043,13 @@ def test_noodlify():
     left_side: list[Nfa] = [left1, left2, left3]
     result = mata_strings.noodlify_for_equation(left_side, right_side)
     assert len(result) == 2
-    assert mata_nfa.Nfa.equivalence_check(result[0][0], noodle1_segment1)
-    assert mata_nfa.Nfa.equivalence_check(result[0][1], noodle1_segment2)
-    assert mata_nfa.Nfa.equivalence_check(result[0][2], noodle1_segment3)
+    assert mata_nfa.equivalence_check(result[0][0], noodle1_segment1)
+    assert mata_nfa.equivalence_check(result[0][1], noodle1_segment2)
+    assert mata_nfa.equivalence_check(result[0][2], noodle1_segment3)
 
-    assert mata_nfa.Nfa.equivalence_check(result[1][0], noodle2_segment1)
-    assert mata_nfa.Nfa.equivalence_check(result[1][1], noodle2_segment2)
-    assert mata_nfa.Nfa.equivalence_check(result[1][2], noodle2_segment3)
+    assert mata_nfa.equivalence_check(result[1][0], noodle2_segment1)
+    assert mata_nfa.equivalence_check(result[1][1], noodle2_segment2)
+    assert mata_nfa.equivalence_check(result[1][2], noodle2_segment3)
 
 
 def test_unify():

--- a/bindings/python/tests/test_regex.py
+++ b/bindings/python/tests/test_regex.py
@@ -12,15 +12,15 @@ def test_regex():
     lhs = parser.from_regex("a|b")
     rhs = parser.from_regex("b|c")
 
-    union = mata_nfa.Nfa.union(lhs, rhs)
-    assert mata_nfa.Nfa.is_in_lang(union, mata_nfa.Nfa.encode_word(symbol_map, "a"))
-    assert mata_nfa.Nfa.is_in_lang(union, mata_nfa.Nfa.encode_word(symbol_map, "b"))
-    assert mata_nfa.Nfa.is_in_lang(union, mata_nfa.Nfa.encode_word(symbol_map, "c"))
+    union = mata_nfa.union(lhs, rhs)
+    assert mata_nfa.is_in_lang(union, mata_nfa.encode_word(symbol_map, "a"))
+    assert mata_nfa.is_in_lang(union, mata_nfa.encode_word(symbol_map, "b"))
+    assert mata_nfa.is_in_lang(union, mata_nfa.encode_word(symbol_map, "c"))
 
-    intersection = mata_nfa.Nfa.intersection(lhs, rhs)
-    assert not mata_nfa.Nfa.is_in_lang(intersection, mata_nfa.Nfa.encode_word(symbol_map, "a"))
-    assert mata_nfa.Nfa.is_in_lang(intersection, mata_nfa.Nfa.encode_word(symbol_map, "b"))
-    assert not mata_nfa.Nfa.is_in_lang(intersection, mata_nfa.Nfa.encode_word(symbol_map, "c"))
+    intersection = mata_nfa.intersection(lhs, rhs)
+    assert not mata_nfa.is_in_lang(intersection, mata_nfa.encode_word(symbol_map, "a"))
+    assert mata_nfa.is_in_lang(intersection, mata_nfa.encode_word(symbol_map, "b"))
+    assert not mata_nfa.is_in_lang(intersection, mata_nfa.encode_word(symbol_map, "c"))
 
 
 def test_stars_concatenation():
@@ -31,4 +31,4 @@ def test_stars_concatenation():
     expected.add_transition(0, ord('c'), 0)
     expected.add_transition(0, ord('a'), 1)
     expected.add_transition(1, ord('a'), 1)
-    assert mata_nfa.Nfa.equivalence_check(aut, expected)
+    assert mata_nfa.equivalence_check(aut, expected)

--- a/examples/notebooks/example-01-ws1s-formulae.ipynb
+++ b/examples/notebooks/example-01-ws1s-formulae.ipynb
@@ -458,7 +458,7 @@
     }
    ],
    "source": [
-    "premise = mata_nfa.Nfa.intersection(x_is_y_plus_one, y_is_z_plus_one)\n",
+    "premise = mata_nfa.intersection(x_is_y_plus_one, y_is_z_plus_one)\n",
     "premise.label = \"x = y + 1 ∧ y = z + 1\"\n",
     "plot(premise)"
    ]
@@ -621,7 +621,7 @@
     }
    ],
    "source": [
-    "not_premise = mata_nfa.Nfa.complement(premise, alphabet=config['alphabet'])\n",
+    "not_premise = mata_nfa.complement(premise, alphabet=config['alphabet'])\n",
     "not_premise.label = \"¬(x = y + 1 ∧ y = z + 1)\"\n",
     "plot(not_premise)"
    ]
@@ -909,7 +909,7 @@
     }
    ],
    "source": [
-    "formula = mata_nfa.Nfa.determinize(mata_nfa.Nfa.union(not_premise, x_is_z_plus_two))\n",
+    "formula = mata_nfa.determinize(mata_nfa.union(not_premise, x_is_z_plus_two))\n",
     "formula.label = \"¬(x = y + 1 ∧ y = z + 1) ∨ x = z + 2\"\n",
     "plot(formula)"
    ]
@@ -981,7 +981,7 @@
     }
    ],
    "source": [
-    "minimized_formula = mata_nfa.Nfa.minimize(formula)\n",
+    "minimized_formula = mata_nfa.minimize(formula)\n",
     "minimized_formula.label = \"¬(x = y + 1 ∧ y = z + 1) ∨ x = z + 2\"\n",
     "plot(minimized_formula)"
    ]
@@ -1015,7 +1015,7 @@
     }
    ],
    "source": [
-    "mata_nfa.Nfa.is_universal(minimized_formula, config['alphabet'])"
+    "mata_nfa.is_universal(minimized_formula, config['alphabet'])"
    ]
   }
  ],

--- a/examples/notebooks/example-02-redos-attacks.ipynb
+++ b/examples/notebooks/example-02-redos-attacks.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "lhs = parser.from_regex(\"^([a-zA-Z0-9])(([\\\\-.]|[_]+)?([a-zA-Z0-9]+))*(@){1}[a-z0-9]+[.]{1}(([a-z]{2,3})|([a-z]{2,3}[.]{1}[a-z]{2,3}))$\")\n",
-    "lhs = mata_nfa.Nfa.minimize(mata_nfa.Nfa.determinize(lhs))"
+    "lhs = mata_nfa.minimize(mata_nfa.determinize(lhs))"
    ]
   },
   {
@@ -113,7 +113,7 @@
     }
    ],
    "source": [
-    "mata_nfa.Nfa.is_in_lang(lhs, translate_string(\"test@gmail.com\"))"
+    "mata_nfa.is_in_lang(lhs, translate_string(\"test@gmail.com\"))"
    ]
   },
   {
@@ -134,7 +134,7 @@
     }
    ],
    "source": [
-    "timeit.timeit(lambda: mata_nfa.Nfa.is_in_lang(lhs, translate_string(\"test@gmail.com\")))"
+    "timeit.timeit(lambda: mata_nfa.is_in_lang(lhs, translate_string(\"test@gmail.com\")))"
    ]
   },
   {
@@ -165,7 +165,7 @@
     }
    ],
    "source": [
-    "mata_nfa.Nfa.is_in_lang(lhs, translate_string(\"testtgmaillcom\"))"
+    "mata_nfa.is_in_lang(lhs, translate_string(\"testtgmaillcom\"))"
    ]
   },
   {
@@ -186,7 +186,7 @@
     }
    ],
    "source": [
-    "timeit.timeit(lambda: mata_nfa.Nfa.is_in_lang(lhs, translate_string(\"testtgmaillcom\")))"
+    "timeit.timeit(lambda: mata_nfa.is_in_lang(lhs, translate_string(\"testtgmaillcom\")))"
    ]
   },
   {
@@ -210,7 +210,7 @@
     "dataset = {'time': [], 'size': []}\n",
     "for i in range(0, 1000):\n",
     "    workload = \"testtgmaillcom\" + \"a\"*i\n",
-    "    time = timeit.timeit(lambda: mata_nfa.Nfa.is_in_lang(lhs, translate_string(workload)), number=10)\n",
+    "    time = timeit.timeit(lambda: mata_nfa.is_in_lang(lhs, translate_string(workload)), number=10)\n",
     "    if float(time):\n",
     "        dataset['time'].append(float(time))\n",
     "        dataset['size'].append(len(workload))\n",

--- a/examples/notebooks/example-03-exploring-maze.ipynb
+++ b/examples/notebooks/example-03-exploring-maze.ipynb
@@ -930,7 +930,7 @@
    ],
    "source": [
     "solution = mata_nfa.Run()\n",
-    "is_empty = mata_nfa.Nfa.is_lang_empty(automaton_maze, solution)\n",
+    "is_empty = mata_nfa.is_lang_empty(automaton_maze, solution)\n",
     "is_empty"
    ]
   },
@@ -1007,7 +1007,7 @@
     "bwidth, bheight = 60, 10\n",
     "big_maze = generate_maze(bwidth, bheight)\n",
     "big_automaton_maze = to_automaton(big_maze)\n",
-    "is_empty = mata_nfa.Nfa.is_lang_empty(big_automaton_maze, solution)\n",
+    "is_empty = mata_nfa.is_lang_empty(big_automaton_maze, solution)\n",
     "if not is_empty:\n",
     "    plot_maze(big_maze, path_to_goal=solution.path)\n",
     "else:\n",


### PR DESCRIPTION
This PR:
  1. Removes classmethods from `Nfa` class to normal functions.
  2. Remarks about a certain issue during development.