### PR TITLE
performance makefile changes to make it work on MacOS

### DIFF
--- a/tests-performance/src/Makefile
+++ b/tests-performance/src/Makefile
@@ -27,8 +27,8 @@ BUILD_DIR := $(shell \
 	fi \
 )
 
-INCLUDE=-I$(INCLUDE_DIR) -I$(THIRD_PARTY_DIR)/simlib/include -I$(THIRD_PARTY_DIR)/re2/include -I $(THIRD_PARTY_DIR) -I $(THIRD_PARTY_DIR)/cudd/cudd
-LIBS_ADD=-L$(BUILD_DIR)/src -L$(BUILD_DIR)/3rdparty/re2 -L$(BUILD_DIR)/3rdparty/simlib -L$(BUILD_DIR)/3rdparty/cudd
+INCLUDE=-I$(INCLUDE_DIR) -I$(THIRD_PARTY_DIR)/simlib/include -I$(THIRD_PARTY_DIR)/re2/include -I $(THIRD_PARTY_DIR) -I $(THIRD_PARTY_DIR)/cudd/include
+LIBS_ADD=-L../../src -L$(BUILD_DIR)/3rdparty/re2 -L$(BUILD_DIR)/3rdparty/simlib -L$(BUILD_DIR)/3rdparty/cudd
 LIBS=-lmata -lsimlib -lre2 -lcudd
 
 


### PR DESCRIPTION
This PR partially fixes linking issues of performancing testing on MacOS.

- Include - I guess it is a typo
- Linking from `src/` instead of `build/src` - I have no idea why is this causing troubles.

Futher the definition of `BUILD_DIR` does not work for me. `../../cmake-build-debug/` exists in my case, but it is completely empty.