### PR TITLE
Refactor delta and delta iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,4 +256,3 @@ Development of this tool has been supported by the following projects: ???.
 This tool as well as the information provided on this web page reflects
 only the author's view and no organization is responsible for any use
 that may be made of the information it contains.
-

--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -389,7 +389,7 @@ def determinize_with_subset_map(cls, Nfa lhs):
   will simply not be visible.
 
 ```cython
-cdef cppclass CMove "Mata::Nfa::Move":
+cdef cppclass CMove "Mata::Nfa::SymbolPost":
     Symbol symbol
     StateSet targets
 #   ^-- class attributes
@@ -398,7 +398,7 @@ cdef cppclass CMove "Mata::Nfa::Move":
 * Implement the getters and setters in Cython class
 
 ```cython
-cdef class Move:
+cdef class SymbolPost:
 # ^-- cython class
     cdef mata_nfa.CMove *thisptr
 #   ^-- wrapped C/C++ object
@@ -455,7 +455,7 @@ result[epsilon_depth_pair.first].append(mata_nfa.Trans(trans.src, trans.symb, tr
   2. `__repr__` returns computer readable representation (usually so it is parsable by other code); this is called in jupyter notebooks when you simply write the name of the vairable.
 
 ```cython
-cdef class Move:
+cdef class SymbolPost:
     def __str__(self):
     # ^-- called in notebook/interpret by typing `str(myvar)`
         trans = "{" + ",".join(map(str, self.targets)) + "}"
@@ -475,7 +475,7 @@ cdef class Move:
 ```cython
 # @file: nfa.pxd
 cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
-    cdef cppclass CMove "Mata::Nfa::Move":
+    cdef cppclass CMove "Mata::Nfa::SymbolPost":
         bool operator<(CMove)
         bool operator<=(CMove)
         bool operator>(CMove)
@@ -486,17 +486,17 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
 
 ```cython
 # @file: nfa.pyx
-cdef class Move:
-    def __lt__(self, Move other):
+cdef class SymbolPost:
+    def __lt__(self, SymbolPost other):
         return dereference(self.thisptr) < dereference(other.thisptr)
 
-    def __gt__(self, Move other):
+    def __gt__(self, SymbolPost other):
         return dereference(self.thisptr) > dereference(other.thisptr)
 
-    def __le__(self, Move other):
+    def __le__(self, SymbolPost other):
         return dereference(self.thisptr) <= dereference(other.thisptr)
 
-    def __ge__(self, Move other):
+    def __ge__(self, SymbolPost other):
         return dereference(self.thisptr) >= dereference(other.thisptr)
 ```
 
@@ -647,7 +647,7 @@ cdef vector[mata_nfa.CMove].iterator end = transitions_list.end()
 transsymbols = []
 while it != end:
 #     ^-- comparsion of two iterators
-    t = Move(
+    t = SymbolPost(
         dereference(it).symbol,
         dereference(it).targets.ToVector()
         # ^-- to access the value of iterator you need to dereference

--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -433,8 +433,8 @@ cdef extern from "mata/nfa.hh" namespace "Mata::Nfa":
 
 ```cython
 # @file: nfa.pxd
-cdef class Trans:
-# ^-- forward declaration of the Trans class
+cdef class Transition:
+# ^-- forward declaration of the Transition class
     cdef CTrans* thisptr
     cdef copy_from(self, CTrans trans)
     # ^-- all of properties (and preferably some cdef methods) must be declared as well
@@ -443,8 +443,8 @@ cdef class Trans:
 ```cython
 # @file: strings.pyx
 cimport libmata.nfa.nfa as mata_nfa
-result[epsilon_depth_pair.first].append(mata_nfa.Trans(trans.src, trans.symb, trans.tgt))
-#                                       ^-- now Trans can be used in other pyx files.
+result[epsilon_depth_pair.first].append(mata_nfa.Transition(trans.source, trans.symbol, trans.target))
+#                                       ^-- now Transition can be used in other pyx files.
 ```
 
 ## Declaring functions for string representation of objects
@@ -689,8 +689,8 @@ lhs.thisptr.get().add_state()
 cdef vector[CTrans] c_transitions = self.thisptr.get().get_transitions_to(state_to)
 trans = []
 for c_transition in c_transitions:
-#   ^-- classic for each loop over std::vector<Trans> does everything behind the scenes
-    trans.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+#   ^-- classic for each loop over std::vector<Transition> does everything behind the scenes
+    trans.append(Transition(c_transition.source, c_transition.symbol, c_transition.target))
 ```
 
 ## Working with strings
@@ -801,18 +801,18 @@ for trans in epsilon_depth_pair.second:
 if epsilon_depth_pair.first not in result:
 result[epsilon_depth_pair.first] = []
 
-                result[epsilon_depth_pair.first].append(mata_nfa.Trans(trans.src, trans.symb, trans.tgt))
+                result[epsilon_depth_pair.first].append(mata_nfa.Transition(trans.source, trans.symbol, trans.target))
                                                                ^
 ------------------------------------------------------------
 
-libmata/nfa/strings.pyx:37:64: cimported module has no attribute 'Trans'
+libmata/nfa/strings.pyx:37:64: cimported module has no attribute 'Transition'
 ```
 
 * The fix is to add the following forward declaration to `.pxd` file.
 
 ```cython
 # @file: nfa.pxd
-cdef class Trans:
+cdef class Transition:
     cdef CTrans* thisptr
     cdef copy_from(self, CTrans trans)
 ```

--- a/bindings/python/example-drawing.ipynb
+++ b/bindings/python/example-drawing.ipynb
@@ -502,7 +502,7 @@
    ],
    "source": [
     "e_h = [\n",
-    "    (lambda aut, edge: edge.symb == 1, {'color': 'red'}),\n",
+    "    (lambda aut, edge: edge.symbol == 1, {'color': 'red'}),\n",
     "    (lambda aut, edge: mata.configuration.Condition.transition_is_cycle, {'style': 'dashed', 'color': 'grey'})\n",
     "]\n",
     "n_h = [\n",

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -56,6 +56,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         vector[CStatePost] post
 
         void reserve(size_t)
+        CStatePost& state_post(State)
         CStatePost& operator[](State)
         void emplace_back()
         void clear()
@@ -151,7 +152,6 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         State add_state()
         State add_state(State)
         void print_to_DOT(ostream)
-        CStatePost get_moves_from(State)
         vector[CTrans] get_transitions_to(State)
         vector[CTrans] get_trans_as_sequence()
         vector[CTrans] get_trans_from_as_sequence(State)

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -78,11 +78,11 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         # Constructor
         CRun() except +
 
-    cdef cppclass CTrans "Mata::Nfa::Trans":
+    cdef cppclass CTrans "Mata::Nfa::Transition":
         # Public Attributes
-        State src
-        Symbol symb
-        State tgt
+        State source
+        Symbol symbol
+        State target
 
         # Constructor
         CTrans() except +
@@ -215,6 +215,6 @@ cdef class Nfa:
     cdef shared_ptr[CNfa] thisptr
     cdef label
 
-cdef class Trans:
+cdef class Transition:
     cdef CTrans* thisptr
     cdef copy_from(self, CTrans trans)

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -40,23 +40,23 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
 
     cdef const Symbol CEPSILON "Mata::Nfa::EPSILON"
 
-    cdef cppclass CPost "Mata::Nfa::Post":
-        void insert(CMove&)
-        CMove& operator[](Symbol)
-        CMove& back()
-        void push_back(CMove&)
-        void remove(CMove&)
+    cdef cppclass CStatePost "Mata::Nfa::StatePost":
+        void insert(CSymbolPost&)
+        CSymbolPost& operator[](Symbol)
+        CSymbolPost& back()
+        void push_back(CSymbolPost&)
+        void remove(CSymbolPost&)
         bool empty()
         size_t size()
-        vector[CMove] ToVector()
-        COrdVector[CMove].const_iterator cbegin()
-        COrdVector[CMove].const_iterator cend()
+        vector[CSymbolPost] ToVector()
+        COrdVector[CSymbolPost].const_iterator cbegin()
+        COrdVector[CSymbolPost].const_iterator cend()
 
     cdef cppclass CDelta "Mata::Nfa::Delta":
-        vector[CPost] post
+        vector[CStatePost] post
 
         void reserve(size_t)
-        CPost& operator[](State)
+        CStatePost& operator[](State)
         void emplace_back()
         void clear()
         bool empty()
@@ -91,21 +91,21 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         bool operator==(CTrans)
         bool operator!=(CTrans)
 
-    cdef cppclass CMove "Mata::Nfa::SymbolPost":
+    cdef cppclass CSymbolPost "Mata::Nfa::SymbolPost":
         # Public Attributes
         Symbol symbol
         StateSet targets
 
         # Constructors
-        CMove() except +
-        CMove(Symbol) except +
-        CMove(Symbol, State) except +
-        CMove(Symbol, StateSet) except +
+        CSymbolPost() except +
+        CSymbolPost(Symbol) except +
+        CSymbolPost(Symbol, State) except +
+        CSymbolPost(Symbol, StateSet) except +
 
-        bool operator<(CMove)
-        bool operator<=(CMove)
-        bool operator>(CMove)
-        bool operator>=(CMove)
+        bool operator<(CSymbolPost)
+        bool operator<=(CSymbolPost)
+        bool operator>(CSymbolPost)
+        bool operator>=(CSymbolPost)
 
     cdef cppclass CNfa "Mata::Nfa::Nfa":
         # Nested iterator
@@ -151,7 +151,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         State add_state()
         State add_state(State)
         void print_to_DOT(ostream)
-        CPost get_moves_from(State)
+        CStatePost get_moves_from(State)
         vector[CTrans] get_transitions_to(State)
         vector[CTrans] get_trans_as_sequence()
         vector[CTrans] get_trans_from_as_sequence(State)
@@ -162,8 +162,8 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         StateSet get_reachable_states()
         StateSet get_terminating_states()
         void remove_epsilon(Symbol) except +
-        COrdVector[CMove].const_iterator get_epsilon_transitions(State state, Symbol epsilon)
-        COrdVector[CMove].const_iterator get_epsilon_transitions(CPost& post, Symbol epsilon)
+        COrdVector[CSymbolPost].const_iterator get_epsilon_transitions(State state, Symbol epsilon)
+        COrdVector[CSymbolPost].const_iterator get_epsilon_transitions(CStatePost& post, Symbol epsilon)
         void clear()
         size_t size()
 

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -91,7 +91,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "Mata::Nfa":
         bool operator==(CTrans)
         bool operator!=(CTrans)
 
-    cdef cppclass CMove "Mata::Nfa::Move":
+    cdef cppclass CMove "Mata::Nfa::SymbolPost":
         # Public Attributes
         Symbol symbol
         StateSet targets

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -412,7 +412,7 @@ cdef class Nfa:
         :param State state: state for which we are getting the transitions
         :return: SymbolPost
         """
-        cdef mata_nfa.CStatePost transitions = self.thisptr.get().get_moves_from(state)
+        cdef mata_nfa.CStatePost transitions = self.thisptr.get().delta.state_post(state)
         cdef vector[mata_nfa.CSymbolPost] transitions_list = transitions.ToVector()
 
         cdef vector[mata_nfa.CSymbolPost].iterator it = transitions_list.begin()
@@ -657,7 +657,7 @@ cdef class Nfa:
         cdef COrdVector[CSymbolPost].const_iterator c_epsilon_transitions_iter = self.thisptr.get().get_epsilon_transitions(
             state, epsilon
         )
-        if c_epsilon_transitions_iter == self.thisptr.get().get_moves_from(state).cend():
+        if c_epsilon_transitions_iter == self.thisptr.get().delta.state_post(state).cend():
             return None
 
         cdef CSymbolPost epsilon_transitions = dereference(c_epsilon_transitions_iter)

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -20,7 +20,7 @@ cimport libmata.alphabets as alph
 
 from libmata.nfa.nfa cimport \
     Symbol, State, StateSet, StateRenaming, \
-    CDelta, CRun, CTrans, CNfa, CMove, CEPSILON
+    CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON
 
 from libmata.alphabets cimport CAlphabet
 from libmata.utils cimport COrdVector, CBinaryRelation, BinaryRelation
@@ -126,7 +126,7 @@ cdef class Trans:
 
 cdef class SymbolPost:
     """Wrapper over pair of symbol and states for transitions"""
-    cdef mata_nfa.CMove *thisptr
+    cdef mata_nfa.CSymbolPost *thisptr
 
     @property
     def symbol(self):
@@ -148,7 +148,7 @@ cdef class SymbolPost:
 
     def __cinit__(self, Symbol symbol, vector[State] states):
         cdef StateSet targets = StateSet(states)
-        self.thisptr = new mata_nfa.CMove(symbol, targets)
+        self.thisptr = new mata_nfa.CSymbolPost(symbol, targets)
 
     def __dealloc__(self):
         if self.thisptr != NULL:
@@ -412,11 +412,11 @@ cdef class Nfa:
         :param State state: state for which we are getting the transitions
         :return: SymbolPost
         """
-        cdef mata_nfa.CPost transitions = self.thisptr.get().get_moves_from(state)
-        cdef vector[mata_nfa.CMove] transitions_list = transitions.ToVector()
+        cdef mata_nfa.CStatePost transitions = self.thisptr.get().get_moves_from(state)
+        cdef vector[mata_nfa.CSymbolPost] transitions_list = transitions.ToVector()
 
-        cdef vector[mata_nfa.CMove].iterator it = transitions_list.begin()
-        cdef vector[mata_nfa.CMove].iterator end = transitions_list.end()
+        cdef vector[mata_nfa.CSymbolPost].iterator it = transitions_list.begin()
+        cdef vector[mata_nfa.CSymbolPost].iterator end = transitions_list.end()
         transsymbols = []
         while it != end:
             t = SymbolPost(
@@ -654,13 +654,13 @@ cdef class Nfa:
         :param epsilon: Epsilon symbol.
         :return: Epsilon transitions if there are any epsilon transitions for the passed state. None otherwise.
         """
-        cdef COrdVector[CMove].const_iterator c_epsilon_transitions_iter = self.thisptr.get().get_epsilon_transitions(
+        cdef COrdVector[CSymbolPost].const_iterator c_epsilon_transitions_iter = self.thisptr.get().get_epsilon_transitions(
             state, epsilon
         )
         if c_epsilon_transitions_iter == self.thisptr.get().get_moves_from(state).cend():
             return None
 
-        cdef CMove epsilon_transitions = dereference(c_epsilon_transitions_iter)
+        cdef CSymbolPost epsilon_transitions = dereference(c_epsilon_transitions_iter)
         return SymbolPost(epsilon_transitions.symbol, epsilon_transitions.targets.ToVector())
 
 

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -124,7 +124,7 @@ cdef class Trans:
         return str(self)
 
 
-cdef class Move:
+cdef class SymbolPost:
     """Wrapper over pair of symbol and states for transitions"""
     cdef mata_nfa.CMove *thisptr
 
@@ -154,22 +154,22 @@ cdef class Move:
         if self.thisptr != NULL:
             del self.thisptr
 
-    def __lt__(self, Move other):
+    def __lt__(self, SymbolPost other):
         return dereference(self.thisptr) < dereference(other.thisptr)
 
-    def __gt__(self, Move other):
+    def __gt__(self, SymbolPost other):
         return dereference(self.thisptr) > dereference(other.thisptr)
 
-    def __le__(self, Move other):
+    def __le__(self, SymbolPost other):
         return dereference(self.thisptr) <= dereference(other.thisptr)
 
-    def __ge__(self, Move other):
+    def __ge__(self, SymbolPost other):
         return dereference(self.thisptr) >= dereference(other.thisptr)
 
-    def __eq__(self, Move other):
+    def __eq__(self, SymbolPost other):
         return self.symbol == other.symbol and self.targets == other.targets
 
-    def __neq__(self, Move other):
+    def __neq__(self, SymbolPost other):
         return self.symbol != other.symbol or self.targets != other.targets
 
     def __str__(self):
@@ -407,10 +407,10 @@ cdef class Nfa:
             yield trans
 
     def get_transitions_from_state(self, State state):
-        """Returns list of Move for the given state
+        """Returns list of SymbolPost for the given state
 
         :param State state: state for which we are getting the transitions
-        :return: Move
+        :return: SymbolPost
         """
         cdef mata_nfa.CPost transitions = self.thisptr.get().get_moves_from(state)
         cdef vector[mata_nfa.CMove] transitions_list = transitions.ToVector()
@@ -419,7 +419,7 @@ cdef class Nfa:
         cdef vector[mata_nfa.CMove].iterator end = transitions_list.end()
         transsymbols = []
         while it != end:
-            t = Move(
+            t = SymbolPost(
                 dereference(it).symbol,
                 dereference(it).targets.ToVector()
             )
@@ -647,7 +647,7 @@ cdef class Nfa:
         """
         self.thisptr.get().remove_epsilon(epsilon)
 
-    def get_epsilon_transitions(self, State state, Symbol epsilon = CEPSILON) -> Move | None:
+    def get_epsilon_transitions(self, State state, Symbol epsilon = CEPSILON) -> SymbolPost | None:
         """Get epsilon transitions for a state.
 
         :param state: State to get epsilon transitions for.
@@ -661,7 +661,7 @@ cdef class Nfa:
             return None
 
         cdef CMove epsilon_transitions = dereference(c_epsilon_transitions_iter)
-        return Move(epsilon_transitions.symbol, epsilon_transitions.targets.ToVector())
+        return SymbolPost(epsilon_transitions.symbol, epsilon_transitions.targets.ToVector())
 
 
 

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -37,9 +37,9 @@ cdef class Run:
     def __cinit__(self):
         """Constructor of the transition
 
-        :param State src: source state
+        :param State source: source state
         :param Symbol s: symbol
-        :param State tgt: target state
+        :param State target: target state
         """
         self.thisptr = new mata_nfa.CRun()
 
@@ -64,38 +64,38 @@ cdef class Run:
     def path(self, value):
         self.thisptr.path = value
 
-cdef class Trans:
+cdef class Transition:
     """Wrapper over the transitions in NFA."""
 
     @property
-    def src(self):
+    def source(self):
         """
         :return: source state of the transition
         """
-        return self.thisptr.src
+        return self.thisptr.source
 
     @property
-    def symb(self):
+    def symbol(self):
         """
         :return: symbol for the transition
         """
-        return self.thisptr.symb
+        return self.thisptr.symbol
 
     @property
-    def tgt(self):
+    def target(self):
         """
         :return: target state of the transition
         """
-        return self.thisptr.tgt
+        return self.thisptr.target
 
-    def __cinit__(self, State src=0, Symbol s=0, State tgt=0):
+    def __cinit__(self, State source=0, Symbol s=0, State target=0):
         """Constructor of the transition
 
-        :param State src: source state
+        :param State source: source state
         :param Symbol s: symbol
-        :param State tgt: target state
+        :param State target: target state
         """
-        self.thisptr = new mata_nfa.CTrans(src, s, tgt)
+        self.thisptr = new mata_nfa.CTrans(source, s, target)
 
     def __dealloc__(self):
         """Destructor"""
@@ -107,18 +107,18 @@ cdef class Trans:
 
         :param CTrans trans: copied transition
         """
-        self.thisptr.src = trans.src
-        self.thisptr.symb = trans.symb
-        self.thisptr.tgt = trans.tgt
+        self.thisptr.source = trans.source
+        self.thisptr.symbol = trans.symbol
+        self.thisptr.target = trans.target
 
-    def __eq__(self, Trans other):
+    def __eq__(self, Transition other):
         return dereference(self.thisptr) == dereference(other.thisptr)
 
-    def __neq__(self, Trans other):
+    def __neq__(self, Transition other):
         return dereference(self.thisptr) != dereference(other.thisptr)
 
     def __str__(self):
-        return f"{self.thisptr.src}-[{self.thisptr.symb}]\u2192{self.thisptr.tgt}"
+        return f"{self.thisptr.source}-[{self.thisptr.symbol}]\u2192{self.thisptr.target}"
 
     def __repr__(self):
         return str(self)
@@ -327,54 +327,54 @@ cdef class Nfa:
         """Unify final states into a single new final state."""
         self.thisptr.get().unify_final()
 
-    def add_transition_object(self, Trans tr):
+    def add_transition_object(self, Transition tr):
         """Adds transition to automaton
 
-        :param Trans tr: added transition
+        :param Transition tr: added transition
         """
         self.thisptr.get().delta.add(dereference(tr.thisptr))
 
-    def add_transition(self, State src, symb, State tgt, alph.Alphabet alphabet = None):
+    def add_transition(self, State source, symbol, State target, alph.Alphabet alphabet = None):
         """Constructs transition and adds it to automaton
 
-        :param State src: source state
-        :param Symbol symb: symbol
-        :param State tgt: target state
+        :param State source: source state
+        :param Symbol symbol: symbol
+        :param State target: target state
         :param alph.Alphabet alphabet: alphabet of the transition
         """
-        if isinstance(symb, str):
+        if isinstance(symbol, str):
             alphabet = alphabet or store().get('alphabet')
             if not alphabet:
-                raise Exception(f"Cannot translate symbol '{symb}' without specified alphabet")
-            self.thisptr.get().delta.add(src, alphabet.translate_symbol(symb), tgt)
+                raise Exception(f"Cannot translate symbol '{symbol}' without specified alphabet")
+            self.thisptr.get().delta.add(source, alphabet.translate_symbol(symbol), target)
         else:
-            self.thisptr.get().delta.add(src, symb, tgt)
+            self.thisptr.get().delta.add(source, symbol, target)
 
-    def remove_trans(self, Trans tr):
+    def remove_trans(self, Transition tr):
         """Removes transition from the automaton.
 
-        :param Trans tr: Transition to be removed.
+        :param Transition tr: Transition to be removed.
         """
         self.thisptr.get().delta.remove(dereference(tr.thisptr))
 
-    def remove_trans_raw(self, State src, Symbol symb, State tgt):
+    def remove_trans_raw(self, State source, Symbol symbol, State target):
         """Constructs transition and removes it from the automaton.
 
-        :param State src: Source state of the transition to be removed.
-        :param Symbol symb: Symbol of the transition to be removed.
-        :param State tgt: Target state of the transition to be removed.
+        :param State source: Source state of the transition to be removed.
+        :param Symbol symbol: Symbol of the transition to be removed.
+        :param State target: Target state of the transition to be removed.
         """
-        self.thisptr.get().delta.remove(src, symb, tgt)
+        self.thisptr.get().delta.remove(source, symbol, target)
 
-    def has_transition(self, State src, Symbol symb, State tgt):
+    def has_transition(self, State source, Symbol symbol, State target):
         """Tests if automaton contains transition
 
-        :param State src: source state
-        :param Symbol symb: symbol
-        :param State tgt: target state
+        :param State source: source state
+        :param Symbol symbol: symbol
+        :param State target: target state
         :return: true if automaton contains transition
         """
-        return self.thisptr.get().delta.contains(src, symb, tgt)
+        return self.thisptr.get().delta.contains(source, symbol, target)
 
     def get_num_of_trans(self):
         """Returns number of transitions in automaton
@@ -400,7 +400,7 @@ cdef class Nfa:
         """
         iterator = self.thisptr.get().begin()
         while iterator != self.thisptr.get().end():
-            trans = Trans()
+            trans = Transition()
             lhs = dereference(iterator)
             trans.copy_from(lhs)
             preinc(iterator)
@@ -435,7 +435,7 @@ cdef class Nfa:
         cdef vector[CTrans] c_transitions = self.thisptr.get().get_transitions_to(state_to)
         trans = []
         for c_transition in c_transitions:
-            trans.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+            trans.append(Transition(c_transition.source, c_transition.symbol, c_transition.target))
         return trans
 
     def get_trans_as_sequence(self):
@@ -446,7 +446,7 @@ cdef class Nfa:
         cdef vector[CTrans] c_transitions = self.thisptr.get().get_trans_as_sequence()
         transitions = []
         for c_transition in c_transitions:
-            transitions.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+            transitions.append(Transition(c_transition.source, c_transition.symbol, c_transition.target))
         return transitions
 
     def get_trans_from_state_as_sequence(self, State state_from):
@@ -457,7 +457,7 @@ cdef class Nfa:
         cdef vector[CTrans] c_transitions = self.thisptr.get().get_trans_from_as_sequence(state_from)
         transitions = []
         for c_transition in c_transitions:
-            transitions.append(Trans(c_transition.src, c_transition.symb, c_transition.tgt))
+            transitions.append(Transition(c_transition.source, c_transition.symbol, c_transition.target))
         return transitions
 
     def get_useful_states(self):
@@ -535,9 +535,9 @@ cdef class Nfa:
         result += "final_states: {}\n".format([s for s in self.thisptr.get().final])
         result += "transitions:\n"
         for trans in self.iterate():
-            symbol = trans.symb if self.thisptr.get().alphabet == NULL \
-                else self.thisptr.get().alphabet.reverse_translate_symbol(trans.symb)
-            result += f"{trans.src}-[{symbol}]\u2192{trans.tgt}\n"
+            symbol = trans.symbol if self.thisptr.get().alphabet == NULL \
+                else self.thisptr.get().alphabet.reverse_translate_symbol(trans.symbol)
+            result += f"{trans.source}-[{symbol}]\u2192{trans.target}\n"
         return result
 
     def __repr__(self):
@@ -593,7 +593,7 @@ cdef class Nfa:
         """
         columns = ['source', 'symbol', 'target']
         data = [
-            [trans.src, trans.symb, trans.tgt] for trans in self.iterate()
+            [trans.source, trans.symbol, trans.target] for trans in self.iterate()
         ]
         return pandas.DataFrame(data, columns=columns)
 
@@ -601,7 +601,7 @@ cdef class Nfa:
         """Transforms the automaton into networkx.Graph
 
         Transforms the automaton into networkx.Graph format,
-        that is represented as graph with edges (src, tgt) with
+        that is represented as graph with edges (source, target) with
         additional properties.
 
         Each symbol is added as an property to each edge.
@@ -610,7 +610,7 @@ cdef class Nfa:
         """
         G = nx.DiGraph()
         for trans in self.iterate():
-            G.add_edge(trans.src, trans.tgt, symbol=trans.symb)
+            G.add_edge(trans.source, trans.target, symbol=trans.symbol)
         return G
 
     def post_map_of(self, State st, alph.Alphabet alphabet):

--- a/bindings/python/libmata/nfa/strings.pyx
+++ b/bindings/python/libmata/nfa/strings.pyx
@@ -34,7 +34,7 @@ cdef class Segmentation:
                 if epsilon_depth_pair.first not in result:
                     result[epsilon_depth_pair.first] = []
 
-                result[epsilon_depth_pair.first].append(mata_nfa.Trans(trans.src, trans.symb, trans.tgt))
+                result[epsilon_depth_pair.first].append(mata_nfa.Transition(trans.source, trans.symbol, trans.target))
 
         return result
 

--- a/bindings/python/libmata/plotting.pyx
+++ b/bindings/python/libmata/plotting.pyx
@@ -120,26 +120,26 @@ def plot_using_graphviz(
         dot.edge(f"q{state}", f"{state}", **edge_configuration)
     edges = {}
     for trans in aut.iterate():
-        key = f"{trans.src},{trans.tgt}"
+        key = f"{trans.source},{trans.target}"
         if key not in edges.keys():
             edges[key] = []
         symbol = "{}".format(
-            alphabet.reverse_translate_symbol(trans.symb) if alphabet else trans.symb
+            alphabet.reverse_translate_symbol(trans.symbol) if alphabet else trans.symbol
         )
         edges[key].append((
-            f"{trans.src}", f"{trans.tgt}", symbol,
+            f"{trans.source}", f"{trans.target}", symbol,
             get_configuration_for(
                 edge_configuration, edge_highlight, aut, trans
             )
         ))
     for edge in edges.values():
-        src = edge[0][0]
-        tgt = edge[0][1]
+        source = edge[0][0]
+        target = edge[0][1]
         label = "<" + " | ".join(sorted(t[2] for t in edge)) + ">"
         style = {}
         for val in edge:
             style.update(val[3])
-        dot.edge(src, tgt, label=label, **style)
+        dot.edge(source, target, label=label, **style)
 
     return dot
 
@@ -256,4 +256,4 @@ class Condition:
     @classmethod
     def transition_is_cycle(cls, _, trans):
         """Tests if transition is self cycle"""
-        return trans.src == trans.tgt
+        return trans.source == trans.target

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -160,38 +160,6 @@ def test_making_initial_and_final_states():
     assert len(nfa.final_states) == 0
 
 
-def test_transitions():
-    """Test adding transitions to automaton"""
-    lhs = mata_nfa.Nfa(3)
-    t1 = mata_nfa.Trans(0, 0, 0)
-    t2 = mata_nfa.Trans(0, 1, 0)
-    t3 = mata_nfa.Trans(1, 1, 1)
-    t4 = mata_nfa.Trans(2, 2, 2)
-
-    # Test adding transition
-    assert lhs.get_num_of_trans() == 0
-    lhs.add_transition(0, 0, 0)
-    assert lhs.get_num_of_trans() == 1
-    assert lhs.has_transition(t1.src, t1.symb, t1.tgt)
-
-    lhs.add_transition_object(t2)
-    assert lhs.get_num_of_trans() == 2
-    assert lhs.has_transition(t2.src, t2.symb, t2.tgt)
-
-    # Test adding add-hoc transition
-    lhs.add_transition(1, 1, 1)
-    assert lhs.get_num_of_trans() == 3
-    assert lhs.has_transition(t3.src, t3.symb, t3.tgt)
-    assert not lhs.has_transition(2, 2, 2)
-    lhs.add_transition_object(t4)
-    assert lhs.get_num_of_trans() == 4
-    assert lhs.has_transition(2, 2, 2)
-
-    # Test that transitions are not duplicated
-    lhs.add_transition(1, 1, 1)
-    assert [t for t in lhs.iterate()] == [t1, t2, t3, t4]
-
-
 def test_post(binary_alphabet):
     """Test various cases of getting post of the states
     :return:

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -861,9 +861,9 @@ def test_segmentation(prepare_automaton_a):
     assert len(epsilon_depths) == 1
     assert 0 in epsilon_depths
     assert len(epsilon_depths[0]) == 3
-    assert mata_nfa.Trans(10, epsilon, 7) in epsilon_depths[0]
-    assert mata_nfa.Trans(7, epsilon, 3) in epsilon_depths[0]
-    assert mata_nfa.Trans(5, epsilon, 9) in epsilon_depths[0]
+    assert mata_nfa.Transition(10, epsilon, 7) in epsilon_depths[0]
+    assert mata_nfa.Transition(7, epsilon, 3) in epsilon_depths[0]
+    assert mata_nfa.Transition(5, epsilon, 9) in epsilon_depths[0]
 
     nfa = mata_nfa.Nfa(ord('q') + 1)
     nfa.make_initial_state(1)
@@ -885,9 +885,9 @@ def test_segmentation(prepare_automaton_a):
     assert len(epsilon_depths[0]) == 1
     assert len(epsilon_depths[1]) == 1
     assert len(epsilon_depths[2]) == 1
-    assert mata_nfa.Trans(1, epsilon, 2) in epsilon_depths[0]
-    assert mata_nfa.Trans(6, epsilon, 7) in epsilon_depths[1]
-    assert mata_nfa.Trans(7, epsilon, 8) in epsilon_depths[2]
+    assert mata_nfa.Transition(1, epsilon, 2) in epsilon_depths[0]
+    assert mata_nfa.Transition(6, epsilon, 7) in epsilon_depths[1]
+    assert mata_nfa.Transition(7, epsilon, 8) in epsilon_depths[2]
 
 
 def test_reduce():

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -170,23 +170,25 @@ def test_transitions():
 
     # Test adding transition
     assert lhs.get_num_of_trans() == 0
-    lhs.add_transition_object(t1)
-    assert lhs.get_num_of_trans() != 0
+    lhs.add_transition(0, 0, 0)
+    assert lhs.get_num_of_trans() == 1
     assert lhs.has_transition(t1.src, t1.symb, t1.tgt)
 
     lhs.add_transition_object(t2)
+    assert lhs.get_num_of_trans() == 2
     assert lhs.has_transition(t2.src, t2.symb, t2.tgt)
 
     # Test adding add-hoc transition
     lhs.add_transition(1, 1, 1)
+    assert lhs.get_num_of_trans() == 3
     assert lhs.has_transition(t3.src, t3.symb, t3.tgt)
     assert not lhs.has_transition(2, 2, 2)
     lhs.add_transition_object(t4)
+    assert lhs.get_num_of_trans() == 4
     assert lhs.has_transition(2, 2, 2)
 
     # Test that transitions are not duplicated
     lhs.add_transition(1, 1, 1)
-
     assert [t for t in lhs.iterate()] == [t1, t2, t3, t4]
 
 

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -672,9 +672,9 @@ def test_shortest(fa_one_divisible_by_two):
 def test_get_trans(fa_one_divisible_by_two):
     lhs = fa_one_divisible_by_two
     t = lhs.get_transitions_from_state(0)
-    assert sorted(t) == sorted([mata_nfa.Move(0, [0]), mata_nfa.Move(1, [1])])
+    assert sorted(t) == sorted([mata_nfa.SymbolPost(0, [0]), mata_nfa.SymbolPost(1, [1])])
     tt = lhs.get_transitions_from_state(1)
-    assert sorted(tt) == sorted([mata_nfa.Move(0, [1]), mata_nfa.Move(1, [2])])
+    assert sorted(tt) == sorted([mata_nfa.SymbolPost(0, [1]), mata_nfa.SymbolPost(1, [2])])
 
 
 def test_trim(prepare_automaton_a):

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -17,10 +17,10 @@ def test_trans():
 
 
 def test_move():
-    a = mata_nfa.Move(0, [0, 1])
-    b = mata_nfa.Move(1, [1])
-    c = mata_nfa.Move(0, [0])
-    d = mata_nfa.Move(1, [])
+    a = mata_nfa.SymbolPost(0, [0, 1])
+    b = mata_nfa.SymbolPost(1, [1])
+    c = mata_nfa.SymbolPost(0, [0])
+    d = mata_nfa.SymbolPost(1, [])
     assert a.symbol == 0
     assert a.targets == [0, 1]
 

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -8,9 +8,9 @@ __author__ = 'Tomas Fiedor'
 
 def test_trans():
     """Tests that the python interpreter can be obtained in reasonable format"""
-    lhs = mata_nfa.Trans(0, 0, 0)
-    rhs = mata_nfa.Trans(0, 1, 1)
-    chs = mata_nfa.Trans(0, 0, 0)
+    lhs = mata_nfa.Transition(0, 0, 0)
+    rhs = mata_nfa.Transition(0, 1, 1)
+    chs = mata_nfa.Transition(0, 0, 0)
 
     assert lhs != rhs
     assert lhs == chs
@@ -44,47 +44,47 @@ def test_transition_operations(prepare_automaton_a):
     nfa = mata_nfa.Nfa(10)
     nfa.add_transition(3, ord('c'), 4)
     assert nfa.has_transition(3, ord('c'), 4)
-    trans = mata_nfa.Trans(4, ord('c'), 5)
+    trans = mata_nfa.Transition(4, ord('c'), 5)
     nfa.add_transition_object(trans)
-    assert nfa.has_transition(trans.src, trans.symb, trans.tgt)
+    assert nfa.has_transition(trans.source, trans.symbol, trans.target)
 
     nfa.remove_trans_raw(3, ord('c'), 4)
     assert not nfa.has_transition(3, ord('c'), 4)
     nfa.remove_trans(trans)
-    assert not nfa.has_transition(trans.src, trans.symb, trans.tgt)
+    assert not nfa.has_transition(trans.source, trans.symbol, trans.target)
 
     nfa = prepare_automaton_a()
 
-    expected_trans = [mata_nfa.Trans(3, ord('b'), 9), mata_nfa.Trans(5, ord('c'), 9), mata_nfa.Trans(9, ord('a'), 9)]
+    expected_trans = [mata_nfa.Transition(3, ord('b'), 9), mata_nfa.Transition(5, ord('c'), 9), mata_nfa.Transition(9, ord('a'), 9)]
 
     trans = nfa.get_transitions_to_state(9)
     assert trans == expected_trans
 
     trans = nfa.get_trans_as_sequence()
     expected_trans = [
-        mata_nfa.Trans(1, ord('a'), 3),
-        mata_nfa.Trans(1, ord('a'), 10),
-        mata_nfa.Trans(1, ord('b'), 7),
-        mata_nfa.Trans(3, ord('a'), 7),
-        mata_nfa.Trans(3, ord('b'), 9),
-        mata_nfa.Trans(5, ord('a'), 5),
-        mata_nfa.Trans(5, ord('c'), 9),
-        mata_nfa.Trans(7, ord('a'), 3),
-        mata_nfa.Trans(7, ord('a'), 5),
-        mata_nfa.Trans(7, ord('b'), 1),
-        mata_nfa.Trans(7, ord('c'), 3),
-        mata_nfa.Trans(9, ord('a'), 9),
-        mata_nfa.Trans(10, ord('a'), 7),
-        mata_nfa.Trans(10, ord('b'), 7),
-        mata_nfa.Trans(10, ord('c'), 7),
+        mata_nfa.Transition(1, ord('a'), 3),
+        mata_nfa.Transition(1, ord('a'), 10),
+        mata_nfa.Transition(1, ord('b'), 7),
+        mata_nfa.Transition(3, ord('a'), 7),
+        mata_nfa.Transition(3, ord('b'), 9),
+        mata_nfa.Transition(5, ord('a'), 5),
+        mata_nfa.Transition(5, ord('c'), 9),
+        mata_nfa.Transition(7, ord('a'), 3),
+        mata_nfa.Transition(7, ord('a'), 5),
+        mata_nfa.Transition(7, ord('b'), 1),
+        mata_nfa.Transition(7, ord('c'), 3),
+        mata_nfa.Transition(9, ord('a'), 9),
+        mata_nfa.Transition(10, ord('a'), 7),
+        mata_nfa.Transition(10, ord('b'), 7),
+        mata_nfa.Transition(10, ord('c'), 7),
     ]
     assert trans == expected_trans
 
     trans = nfa.get_trans_from_state_as_sequence(1)
     expected_trans = [
-        mata_nfa.Trans(1, ord('a'), 3),
-        mata_nfa.Trans(1, ord('a'), 10),
-        mata_nfa.Trans(1, ord('b'), 7),
+        mata_nfa.Transition(1, ord('a'), 3),
+        mata_nfa.Transition(1, ord('a'), 10),
+        mata_nfa.Transition(1, ord('b'), 7),
     ]
     assert trans == expected_trans
 
@@ -92,25 +92,25 @@ def test_transition_operations(prepare_automaton_a):
 def test_transitions():
     """Test adding transitions to automaton"""
     lhs = mata_nfa.Nfa(3)
-    t1 = mata_nfa.Trans(0, 0, 0)
-    t2 = mata_nfa.Trans(0, 1, 0)
-    t3 = mata_nfa.Trans(1, 1, 1)
-    t4 = mata_nfa.Trans(2, 2, 2)
+    t1 = mata_nfa.Transition(0, 0, 0)
+    t2 = mata_nfa.Transition(0, 1, 0)
+    t3 = mata_nfa.Transition(1, 1, 1)
+    t4 = mata_nfa.Transition(2, 2, 2)
 
     # Test adding transition.
     assert lhs.get_num_of_trans() == 0
     lhs.add_transition(0, 0, 0)
     assert lhs.get_num_of_trans() == 1
-    assert lhs.has_transition(t1.src, t1.symb, t1.tgt)
+    assert lhs.has_transition(t1.source, t1.symbol, t1.target)
 
     lhs.add_transition_object(t2)
     assert lhs.get_num_of_trans() == 2
-    assert lhs.has_transition(t2.src, t2.symb, t2.tgt)
+    assert lhs.has_transition(t2.source, t2.symbol, t2.target)
 
     # Test adding add-hoc transition.
     lhs.add_transition(1, 1, 1)
     assert lhs.get_num_of_trans() == 3
-    assert lhs.has_transition(t3.src, t3.symb, t3.tgt)
+    assert lhs.has_transition(t3.source, t3.symbol, t3.target)
     assert not lhs.has_transition(2, 2, 2)
     lhs.add_transition_object(t4)
     assert lhs.get_num_of_trans() == 4
@@ -119,5 +119,3 @@ def test_transitions():
     # Test that transitions are not duplicated.
     lhs.add_transition_object(t3)
     assert [t for t in lhs.iterate()] == [t1, t2, t3, t4]
-
-

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -87,3 +87,37 @@ def test_transition_operations(prepare_automaton_a):
         mata_nfa.Trans(1, ord('b'), 7),
     ]
     assert trans == expected_trans
+
+
+def test_transitions():
+    """Test adding transitions to automaton"""
+    lhs = mata_nfa.Nfa(3)
+    t1 = mata_nfa.Trans(0, 0, 0)
+    t2 = mata_nfa.Trans(0, 1, 0)
+    t3 = mata_nfa.Trans(1, 1, 1)
+    t4 = mata_nfa.Trans(2, 2, 2)
+
+    # Test adding transition.
+    assert lhs.get_num_of_trans() == 0
+    lhs.add_transition(0, 0, 0)
+    assert lhs.get_num_of_trans() == 1
+    assert lhs.has_transition(t1.src, t1.symb, t1.tgt)
+
+    lhs.add_transition_object(t2)
+    assert lhs.get_num_of_trans() == 2
+    assert lhs.has_transition(t2.src, t2.symb, t2.tgt)
+
+    # Test adding add-hoc transition.
+    lhs.add_transition(1, 1, 1)
+    assert lhs.get_num_of_trans() == 3
+    assert lhs.has_transition(t3.src, t3.symb, t3.tgt)
+    assert not lhs.has_transition(2, 2, 2)
+    lhs.add_transition_object(t4)
+    assert lhs.get_num_of_trans() == 4
+    assert lhs.has_transition(2, 2, 2)
+
+    # Test that transitions are not duplicated.
+    lhs.add_transition_object(t3)
+    assert [t for t in lhs.iterate()] == [t1, t2, t3, t4]
+
+

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -5,6 +5,8 @@
 
 #include "mata/nfa/types.hh"
 
+#include <iterator>
+
 namespace Mata::Nfa {
 
 /**
@@ -112,11 +114,11 @@ public:
         Move move_{};
 
     public:
-        using iterator_category = std::bidirectional_iterator_tag;
-        using value_type = int;
-        using difference_type = int;
-        using pointer = int*;
-        using reference = int&;
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = Move;
+        using difference_type = unsigned;
+        using pointer = Move*;
+        using reference = Move&;
 
         explicit moves_const_iterator(const std::vector<SymbolPost>& symbol_posts, bool is_end = false);
 
@@ -320,11 +322,11 @@ public:
         Trans transition{};
 
     public:
-        using iterator_category = std::bidirectional_iterator_tag;
-        using value_type = int;
-        using difference_type = int;
-        using pointer = int*;
-        using reference = int&;
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = Trans;
+        using difference_type = unsigned;
+        using pointer = Trans*;
+        using reference = Trans&;
 
         explicit transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise = false);
 

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -193,7 +193,7 @@ public:
     /**
      * Iterator over transitions. It iterates over triples (lhs, symbol, rhs) where lhs and rhs are states.
      */
-    struct const_iterator {
+    struct transitions_const_iterator {
     private:
         const std::vector<StatePost>& post;
         size_t current_state;
@@ -208,35 +208,40 @@ public:
         using pointer = int*;
         using reference = int&;
 
-        explicit const_iterator(const std::vector<StatePost>& post_p, bool ise = false);
+        explicit transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise = false);
 
-        const_iterator(const std::vector<StatePost>& post_p, size_t as,
-                       StatePost::const_iterator pi, StateSet::const_iterator ti, bool ise = false) :
+        transitions_const_iterator(const std::vector<StatePost>& post_p, size_t as,
+                                   StatePost::const_iterator pi, StateSet::const_iterator ti, bool ise = false) :
                 post(post_p), current_state(as), post_iterator(pi), targets_position(ti), is_end(ise) {};
 
-        const_iterator(const const_iterator& other) = default;
+        transitions_const_iterator(const transitions_const_iterator& other) = default;
 
         Trans operator*() const { return Trans{current_state, (*post_iterator).symbol, *targets_position}; }
 
         // Prefix increment
-        const_iterator& operator++();
+        transitions_const_iterator& operator++();
         // Postfix increment
-        const_iterator operator++(int);
+        const transitions_const_iterator operator++(int);
 
-        const_iterator& operator=(const const_iterator& x);
+        transitions_const_iterator& operator=(const transitions_const_iterator& x);
 
-        friend bool operator==(const const_iterator& a, const const_iterator& b);
-        friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); };
+        friend bool operator==(const transitions_const_iterator& a, const transitions_const_iterator& b);
+        friend bool operator!=(const transitions_const_iterator& a, const transitions_const_iterator& b) { return !(a == b); };
     };
 
-    const_iterator cbegin() const { return const_iterator(posts); }
-    const_iterator cend() const { return const_iterator(posts, true); }
-    const_iterator begin() const { return cbegin(); }
-    const_iterator end() const { return cend(); }
+    transitions_const_iterator transitions_cbegin() const { return transitions_const_iterator(posts); }
+    transitions_const_iterator transitions_cend() const { return transitions_const_iterator(posts, true); }
+    transitions_const_iterator transitions_begin() const { return transitions_cbegin(); }
+    transitions_const_iterator transitions_end() const { return transitions_cend(); }
 
+    using const_iterator = std::vector<StatePost>::const_iterator;
+    const_iterator cbegin() const { return posts.cbegin(); }
+    const_iterator cend() const { return posts.cend(); }
+    const_iterator begin() const { return posts.begin(); }
+    const_iterator end() const { return posts.end(); }
 }; // struct Delta.
 
-bool operator==(const Delta::const_iterator& a, const Delta::const_iterator& b);
+bool operator==(const Delta::transitions_const_iterator& a, const Delta::transitions_const_iterator& b);
 
 } // namespace Mata::Nfa.
 

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -97,16 +97,16 @@ public:
  */
 class Delta {
 private:
-    std::vector<StatePost> posts;
+    std::vector<StatePost> state_posts;
 
 public:
-    inline static const StatePost empty_post; // When posts[q] is not allocated, then delta[q] returns this.
+    inline static const StatePost empty_state_post; // When posts[q] is not allocated, then delta[q] returns this.
 
-    Delta() : posts() {}
-    explicit Delta(size_t n) : posts(n) {}
+    Delta() : state_posts() {}
+    explicit Delta(size_t n) : state_posts(n) {}
 
     void reserve(size_t n) {
-        posts.reserve(n);
+        state_posts.reserve(n);
     };
 
     /**
@@ -126,24 +126,24 @@ public:
     // But it feels fragile, before doing something like that, better think and talk to people.
     StatePost& get_mutable_post(State q);
 
-    void defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
 
     // Get a constant reference to the post of a state. No side effects.
     const StatePost & operator[] (State q) const;
+    void defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
 
-    void emplace_back() { posts.emplace_back(); }
+    void emplace_back() { state_posts.emplace_back(); }
 
-    void clear() { posts.clear(); }
+    void clear() { state_posts.clear(); }
 
     void increase_size(size_t n) {
-        assert(n >= posts.size());
-        posts.resize(n);
+        assert(n >= state_posts.size());
+        state_posts.resize(n);
     }
 
     /**
      * @return Number of states in the whole Delta, including both source and target states.
      */
-    size_t num_of_states() const { return posts.size(); }
+    size_t num_of_states() const { return state_posts.size(); }
 
     void add(State state_from, Symbol symbol, State state_to);
     void add(const Trans& trans) { add(trans.src, trans.symb, trans.tgt); }
@@ -165,7 +165,7 @@ public:
      */
     void append(const std::vector<StatePost>& post_vector) {
         for(const StatePost& pst : post_vector) {
-            this->posts.push_back(pst);
+            this->state_posts.push_back(pst);
         }
     }
 
@@ -229,8 +229,8 @@ public:
         friend bool operator!=(const transitions_const_iterator& a, const transitions_const_iterator& b) { return !(a == b); };
     };
 
-    transitions_const_iterator transitions_cbegin() const { return transitions_const_iterator(posts); }
-    transitions_const_iterator transitions_cend() const { return transitions_const_iterator(posts, true); }
+    transitions_const_iterator transitions_cbegin() const { return transitions_const_iterator(state_posts); }
+    transitions_const_iterator transitions_cend() const { return transitions_const_iterator(state_posts, true); }
     transitions_const_iterator transitions_begin() const { return transitions_cbegin(); }
     transitions_const_iterator transitions_end() const { return transitions_cend(); }
 
@@ -250,10 +250,10 @@ public:
     }
 
     using const_iterator = std::vector<StatePost>::const_iterator;
-    const_iterator cbegin() const { return posts.cbegin(); }
-    const_iterator cend() const { return posts.cend(); }
-    const_iterator begin() const { return posts.begin(); }
-    const_iterator end() const { return posts.end(); }
+    const_iterator cbegin() const { return state_posts.cbegin(); }
+    const_iterator cend() const { return state_posts.cend(); }
+    const_iterator begin() const { return state_posts.begin(); }
+    const_iterator end() const { return state_posts.end(); }
 }; // struct Delta.
 
 bool operator==(const Delta::transitions_const_iterator& a, const Delta::transitions_const_iterator& b);

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -234,6 +234,21 @@ public:
     transitions_const_iterator transitions_begin() const { return transitions_cbegin(); }
     transitions_const_iterator transitions_end() const { return transitions_cend(); }
 
+    struct TransitionsIterator {
+        transitions_const_iterator m_begin;
+        transitions_const_iterator m_end;
+        transitions_const_iterator begin() const { return m_begin; }
+        transitions_const_iterator end() const { return m_end; }
+    };
+
+    /**
+     * Iterate over transitions represented as 'Trans' instances.
+     * @return Iterator over transitions.
+     */
+    TransitionsIterator transitions() const {
+        return { transitions_begin(), transitions_end() };
+    }
+
     using const_iterator = std::vector<StatePost>::const_iterator;
     const_iterator cbegin() const { return posts.cbegin(); }
     const_iterator cend() const { return posts.cend(); }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -6,29 +6,31 @@
 namespace Mata::Nfa {
 
 /**
- * Structure represents a move which is a symbol and a set of target states of transitions.
+ * Structure represents a post of a single @c symbol: a set of target states in transitions.
+ *
+ * A set of @c SymbolPost is describing the automata transitions from a single source state.
  */
-class Move {
+class SymbolPost {
 public:
     Symbol symbol{};
     StateSet targets{};
 
-    Move() = default;
-    explicit Move(Symbol symbol) : symbol{ symbol }, targets{} {}
-    Move(Symbol symbol, State state_to) : symbol{ symbol }, targets{ state_to } {}
-    Move(Symbol symbol, StateSet states_to) : symbol{ symbol }, targets{ std::move(states_to) } {}
+    SymbolPost() = default;
+    explicit SymbolPost(Symbol symbol) : symbol{ symbol }, targets{} {}
+    SymbolPost(Symbol symbol, State state_to) : symbol{ symbol }, targets{ state_to } {}
+    SymbolPost(Symbol symbol, StateSet states_to) : symbol{ symbol }, targets{ std::move(states_to) } {}
 
-    Move(Move&& rhs) noexcept : symbol{ rhs.symbol }, targets{ std::move(rhs.targets) } {}
-    Move(const Move& rhs) = default;
-    Move& operator=(Move&& rhs) noexcept;
-    Move& operator=(const Move& rhs) = default;
+    SymbolPost(SymbolPost&& rhs) noexcept : symbol{ rhs.symbol }, targets{ std::move(rhs.targets) } {}
+    SymbolPost(const SymbolPost& rhs) = default;
+    SymbolPost& operator=(SymbolPost&& rhs) noexcept;
+    SymbolPost& operator=(const SymbolPost& rhs) = default;
 
-    inline bool operator<(const Move& rhs) const { return symbol < rhs.symbol; }
-    inline bool operator<=(const Move& rhs) const { return symbol <= rhs.symbol; }
-    inline bool operator==(const Move& rhs) const { return symbol == rhs.symbol; }
-    inline bool operator!=(const Move& rhs) const { return symbol != rhs.symbol; }
-    inline bool operator>(const Move& rhs) const { return symbol > rhs.symbol; }
-    inline bool operator>=(const Move& rhs) const { return symbol >= rhs.symbol; }
+    inline bool operator<(const SymbolPost& rhs) const { return symbol < rhs.symbol; }
+    inline bool operator<=(const SymbolPost& rhs) const { return symbol <= rhs.symbol; }
+    inline bool operator==(const SymbolPost& rhs) const { return symbol == rhs.symbol; }
+    inline bool operator!=(const SymbolPost& rhs) const { return symbol != rhs.symbol; }
+    inline bool operator>(const SymbolPost& rhs) const { return symbol > rhs.symbol; }
+    inline bool operator>=(const SymbolPost& rhs) const { return symbol >= rhs.symbol; }
 
     StateSet::iterator begin() { return targets.begin(); }
     StateSet::iterator end() { return targets.end(); }
@@ -59,9 +61,9 @@ public:
  * It is an ordered vector containing possible Moves (i.e., pair of symbol and target states.
  * Vector is ordered by symbols which are numbers.
  */
-class Post : private Util::OrdVector<Move> {
+class Post : private Util::OrdVector<SymbolPost> {
 private:
-    using super = Util::OrdVector<Move>;
+    using super = Util::OrdVector<SymbolPost>;
 public:
     using super::iterator, super::const_iterator;
     using super::begin, super::end, super::cbegin, super::cend;

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -238,6 +238,7 @@ public:
         StatePost::const_iterator post_iterator{};
         StateSet::const_iterator targets_position{};
         bool is_end;
+        Trans transition{};
 
     public:
         using iterator_category = std::bidirectional_iterator_tag;
@@ -249,12 +250,11 @@ public:
         explicit transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise = false);
 
         transitions_const_iterator(const std::vector<StatePost>& post_p, size_t as,
-                                   StatePost::const_iterator pi, StateSet::const_iterator ti, bool ise = false) :
-                post(post_p), current_state(as), post_iterator(pi), targets_position(ti), is_end(ise) {};
+                                   StatePost::const_iterator pi, StateSet::const_iterator ti, bool ise = false);
 
         transitions_const_iterator(const transitions_const_iterator& other) = default;
 
-        Trans operator*() const { return Trans{current_state, (*post_iterator).symbol, *targets_position}; }
+        const Trans& operator*() const { return transition; }
 
         // Prefix increment
         transitions_const_iterator& operator++();

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -28,12 +28,12 @@ struct Transition {
 };
 
 /**
- * Move from a @c StatePost for a single source state, represented as a pair of @c symbol and target state @c tgt_state.
+ * Move from a @c StatePost for a single source state, represented as a pair of @c symbol and target state @c target.
  */
 class Move {
 public:
     Symbol symbol;
-    State tgt_state;
+    State target;
 
     bool operator==(const Move&) const = default;
 }; // class Move.

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -105,11 +105,11 @@ public:
      */
     struct moves_const_iterator {
     private:
-        const std::vector<SymbolPost>& m_symbol_posts{};
-        std::vector<SymbolPost>::const_iterator m_symbol_post_it{};
-        StateSet::const_iterator m_target_states_it{};
-        bool m_is_end{ false };
-        Move m_move{};
+        const std::vector<SymbolPost>& symbol_posts_{};
+        std::vector<SymbolPost>::const_iterator symbol_post_it_{};
+        StateSet::const_iterator target_states_it_{};
+        bool is_end_{ false };
+        Move move_{};
 
     public:
         using iterator_category = std::bidirectional_iterator_tag;
@@ -126,7 +126,7 @@ public:
 
         moves_const_iterator(const moves_const_iterator& other) = default;
 
-        const Move& operator*() const { return m_move; }
+        const Move& operator*() const { return move_; }
 
         // Prefix increment
         moves_const_iterator& operator++();
@@ -144,18 +144,19 @@ public:
     moves_const_iterator moves_begin() const { return moves_cbegin(); }
     moves_const_iterator moves_end() const { return moves_cend(); }
 
-    struct MovesIterator {
-        moves_const_iterator m_begin;
-        moves_const_iterator m_end;
-        moves_const_iterator begin() const { return m_begin; }
-        moves_const_iterator end() const { return m_end; }
+    class Moves {
+    public:
+        moves_const_iterator begin_;
+        moves_const_iterator end_;
+        moves_const_iterator begin() const { return begin_; }
+        moves_const_iterator end() const { return end_; }
     };
 
     /**
      * Iterate over moves represented as 'Move' instances.
      * @return Iterator over moves.
      */
-    MovesIterator moves() const { return { .m_begin = moves_begin(), .m_end = moves_end() }; }
+    Moves moves() const { return { .begin_ = moves_begin(), .end_ = moves_end() }; }
 }; // struct Post.
 
 /**
@@ -165,7 +166,7 @@ public:
  *  state), specified for a single source state.
  * Its underlying data structure is vector of StatePost classes. Each index to the vector corresponds to one source
  *  state, that is, a number for a certain state is an index to the vector of state posts.
- * Transition relation (delta) in Mata stores a set of transitions in a four-level hierarchical structure: 
+ * Transition relation (delta) in Mata stores a set of transitions in a four-level hierarchical structure:
  *  Delta, StatePost, SymbolPost, and a set of target states.
  * A vector of 'StatePost's indexed by a source states on top, where the StatePost for a state 'q' (whose number is
  *  'q' and it is the index to the vector of 'StatePost's) stores a set of 'Move's from the source state 'q'.
@@ -350,18 +351,18 @@ public:
     transitions_const_iterator transitions_begin() const { return transitions_cbegin(); }
     transitions_const_iterator transitions_end() const { return transitions_cend(); }
 
-    struct TransitionsIterator {
-        transitions_const_iterator m_begin;
-        transitions_const_iterator m_end;
-        transitions_const_iterator begin() const { return m_begin; }
-        transitions_const_iterator end() const { return m_end; }
+    struct Transitions {
+        transitions_const_iterator begin_;
+        transitions_const_iterator end_;
+        transitions_const_iterator begin() const { return begin_; }
+        transitions_const_iterator end() const { return end_; }
     };
 
     /**
      * Iterate over transitions represented as 'Trans' instances.
      * @return Iterator over transitions.
      */
-    TransitionsIterator transitions() const { return { .m_begin = transitions_begin(), .m_end = transitions_end() }; }
+    Transitions transitions() const { return { .begin_ = transitions_begin(), .end_ = transitions_end() }; }
 
     using const_iterator = std::vector<StatePost>::const_iterator;
     const_iterator cbegin() const { return state_posts.cbegin(); }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -234,8 +234,6 @@ public:
     const_iterator begin() const { return cbegin(); }
     const_iterator end() const { return cend(); }
 
-private:
-    State find_max_state();
 }; // struct Delta.
 
 bool operator==(const Delta::const_iterator& a, const Delta::const_iterator& b);

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -25,12 +25,8 @@ public:
     SymbolPost& operator=(SymbolPost&& rhs) noexcept;
     SymbolPost& operator=(const SymbolPost& rhs) = default;
 
-    inline bool operator<(const SymbolPost& rhs) const { return symbol < rhs.symbol; }
-    inline bool operator<=(const SymbolPost& rhs) const { return symbol <= rhs.symbol; }
-    inline bool operator==(const SymbolPost& rhs) const { return symbol == rhs.symbol; }
-    inline bool operator!=(const SymbolPost& rhs) const { return symbol != rhs.symbol; }
-    inline bool operator>(const SymbolPost& rhs) const { return symbol > rhs.symbol; }
-    inline bool operator>=(const SymbolPost& rhs) const { return symbol >= rhs.symbol; }
+    std::weak_ordering operator<=>(const SymbolPost& other) const { return symbol <=> other.symbol; }
+    bool operator==(const SymbolPost& other) const { return symbol == other.symbol; }
 
     StateSet::iterator begin() { return targets.begin(); }
     StateSet::iterator end() { return targets.end(); }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -9,6 +9,24 @@
 
 namespace Mata::Nfa {
 
+/// A single transition in Delta represented as a triple(source, symbol, target).
+struct Transition {
+    State source; ///< Source state.
+    Symbol symbol; ///< Transition symbol.
+    State target; ///< Target state.
+
+    Transition() : source(), symbol(), target() { }
+    Transition(const Transition&) = default;
+    Transition(Transition&&) = default;
+    Transition &operator=(const Transition&) = default;
+    Transition &operator=(Transition&&) = default;
+    Transition(const State source, const Symbol symbol, const State target)
+            : source(source), symbol(symbol), target(target) {}
+
+    bool operator==(const Transition& rhs) const { return source == rhs.source && symbol == rhs.symbol && target == rhs.target; }
+    bool operator!=(const Transition& rhs) const { return !this->operator==(rhs); }
+};
+
 /**
  * Move from a @c StatePost for a single source state, represented as a pair of @c symbol and target state @c tgt_state.
  */
@@ -258,9 +276,9 @@ public:
     size_t num_of_states() const { return state_posts.size(); }
 
     void add(State state_from, Symbol symbol, State state_to);
-    void add(const Trans& trans) { add(trans.src, trans.symb, trans.tgt); }
+    void add(const Transition& trans) { add(trans.source, trans.symbol, trans.target); }
     void remove(State src, Symbol symb, State tgt);
-    void remove(const Trans& trans) { remove(trans.src, trans.symb, trans.tgt); }
+    void remove(const Transition& trans) { remove(trans.source, trans.symbol, trans.target); }
 
     /**
      * Check whether @c Delta contains a passed transition.
@@ -269,7 +287,7 @@ public:
     /**
      * Check whether @c Delta contains a transition passed as a triple.
      */
-    bool contains(const Trans& transition) const;
+    bool contains(const Transition& transition) const;
 
     /**
      * Check whether automaton contains no transitions.
@@ -319,14 +337,14 @@ public:
         StatePost::const_iterator post_iterator{};
         StateSet::const_iterator targets_position{};
         bool is_end;
-        Trans transition{};
+        Transition transition{};
 
     public:
         using iterator_category = std::forward_iterator_tag;
-        using value_type = Trans;
+        using value_type = Transition;
         using difference_type = unsigned;
-        using pointer = Trans*;
-        using reference = Trans&;
+        using pointer = Transition*;
+        using reference = Transition&;
 
         explicit transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise = false);
 
@@ -335,7 +353,7 @@ public:
 
         transitions_const_iterator(const transitions_const_iterator& other) = default;
 
-        const Trans& operator*() const { return transition; }
+        const Transition& operator*() const { return transition; }
 
         // Prefix increment
         transitions_const_iterator& operator++();

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -159,10 +159,19 @@ public:
 }; // struct Post.
 
 /**
- * Delta is a data structure for representing transition relation.
- * Its underlying data structure is vector of Post structures.
- * Each index of vector corresponds to one state, that is a number of
- * state is an index to the vector of Posts.
+ * @brief Delta is a data structure for representing transition relation.
+ *
+ * Transition is represented as a triple Trans(source state, symbol, target state). Move is the part (symbol, target
+ *  state), specified for a single source state.
+ * Its underlying data structure is vector of StatePost classes. Each index to the vector corresponds to one source
+ *  state, that is, a number for a certain state is an index to the vector of state posts.
+ * Transition relation (delta) in Mata stores a set of transitions in a four-level hierarchical structure: 
+ *  Delta, StatePost, SymbolPost, and a set of target states.
+ * A vector of 'StatePost's indexed by a source states on top, where the StatePost for a state 'q' (whose number is
+ *  'q' and it is the index to the vector of 'StatePost's) stores a set of 'Move's from the source state 'q'.
+ * Namely, 'StatePost' has a vector of 'SymbolPost's, where each 'SymbolPost' stores a symbol 'a' and a vector of
+ *  target states of 'a'-moves from state 'q'. 'SymbolPost's are ordered by the symbol, target states are ordered by
+ *  the state number.
  */
 class Delta {
 private:

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -246,7 +246,7 @@ public:
      * @return Iterator over transitions.
      */
     TransitionsIterator transitions() const {
-        return { transitions_begin(), transitions_end() };
+        return { .m_begin = transitions_begin(), .m_end = transitions_end() };
     }
 
     using const_iterator = std::vector<StatePost>::const_iterator;

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -8,6 +8,17 @@
 namespace Mata::Nfa {
 
 /**
+ * Move from a @c StatePost for a single source state, represented as a pair of @c symbol and target state @c tgt_state.
+ */
+class Move {
+public:
+    Symbol symbol;
+    State tgt_state;
+
+    bool operator==(const Move&) const = default;
+}; // class Move.
+
+/**
  * Structure represents a post of a single @c symbol: a set of target states in transitions.
  *
  * A set of @c SymbolPost, called @c StatePost, is describing the automata transitions from a single source state.
@@ -87,6 +98,64 @@ public:
     using super::find;
     iterator find(const Symbol symbol) { return super::find({ symbol, {} }); }
     const_iterator find(const Symbol symbol) const { return super::find({ symbol, {} }); }
+
+    /**
+     * Iterator over moves. It iterates over pairs (symbol, target state) for a current source state whose state post
+     *  we iterate.
+     */
+    struct moves_const_iterator {
+    private:
+        const std::vector<SymbolPost>& m_symbol_posts{};
+        std::vector<SymbolPost>::const_iterator m_symbol_post_it{};
+        StateSet::const_iterator m_target_states_it{};
+        bool m_is_end{ false };
+        Move m_move{};
+
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = int;
+        using difference_type = int;
+        using pointer = int*;
+        using reference = int&;
+
+        explicit moves_const_iterator(const std::vector<SymbolPost>& symbol_posts, bool is_end = false);
+
+        moves_const_iterator(const std::vector<SymbolPost>& symbol_posts,
+                             std::vector<SymbolPost>::const_iterator symbol_posts_it,
+                             StateSet::const_iterator target_states_it, bool is_end = false);
+
+        moves_const_iterator(const moves_const_iterator& other) = default;
+
+        const Move& operator*() const { return m_move; }
+
+        // Prefix increment
+        moves_const_iterator& operator++();
+        // Postfix increment
+        const moves_const_iterator operator++(int);
+
+        moves_const_iterator& operator=(const moves_const_iterator& x);
+
+        bool operator==(const moves_const_iterator& other) const;
+        bool operator!=(const moves_const_iterator& other) const { return !(*this == other); };
+    };
+
+    moves_const_iterator moves_cbegin() const { return moves_const_iterator(ToVector()); }
+    moves_const_iterator moves_cend() const { return moves_const_iterator(ToVector(), true); }
+    moves_const_iterator moves_begin() const { return moves_cbegin(); }
+    moves_const_iterator moves_end() const { return moves_cend(); }
+
+    struct MovesIterator {
+        moves_const_iterator m_begin;
+        moves_const_iterator m_end;
+        moves_const_iterator begin() const { return m_begin; }
+        moves_const_iterator end() const { return m_end; }
+    };
+
+    /**
+     * Iterate over moves represented as 'Move' instances.
+     * @return Iterator over moves.
+     */
+    MovesIterator moves() const { return { .m_begin = moves_begin(), .m_end = moves_end() }; }
 }; // struct Post.
 
 /**
@@ -263,8 +332,8 @@ public:
 
         transitions_const_iterator& operator=(const transitions_const_iterator& x);
 
-        friend bool operator==(const transitions_const_iterator& a, const transitions_const_iterator& b);
-        friend bool operator!=(const transitions_const_iterator& a, const transitions_const_iterator& b) { return !(a == b); };
+        bool operator==(const transitions_const_iterator& other) const;
+        bool operator!=(const transitions_const_iterator& other) const { return !(*this == other); };
     };
 
     transitions_const_iterator transitions_cbegin() const { return transitions_const_iterator(state_posts); }
@@ -283,9 +352,7 @@ public:
      * Iterate over transitions represented as 'Trans' instances.
      * @return Iterator over transitions.
      */
-    TransitionsIterator transitions() const {
-        return { .m_begin = transitions_begin(), .m_end = transitions_end() };
-    }
+    TransitionsIterator transitions() const { return { .m_begin = transitions_begin(), .m_end = transitions_end() }; }
 
     using const_iterator = std::vector<StatePost>::const_iterator;
     const_iterator cbegin() const { return state_posts.cbegin(); }
@@ -293,8 +360,6 @@ public:
     const_iterator begin() const { return state_posts.begin(); }
     const_iterator end() const { return state_posts.end(); }
 }; // struct Delta.
-
-bool operator==(const Delta::transitions_const_iterator& a, const Delta::transitions_const_iterator& b);
 
 } // namespace Mata::Nfa.
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -252,7 +252,8 @@ public:
      *
      * The operation has constant time complexity.
      */
-    size_t get_num_of_trans() const { return static_cast<size_t>(std::distance(delta.begin(), delta.end())); }
+    size_t get_num_of_trans() const { return static_cast<size_t>(std::distance(delta.transitions_begin(),
+                                                                               delta.transitions_end())); }
 
     /**
      * Get transitions as a sequence of @c Trans.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -204,9 +204,9 @@ public:
     StateSet get_useful_states_old() const;
 
     /**
-     * @brief Get the useful states using a modified Tarjan's algorithm. A state 
+     * @brief Get the useful states using a modified Tarjan's algorithm. A state
      * is useful if it is reachable from an initial state and can reach a final state.
-     * 
+     *
      * @return BoolVector Bool vector whose ith value is true iff the state i is useful.
      */
     BoolVector get_useful_states() const;
@@ -259,14 +259,14 @@ public:
      * Get transitions as a sequence of @c Trans.
      * @return Sequence of transitions as @c Trans.
      */
-    std::vector<Trans> get_trans_as_sequence() const;
+    std::vector<Transition> get_trans_as_sequence() const;
 
     /**
      * Get transitions from @p state_from as a sequence of @c Trans.
      * @param state_from[in] Source state_from of transitions to get.
      * @return Sequence of transitions as @c Trans from @p state_from.
      */
-    std::vector<Trans> get_trans_from_as_sequence(State state_from) const;
+    std::vector<Transition> get_trans_from_as_sequence(State state_from) const;
 
     /**
      * Get transitions leading to @p state_to.
@@ -274,7 +274,7 @@ public:
      * @return Sequence of @c Trans transitions leading to @p state_to.
      * (!slow!, traverses the entire delta)
      */
-    std::vector<Trans> get_transitions_to(State state_to) const;
+    std::vector<Transition> get_transitions_to(State state_to) const;
 
     /**
      * Unify transitions to create a directed graph with at most a single transition between two states.
@@ -339,7 +339,7 @@ public:
         size_t trIt;
         StatePost::const_iterator tlIt;
         StateSet::const_iterator ssIt;
-        Trans trans;
+        Transition trans;
         bool is_end = { false };
 
         const_iterator() : nfa(), trIt(0), tlIt(), ssIt(), trans() { };
@@ -351,7 +351,7 @@ public:
         //  adds clutter and makes people write inefficient code.
         void refresh_trans() { this->trans = {trIt, this->tlIt->symbol, *(this->ssIt)}; }
 
-        const Trans& operator*() const { return this->trans; }
+        const Transition& operator*() const { return this->trans; }
 
         bool operator==(const const_iterator& rhs) const;
         bool operator!=(const const_iterator& rhs) const { return !(*this == rhs);}
@@ -721,16 +721,16 @@ Run encode_word(const Alphabet* alphabet, const std::vector<std::string>& input)
 
 namespace std {
 template <>
-struct hash<Mata::Nfa::Trans> {
-	inline size_t operator()(const Mata::Nfa::Trans& trans) const {
-		size_t accum = std::hash<Mata::Nfa::State>{}(trans.src);
-		accum = Mata::Util::hash_combine(accum, trans.symb);
-		accum = Mata::Util::hash_combine(accum, trans.tgt);
+struct hash<Mata::Nfa::Transition> {
+	inline size_t operator()(const Mata::Nfa::Transition& trans) const {
+		size_t accum = std::hash<Mata::Nfa::State>{}(trans.source);
+		accum = Mata::Util::hash_combine(accum, trans.symbol);
+		accum = Mata::Util::hash_combine(accum, trans.target);
 		return accum;
 	}
 };
 
-std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Trans& trans);
+std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Transition& trans);
 std::ostream& operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa);
 } // namespace std.
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -269,24 +269,6 @@ public:
     std::vector<Trans> get_trans_from_as_sequence(State state_from) const;
 
     /**
-     * Get transitions leading from @p state_from.
-     *
-     * If we try to access a state which is present in the delta as a target state, yet does not have allocated space
-     *  for itself in @c post, @c post is resized to include @p state_from.
-     * @param state_from[in] Source state for transitions to get.
-     * @return List of transitions leading from @p state_from.
-     */
-    const StatePost& get_moves_from(const State state_from) const {
-        const size_t state_post_size{ size() };
-        if (state_from >= state_post_size) {
-            throw std::runtime_error(
-                    "Cannot get moves from nonexistent state '" + std::to_string(state_from)
-                    + "' for StatePost of size '" + std::to_string(state_post_size) + "'.");
-        }
-        return delta[state_from];
-    }
-
-    /**
      * Get transitions leading to @p state_to.
      * @param state_to[in] Target state for transitions to get.
      * @return Sequence of @c Trans transitions leading to @p state_to.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -275,12 +275,12 @@ public:
      * @param state_from[in] Source state for transitions to get.
      * @return List of transitions leading from @p state_from.
      */
-    const Post& get_moves_from(const State state_from) const {
-        const size_t post_size{ size() };
-        if (state_from >= post_size) {
+    const StatePost& get_moves_from(const State state_from) const {
+        const size_t state_post_size{ size() };
+        if (state_from >= state_post_size) {
             throw std::runtime_error(
                     "Cannot get moves from nonexistent state '" + std::to_string(state_from)
-                    + "' for Post of size '" + std::to_string(post_size) + "'.");
+                    + "' for StatePost of size '" + std::to_string(state_post_size) + "'.");
         }
         return delta[state_from];
     }
@@ -354,7 +354,7 @@ public:
     struct const_iterator {
         const Nfa* nfa;
         size_t trIt;
-        Post::const_iterator tlIt;
+        StatePost::const_iterator tlIt;
         StateSet::const_iterator ssIt;
         Trans trans;
         bool is_end = { false };
@@ -385,7 +385,7 @@ public:
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    Post::const_iterator get_epsilon_transitions(State state, Symbol epsilon = EPSILON) const;
+    StatePost::const_iterator get_epsilon_transitions(State state, Symbol epsilon = EPSILON) const;
 
     /**
      * Return all epsilon transitions from epsilon symbol under given state transitions.
@@ -394,7 +394,7 @@ public:
      * @return Returns reference element of transition list with epsilon transitions or end of transition list when
      * there are no epsilon transitions.
      */
-    static Post::const_iterator get_epsilon_transitions(const Post& post, Symbol epsilon = EPSILON);
+    static StatePost::const_iterator get_epsilon_transitions(const StatePost& post, Symbol epsilon = EPSILON);
 
     /**
      * @brief Expand alphabet by symbols from this automaton to given alphabet
@@ -701,7 +701,8 @@ Nfa fragile_revert(const Nfa& aut);
 Nfa simple_revert(const Nfa& aut);
 
 // Reverting the automaton by a modification of the simple algorithm.
-// It replaces random access addition to Move by push_back and sorting later, so far seems the slowest of all, except on dense automata, where it is almost as slow as simple_revert. Candidate for removal.
+// It replaces random access addition to SymbolPost by push_back and sorting later, so far seems the slowest of all, except on
+//  dense automata, where it is almost as slow as simple_revert. Candidate for removal.
 Nfa somewhat_simple_revert(const Nfa& aut);
 
 // Removing epsilon transitions

--- a/include/mata/nfa/strings.hh
+++ b/include/mata/nfa/strings.hh
@@ -150,8 +150,8 @@ public:
     using EpsilonDepth = size_t; ///< Depth of ε-transitions.
     /// Dictionary of lists of ε-transitions grouped by their depth.
     /// For each depth 'i' we have 'depths[i]' which contains a list of ε-transitions of depth 'i'.
-    using EpsilonDepthTransitions = std::unordered_map<EpsilonDepth, std::vector<Trans>>;
-    using EpsilonDepthTransitionMap = std::unordered_map<EpsilonDepth, std::unordered_map<State, std::vector<Trans>>>;
+    using EpsilonDepthTransitions = std::unordered_map<EpsilonDepth, std::vector<Transition>>;
+    using EpsilonDepthTransitionMap = std::unordered_map<EpsilonDepth, std::unordered_map<State, std::vector<Transition>>>;
 
     /**
      * Prepare automaton @p aut for segmentation.
@@ -225,14 +225,14 @@ private:
      * @param[in] current_depth Current depth.
      * @param[in] transition Current epsilon transition.
      */
-    void update_next_segment(size_t current_depth, const Trans& transition);
+    void update_next_segment(size_t current_depth, const Transition& transition);
 
     /**
      * Update current segment automaton.
      * @param[in] current_depth Current depth.
      * @param[in] transition Current epsilon transition.
      */
-    void update_current_segment(size_t current_depth, const Trans& transition);
+    void update_current_segment(size_t current_depth, const Transition& transition);
 
     /**
      * Initialize map of visited states.

--- a/include/mata/nfa/strings.hh
+++ b/include/mata/nfa/strings.hh
@@ -259,7 +259,7 @@ private:
      * @param depth[in] Current depth.
      * @param worklist[out] Worklist of state and depth pairs to process.
      */
-    void add_transitions_to_worklist(const StateDepthTuple& state_depth_pair, const Move& move,
+    void add_transitions_to_worklist(const StateDepthTuple& state_depth_pair, const SymbolPost& move,
                                      std::deque<StateDepthTuple>& worklist);
 
     /**
@@ -268,7 +268,7 @@ private:
      * @param[in] move Move from current state.
      * @param[out] worklist Worklist of state and depth pairs to process.
      */
-    void handle_epsilon_transitions(const StateDepthTuple& state_depth_pair, const Move& move,
+    void handle_epsilon_transitions(const StateDepthTuple& state_depth_pair, const SymbolPost& move,
                                     std::deque<StateDepthTuple>& worklist);
 
     /**

--- a/include/mata/nfa/types.hh
+++ b/include/mata/nfa/types.hh
@@ -44,23 +44,6 @@ public:
     static const Symbol max_symbol = std::numeric_limits<Symbol>::max();
 };
 
-/// A single transition in Delta.
-struct Trans {
-    State src;
-    Symbol symb;
-    State tgt;
-
-    Trans() : src(), symb(), tgt() { }
-    Trans(const Trans &) = default;
-    Trans(Trans &&) = default;
-    Trans &operator=(const Trans &) = default;
-    Trans &operator=(Trans &&) = default;
-    Trans(State src, Symbol symb, State tgt) : src(src), symb(symb), tgt(tgt) {}
-
-    bool operator==(const Trans& rhs) const { return src == rhs.src && symb == rhs.symb && tgt == rhs.tgt; }
-    bool operator!=(const Trans& rhs) const { return !this->operator==(rhs); }
-};
-
 struct Nfa; ///< A non-deterministic finite automaton.
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.

--- a/include/mata/nfa/types.hh
+++ b/include/mata/nfa/types.hh
@@ -6,6 +6,8 @@
 #include "mata/alphabet.hh"
 #include "mata/parser/parser.hh"
 
+#include <limits>
+
 namespace Mata::Nfa {
 
 extern const std::string TYPE_NFA;

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -119,7 +119,7 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Add rhs transitions to the result.
     for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
     {
-        for (const SymbolPost& rhs_move: rhs.get_moves_from(rhs_state))
+        for (const SymbolPost& rhs_move: rhs.delta.state_post(rhs_state))
         {
             for (const State& rhs_state_to: rhs_move.targets)
             {

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -43,7 +43,7 @@ Nfa& Nfa::concatenate(const Nfa& aut) {
 
     // connect both parts
     for(const State& ini : aut.initial) {
-        const Post& ini_post = this->delta[upd_fnc(ini)];
+        const StatePost& ini_post = this->delta[upd_fnc(ini)];
         // is ini state also final?
         bool is_final = aut.final[ini];
         for(const State& fin : this->final) {

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -50,7 +50,7 @@ Nfa& Nfa::concatenate(const Nfa& aut) {
             if(is_final) {
                 new_fin.insert(fin);
             }
-            for(const Move& ini_mv : ini_post) {
+            for(const SymbolPost& ini_mv : ini_post) {
                 // TODO: this should be done efficiently in a delta method
                 // TODO: in fact it is not efficient for now
                 for(const State& dest : ini_mv.targets) {
@@ -119,7 +119,7 @@ Nfa Algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     // Add rhs transitions to the result.
     for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
     {
-        for (const Move& rhs_move: rhs.get_moves_from(rhs_state))
+        for (const SymbolPost& rhs_move: rhs.get_moves_from(rhs_state))
         {
             for (const State& rhs_state_to: rhs_move.targets)
             {

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -192,15 +192,17 @@ bool Delta::empty() const
     return this->transitions_begin() == this->transitions_end();
 }
 
-Delta::transitions_const_iterator::transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise) :
-    post(post_p), current_state(0), is_end{ ise }
-{
+Delta::transitions_const_iterator::transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise)
+    : post(post_p), current_state(0), is_end{ ise } {
     const size_t post_size = post.size();
     for (size_t i = 0; i < post_size; ++i) {
         if (!post[i].empty()) {
             current_state = i;
             post_iterator = post[i].begin();
             targets_position = post_iterator->targets.begin();
+            transition.src = current_state;
+            transition.symb = post_iterator->symbol;
+            transition.tgt = *targets_position;
             return;
         }
     }
@@ -209,17 +211,29 @@ Delta::transitions_const_iterator::transitions_const_iterator(const std::vector<
     is_end = true;
 }
 
-Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++()
-{
+Delta::transitions_const_iterator::transitions_const_iterator(
+    const std::vector<StatePost>& post_p, size_t as, StatePost::const_iterator pi, StateSet::const_iterator ti,
+    bool ise)
+    : post(post_p), current_state(as), post_iterator(pi), targets_position(ti), is_end(ise) {
+    transition.src = current_state;
+    transition.symb = post_iterator->symbol;
+    transition.tgt = *targets_position;
+};
+
+Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++() {
     assert(post.begin() != post.end());
 
     ++targets_position;
-    if (targets_position != post_iterator->targets.end())
+    if (targets_position != post_iterator->targets.end()) {
+        transition.tgt = *targets_position;
         return *this;
+    }
 
     ++post_iterator;
     if (post_iterator != post[current_state].cend()) {
         targets_position = post_iterator->targets.begin();
+        transition.symb = post_iterator->symbol;
+        transition.tgt = *targets_position;
         return *this;
     }
 
@@ -233,6 +247,10 @@ Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++
         post_iterator = post[current_state].begin();
         targets_position = post_iterator->targets.begin();
     }
+
+    transition.src = current_state;
+    transition.symb = post_iterator->symbol;
+    transition.tgt = *targets_position;
 
     return *this;
 }

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -185,10 +185,10 @@ bool Delta::contains(State src, Symbol symb, State tgt) const
 
 bool Delta::empty() const
 {
-    return this->begin() == this->end();
+    return this->transitions_begin() == this->transitions_end();
 }
 
-Delta::const_iterator::const_iterator(const std::vector<StatePost>& post_p, bool ise) :
+Delta::transitions_const_iterator::transitions_const_iterator(const std::vector<StatePost>& post_p, bool ise) :
     post(post_p), current_state(0), is_end{ ise }
 {
     const size_t post_size = post.size();
@@ -205,7 +205,7 @@ Delta::const_iterator::const_iterator(const std::vector<StatePost>& post_p, bool
     is_end = true;
 }
 
-Delta::const_iterator& Delta::const_iterator::operator++()
+Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++()
 {
     assert(post.begin() != post.end());
 
@@ -233,13 +233,13 @@ Delta::const_iterator& Delta::const_iterator::operator++()
     return *this;
 }
 
-Delta::const_iterator Delta::const_iterator::operator++(int) {
-    const const_iterator tmp = *this;
+const Delta::transitions_const_iterator Delta::transitions_const_iterator::operator++(int) {
+    const transitions_const_iterator tmp = *this;
     ++(*this);
     return tmp;
 }
 
-Delta::const_iterator& Delta::const_iterator::operator=(const Delta::const_iterator& x) {
+Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator=(const Delta::transitions_const_iterator& x) {
     this->post_iterator = x.post_iterator;
     this->targets_position = x.targets_position;
     this->current_state = x.current_state;
@@ -248,7 +248,7 @@ Delta::const_iterator& Delta::const_iterator::operator=(const Delta::const_itera
     return *this;
 }
 
-bool Mata::Nfa::operator==(const Delta::const_iterator& a, const Delta::const_iterator& b) {
+bool Mata::Nfa::operator==(const Delta::transitions_const_iterator& a, const Delta::transitions_const_iterator& b) {
     if (a.is_end && b.is_end) {
         return true;
     } else if ((a.is_end && !b.is_end) || (!a.is_end && b.is_end)) {

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -182,8 +182,8 @@ bool Delta::contains(State src, Symbol symb, State tgt) const
     return symbol_transitions->targets.find(tgt) != symbol_transitions->targets.end();
 }
 
-bool Delta::contains(const Trans& transition) const {
-    return contains(transition.src, transition.symb, transition.tgt);
+bool Delta::contains(const Transition& transition) const {
+    return contains(transition.source, transition.symbol, transition.target);
 }
 
 bool Delta::empty() const
@@ -199,9 +199,9 @@ Delta::transitions_const_iterator::transitions_const_iterator(const std::vector<
             current_state = i;
             post_iterator = post[i].begin();
             targets_position = post_iterator->targets.begin();
-            transition.src = current_state;
-            transition.symb = post_iterator->symbol;
-            transition.tgt = *targets_position;
+            transition.source = current_state;
+            transition.symbol = post_iterator->symbol;
+            transition.target = *targets_position;
             return;
         }
     }
@@ -214,9 +214,9 @@ Delta::transitions_const_iterator::transitions_const_iterator(
     const std::vector<StatePost>& post_p, size_t as, StatePost::const_iterator pi, StateSet::const_iterator ti,
     bool ise)
     : post(post_p), current_state(as), post_iterator(pi), targets_position(ti), is_end(ise) {
-    transition.src = current_state;
-    transition.symb = post_iterator->symbol;
-    transition.tgt = *targets_position;
+    transition.source = current_state;
+    transition.symbol = post_iterator->symbol;
+    transition.target = *targets_position;
 };
 
 Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++() {
@@ -224,15 +224,15 @@ Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++
 
     ++targets_position;
     if (targets_position != post_iterator->targets.end()) {
-        transition.tgt = *targets_position;
+        transition.target = *targets_position;
         return *this;
     }
 
     ++post_iterator;
     if (post_iterator != post[current_state].cend()) {
         targets_position = post_iterator->targets.begin();
-        transition.symb = post_iterator->symbol;
-        transition.tgt = *targets_position;
+        transition.symbol = post_iterator->symbol;
+        transition.target = *targets_position;
         return *this;
     }
 
@@ -247,9 +247,9 @@ Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator++
         targets_position = post_iterator->targets.begin();
     }
 
-    transition.src = current_state;
-    transition.symb = post_iterator->symbol;
-    transition.tgt = *targets_position;
+    transition.source = current_state;
+    transition.symbol = post_iterator->symbol;
+    transition.target = *targets_position;
 
     return *this;
 }
@@ -267,9 +267,9 @@ Delta::transitions_const_iterator& Delta::transitions_const_iterator::operator=(
     this->targets_position = x.targets_position;
     this->current_state = x.current_state;
     this->is_end = x.is_end;
-    transition.src = x.transition.src;
-    transition.symb = x.transition.symb;
-    transition.tgt = x.transition.tgt;
+    transition.source = x.transition.source;
+    transition.symbol = x.transition.symbol;
+    transition.target = x.transition.target;
     return *this;
 }
 

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -349,55 +349,55 @@ void Delta::defragment(const BoolVector& is_staying, const std::vector<State>& r
 }
 
 StatePost::moves_const_iterator::moves_const_iterator(const std::vector<SymbolPost>& symbol_posts, bool is_end)
-    : m_symbol_posts{ symbol_posts }, m_symbol_post_it{ m_symbol_posts.cbegin() }, m_is_end{ is_end } {
-    while (m_symbol_post_it != m_symbol_posts.cend()) {
-        if (!m_symbol_post_it->empty()) {
-            m_target_states_it = m_symbol_post_it->targets.begin();
-            m_move.symbol = m_symbol_post_it->symbol;
-            m_move.tgt_state = *m_target_states_it;
+    : symbol_posts_{ symbol_posts }, symbol_post_it_{ symbol_posts_.cbegin() }, is_end_{ is_end } {
+    while (symbol_post_it_ != symbol_posts_.cend()) {
+        if (!symbol_post_it_->empty()) {
+            target_states_it_ = symbol_post_it_->targets.begin();
+            move_.symbol = symbol_post_it_->symbol;
+            move_.tgt_state = *target_states_it_;
             return;
         }
-        ++m_symbol_post_it;
+        ++symbol_post_it_;
     }
     // No move found. We are at the end of moves.
-    m_is_end = true;
+    is_end_ = true;
 }
 
 StatePost::moves_const_iterator::moves_const_iterator(
     const std::vector<SymbolPost>& symbol_posts, std::vector<SymbolPost>::const_iterator symbol_posts_it,
     StateSet::const_iterator target_states_it, bool is_end)
-    : m_symbol_posts{ symbol_posts }, m_symbol_post_it{ symbol_posts_it }, m_target_states_it{ target_states_it },
-      m_is_end{ is_end } {
-        while (m_symbol_post_it != m_symbol_posts.cend()) {
-            if (!m_symbol_post_it->empty()) {
-                m_target_states_it = m_symbol_post_it->targets.begin();
-                m_move.symbol = m_symbol_post_it->symbol;
-                m_move.tgt_state = *m_target_states_it;
+    : symbol_posts_{ symbol_posts }, symbol_post_it_{ symbol_posts_it }, target_states_it_{ target_states_it },
+      is_end_{ is_end } {
+        while (symbol_post_it_ != symbol_posts_.cend()) {
+            if (!symbol_post_it_->empty()) {
+                target_states_it_ = symbol_post_it_->targets.begin();
+                move_.symbol = symbol_post_it_->symbol;
+                move_.tgt_state = *target_states_it_;
                 return;
             }
         }
         // No move found. We are at the end of moves.
-        m_is_end = true;
+        is_end_ = true;
 }
 
 StatePost::moves_const_iterator& StatePost::moves_const_iterator::operator++() {
-    assert(m_symbol_posts.begin() != m_symbol_posts.end());
+    assert(symbol_posts_.begin() != symbol_posts_.end());
 
-    ++m_target_states_it;
-    if (m_target_states_it != m_symbol_post_it->targets.end()) {
-        m_move.tgt_state = *m_target_states_it;
+    ++target_states_it_;
+    if (target_states_it_ != symbol_post_it_->targets.end()) {
+        move_.tgt_state = *target_states_it_;
         return *this;
     }
 
-    ++m_symbol_post_it;
-    if (m_symbol_post_it != m_symbol_posts.cend()) {
-        m_target_states_it = m_symbol_post_it->targets.begin();
-        m_move.symbol = m_symbol_post_it->symbol;
-        m_move.tgt_state = *m_target_states_it;
+    ++symbol_post_it_;
+    if (symbol_post_it_ != symbol_posts_.cend()) {
+        target_states_it_ = symbol_post_it_->targets.begin();
+        move_.symbol = symbol_post_it_->symbol;
+        move_.tgt_state = *target_states_it_;
         return *this;
     }
 
-    m_is_end = true;
+    is_end_ = true;
     return *this;
 }
 
@@ -410,20 +410,20 @@ const StatePost::moves_const_iterator StatePost::moves_const_iterator::operator+
 StatePost::moves_const_iterator& StatePost::moves_const_iterator::operator=(const StatePost::moves_const_iterator& x) {
     // FIXME: this->symbol_posts is never updated, because it is a const reference to std::vector which does not have
     //  assignment operator defined.
-    m_is_end = x.m_is_end;
-    m_move.symbol = x.m_move.symbol;
-    m_move.tgt_state = x.m_move.tgt_state;
-    m_symbol_post_it = x.m_symbol_post_it;
-    m_target_states_it = x.m_target_states_it;
+    is_end_ = x.is_end_;
+    move_.symbol = x.move_.symbol;
+    move_.tgt_state = x.move_.tgt_state;
+    symbol_post_it_ = x.symbol_post_it_;
+    target_states_it_ = x.target_states_it_;
     return *this;
 }
 
 bool Mata::Nfa::StatePost::moves_const_iterator::operator==(const StatePost::moves_const_iterator& other) const {
-    if (m_is_end && other.m_is_end) {
+    if (is_end_ && other.is_end_) {
         return true;
-    } else if ((m_is_end && !other.m_is_end) || (!m_is_end && other.m_is_end)) {
+    } else if ((is_end_ && !other.is_end_) || (!is_end_ && other.is_end_)) {
         return false;
     } else {
-        return m_symbol_post_it == other.m_symbol_post_it && m_target_states_it == other.m_target_states_it;
+        return symbol_post_it_ == other.symbol_post_it_ && target_states_it_ == other.target_states_it_;
     }
 }

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -354,7 +354,7 @@ StatePost::moves_const_iterator::moves_const_iterator(const std::vector<SymbolPo
         if (!symbol_post_it_->empty()) {
             target_states_it_ = symbol_post_it_->targets.begin();
             move_.symbol = symbol_post_it_->symbol;
-            move_.tgt_state = *target_states_it_;
+            move_.target = *target_states_it_;
             return;
         }
         ++symbol_post_it_;
@@ -372,7 +372,7 @@ StatePost::moves_const_iterator::moves_const_iterator(
             if (!symbol_post_it_->empty()) {
                 target_states_it_ = symbol_post_it_->targets.begin();
                 move_.symbol = symbol_post_it_->symbol;
-                move_.tgt_state = *target_states_it_;
+                move_.target = *target_states_it_;
                 return;
             }
         }
@@ -385,7 +385,7 @@ StatePost::moves_const_iterator& StatePost::moves_const_iterator::operator++() {
 
     ++target_states_it_;
     if (target_states_it_ != symbol_post_it_->targets.end()) {
-        move_.tgt_state = *target_states_it_;
+        move_.target = *target_states_it_;
         return *this;
     }
 
@@ -393,7 +393,7 @@ StatePost::moves_const_iterator& StatePost::moves_const_iterator::operator++() {
     if (symbol_post_it_ != symbol_posts_.cend()) {
         target_states_it_ = symbol_post_it_->targets.begin();
         move_.symbol = symbol_post_it_->symbol;
-        move_.tgt_state = *target_states_it_;
+        move_.target = *target_states_it_;
         return *this;
     }
 
@@ -412,7 +412,7 @@ StatePost::moves_const_iterator& StatePost::moves_const_iterator::operator=(cons
     //  assignment operator defined.
     is_end_ = x.is_end_;
     move_.symbol = x.move_.symbol;
-    move_.tgt_state = x.move_.tgt_state;
+    move_.target = x.move_.target;
     symbol_post_it_ = x.symbol_post_it_;
     target_states_it_ = x.target_states_it_;
     return *this;

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -259,22 +259,6 @@ bool Mata::Nfa::operator==(const Delta::const_iterator& a, const Delta::const_it
     }
 }
 
-State Delta::find_max_state() {
-    size_t max = 0;
-    State src = 0;
-    for (StatePost & p: posts) {
-        if (src > max)
-            max = src;
-        for (SymbolPost & m: p) {
-            if (!m.targets.empty())
-                if (m.targets.back() > max)
-                    max = m.targets.back();
-        }
-        src++;
-    }
-    return max;
-}
-
 std::vector<StatePost> Delta::transform(const std::function<State(State)>& lambda) const {
     std::vector<StatePost> cp_post_vector;
     cp_post_vector.reserve(num_of_states());

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -19,7 +19,7 @@ using Mata::BoolVector;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 
-Move& Move::operator=(Move&& rhs) noexcept {
+SymbolPost& SymbolPost::operator=(SymbolPost&& rhs) noexcept {
     if (*this != rhs) {
         symbol = rhs.symbol;
         targets = std::move(rhs.targets);
@@ -27,7 +27,7 @@ Move& Move::operator=(Move&& rhs) noexcept {
     return *this;
 }
 
-void Move::insert(State s) {
+void SymbolPost::insert(State s) {
     if(targets.empty() || targets.back() < s) {
         targets.push_back(s);
         return;
@@ -40,7 +40,7 @@ void Move::insert(State s) {
     }
 }
 
-void Move::insert(const StateSet& states) {
+void SymbolPost::insert(const StateSet& states) {
     for (State s : states) {
         insert(s);
     }
@@ -59,7 +59,7 @@ Post::const_iterator Nfa::Nfa::get_epsilon_transitions(const Post& state_transit
                 return std::prev(state_transitions.end());
             }
         } else {
-            return state_transitions.find(Move(epsilon));
+            return state_transitions.find(SymbolPost(epsilon));
         }
     }
 
@@ -70,7 +70,7 @@ size_t Delta::size() const
 {
     size_t size = 0;
     for (State q = 0; q < num_of_states(); ++q)
-        for (const Move & m: (*this)[q])
+        for (const SymbolPost & m: (*this)[q])
             size = size + m.size();
 
     return size;
@@ -90,13 +90,13 @@ void Delta::add(State state_from, Symbol symbol, State state_to) {
     } else if (state_transitions.back().symbol < symbol) {
         state_transitions.insert({ symbol, state_to });
     } else {
-        const auto symbol_transitions{ state_transitions.find(Move{ symbol }) };
+        const auto symbol_transitions{ state_transitions.find(SymbolPost{ symbol }) };
         if (symbol_transitions != state_transitions.end()) {
             // Add transition with symbol already used on transitions from state_from.
             symbol_transitions->insert(state_to);
         } else {
             // Add transition to a new Move struct with symbol yet unused on transitions from state_from.
-            const Move new_symbol_transitions{ symbol, state_to };
+            const SymbolPost new_symbol_transitions{ symbol, state_to };
             state_transitions.insert(new_symbol_transitions);
         }
     }
@@ -128,7 +128,7 @@ void Delta::add(const State state_from, const Symbol symbol, const StateSet& sta
         } else {
             // Add transition to a new Move struct with symbol yet unused on transitions from state_from.
             // Move new_symbol_transitions{ symbol, states };
-            state_transitions.insert(Move{symbol, states});
+            state_transitions.insert(SymbolPost{ symbol, states});
         }
     }
 }
@@ -175,7 +175,7 @@ bool Delta::contains(State src, Symbol symb, State tgt) const
     if (tl.empty()) {
         return false;
     }
-    auto symbol_transitions{ tl.find(Move{symb} ) };
+    auto symbol_transitions{ tl.find(SymbolPost{ symb} ) };
     if (symbol_transitions == tl.cend()) {
         return false;
     }
@@ -265,7 +265,7 @@ State Delta::find_max_state() {
     for (Post & p: posts) {
         if (src > max)
             max = src;
-        for (Move & m: p) {
+        for (SymbolPost & m: p) {
             if (!m.targets.empty())
                 if (m.targets.back() > max)
                     max = m.targets.back();
@@ -281,13 +281,13 @@ std::vector<Post> Delta::transform(const std::function<State(State)>& lambda) co
     for(const Post& act_post: this->posts) {
         Post cp_post;
         cp_post.reserve(act_post.size());
-        for(const Move& mv : act_post) {
+        for(const SymbolPost& mv : act_post) {
             StateSet cp_dest;
             cp_dest.reserve(mv.size());
             for(const State& state : mv.targets) {
                 cp_dest.push_back(std::move(lambda(state)));
             }
-            cp_post.push_back(std::move(Move(mv.symbol, cp_dest)));
+            cp_post.push_back(std::move(SymbolPost(mv.symbol, cp_dest)));
         }
         cp_post_vector.emplace_back(cp_post);
     }
@@ -331,7 +331,7 @@ void Delta::defragment(const BoolVector& is_staying, const std::vector<State>& r
             move->targets.rename(renaming);
         }
         p.erase(
-                std::remove_if(p.begin(), p.end(), [&](Move& move) -> bool {
+                std::remove_if(p.begin(), p.end(), [&](SymbolPost& move) -> bool {
                     return move.targets.empty();
                 }),
                 p.end()

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -108,7 +108,7 @@ bool Mata::Nfa::Algorithms::is_included_antichains(
     }
 
     //For synchronised iteration over the set of states
-    using Iterator = Mata::Util::OrdVector<Move>::const_iterator;
+    using Iterator = Mata::Util::OrdVector<SymbolPost>::const_iterator;
     Mata::Util::SynchronizedExistentialIterator<Iterator> sync_iterator;
 
     while (!worklist.empty()) {

--- a/src/nfa/intersection.cc
+++ b/src/nfa/intersection.cc
@@ -32,7 +32,7 @@ void add_product_transition(Nfa& product, std::unordered_map<std::pair<State,Sta
                             const std::pair<State,State>& pair_to_process, SymbolPost& intersection_transition) {
     if (intersection_transition.empty()) { return; }
 
-    auto& intersect_state_transitions{ product.delta.get_mutable_post(product_map[pair_to_process]) };
+    auto& intersect_state_transitions{ product.delta.mutable_state_post(product_map[pair_to_process]) };
     auto intersection_move_iter{ intersect_state_transitions.find(intersection_transition) };
     if (intersection_move_iter == intersect_state_transitions.end()) {
         intersect_state_transitions.insert(intersection_transition);

--- a/src/nfa/intersection.cc
+++ b/src/nfa/intersection.cc
@@ -126,7 +126,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(
         Mata::Util::push_back(sync_iterator,rhs.delta[pair_to_process.second]);
 
         while (sync_iterator.advance()) {
-            std::vector<Post::const_iterator> moves = sync_iterator.get_current();
+            std::vector<StatePost::const_iterator> moves = sync_iterator.get_current();
             assert(moves.size() == 2); // One move per state in the pair.
 
             // Compute product for state transitions with same symbols.
@@ -151,7 +151,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(
             // Add transitions of the current state pair for an epsilon preserving product.
 
             // Check for lhs epsilon transitions.
-            const Post& lhs_post{ lhs.delta[pair_to_process.first] };
+            const StatePost& lhs_post{ lhs.delta[pair_to_process.first] };
             if (!lhs_post.empty()) {
                 const auto& lhs_state_last_transitions{ lhs_post.back() };
                 if (epsilons.find(lhs_state_last_transitions.symbol) != epsilons.end()) {
@@ -169,7 +169,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(
             }
 
             // Check for rhs epsilon transitions in case only rhs has any transitions and add them.
-            const Post& rhs_post{ rhs.delta[pair_to_process.second]};
+            const StatePost& rhs_post{ rhs.delta[pair_to_process.second]};
             if (!rhs_post.empty()) {
                 const auto& rhs_state_last_transitions{ rhs_post.back()};
                 if (epsilons.find(rhs_state_last_transitions.symbol) != epsilons.end()) {

--- a/src/nfa/intersection.cc
+++ b/src/nfa/intersection.cc
@@ -29,8 +29,7 @@ namespace {
  * @param[in] intersection_transition State transitions to add to the product.
  */
 void add_product_transition(Nfa& product, std::unordered_map<std::pair<State,State>, State>& product_map,
-                            const std::pair<State,State>& pair_to_process,
-                            Move& intersection_transition) {
+                            const std::pair<State,State>& pair_to_process, SymbolPost& intersection_transition) {
     if (intersection_transition.empty()) { return; }
 
     auto& intersect_state_transitions{ product.delta.get_mutable_post(product_map[pair_to_process]) };
@@ -60,7 +59,7 @@ void create_product_state_and_trans(
             std::unordered_set<std::pair<State,State>>& pairs_to_process,
             const State lhs_state_to,
             const State rhs_state_to,
-            Move& intersect_transitions
+            SymbolPost& intersect_transitions
 ) {
     const std::pair<State,State> intersect_state_pair_to(lhs_state_to, rhs_state_to);
     State intersect_state_to;
@@ -91,8 +90,9 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon,
     return Algorithms::intersection_eps(lhs, rhs, preserve_epsilon, epsilons, prod_map);
 }
 
-Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon, const std::set<Symbol>& epsilons,
-                 std::unordered_map<std::pair<State,State>, State> *prod_map) {
+Nfa Mata::Nfa::Algorithms::intersection_eps(
+        const Nfa& lhs, const Nfa& rhs, bool preserve_epsilon, const std::set<Symbol>& epsilons,
+        std::unordered_map<std::pair<State, State>, State> *prod_map) {
     Nfa product{}; // Product of the intersection.
     // Product map for the generated intersection mapping original state pairs to new product states.
     std::unordered_map<std::pair<State,State>, State> product_map{};
@@ -121,7 +121,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
         pairs_to_process.erase(pair_to_process);
         // Compute classic product for current state pair.
 
-        Mata::Util::SynchronizedUniversalIterator<Mata::Util::OrdVector<Move>::const_iterator> sync_iterator(2);
+        Mata::Util::SynchronizedUniversalIterator<Mata::Util::OrdVector<SymbolPost>::const_iterator> sync_iterator(2);
         Mata::Util::push_back(sync_iterator,lhs.delta[pair_to_process.first]);
         Mata::Util::push_back(sync_iterator,rhs.delta[pair_to_process.second]);
 
@@ -133,7 +133,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
             // Find all transitions that have the same symbol for first and the second state in the pair_to_process.
             // Create transition from the pair_to_process to all pairs between states to which first transition goes
             //  and states to which second one goes.
-            Move intersection_transition{moves[0]->symbol};
+            SymbolPost intersection_transition{ moves[0]->symbol };
             for (const State this_state_to: moves[0]->targets)
             {
                 for (const State other_state_to: moves[1]->targets)
@@ -158,7 +158,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
                     // Compute product for state transitions with lhs state epsilon transition.
                     // Create transition from the pair_to_process to all pairs between states to which first transition
                     //  goes and states to which second one goes.
-                    Move intersection_transition{lhs_state_last_transitions.symbol};
+                    SymbolPost intersection_transition{ lhs_state_last_transitions.symbol };
                     for (const State lhs_state_to: lhs_state_last_transitions.targets) {
                         create_product_state_and_trans(product, product_map, lhs, rhs, pairs_to_process,
                                                        lhs_state_to, pair_to_process.second,
@@ -176,7 +176,7 @@ Nfa Mata::Nfa::Algorithms::intersection_eps(const Nfa& lhs, const Nfa& rhs, bool
                     // Compute product for state transitions with rhs state epsilon transition.
                     // Create transition from the pair_to_process to all pairs between states to which first transition
                     //  goes and states to which second one goes.
-                    Move intersection_transition{rhs_state_last_transitions.symbol};
+                    SymbolPost intersection_transition{ rhs_state_last_transitions.symbol };
                     for (const State rhs_state_to: rhs_state_last_transitions.targets) {
                         create_product_state_and_trans(product, product_map, lhs, rhs, pairs_to_process,
                                                        pair_to_process.first, rhs_state_to,

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -560,7 +560,7 @@ void Nfa::print_to_mata(std::ostream &output) const {
         output << std::endl;
     }
 
-    for (Trans trans : delta) {
+    for (Trans trans : delta.transitions()) {
         output << "q" << trans.src << " " << trans.symb << " q" << trans.tgt << std::endl;
     }
 }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -644,7 +644,7 @@ Nfa::const_iterator Nfa::const_iterator::for_begin(const Nfa* nfa)
 
     const_iterator result;
 
-    if (nfa->delta.begin() == nfa->delta.end()) {
+    if (nfa->delta.transitions_begin() == nfa->delta.transitions_end()) {
         result.is_end = true;
         return result;
     }
@@ -707,7 +707,7 @@ Nfa::const_iterator& Nfa::const_iterator::operator++()
 
     // out of transition list
     ++this->trIt;
-    assert(this->nfa->delta.begin() != this->nfa->delta.end());
+    assert(this->nfa->delta.transitions_begin() != this->nfa->delta.transitions_end());
 
     while (this->trIt < this->nfa->delta.num_of_states() &&
            this->nfa->get_moves_from(this->trIt).empty())

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -62,7 +62,7 @@ namespace {
             state = worklist.back();
             worklist.pop_back();
 
-            for (const Move& move: nfa.delta[state])
+            for (const SymbolPost& move: nfa.delta[state])
             {
                 for (const State target_state: move.targets)
                 {
@@ -100,7 +100,7 @@ namespace {
             state = worklist.back();
             worklist.pop_back();
 
-            for (const Move& move: nfa.delta[state]) {
+            for (const SymbolPost& move: nfa.delta[state]) {
                 for (const State target_state: move.targets) {
                     if (states_to_consider[target_state] && !reachable[target_state]) {
                         worklist.push_back(target_state);
@@ -126,7 +126,7 @@ namespace {
             // ...add all transitions from 's' to some reachable state to the trimmed automaton.
             for (const auto& state_transitions_with_symbol: nfa.delta[original_state_mapping.first])
             {
-                Move new_state_trans_with_symbol(state_transitions_with_symbol.symbol);
+                SymbolPost new_state_trans_with_symbol(state_transitions_with_symbol.symbol);
                 for (State old_state_to: state_transitions_with_symbol.targets)
                 {
                     auto iter_to_new_state_to = state_renaming.find(old_state_to);
@@ -180,7 +180,7 @@ namespace {
     void collect_directed_transitions(const Nfa& nfa, const Symbol abstract_symbol, Nfa& digraph) {
         const State num_of_states{nfa.size() };
         for (State src_state{ 0 }; src_state < num_of_states; ++src_state) {
-            for (const Move& move: nfa.delta[src_state]) {
+            for (const SymbolPost& move: nfa.delta[src_state]) {
                 for (const State tgt_state: move.targets) {
                     // Directly try to add the transition. Finding out whether the transition is already in the digraph
                     //  only iterates through transition relation again.
@@ -515,7 +515,7 @@ void Nfa::print_to_DOT(std::ostream &output) const {
 
     const size_t delta_size = delta.num_of_states();
     for (State source = 0; source != delta_size; ++source) {
-        for (const Move &move: delta[source]) {
+        for (const SymbolPost &move: delta[source]) {
             output << source << " -> {";
             for (State target: move.targets) {
                 output << target << " ";
@@ -612,7 +612,7 @@ std::vector<Trans> Nfa::get_transitions_to(State state_to) const {
     std::vector<Trans> transitions_to_state{};
     const size_t num_of_states{ delta.num_of_states() };
     for (State state_from{ 0 }; state_from < num_of_states; ++state_from) {
-        for (const Move& state_from_move: delta[state_from]) {
+        for (const SymbolPost& state_from_move: delta[state_from]) {
             const auto target_state{ state_from_move.targets.find(state_to) };
             if (target_state != state_from_move.targets.end()) {
                 transitions_to_state.emplace_back(state_from, state_from_move.symbol, state_to );
@@ -750,7 +750,7 @@ Mata::Util::OrdVector<Symbol> Nfa::get_used_symbols_vec() const {
 #endif
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             Util::reserve_on_insert(symbols);
             symbols.push_back(move.symbol);
         }
@@ -770,7 +770,7 @@ std::set<Symbol> Nfa::get_used_symbols_set() const {
 #endif
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             symbols.insert(move.symbol);
         }
     }
@@ -792,7 +792,7 @@ Mata::Util::SparseSet<Symbol> Nfa::get_used_symbols_sps() const {
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             symbols.insert(move.symbol);
         }
     }
@@ -813,7 +813,7 @@ std::vector<bool> Nfa::get_used_symbols_bv() const {
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             reserve_on_insert(symbols,move.symbol);
             symbols[move.symbol]=true;
         }
@@ -833,7 +833,7 @@ BoolVector Nfa::get_used_symbols_chv() const {
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             reserve_on_insert(symbols,move.symbol);
             symbols[move.symbol]=true;
         }
@@ -847,7 +847,7 @@ Symbol Nfa::get_max_symbol() const {
     Symbol max = 0;
     for (State q = 0; q< delta.num_of_states(); ++q) {
         const Post & post = delta[q];
-        for (const Move & move: post) {
+        for (const SymbolPost & move: post) {
             if (move.symbol > max)
                 max = move.symbol;
         }
@@ -888,7 +888,7 @@ void Nfa::unify_final() {
 void Nfa::add_symbols_to(OnTheFlyAlphabet& target_alphabet) const {
     size_t aut_num_of_states{size() };
     for (Mata::Nfa::State state{ 0 }; state < aut_num_of_states; ++state) {
-        for (const Move& move: delta[state]) {
+        for (const SymbolPost& move: delta[state]) {
             target_alphabet.update_next_symbol_value(move.symbol);
             target_alphabet.try_add_new_symbol(std::to_string(move.symbol), move.symbol);
         }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -560,14 +560,14 @@ void Nfa::print_to_mata(std::ostream &output) const {
         output << std::endl;
     }
 
-    for (Trans trans : delta.transitions()) {
-        output << "q" << trans.src << " " << trans.symb << " q" << trans.tgt << std::endl;
+    for (Transition trans : delta.transitions()) {
+        output << "q" << trans.source << " " << trans.symbol << " q" << trans.target << std::endl;
     }
 }
 
-std::vector<Trans> Nfa::get_trans_as_sequence() const
+std::vector<Transition> Nfa::get_trans_as_sequence() const
 {
-    std::vector<Trans> trans_sequence{};
+    std::vector<Transition> trans_sequence{};
 
     for (State state_from{ 0 }; state_from < delta.num_of_states(); ++state_from)
     {
@@ -575,7 +575,7 @@ std::vector<Trans> Nfa::get_trans_as_sequence() const
         {
             for (State state_to: transition_from_state.targets)
             {
-                trans_sequence.push_back(Trans{ state_from, transition_from_state.symbol, state_to });
+                trans_sequence.push_back(Transition{ state_from, transition_from_state.symbol, state_to });
             }
         }
     }
@@ -583,9 +583,9 @@ std::vector<Trans> Nfa::get_trans_as_sequence() const
     return trans_sequence;
 }
 
-std::vector<Trans> Nfa::get_trans_from_as_sequence(State state_from) const
+std::vector<Transition> Nfa::get_trans_from_as_sequence(State state_from) const
 {
-    std::vector<Trans> trans_sequence{};
+    std::vector<Transition> trans_sequence{};
 
     for (const auto& transition_from_state: delta[state_from])
     {
@@ -608,8 +608,8 @@ void Nfa::get_one_letter_aut(Nfa& result) const {
     result = get_one_letter_aut();
 }
 
-std::vector<Trans> Nfa::get_transitions_to(State state_to) const {
-    std::vector<Trans> transitions_to_state{};
+std::vector<Transition> Nfa::get_transitions_to(State state_to) const {
+    std::vector<Transition> transitions_to_state{};
     const size_t num_of_states{ delta.num_of_states() };
     for (State state_from{ 0 }; state_from < num_of_states; ++state_from) {
         for (const SymbolPost& state_from_move: delta[state_from]) {
@@ -877,7 +877,7 @@ void Nfa::unify_final() {
     for (const auto& orig_final_state: final) {
         const auto transitions_to{ get_transitions_to(orig_final_state) };
         for (const auto& transitions: transitions_to) {
-            delta.add(transitions.src, transitions.symb, new_final_state);
+            delta.add(transitions.source, transitions.symbol, new_final_state);
         }
         if (initial[orig_final_state]) { initial.insert(new_final_state); }
     }
@@ -949,9 +949,9 @@ bool Nfa::is_identical(const Nfa& aut) {
         return false;
     }
 
-    std::vector<Trans> this_trans;
+    std::vector<Transition> this_trans;
     for (auto trans: *this) { this_trans.push_back(trans); }
-    std::vector<Trans> aut_trans;
+    std::vector<Transition> aut_trans;
     for (auto trans: aut) { aut_trans.push_back(trans); }
     return this_trans == aut_trans;
 }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -295,8 +295,8 @@ namespace {
     // of useful states. It contains Tarjan's metadata and the state of the 
     // iteration through the successors. 
     struct TarjanNodeData {
-        Post::const_iterator post_it{};
-        Post::const_iterator post_end{};
+        StatePost::const_iterator post_it{};
+        StatePost::const_iterator post_end{};
         StateSet::const_iterator targets_it{};
         StateSet::const_iterator targets_end{};
         // index of a node (corresponds to the time of discovery)
@@ -351,7 +351,7 @@ namespace {
             return this->post_it == this->post_end;
         }
     };
-}
+};
 
 /**
  * @brief This function employs non-recursive version of Tarjan's algorithm for finding SCCs 
@@ -629,7 +629,7 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
     }
 
     for (const State state: states) {
-        const Post& post{ delta[state] };
+        const StatePost& post{ delta[state] };
         const auto move_it{ post.find(symbol) };
         if (move_it != post.end()) {
             res.insert(move_it->targets);
@@ -695,7 +695,7 @@ Nfa::const_iterator& Nfa::const_iterator::operator++()
 
     // out of state set
     ++(this->tlIt);
-    const Post& tlist = this->nfa->get_moves_from(this->trIt);
+    const StatePost& tlist = this->nfa->get_moves_from(this->trIt);
     assert(!tlist.empty());
     if (this->tlIt != tlist.end())
     {
@@ -749,7 +749,7 @@ Mata::Util::OrdVector<Symbol> Nfa::get_used_symbols_vec() const {
     std::vector<Symbol>  symbols{};
 #endif
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             Util::reserve_on_insert(symbols);
             symbols.push_back(move.symbol);
@@ -769,7 +769,7 @@ std::set<Symbol> Nfa::get_used_symbols_set() const {
     static std::set<Symbol>  symbols{};
 #endif
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             symbols.insert(move.symbol);
         }
@@ -791,7 +791,7 @@ Mata::Util::SparseSet<Symbol> Nfa::get_used_symbols_sps() const {
 #endif
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             symbols.insert(move.symbol);
         }
@@ -812,7 +812,7 @@ std::vector<bool> Nfa::get_used_symbols_bv() const {
 #endif
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             reserve_on_insert(symbols,move.symbol);
             symbols[move.symbol]=true;
@@ -832,7 +832,7 @@ BoolVector Nfa::get_used_symbols_chv() const {
 #endif
     //symbols.dont_track_elements();
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             reserve_on_insert(symbols,move.symbol);
             symbols[move.symbol]=true;
@@ -846,7 +846,7 @@ BoolVector Nfa::get_used_symbols_chv() const {
 Symbol Nfa::get_max_symbol() const {
     Symbol max = 0;
     for (State q = 0; q< delta.num_of_states(); ++q) {
-        const Post & post = delta[q];
+        const StatePost & post = delta[q];
         for (const SymbolPost & move: post) {
             if (move.symbol > max)
                 max = move.symbol;
@@ -859,7 +859,7 @@ Symbol Nfa::get_max_symbol() const {
     if (initial.empty() || initial.size() == 1) { return; }
     const State new_initial_state{add_state() };
     for (const State orig_initial_state: initial) {
-        const Post& moves{ get_moves_from(orig_initial_state) };
+        const StatePost& moves{ get_moves_from(orig_initial_state) };
         for (const auto& transitions: moves) {
             for (const State state_to: transitions.targets) {
                 delta.add(new_initial_state, transitions.symbol, state_to);
@@ -910,7 +910,7 @@ Nfa& Nfa::operator=(Nfa&& other) noexcept {
 void Nfa::clear_transitions() {
     const size_t delta_size = delta.num_of_states();
     for (size_t i = 0; i < delta_size; ++i) {
-        delta.get_mutable_post(i) = Post();
+        delta.get_mutable_post(i) = StatePost();
     }
 }
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -21,6 +21,7 @@
 #include <iterator>
 
 // MATA headers
+#include "mata/nfa/delta.hh"
 #include "mata/utils/sparse-set.hh"
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/algorithms.hh"
@@ -191,7 +192,7 @@ Nfa Mata::Nfa::remove_epsilon(const Nfa& aut, Symbol epsilon) {
     while (changed) { // Compute the fixpoint.
         changed = false;
         for (size_t i = 0; i < num_of_states; ++i) {
-            const Post& post{ aut.delta[i] };
+            const StatePost& post{ aut.delta[i] };
             const auto eps_move_it { post.find(epsilon) };//TODO: make faster if default epsilon
             if (eps_move_it != post.end()) {
                 StateSet& src_eps_cl = eps_closure[i];
@@ -322,7 +323,7 @@ Nfa Mata::Nfa::fragile_revert(const Nfa& aut) {
         for (size_t i{ 0 }; i < sources[symbol].size(); ++i) {
             State tgt_state =sources[symbol][i];
             State src_state =targets[symbol][i];
-            Post & src_post = result.delta.get_mutable_post(src_state);
+            StatePost & src_post = result.delta.get_mutable_post(src_state);
             if (src_post.empty() || src_post.back().symbol != symbol) {
                 src_post.push_back(SymbolPost(symbol));
             }
@@ -334,7 +335,7 @@ Nfa Mata::Nfa::fragile_revert(const Nfa& aut) {
     for (size_t i{ 0 }; i < e_sources.size(); ++i) {
         State tgt_state =e_sources[i];
         State src_state =e_targets[i];
-        Post & src_post = result.delta.get_mutable_post(src_state);
+        StatePost & src_post = result.delta.get_mutable_post(src_state);
         if (src_post.empty() || src_post.back().symbol != EPSILON) {
             src_post.push_back(SymbolPost(EPSILON));
         }
@@ -385,7 +386,7 @@ Nfa Mata::Nfa::somewhat_simple_revert(const Nfa& aut) {
     for (State sourceState{ 0 }; sourceState < num_of_states; ++sourceState) {
         for (const SymbolPost &transition: aut.delta[sourceState]) {
             for (const State targetState: transition.targets) {
-                Post & post = result.delta.get_mutable_post(targetState);
+                StatePost & post = result.delta.get_mutable_post(targetState);
                 //auto move = std::find(post.begin(),post.end(),Move(transition.symbol));
                 auto move = post.find(SymbolPost(transition.symbol));
                 if (move == post.end()) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -92,7 +92,7 @@ namespace {
             }
 
             if (quot_proj[q] == q) { // we process only transitions starting from the representative state, this is enough for simulation
-                for (const auto &q_trans : aut.get_moves_from(q)) {
+                for (const auto &q_trans : aut.delta.state_post(q)) {
                     const StateSet representatives_of_states_to = [&]{
                         StateSet state_set;
                         for (auto s : q_trans.targets) {
@@ -118,7 +118,7 @@ namespace {
 
                     // add the transition 'q_class_state-q_trans.symbol->representatives_class_states' at the end of transition list of transitions starting from q_class_state
                     // as the q_trans.symbol should be the largest symbol we saw (as we iterate trough getTransitionsFromState(q) which is ordered)
-                    result.delta.get_mutable_post(q_class_state).insert(SymbolPost(q_trans.symbol, representatives_class_states));
+                    result.delta.mutable_state_post(q_class_state).insert(SymbolPost(q_trans.symbol, representatives_class_states));
                 }
 
                 if (aut.final[q]) { // if q is final, then all states in its class are final => we make q_class_state final
@@ -323,7 +323,7 @@ Nfa Mata::Nfa::fragile_revert(const Nfa& aut) {
         for (size_t i{ 0 }; i < sources[symbol].size(); ++i) {
             State tgt_state =sources[symbol][i];
             State src_state =targets[symbol][i];
-            StatePost & src_post = result.delta.get_mutable_post(src_state);
+            StatePost & src_post = result.delta.mutable_state_post(src_state);
             if (src_post.empty() || src_post.back().symbol != symbol) {
                 src_post.push_back(SymbolPost(symbol));
             }
@@ -335,7 +335,7 @@ Nfa Mata::Nfa::fragile_revert(const Nfa& aut) {
     for (size_t i{ 0 }; i < e_sources.size(); ++i) {
         State tgt_state =e_sources[i];
         State src_state =e_targets[i];
-        StatePost & src_post = result.delta.get_mutable_post(src_state);
+        StatePost & src_post = result.delta.mutable_state_post(src_state);
         if (src_post.empty() || src_post.back().symbol != EPSILON) {
             src_post.push_back(SymbolPost(EPSILON));
         }
@@ -386,7 +386,7 @@ Nfa Mata::Nfa::somewhat_simple_revert(const Nfa& aut) {
     for (State sourceState{ 0 }; sourceState < num_of_states; ++sourceState) {
         for (const SymbolPost &transition: aut.delta[sourceState]) {
             for (const State targetState: transition.targets) {
-                StatePost & post = result.delta.get_mutable_post(targetState);
+                StatePost & post = result.delta.mutable_state_post(targetState);
                 //auto move = std::find(post.begin(),post.end(),Move(transition.symbol));
                 auto move = post.find(SymbolPost(transition.symbol));
                 if (move == post.end()) {
@@ -404,7 +404,7 @@ Nfa Mata::Nfa::somewhat_simple_revert(const Nfa& aut) {
     for (State q = 0, states_num = result.delta.num_of_states(); q < states_num; ++q) {
         //Post & post = result.delta.get_mutable_post(q);
         //Util::sort_and_rmdupl(post);
-        for (auto m = result.delta.get_mutable_post(q).begin(); m != result.delta.get_mutable_post(q).end(); ++m) {
+        for (auto m = result.delta.mutable_state_post(q).begin(); m != result.delta.mutable_state_post(q).end(); ++m) {
             sort_and_rmdupl(m->targets);
         }
     }
@@ -667,7 +667,7 @@ Nfa Mata::Nfa::uni(const Nfa &lhs, const Nfa &rhs) {
                 union_symbol_post.insert(lhs_state_renaming[target_state]);
             }
 
-            union_nfa.delta.get_mutable_post(union_state).insert(union_symbol_post);
+            union_nfa.delta.mutable_state_post(union_state).insert(union_symbol_post);
         }
     }
 
@@ -807,7 +807,7 @@ Nfa Mata::Nfa::determinize(
                 }
                 worklist.emplace_back(std::make_pair(Tid, T));
             }
-            result.delta.get_mutable_post(Sid).insert(SymbolPost(currentSymbol, Tid));
+            result.delta.mutable_state_post(Sid).insert(SymbolPost(currentSymbol, Tid));
         }
     }
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -42,7 +42,7 @@ namespace {
         const size_t state_num = aut.size();
         Simlib::ExplicitLTS LTSforSimulation(state_num);
 
-        for (const auto& transition : aut.delta) {
+        for (const auto& transition : aut.delta.transitions()) {
             LTSforSimulation.add_transition(transition.src, transition.symb, transition.tgt);
             if (transition.symb > maxSymbol) {
                 maxSymbol = transition.symb;
@@ -822,12 +822,10 @@ std::ostream& std::operator<<(std::ostream& os, const Mata::Nfa::Nfa& nfa) {
 }
 
 void Mata::Nfa::fill_alphabet(const Mata::Nfa::Nfa& nfa, OnTheFlyAlphabet& alphabet) {
-    const size_t nfa_num_of_states{ nfa.size() };
-    for (Mata::Nfa::State state{ 0 }; state < nfa_num_of_states; ++state) {
-        // TODO: Rewrite to not create 'Trans' instances and iterate over same symbols all the time.
-        for (const Trans& state_transitions: nfa.delta) {
-            alphabet.update_next_symbol_value(state_transitions.symb);
-            alphabet.try_add_new_symbol(std::to_string(state_transitions.symb), state_transitions.symb);
+    for (const StatePost& state_post: nfa.delta) {
+        for (const SymbolPost& symbol_post: state_post) {
+            alphabet.update_next_symbol_value(symbol_post.symbol);
+            alphabet.try_add_new_symbol(std::to_string(symbol_post.symbol), symbol_post.symbol);
         }
     }
 }

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -43,9 +43,9 @@ namespace {
         Simlib::ExplicitLTS LTSforSimulation(state_num);
 
         for (const auto& transition : aut.delta.transitions()) {
-            LTSforSimulation.add_transition(transition.src, transition.symb, transition.tgt);
-            if (transition.symb > maxSymbol) {
-                maxSymbol = transition.symb;
+            LTSforSimulation.add_transition(transition.source, transition.symbol, transition.target);
+            if (transition.symbol > maxSymbol) {
+                maxSymbol = transition.symbol;
             }
         }
 
@@ -131,9 +131,9 @@ namespace {
     }
 }
 
-std::ostream &std::operator<<(std::ostream &os, const Mata::Nfa::Trans &trans) { // {{{
-    std::string result = "(" + std::to_string(trans.src) + ", " +
-                         std::to_string(trans.symb) + ", " + std::to_string(trans.tgt) + ")";
+std::ostream &std::operator<<(std::ostream &os, const Mata::Nfa::Transition &trans) { // {{{
+    std::string result = "(" + std::to_string(trans.source) + ", " +
+                         std::to_string(trans.symbol) + ", " + std::to_string(trans.target) + ")";
     return os << result;
 }
 

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -462,7 +462,7 @@ namespace {
             std::vector<Mata::Nfa::State> renumbered_states(program_size, Mata::Nfa::Limits::max_state);
             Mata::Nfa::Nfa& renumbered_explicit_nfa = *output_nfa;
             for (Mata::Nfa::State state{ 0 }; state < program_size; state++) {
-                const auto& transition_list = input_nfa.get_moves_from(state);
+                const auto& transition_list = input_nfa.delta.state_post(state);
                 // If the transition list is empty, the state is not used
                 if (transition_list.empty()) {
                     continue;
@@ -480,7 +480,7 @@ namespace {
             }
 
             for (Mata::Nfa::State state{ 0 }; state < program_size; state++) {
-                const auto& transition_list = input_nfa.get_moves_from(state);
+                const auto& transition_list = input_nfa.delta.state_post(state);
                 for (const auto& transition: transition_list) {
                     for (auto stateTo: transition.targets) {
                         if (renumbered_states[stateTo] == Mata::Nfa::Limits::max_state) {

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -73,7 +73,7 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
 
     NoodleSequence noodles{};
     // noodle of epsilon transitions (each from different depth)
-    std::vector<Trans> epsilon_noodle(epsilon_depths_size);
+    std::vector<Transition> epsilon_noodle(epsilon_depths_size);
     // for each combination of ε-transitions, create the automaton.
     // based on https://stackoverflow.com/questions/48270565/create-all-possible-combinations-of-multiple-vectors
     for (size_t index{ 0 }; index < num_of_permutations; ++index) {
@@ -88,7 +88,7 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
         Noodle noodle;
 
         // epsilon_noodle[0] for sure exists, as we sorted out the case of only one segment at the beginning
-        auto first_segment_iter = segments_one_initial_final.find(std::make_pair(unused_state, epsilon_noodle[0].src));
+        auto first_segment_iter = segments_one_initial_final.find(std::make_pair(unused_state, epsilon_noodle[0].source));
         if (first_segment_iter != segments_one_initial_final.end()) {
             noodle.push_back(first_segment_iter->second);
         } else {
@@ -98,7 +98,7 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
         bool all_segments_exist = true;
         for (auto iter = epsilon_noodle.begin(); iter + 1 != epsilon_noodle.end(); ++iter) {
             auto next_iter = iter + 1;
-            auto segment_iter = segments_one_initial_final.find(std::make_pair(iter->tgt, next_iter->src));
+            auto segment_iter = segments_one_initial_final.find(std::make_pair(iter->target, next_iter->source));
             if (segment_iter != segments_one_initial_final.end()) {
                 noodle.push_back(segment_iter->second);
             } else {
@@ -112,7 +112,7 @@ SegNfa::NoodleSequence SegNfa::noodlify(const SegNfa& aut, const Symbol epsilon,
         }
 
         auto last_segment_iter = segments_one_initial_final.find(
-                std::make_pair(epsilon_noodle.back().tgt, unused_state));
+                std::make_pair(epsilon_noodle.back().target, unused_state));
         if (last_segment_iter != segments_one_initial_final.end()) {
             noodle.push_back(last_segment_iter->second);
         } else {
@@ -233,7 +233,7 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
             continue;
         }
 
-        for(const Trans& tr : epsilon_depths_map.at(item.seg_id).at(item.fin)) {
+        for(const Transition& tr : epsilon_depths_map.at(item.seg_id).at(item.fin)) {
             //TODO: is the use of SparseSet here good? It may take a lot of space. Do you need constant test? Otherwise what about StateSet?
             Mata::Util::SparseSet<Mata::Nfa::State> fins = segments[item.seg_id+1].final; // final states of the segment
             if(item.seg_id + 1 == segments.size() - 1) { // last segment
@@ -241,7 +241,7 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
             }
 
             for(const State& fn : fins) {
-                auto seg_iter = segments_one_initial_final.find({tr.tgt, fn});
+                auto seg_iter = segments_one_initial_final.find({ tr.target, fn});
                 if(seg_iter == segments_one_initial_final.end())
                     continue;
 
@@ -249,7 +249,7 @@ SegNfa::NoodleSubstSequence SegNfa::noodlify_mult_eps(const SegNfa& aut, const s
                 new_item.seg_id++;
                 // do not include segmets with trivial epsilon language
                 if(seg_iter->second->final.size() != 1 || seg_iter->second->get_num_of_trans() > 0) { // L(seg_iter) != {epsilon}
-                    new_item.noodle.emplace_back(seg_iter->second, process_eps_map(visited_eps[tr.tgt]));
+                    new_item.noodle.emplace_back(seg_iter->second, process_eps_map(visited_eps[tr.target]));
                 }
                 new_item.fin = fn;
                 lifo.push_back(new_item);

--- a/src/strings/nfa-segmentation.cc
+++ b/src/strings/nfa-segmentation.cc
@@ -23,7 +23,7 @@ using namespace Mata::Strings;
 void SegNfa::Segmentation::process_state_depth_pair(const StateDepthTuple& state_depth_pair,
                                                     std::deque<StateDepthTuple>& worklist) {
     auto outgoing_post{ automaton.delta[state_depth_pair.state] };
-    for (const Move& outgoing_move: outgoing_post) {
+    for (const SymbolPost& outgoing_move: outgoing_post) {
         if (this->epsilons.find(outgoing_move.symbol) != this->epsilons.end()) {
             handle_epsilon_transitions(state_depth_pair, outgoing_move, worklist);
         } else { // Handle other transitions.
@@ -33,7 +33,7 @@ void SegNfa::Segmentation::process_state_depth_pair(const StateDepthTuple& state
 }
 
 void SegNfa::Segmentation::handle_epsilon_transitions(const StateDepthTuple& state_depth_pair,
-                                                      const Move& move,
+                                                      const SymbolPost& move,
                                                       std::deque<StateDepthTuple>& worklist)
 {
     /// TODO: Maybe we don't need to keep the transitions in both structures
@@ -57,7 +57,7 @@ void SegNfa::Segmentation::handle_epsilon_transitions(const StateDepthTuple& sta
 }
 
 void SegNfa::Segmentation::add_transitions_to_worklist(const StateDepthTuple& state_depth_pair,
-                                                      const Move& move,
+                                                      const SymbolPost& move,
                                                       std::deque<StateDepthTuple>& worklist)
 {
     for (State target_state: move.targets)

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -104,7 +104,7 @@ void ShortestWordsMap::compute_for_state(const State state)
     const WordLength dst_length_plus_one{ dst.first + 1 };
     LengthWordsPair act;
 
-    for (const SymbolPost& transition: reversed_automaton.get_moves_from(state))
+    for (const SymbolPost& transition: reversed_automaton.delta.state_post(state))
     {
         for (const State state_to: transition.targets)
         {

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -172,7 +172,7 @@ std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& au
     while(curr_state.has_value()) {
         visited.insert(curr_state.value());
         handles[curr_state.value()] = cnt++;
-        Nfa::Post post = one_letter.delta[curr_state.value()];
+        Nfa::StatePost post = one_letter.delta[curr_state.value()];
 
         curr_state.reset();
         assert(post.size() <= 1);

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -104,7 +104,7 @@ void ShortestWordsMap::compute_for_state(const State state)
     const WordLength dst_length_plus_one{ dst.first + 1 };
     LengthWordsPair act;
 
-    for (const Move& transition: reversed_automaton.get_moves_from(state))
+    for (const SymbolPost& transition: reversed_automaton.get_moves_from(state))
     {
         for (const State state_to: transition.targets)
         {
@@ -176,7 +176,7 @@ std::set<std::pair<int, int>> Mata::Strings::get_word_lengths(const Nfa::Nfa& au
 
         curr_state.reset();
         assert(post.size() <= 1);
-        for(const Move& move : post) {
+        for(const SymbolPost& move : post) {
             assert(move.targets.size() == 1);
             Nfa::State tgt = *move.targets.begin();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(tests
 		re2parser.cc
 		mintermization.cc
 		afa/afa.cc
+		nfa/delta.cc
 		nfa/nfa.cc
 		nfa/builder.cc
 		nfa/nfa-concatenation.cc

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -23,3 +23,65 @@ TEST_CASE("Mata::Nfa::SymbolPost") {
     CHECK(SymbolPost{ 1, StateSet{ 0 } } >= SymbolPost{ 0, StateSet{ 1 } });
     CHECK(SymbolPost{ 1, StateSet{ 0 } } >= SymbolPost{ 0, StateSet{ 1 } });
 }
+
+TEST_CASE("Mata::Nfa::Delta::state_post()") {
+    Mata::Nfa::Nfa aut{};
+
+    SECTION("Add new states within the limit") {
+        aut.add_state(19);
+        aut.initial.insert(0);
+        aut.initial.insert(1);
+        aut.initial.insert(2);
+        REQUIRE_NOTHROW(aut.delta.state_post(0));
+        REQUIRE_NOTHROW(aut.delta.state_post(1));
+        REQUIRE_NOTHROW(aut.delta.state_post(2));
+        REQUIRE(aut.delta.state_post(0).empty());
+        REQUIRE(aut.delta.state_post(1).empty());
+        REQUIRE(aut.delta.state_post(2).empty());
+
+        CHECK(&aut.delta.state_post(4) == &aut.delta[4]);
+    }
+
+    SECTION("Add new states over the limit") {
+        aut.add_state(1);
+        REQUIRE_NOTHROW(aut.initial.insert(0));
+        REQUIRE_NOTHROW(aut.initial.insert(1));
+        REQUIRE_NOTHROW(aut.delta.state_post(0));
+        REQUIRE_NOTHROW(aut.delta.state_post(1));
+        REQUIRE_NOTHROW(aut.delta.state_post(2));
+        CHECK(aut.delta.state_post(0).empty());
+        CHECK(aut.delta.state_post(1).empty());
+        CHECK(aut.delta.state_post(2).empty());
+    }
+
+    SECTION("Add new states without specifying the number of states") {
+        CHECK_NOTHROW(aut.initial.insert(0));
+        CHECK_NOTHROW(aut.delta.state_post(2));
+        CHECK(aut.delta.state_post(0).empty());
+        CHECK(aut.delta.state_post(2).empty());
+    }
+
+    SECTION("Add new initial without specifying the number of states with over +1 number") {
+        REQUIRE_NOTHROW(aut.initial.insert(25));
+        CHECK_NOTHROW(aut.delta.state_post(25));
+        CHECK_NOTHROW(aut.delta.state_post(26));
+        CHECK(aut.delta.state_post(25).empty());
+        CHECK(aut.delta.state_post(26).empty());
+    }
+}
+
+TEST_CASE("Mata::Nfa::Delta::mutable_post()") {
+    Nfa nfa;
+
+    SECTION("Default initialized") {
+        CHECK(nfa.delta.num_of_states() == 0);
+        CHECK(nfa.delta.mutable_state_post(0).empty());
+        CHECK(nfa.delta.num_of_states() == 1);
+
+        CHECK(nfa.delta.mutable_state_post(9).empty());
+        CHECK(nfa.delta.num_of_states() == 10);
+
+        CHECK(nfa.delta.mutable_state_post(9).empty());
+        CHECK(nfa.delta.num_of_states() == 10);
+    }
+}

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -1,12 +1,13 @@
 // TODO: some header
 
-#include "../3rdparty/catch.hpp"
-
 #include "nfa-util.hh"
 
 #include "mata/alphabet.hh"
 #include "mata/nfa/types.hh"
 #include "mata/nfa/delta.hh"
+#include "mata/nfa/nfa.hh"
+
+#include "../3rdparty/catch.hpp"
 
 using namespace Mata::Nfa;
 

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -1,0 +1,24 @@
+// TODO: some header
+
+#include "../3rdparty/catch.hpp"
+
+#include "nfa-util.hh"
+
+#include "mata/alphabet.hh"
+#include "mata/nfa/types.hh"
+#include "mata/nfa/delta.hh"
+
+using namespace Mata::Nfa;
+
+using Symbol = Mata::Symbol;
+
+TEST_CASE("Mata::Nfa::SymbolPost") {
+    CHECK(SymbolPost{ 0, StateSet{} } == SymbolPost{ 0, StateSet{ 0, 1 } });
+    CHECK(SymbolPost{ 1, StateSet{} } != SymbolPost{ 0, StateSet{} });
+    CHECK(SymbolPost{ 0, StateSet{ 1 } } < SymbolPost{ 1, StateSet{} });
+    CHECK(SymbolPost{ 0, StateSet{ 1 } } <= SymbolPost{ 1, StateSet{} });
+    CHECK(SymbolPost{ 0, StateSet{ 1 } } <= SymbolPost{ 0, StateSet{} });
+    CHECK(SymbolPost{ 1, StateSet{ 0 } } > SymbolPost{ 0, StateSet{ 1 } });
+    CHECK(SymbolPost{ 1, StateSet{ 0 } } >= SymbolPost{ 0, StateSet{ 1 } });
+    CHECK(SymbolPost{ 1, StateSet{ 0 } } >= SymbolPost{ 0, StateSet{ 1 } });
+}

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -103,8 +103,11 @@ TEST_CASE("Mata::Nfa::StatePost iteration over moves") {
         nfa.delta.add(2, 0, 3);
 
         state_post = nfa.delta.state_post(0);
-        Mata::Nfa::StatePost::MovesIterator moves{ state_post.moves() };
-        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        Mata::Nfa::StatePost::Moves moves{ state_post.moves() };
+        iterated_moves.clear();
+        for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
+            iterated_moves.push_back(*move_it);
+        }
         expected_moves = std::vector<Move>{ { 1, 1 }, { 2, 1 }, { 5, 1 } };
         CHECK(iterated_moves == expected_moves);
         iterated_moves.clear();
@@ -173,8 +176,11 @@ TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
         nfa.delta.add(2, 0, 1);
         nfa.delta.add(2, 0, 3);
 
-        Mata::Nfa::Delta::TransitionsIterator transitions{ nfa.delta.transitions() };
-        iterated_transitions = std::vector<Trans>{ transitions.begin(), transitions.end() };
+        Mata::Nfa::Delta::Transitions transitions{ nfa.delta.transitions() };
+        iterated_transitions.clear();
+        for (auto transitions_it{ transitions.begin() }; transitions_it != transitions.end(); ++transitions_it) {
+            iterated_transitions.push_back(*transitions_it);
+        }
         expected_transitions = std::vector<Trans>{
             { 0, 1, 1 }, { 0, 2, 1 }, { 0, 5, 1 }, { 1, 3, 2 }, { 2, 0, 1 }, { 2, 0, 3 }
         };

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -177,8 +177,8 @@ TEST_CASE("Mata::Nfa::StatePost iteration over moves") {
 
 TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
     Nfa nfa;
-    std::vector<Trans> iterated_transitions{};
-    std::vector<Trans> expected_transitions{};
+    std::vector<Transition> iterated_transitions{};
+    std::vector<Transition> expected_transitions{};
 
     SECTION("Simple NFA") {
         nfa.initial.insert(0);
@@ -192,11 +192,11 @@ TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
 
         Mata::Nfa::Delta::Transitions transitions{ nfa.delta.transitions() };
         iterated_transitions.clear();
-        for (auto transitions_it{ transitions.begin() }; 
+        for (auto transitions_it{ transitions.begin() };
              transitions_it != transitions.end(); ++transitions_it) {
             iterated_transitions.push_back(*transitions_it);
         }
-        expected_transitions = std::vector<Trans>{
+        expected_transitions = std::vector<Transition>{
             { 0, 1, 1 }, { 0, 2, 1 }, { 0, 5, 1 }, { 1, 3, 2 }, { 2, 0, 1 }, { 2, 0, 3 }
         };
         CHECK(iterated_transitions == expected_transitions);
@@ -205,7 +205,7 @@ TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
         CHECK(iterated_transitions == expected_transitions);
 
         iterated_transitions.clear();
-        for (const Trans& transition: nfa.delta.transitions()) { iterated_transitions.push_back(transition); }
+        for (const Transition& transition: nfa.delta.transitions()) { iterated_transitions.push_back(transition); }
         CHECK(iterated_transitions == expected_transitions);
     }
 }

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -103,60 +103,74 @@ TEST_CASE("Mata::Nfa::StatePost iteration over moves") {
         nfa.delta.add(2, 0, 3);
 
         state_post = nfa.delta.state_post(0);
+        expected_moves = std::vector<Move>{ { 1, 1 }, { 2, 1 }, { 5, 1 } };
         Mata::Nfa::StatePost::Moves moves{ state_post.moves() };
         iterated_moves.clear();
         for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
             iterated_moves.push_back(*move_it);
         }
-        expected_moves = std::vector<Move>{ { 1, 1 }, { 2, 1 }, { 5, 1 } };
         CHECK(iterated_moves == expected_moves);
+
+        iterated_moves = { moves.begin(), moves.end() };
+        CHECK(iterated_moves == expected_moves);
+
         iterated_moves.clear();
-        for (const Move& move: state_post.moves()) {
-            iterated_moves.push_back(move);
-        }
+        for (const Move& move: state_post.moves()) { iterated_moves.push_back(move); }
         CHECK(iterated_moves == expected_moves);
+
 
         state_post = nfa.delta.state_post(1);
         moves = state_post.moves();
-        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        iterated_moves.clear();
+        for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
+            iterated_moves.push_back(*move_it);
+        }
         expected_moves = std::vector<Move>{ { 3, 2 } };
         CHECK(iterated_moves == expected_moves);
+        iterated_moves = { moves.begin(), moves.end() };
+        CHECK(iterated_moves == expected_moves);
         iterated_moves.clear();
-        for (const Move& move: state_post.moves()) {
-            iterated_moves.push_back(move);
-        }
+        for (const Move& move: state_post.moves()) { iterated_moves.push_back(move); }
         CHECK(iterated_moves == expected_moves);
 
         state_post = nfa.delta.state_post(2);
         moves = state_post.moves();
-        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
-
+        iterated_moves.clear();
+        for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
+            iterated_moves.push_back(*move_it);
+        }
         expected_moves = std::vector<Move>{ { 0, 1 }, { 0, 3 } };
         CHECK(iterated_moves == expected_moves);
+        iterated_moves = { moves.begin(), moves.end() };
+        CHECK(iterated_moves == expected_moves);
         iterated_moves.clear();
-        for (const Move& move: state_post.moves()) {
-            iterated_moves.push_back(move);
-        }
+        for (const Move& move: state_post.moves()) { iterated_moves.push_back(move); }
         CHECK(iterated_moves == expected_moves);
 
         state_post = nfa.delta.state_post(3);
         moves = state_post.moves();
-        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        iterated_moves.clear();
+        for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
+            iterated_moves.push_back(*move_it);
+        }
+        CHECK(iterated_moves.empty());
+        iterated_moves = { moves.begin(), moves.end() };
         CHECK(iterated_moves.empty());
         iterated_moves.clear();
-        for (const Move& move: state_post.moves()) {
-            iterated_moves.push_back(move);
-        }
+        for (const Move& move: state_post.moves()) { iterated_moves.push_back(move); }
         CHECK(iterated_moves.empty());
 
         state_post = nfa.delta.state_post(4);
         moves = state_post.moves();
-        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        iterated_moves.clear();
+        for (auto move_it{ moves.begin() }; move_it != moves.end(); ++move_it) {
+            iterated_moves.push_back(*move_it);
+        }
+        CHECK(iterated_moves.empty());
+        iterated_moves = { moves.begin(), moves.end() };
         CHECK(iterated_moves.empty());
         iterated_moves.clear();
-        for (const Move& move: state_post.moves()) {
-           iterated_moves.push_back(move);
-        }
+        for (const Move& move: state_post.moves()) { iterated_moves.push_back(move); }
         CHECK(iterated_moves.empty());
     }
 }
@@ -178,12 +192,20 @@ TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
 
         Mata::Nfa::Delta::Transitions transitions{ nfa.delta.transitions() };
         iterated_transitions.clear();
-        for (auto transitions_it{ transitions.begin() }; transitions_it != transitions.end(); ++transitions_it) {
+        for (auto transitions_it{ transitions.begin() }; 
+             transitions_it != transitions.end(); ++transitions_it) {
             iterated_transitions.push_back(*transitions_it);
         }
         expected_transitions = std::vector<Trans>{
             { 0, 1, 1 }, { 0, 2, 1 }, { 0, 5, 1 }, { 1, 3, 2 }, { 2, 0, 1 }, { 2, 0, 3 }
         };
+        CHECK(iterated_transitions == expected_transitions);
+
+        iterated_transitions = { transitions.begin(), transitions.end() };
+        CHECK(iterated_transitions == expected_transitions);
+
+        iterated_transitions.clear();
+        for (const Trans& transition: nfa.delta.transitions()) { iterated_transitions.push_back(transition); }
         CHECK(iterated_transitions == expected_transitions);
     }
 }

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -85,3 +85,99 @@ TEST_CASE("Mata::Nfa::Delta::mutable_post()") {
         CHECK(nfa.delta.num_of_states() == 10);
     }
 }
+
+TEST_CASE("Mata::Nfa::StatePost iteration over moves") {
+    Nfa nfa;
+    std::vector<Move> iterated_moves{};
+    std::vector<Move> expected_moves{};
+    StatePost state_post{};
+
+    SECTION("Simple NFA") {
+        nfa.initial.insert(0);
+        nfa.final.insert(3);
+        nfa.delta.add(0, 1, 1);
+        nfa.delta.add(0, 2, 1);
+        nfa.delta.add(0, 5, 1);
+        nfa.delta.add(1, 3, 2);
+        nfa.delta.add(2, 0, 1);
+        nfa.delta.add(2, 0, 3);
+
+        state_post = nfa.delta.state_post(0);
+        Mata::Nfa::StatePost::MovesIterator moves{ state_post.moves() };
+        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        expected_moves = std::vector<Move>{ { 1, 1 }, { 2, 1 }, { 5, 1 } };
+        CHECK(iterated_moves == expected_moves);
+        iterated_moves.clear();
+        for (const Move& move: state_post.moves()) {
+            iterated_moves.push_back(move);
+        }
+        CHECK(iterated_moves == expected_moves);
+
+        state_post = nfa.delta.state_post(1);
+        moves = state_post.moves();
+        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        expected_moves = std::vector<Move>{ { 3, 2 } };
+        CHECK(iterated_moves == expected_moves);
+        iterated_moves.clear();
+        for (const Move& move: state_post.moves()) {
+            iterated_moves.push_back(move);
+        }
+        CHECK(iterated_moves == expected_moves);
+
+        state_post = nfa.delta.state_post(2);
+        moves = state_post.moves();
+        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+
+        expected_moves = std::vector<Move>{ { 0, 1 }, { 0, 3 } };
+        CHECK(iterated_moves == expected_moves);
+        iterated_moves.clear();
+        for (const Move& move: state_post.moves()) {
+            iterated_moves.push_back(move);
+        }
+        CHECK(iterated_moves == expected_moves);
+
+        state_post = nfa.delta.state_post(3);
+        moves = state_post.moves();
+        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        CHECK(iterated_moves.empty());
+        iterated_moves.clear();
+        for (const Move& move: state_post.moves()) {
+            iterated_moves.push_back(move);
+        }
+        CHECK(iterated_moves.empty());
+
+        state_post = nfa.delta.state_post(4);
+        moves = state_post.moves();
+        iterated_moves = std::vector<Move>{ moves.begin(), moves.end() };
+        CHECK(iterated_moves.empty());
+        iterated_moves.clear();
+        for (const Move& move: state_post.moves()) {
+           iterated_moves.push_back(move);
+        }
+        CHECK(iterated_moves.empty());
+    }
+}
+
+TEST_CASE("Mata::Nfa::Delta iteration over transitions") {
+    Nfa nfa;
+    std::vector<Trans> iterated_transitions{};
+    std::vector<Trans> expected_transitions{};
+
+    SECTION("Simple NFA") {
+        nfa.initial.insert(0);
+        nfa.final.insert(3);
+        nfa.delta.add(0, 1, 1);
+        nfa.delta.add(0, 2, 1);
+        nfa.delta.add(0, 5, 1);
+        nfa.delta.add(1, 3, 2);
+        nfa.delta.add(2, 0, 1);
+        nfa.delta.add(2, 0, 3);
+
+        Mata::Nfa::Delta::TransitionsIterator transitions{ nfa.delta.transitions() };
+        iterated_transitions = std::vector<Trans>{ transitions.begin(), transitions.end() };
+        expected_transitions = std::vector<Trans>{
+            { 0, 1, 1 }, { 0, 2, 1 }, { 0, 5, 1 }, { 1, 3, 2 }, { 2, 0, 1 }, { 2, 0, 3 }
+        };
+        CHECK(iterated_transitions == expected_transitions);
+    }
+}

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -123,8 +123,8 @@ TEST_CASE("Mata::Nfa::Delta.transform/append")
         auto upd_fnc = [&](State st) {
             return st + 5;
         };
-        std::vector<Post> posts = a.delta.transform(upd_fnc);
-        a.delta.append(posts);
+        std::vector<StatePost> state_posts = a.delta.transform(upd_fnc);
+        a.delta.append(state_posts);
 
         REQUIRE(a.delta.contains(4, 'a', 6));
         REQUIRE(a.delta.contains(5, 'b', 7));
@@ -2690,21 +2690,21 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     CHECK(aut.get_epsilon_transitions(5) == aut.get_moves_from(5).end());
     CHECK(aut.get_epsilon_transitions(19) == aut.get_moves_from(19).end());
 
-    Post post{ aut.delta[0] };
-    state_eps_trans = Nfa::get_epsilon_transitions(post);
+    StatePost state_post{ aut.delta[0] };
+    state_eps_trans = aut.get_epsilon_transitions(state_post);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3 });
-    post = aut.delta[3];
-    state_eps_trans = Nfa::get_epsilon_transitions(post);
+    state_post = aut.delta[3];
+    state_eps_trans = Nfa::get_epsilon_transitions(state_post);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3, 4 });
 
-    post = aut.get_moves_from(1);
-    CHECK(aut.get_epsilon_transitions(post) == post.end());
-    post = aut.get_moves_from(5);
-    CHECK(aut.get_epsilon_transitions(post) == post.end());
-    post = aut.get_moves_from(19);
-    CHECK(aut.get_epsilon_transitions(post) == post.end());
+    state_post = aut.get_moves_from(1);
+    CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
+    state_post = aut.get_moves_from(5);
+    CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
+    state_post = aut.get_moves_from(19);
+    CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
 }
 
 TEST_CASE("Mata::Nfa::Nfa::delta()") {

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -110,6 +110,36 @@ TEST_CASE("Mata::Nfa::Nfa::delta.add()/delta.contains()")
         REQUIRE(a.delta.contains(0, 'b', 0));
     }
 
+    SECTION("Iterating over transitions") {
+        Trans t1{ 0, 0, 0};
+        Trans t2{ 0, 1, 0};
+        Trans t3{ 1, 1, 1};
+        Trans t4{ 2, 2, 2};
+        a.delta.add(t1);
+        a.delta.add(t2);
+        a.delta.add(t3);
+        a.delta.add(t4);
+        a.delta.add(t3);
+        size_t transitions_cnt{ 0 };
+        std::vector<Trans> expected_transitions{ t1, t2, t3, t4 };
+        std::vector<Trans> iterated_transitions{};
+        for (auto trans_it{ a.delta.transitions_begin()}; trans_it != a.delta.transitions_end(); ++trans_it) {
+            iterated_transitions.push_back(*trans_it);
+            ++transitions_cnt;
+        }
+        CHECK(transitions_cnt == 4);
+        CHECK(expected_transitions == iterated_transitions);
+
+        transitions_cnt = 0;
+        iterated_transitions.clear();
+        for (const Trans& trans: a.delta.transitions()) {
+            iterated_transitions.push_back(trans);
+            ++transitions_cnt;
+        }
+        CHECK(transitions_cnt == 4);
+        CHECK(expected_transitions == iterated_transitions);
+    }
+
 } // }}}
 
 TEST_CASE("Mata::Nfa::Delta.transform/append")

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -49,7 +49,7 @@ TEST_CASE("Mata::Nfa::size()") {
 }
 
 TEST_CASE("Mata::Nfa::Trans::operator<<") {
-    Trans trans(1, 2, 3);
+    Transition trans(1, 2, 3);
     REQUIRE(std::to_string(trans) == "(1, 2, 3)");
 }
 
@@ -111,18 +111,18 @@ TEST_CASE("Mata::Nfa::Nfa::delta.add()/delta.contains()")
     }
 
     SECTION("Iterating over transitions") {
-        Trans t1{ 0, 0, 0};
-        Trans t2{ 0, 1, 0};
-        Trans t3{ 1, 1, 1};
-        Trans t4{ 2, 2, 2};
+        Transition t1{ 0, 0, 0};
+        Transition t2{ 0, 1, 0};
+        Transition t3{ 1, 1, 1};
+        Transition t4{ 2, 2, 2};
         a.delta.add(t1);
         a.delta.add(t2);
         a.delta.add(t3);
         a.delta.add(t4);
         a.delta.add(t3);
         size_t transitions_cnt{ 0 };
-        std::vector<Trans> expected_transitions{ t1, t2, t3, t4 };
-        std::vector<Trans> iterated_transitions{};
+        std::vector<Transition> expected_transitions{ t1, t2, t3, t4 };
+        std::vector<Transition> iterated_transitions{};
         for (auto trans_it{ a.delta.transitions_begin()}; trans_it != a.delta.transitions_end(); ++trans_it) {
             iterated_transitions.push_back(*trans_it);
             ++transitions_cnt;
@@ -132,7 +132,7 @@ TEST_CASE("Mata::Nfa::Nfa::delta.add()/delta.contains()")
 
         transitions_cnt = 0;
         iterated_transitions.clear();
-        for (const Trans& trans: a.delta.transitions()) {
+        for (const Transition& trans: a.delta.transitions()) {
             iterated_transitions.push_back(trans);
             ++transitions_cnt;
         }
@@ -2245,7 +2245,7 @@ TEST_CASE("Mata::Nfa::delta.remove()")
 
 TEST_CASE("Mata::Nfa::get_trans_as_sequence(}") {
     Nfa aut('q' + 1);
-    std::vector<Trans> expected{};
+    std::vector<Transition> expected{};
 
     aut.delta.add(1, 2, 3);
     expected.emplace_back(1, 2, 3);

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2243,46 +2243,6 @@ TEST_CASE("Mata::Nfa::delta.remove()")
     }
 }
 
-TEST_CASE("Mafa::Nfa::get_moves_from()") {
-    Nfa aut{};
-
-    SECTION("Add new states within the limit") {
-        aut.add_state(19);
-        aut.initial.insert(0);
-        aut.initial.insert(1);
-        aut.initial.insert(2);
-        REQUIRE_NOTHROW(aut.get_moves_from(0));
-        REQUIRE_NOTHROW(aut.get_moves_from(1));
-        REQUIRE_NOTHROW(aut.get_moves_from(2));
-        REQUIRE(aut.get_moves_from(0).empty());
-        REQUIRE(aut.get_moves_from(1).empty());
-        REQUIRE(aut.get_moves_from(2).empty());
-    }
-
-    SECTION("Add new states over the limit") {
-        aut.add_state(1);
-        REQUIRE_NOTHROW(aut.initial.insert(0));
-        REQUIRE_NOTHROW(aut.initial.insert(1));
-        REQUIRE_NOTHROW(aut.get_moves_from(0));
-        REQUIRE_NOTHROW(aut.get_moves_from(1));
-        REQUIRE_THROWS(aut.get_moves_from(2));
-        REQUIRE(aut.get_moves_from(0).empty());
-        REQUIRE(aut.get_moves_from(1).empty());
-        REQUIRE_THROWS(aut.get_moves_from(2));
-    }
-
-    SECTION("Add new states without specifying the number of states") {
-        CHECK_NOTHROW(aut.initial.insert(0));
-        CHECK_THROWS_AS(aut.get_moves_from(2), std::runtime_error);
-    }
-
-    SECTION("Add new initial without specifying the number of states with over +1 number") {
-        REQUIRE_NOTHROW(aut.initial.insert(25));
-        CHECK_NOTHROW(aut.get_moves_from(25));
-        CHECK_THROWS(aut.get_moves_from(26));
-    }
-}
-
 TEST_CASE("Mata::Nfa::get_trans_as_sequence(}") {
     Nfa aut('q' + 1);
     std::vector<Trans> expected{};
@@ -2557,16 +2517,16 @@ TEST_CASE("Mata::Nfa::delta.operator[]")
     aut.delta[25];
     REQUIRE(aut.size() == 20);
 
-    aut.delta.get_mutable_post(25);
+    aut.delta.mutable_state_post(25);
     REQUIRE(aut.size() == 26);
     REQUIRE(aut.delta[25].empty());
 
-    aut.delta.get_mutable_post(50);
+    aut.delta.mutable_state_post(50);
     REQUIRE(aut.size() == 51);
     REQUIRE(aut.delta[50].empty());
 
     Nfa aut1 = aut;
-    aut1.delta.get_mutable_post(60);
+    aut1.delta.mutable_state_post(60);
     REQUIRE(aut1.size() == 61);
     REQUIRE(aut1.delta[60].empty());
 
@@ -2716,9 +2676,9 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     CHECK(state_eps_trans->symbol == 42);
     CHECK(state_eps_trans->targets == StateSet{3, 4, 6 });
 
-    CHECK(aut.get_epsilon_transitions(1) == aut.get_moves_from(1).end());
-    CHECK(aut.get_epsilon_transitions(5) == aut.get_moves_from(5).end());
-    CHECK(aut.get_epsilon_transitions(19) == aut.get_moves_from(19).end());
+    CHECK(aut.get_epsilon_transitions(1) == aut.delta.state_post(1).end());
+    CHECK(aut.get_epsilon_transitions(5) == aut.delta.state_post(5).end());
+    CHECK(aut.get_epsilon_transitions(19) == aut.delta.state_post(19).end());
 
     StatePost state_post{ aut.delta[0] };
     state_eps_trans = aut.get_epsilon_transitions(state_post);
@@ -2729,11 +2689,11 @@ TEST_CASE("Mata::Nfa::Nfa::get_epsilon_transitions()") {
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3, 4 });
 
-    state_post = aut.get_moves_from(1);
+    state_post = aut.delta.state_post(1);
     CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
-    state_post = aut.get_moves_from(5);
+    state_post = aut.delta.state_post(5);
     CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
-    state_post = aut.get_moves_from(19);
+    state_post = aut.delta.state_post(19);
     CHECK(aut.get_epsilon_transitions(state_post) == state_post.end());
 }
 
@@ -2909,6 +2869,5 @@ TEST_CASE("Mata::Nfa::get_useful_states_tarjan") {
 		Mata::BoolVector ref({1, 1, 1, 1});
 		CHECK(bv == ref);
 	}
-	
-}
 
+}

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -151,25 +151,25 @@ TEST_CASE("Mata::Nfa::Nfa iteration")
     {
         aut.delta.add('q', 'a', 'r');
         aut.delta.add('q', 'b', 'r');
-        auto it = aut.delta.begin();
-        auto jt = aut.delta.begin();
+        auto it = aut.delta.transitions_begin();
+        auto jt = aut.delta.transitions_begin();
         REQUIRE(it == jt);
         ++it;
         REQUIRE(it != jt);
-        REQUIRE((it != aut.delta.begin() && it != aut.delta.end()));
-        REQUIRE(jt == aut.delta.begin());
+        REQUIRE((it != aut.delta.transitions_begin() && it != aut.delta.transitions_end()));
+        REQUIRE(jt == aut.delta.transitions_begin());
 
         ++jt;
         REQUIRE(it == jt);
-        REQUIRE((jt != aut.delta.begin() && jt != aut.delta.end()));
+        REQUIRE((jt != aut.delta.transitions_begin() && jt != aut.delta.transitions_end()));
 
-        jt = aut.delta.end();
+        jt = aut.delta.transitions_end();
         REQUIRE(it != jt);
-        REQUIRE((jt != aut.delta.begin() && jt == aut.delta.end()));
+        REQUIRE((jt != aut.delta.transitions_begin() && jt == aut.delta.transitions_end()));
 
-        it = aut.delta.end();
+        it = aut.delta.transitions_end();
         REQUIRE(it == jt);
-        REQUIRE((it != aut.delta.begin() && it == aut.delta.end()));
+        REQUIRE((it != aut.delta.transitions_begin() && it == aut.delta.transitions_end()));
     }
 } // }}}
 

--- a/tests/strings/nfa-segmentation.cc
+++ b/tests/strings/nfa-segmentation.cc
@@ -82,7 +82,7 @@ TEST_CASE("Mata::Nfa::Segmentation::get_epsilon_depths()")
         FILL_WITH_AUT_A(aut);
         auto segmentation{SegNfa::Segmentation{aut, epsilons } };
         const auto& epsilon_depth_transitions{ segmentation.get_epsilon_depths() };
-        REQUIRE(epsilon_depth_transitions == SegNfa::Segmentation::EpsilonDepthTransitions{{0, std::vector<Trans>{
+        REQUIRE(epsilon_depth_transitions == SegNfa::Segmentation::EpsilonDepthTransitions{{0, std::vector<Transition>{
                 {10, epsilon, 7}, {7, epsilon, 3}, {5, epsilon, 9}}
        }});
     }
@@ -103,9 +103,9 @@ TEST_CASE("Mata::Nfa::Segmentation::get_epsilon_depths()")
         const auto& epsilon_depth_transitions{ segmentation.get_epsilon_depths() };
 
         REQUIRE(epsilon_depth_transitions == SegNfa::Segmentation::EpsilonDepthTransitions{
-                {0, std::vector<Trans>{{1, epsilon, 2}}},
-                {1, std::vector<Trans>{{6, epsilon, 7}}},
-                {2, std::vector<Trans>{{7, epsilon, 8}}},
+                {0, std::vector<Transition>{{ 1, epsilon, 2}}},
+                {1, std::vector<Transition>{{ 6, epsilon, 7}}},
+                {2, std::vector<Transition>{{ 7, epsilon, 8}}},
         });
     }
 


### PR DESCRIPTION
This PR refactors the whole transition relation delta. Namely, it:
- renames `Post` to `StatePost`,
- renames `Move` to `SymbolPost`,
- modifies iterators over `Delta`, `StatePost`, `SymbolPost` to iterate by default (using `begin()` and `end()`) through the underlying vector (state posts for `Delta`, symbol posts for `StatePost` and target states for `SymbolPost`),
- adds iterator over transitions as triples represented by `Trans`, named `transitions_const_iterator` in `Delta`,
- adds iterator over moves (a new type `Move` representing a pair of symbol and target state for a single `StatePost` – for a single source state), named `moves_const_iterator` in `StatePost`. 