### PR TITLE
Add support for local coverage

### DIFF
--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -10,10 +10,10 @@ runs:
   using: 'composite'
   steps:
     - name: Building MacOS dependencies
-      if: ${{ github.event.inputs.os == 'macos-latest' }}
+      if: ${{ inputs.os == 'macos-latest' }}
       shell: sh
       run: brew install lcov gcovr automake
     - name: Building Unix dependencies
-      if: ${{ github.event.inputs.os == 'ubuntu-latest' }}
+      if: ${{ inputs.os == 'ubuntu-latest' }}
       shell: sh
       run: sudo apt-get install -y build-essential lcov gcovr xdg-utils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,6 @@ endif()
 #                             OUTPUT CUSTOMIZATION
 ##############################################################################
 
-# Build with Clang? -- currently does nothing, initialize with
-#   $ CXX=clang++ make debug
-# to enable Clang
-option(USE_CLANG "build with clang" OFF)
-# option(USE_CLANG "build with clang" ON)
-
 # Common compiler flags.
 set(COMMON_COMPILER_FLAGS
         -fms-extensions
@@ -79,6 +73,8 @@ endif ()
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
+    include(CodeCoverage)
+    setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)
 endif()
 
 ##############################################################################
@@ -123,11 +119,6 @@ message("-- Default C++ compiler: ${CMAKE_CXX_COMPILER}")
 # Include CTest so that sophisticated testing can be done now
 include(CTest)
 enable_testing()
-
-# if(CMAKE_COMPILER_IS_GNUCXX)
-#    include(CodeCoverage)
-#    setup_target_for_coverage(${PROJECT_NAME}_coverage tests coverage)
-# endif()
 
 ##############################################################################
 #                                SUB-MODULES

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ doc:
 test:
 	cd $(BUILD_DIR) && ctest $(TEST_FLAGS)
 
+test-coverage:
+	cd $(BUILD_DIR) && ctest $(TEST_FLAGS)
+	gcovr -p -e "3rdparty/*" -j 6 --exclude-unreachable-branches --exclude-throw-branches build/src build/tests
+
 check:
 	cd $(BUILD_DIR) && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. && cppcheck --project=compile_commands.json --quiet --error-exitcode=1
 


### PR DESCRIPTION
This PR adds support for running coverage metrics local.

Run `make coverage` and `make test-coverage` to compile the library for coverage testing and then running tests and outputing coverage sorted by covered-percentage.