### PR TITLE
Useful states fixing

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -203,8 +203,12 @@ public:
      */
     StateSet get_useful_states_old() const;
 
-    BoolVector get_useful_states() const;
-
+    /**
+     * @brief Get the useful states using a modified Tarjan's algorithm. A state 
+     * is useful if it is reachable from an initial state and can reach a final state.
+     * 
+     * @return BoolVector Bool vector whose ith value is true iff the state i is useful.
+     */
     BoolVector get_useful_states_tarjan() const;
 
     /**

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -205,6 +205,8 @@ public:
 
     BoolVector get_useful_states() const;
 
+    BoolVector get_useful_states_tarjan() const;
+
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.
      *

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -209,7 +209,7 @@ public:
      * 
      * @return BoolVector Bool vector whose ith value is true iff the state i is useful.
      */
-    BoolVector get_useful_states_tarjan() const;
+    BoolVector get_useful_states() const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states.

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -237,11 +237,11 @@ void Nfa::trim_reverting(StateToStateMap* state_map)
 void Nfa::trim_inplace(StateToStateMap* state_map)
 {
 #ifdef _STATIC_STRUCTURES_
-    BoolVector useful_states{ get_useful_states_tarjan() };
+    BoolVector useful_states{ useful_states() };
     useful_states.clear();
-    useful_states = get_useful_states_tarjan();
+    useful_states = useful_states();
 #else
-    BoolVector useful_states(get_useful_states_tarjan());
+    BoolVector useful_states(get_useful_states());
 #endif
 
     std::vector<State> renaming(useful_states.size());
@@ -355,7 +355,7 @@ struct TarjanNodeData {
     }
 };
 
-BoolVector Nfa::get_useful_states_tarjan() const {
+BoolVector Nfa::get_useful_states() const {
     BoolVector reached_and_reaching(this->size(),false); 
     std::vector<TarjanNodeData> node_info(this->size());
     std::deque<State> program_stack;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -237,9 +237,9 @@ void Nfa::trim_reverting(StateToStateMap* state_map)
 void Nfa::trim_inplace(StateToStateMap* state_map)
 {
 #ifdef _STATIC_STRUCTURES_
-    BoolVector useful_states{ get_useful_states() };
+    BoolVector useful_states{ get_useful_states_tarjan() };
     useful_states.clear();
-    useful_states = get_useful_states();
+    useful_states = get_useful_states_tarjan();
 #else
     BoolVector useful_states(get_useful_states_tarjan());
 #endif

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3043,3 +3043,35 @@ TEST_CASE("Mata::Nfa:: print_to_mata") {
 
 	CHECK(are_equivalent(aut_big, aut_big_from_mata));
 }
+
+TEST_CASE("Mata::Nfa::trim bug") {
+	Nfa aut(5, {0}, {4});
+    aut.delta.add(0, 122, 1);
+	aut.delta.add(1, 98, 1);
+	aut.delta.add(1, 122, 1);
+	aut.delta.add(1, 97, 2);
+	aut.delta.add(2, 122, 1);
+	aut.delta.add(2, 97, 1);
+	aut.delta.add(1, 97, 4);
+	aut.delta.add(3, 97, 4);
+
+	Nfa aut_copy {aut};
+	aut.trim();
+	CHECK(are_equivalent(aut_copy, aut));
+}
+
+TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
+	Nfa aut(5, {0}, {4});
+    aut.delta.add(0, 122, 1);
+	aut.delta.add(1, 98, 1);
+	aut.delta.add(1, 122, 1);
+	aut.delta.add(1, 97, 2);
+	aut.delta.add(2, 122, 1);
+	aut.delta.add(2, 97, 1);
+	aut.delta.add(1, 97, 4);
+	aut.delta.add(3, 97, 4);
+
+	Mata::BoolVector bv = aut.get_useful_states_tarjan();
+	Mata::BoolVector ref({1, 1, 1, 0, 1});
+	CHECK(bv == ref);
+}

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3072,7 +3072,7 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		aut.delta.add(1, 97, 4);
 		aut.delta.add(3, 97, 4);
 
-		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector bv = aut.get_useful_states();
 		Mata::BoolVector ref({1, 1, 1, 0, 1});
 		CHECK(bv == ref);
 	}
@@ -3084,7 +3084,7 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		aut.delta.add(1, 98, 4);
 		aut.delta.add(4, 97, 3);
 
-		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector bv = aut.get_useful_states();
 		Mata::BoolVector ref({1, 0, 1, 0, 0});
 		CHECK(bv == ref);
 	}
@@ -3094,7 +3094,7 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		aut.delta.add(0, 122, 0);
 		aut.delta.add(1, 98, 1);
 
-		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector bv = aut.get_useful_states();
 		Mata::BoolVector ref({1, 1});
 		CHECK(bv == ref);
 	}
@@ -3110,7 +3110,7 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		aut.delta.add(1, 97, 4);
 		aut.delta.add(3, 97, 4);
 
-		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector bv = aut.get_useful_states();
 		Mata::BoolVector ref({0, 0, 0, 0, 0});
 		CHECK(bv == ref);
 	}
@@ -3119,12 +3119,12 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		Mata::Nfa::Nfa aut;
 		Mata::Parser::create_nfa(&aut, "(a+b*a*)", false, EPSILON, false);
 
-		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector bv = aut.get_useful_states();
 		Mata::BoolVector ref({1, 0, 1, 0, 1, 0, 1, 0, 0});
 		CHECK(bv == ref);
 
 		aut = Mata::Nfa::reduce(aut);
