### PR TITLE
Bump CMake version to get rid of deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(libMATA)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
This PR bumps the CMake minimal required version to CMake 3.5.0 (from 2016), the first version not being deprecated in the next release of CMake (which will remain compatible with 3.5.0).