-		bv = aut.get_useful_states_tarjan();
+		bv = aut.get_useful_states();
 		CHECK(bv == Mata::BoolVector({1,1,1,1}));
 	}
 	

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3061,17 +3061,72 @@ TEST_CASE("Mata::Nfa::trim bug") {
 }
 
 TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
-	Nfa aut(5, {0}, {4});
-    aut.delta.add(0, 122, 1);
-	aut.delta.add(1, 98, 1);
-	aut.delta.add(1, 122, 1);
-	aut.delta.add(1, 97, 2);
-	aut.delta.add(2, 122, 1);
-	aut.delta.add(2, 97, 1);
-	aut.delta.add(1, 97, 4);
-	aut.delta.add(3, 97, 4);
+	SECTION("Nfa 1") {
+		Nfa aut(5, {0}, {4});
+		aut.delta.add(0, 122, 1);
+		aut.delta.add(1, 98, 1);
+		aut.delta.add(1, 122, 1);
+		aut.delta.add(1, 97, 2);
+		aut.delta.add(2, 122, 1);
+		aut.delta.add(2, 97, 1);
+		aut.delta.add(1, 97, 4);
+		aut.delta.add(3, 97, 4);
 
-	Mata::BoolVector bv = aut.get_useful_states_tarjan();
-	Mata::BoolVector ref({1, 1, 1, 0, 1});
-	CHECK(bv == ref);
+		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector ref({1, 1, 1, 0, 1});
+		CHECK(bv == ref);
+	}
+
+	SECTION("Nfa 2") {
+		Nfa aut(5, {0, 1}, {2});
+		aut.delta.add(0, 122, 2);
+		aut.delta.add(2, 98, 3);
+		aut.delta.add(1, 98, 4);
+		aut.delta.add(4, 97, 3);
+
+		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector ref({1, 0, 1, 0, 0});
+		CHECK(bv == ref);
+	}
+
+	SECTION("Nfa 3") {
+		Nfa aut(2, {0, 1}, {0, 1});
+		aut.delta.add(0, 122, 0);
+		aut.delta.add(1, 98, 1);
+
+		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector ref({1, 1});
+		CHECK(bv == ref);
+	}
+
+	SECTION("Nfa no final") {
+		Nfa aut(5, {0}, {});
+		aut.delta.add(0, 122, 1);
+		aut.delta.add(1, 98, 1);
+		aut.delta.add(1, 122, 1);
+		aut.delta.add(1, 97, 2);
+		aut.delta.add(2, 122, 1);
+		aut.delta.add(2, 97, 1);
+		aut.delta.add(1, 97, 4);
+		aut.delta.add(3, 97, 4);
+
+		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector ref({0, 0, 0, 0, 0});
+		CHECK(bv == ref);
+	}
+
+	SECTION("from regex (a+b*a*)") {
+		Mata::Nfa::Nfa aut;
+		Mata::Parser::create_nfa(&aut, "(a+b*a*)", false, EPSILON, false);
+
+		Mata::BoolVector bv = aut.get_useful_states_tarjan();
+		Mata::BoolVector ref({1, 0, 1, 0, 1, 0, 1, 0, 0});
+		CHECK(bv == ref);
+
+		aut = Mata::Nfa::reduce(aut);
+		bv = aut.get_useful_states_tarjan();
+		CHECK(bv == Mata::BoolVector({1,1,1,1}));
+	}
+	
 }
+

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3046,7 +3046,7 @@ TEST_CASE("Mata::Nfa:: print_to_mata") {
 
 TEST_CASE("Mata::Nfa::trim bug") {
 	Nfa aut(5, {0}, {4});
-    aut.delta.add(0, 122, 1);
+	aut.delta.add(0, 122, 1);
 	aut.delta.add(1, 98, 1);
 	aut.delta.add(1, 122, 1);
 	aut.delta.add(1, 97, 2);

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3077,6 +3077,24 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		CHECK(bv == ref);
 	}
 
+	SECTION("Empty NFA") {
+		Nfa aut;
+		Mata::BoolVector bv = aut.get_useful_states();
+		CHECK(bv == Mata::BoolVector({}));
+	}
+
+	SECTION("Single-state NFA") {
+		Nfa aut(1, {0}, {});
+		Mata::BoolVector bv = aut.get_useful_states();
+		CHECK(bv == Mata::BoolVector({0}));
+	}
+
+	SECTION("Single-state NFA acc") {
+		Nfa aut(1, {0}, {0});
+		Mata::BoolVector bv = aut.get_useful_states();
+		CHECK(bv == Mata::BoolVector({1}));
+	}
+
 	SECTION("Nfa 2") {
 		Nfa aut(5, {0, 1}, {2});
 		aut.delta.add(0, 122, 2);


### PR DESCRIPTION
This PR fixes the `useful_states` function with the Tarjan-based implementation. A couple of questions to consider/discuss:

- Tarjan-based SCC decomposition is quite general and can be used elsewhere. I was wondering if we can do some parameterized Tarjan by a lambda performing action on each SCC. In this framework, however, it is not easily possible to express the computation of useful states as the usefulness is not a property of a single SCC.
- The working with iterators inside `NodeData` sucks. This could be somehow improved by `Post::transitions` iterator (iterator over a single post getting triplets (q,a,p))
- There is a lot of obsolete code related to trim and computation of useful states. I remove it later in this PR.