### PR TITLE
Fix bugs in tests-integration sources

### DIFF
--- a/tests-integration/src/binary-operations.cc
+++ b/tests-integration/src/binary-operations.cc
@@ -30,37 +30,27 @@ int main(int argc, char *argv[]) {
     std::cout << std::fixed << std::setprecision(4);
 
     Nfa intersect_aut;
-    auto start = std::chrono::system_clock::now();
+    TIME_BEGIN(intersection);
     Mata::Nfa::Plumbing::intersection(&intersect_aut, lhs, rhs);
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed = end - start;
-    std::cout << "intersection: " << elapsed.count() << "\n";
+    TIME_END(intersection);
 
     Nfa concat_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(concatenation);
     Mata::Nfa::Plumbing::concatenate(&concat_aut, lhs, rhs);
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "concatenation: " << elapsed.count() << "\n";
+    TIME_END(concatenation);
 
     Nfa union_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(union);
     Mata::Nfa::Plumbing::uni(&union_aut, lhs, rhs);
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "union: " << elapsed.count() << "\n";
+    TIME_END(union);
 
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(naive_inclusion);
     Mata::Nfa::Algorithms::is_included_naive(lhs, rhs, &alphabet);
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "naive-inclusion: " << elapsed.count() << "\n";
+    TIME_END(naive_inclusion);
 
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(antichain_inclusion);
     Mata::Nfa::Algorithms::is_included_antichains(lhs, rhs, &alphabet);
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "antichain-inclusion: " << elapsed.count() << "\n";
+    TIME_END(antichain_inclusion);
 
     return EXIT_SUCCESS;
 }

--- a/tests-integration/src/binary-operations.cc
+++ b/tests-integration/src/binary-operations.cc
@@ -1,11 +1,11 @@
 /**
  * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
- *  - If you want to skip mintermization, set the variable `SKIP_MINTERMIZATION` below to `false`
+ *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
 #include "utils/utils.hh"
 
-constexpr bool SKIP_MINTERMIZATION{ false };
+constexpr bool MINTERMIZE_AUTOMATA{ true};
 
 int main(int argc, char *argv[]) {
     if (argc != 3) {
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
     std::vector<std::string> filenames {argv[1], argv[2]};
     std::vector<Nfa> automata;
     Mata::OnTheFlyAlphabet alphabet;
-    if (load_automata(filenames, automata, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
+    if (load_automata(filenames, automata, alphabet, MINTERMIZE_AUTOMATA) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
     // This might be less-efficient, but more readable.

--- a/tests-integration/src/binary-operations.cc
+++ b/tests-integration/src/binary-operations.cc
@@ -19,10 +19,10 @@ int main(int argc, char *argv[]) {
     Nfa lhs;
     Nfa rhs;
     Mata::OnTheFlyAlphabet alphabet;
-    if (load_automaton(lhs_filename, lhs, alphabet, SKIP_MINTERMIZATION, "lhs") != EXIT_SUCCESS) {
+    if (load_automaton(lhs_filename, lhs, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
-    if (load_automaton(rhs_filename, rhs, alphabet, SKIP_MINTERMIZATION, "rhs") != EXIT_SUCCESS) {
+    if (load_automaton(rhs_filename, rhs, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
 

--- a/tests-integration/src/binary-operations.cc
+++ b/tests-integration/src/binary-operations.cc
@@ -13,18 +13,15 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    std::string lhs_filename = argv[1];
-    std::string rhs_filename = argv[2];
-
-    Nfa lhs;
-    Nfa rhs;
+    std::vector<std::string> filenames {argv[1], argv[2]};
+    std::vector<Nfa> automata;
     Mata::OnTheFlyAlphabet alphabet;
-    if (load_automaton(lhs_filename, lhs, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
+    if (load_automata(filenames, automata, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
-    if (load_automaton(rhs_filename, rhs, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
-        return EXIT_FAILURE;
-    }
+    // This might be less-efficient, but more readable.
+    Nfa lhs = automata[0];
+    Nfa rhs = automata[1];
 
     // Setting precision of the times to fixed points and 4 decimal places
     std::cout << std::fixed << std::setprecision(4);

--- a/tests-integration/src/nfa-operations.cc
+++ b/tests-integration/src/nfa-operations.cc
@@ -36,7 +36,6 @@ int main(int argc, char *argv[]) {
     Nfa trimmed_aut = aut;
     TIME_BEGIN(trim);
     trimmed_aut.trim();
-    auto end = std::chrono::system_clock::now();
     TIME_END(trim);
 
     return EXIT_SUCCESS;

--- a/tests-integration/src/nfa-operations.cc
+++ b/tests-integration/src/nfa-operations.cc
@@ -1,6 +1,6 @@
 /**
  * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
- *  - If you want to skip mintermization, set the variable `SKIP_MINTERMIZATION` below to `false`
+ *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
 #include "utils/utils.hh"
@@ -14,7 +14,7 @@
 
 using namespace Mata::Nfa;
 
-const bool SKIP_MINTERMIZATION{ false };
+const bool MINTERMIZE_AUTOMATA{ true};
 
 int main(int argc, char *argv[]) {
     if (argc != 2) {
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
 
     Nfa aut;
     Mata::OnTheFlyAlphabet alphabet{};
-    if (load_automaton(filename, aut, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
+    if (load_automaton(filename, aut, alphabet, MINTERMIZE_AUTOMATA) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
 

--- a/tests-integration/src/nfa-operations.cc
+++ b/tests-integration/src/nfa-operations.cc
@@ -5,19 +5,12 @@
 
 #include "utils/utils.hh"
 
-#include "mata/parser/inter-aut.hh"
 #include "mata/nfa/nfa.hh"
-#include "mata/nfa/builder.hh"
-#include "mata/nfa/plumbing.hh"
-#include "mata/nfa/algorithms.hh"
-#include "mata/parser/mintermization.hh"
 
 #include <iostream>
 #include <iomanip>
-#include <fstream>
 #include <chrono>
 #include <string>
-#include <cstring>
 
 using namespace Mata::Nfa;
 
@@ -41,10 +34,10 @@ int main(int argc, char *argv[]) {
     std::cout << std::fixed << std::setprecision(5);
 
     Nfa trimmed_aut = aut;
-    auto start = std::chrono::system_clock::now();
+    TIME_BEGIN(trim);
     trimmed_aut.trim();
     auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed = end - start;
-    std::cout << "trim: " << elapsed.count() << "\n";
+    TIME_END(trim);
+
     return EXIT_SUCCESS;
 }

--- a/tests-integration/src/templates/template-with-cli-args.cc
+++ b/tests-integration/src/templates/template-with-cli-args.cc
@@ -1,6 +1,6 @@
 /**
  * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
- *  - If you want to skip mintermization, set the variable `SKIP_MINTERMIZATION` below to `false`
+ *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
 #include "utils/utils.hh"
@@ -13,7 +13,7 @@
 
 using namespace Mata::Nfa;
 
-const bool SKIP_MINTERMIZATION = false;
+const bool MINTERMIZE_AUTOMATA = true;
 
 int main(int argc, char *argv[])
 {
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 
     Nfa aut;
     Mata::OnTheFlyAlphabet alphabet{};
-    if (load_automaton(filename, aut, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
+    if (load_automaton(filename, aut, alphabet, MINTERMIZE_AUTOMATA) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
 

--- a/tests-integration/src/templates/template-with-list-of-automata.cc
+++ b/tests-integration/src/templates/template-with-list-of-automata.cc
@@ -1,6 +1,6 @@
 /**
  * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
- *  - If you want to skip mintermization, set the variable `SKIP_MINTERMIZATION` below to `false`
+ *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
 #include "utils/utils.hh"
@@ -16,7 +16,7 @@
 
 using namespace Mata::Nfa;
 
-const bool SKIP_MINTERMIZATION = false;
+const bool MINTERMIZE_AUTOMATA = true;
 
 int main(int argc, char *argv[])
 {
@@ -122,7 +122,7 @@ int main(int argc, char *argv[])
     for (const auto& aut_file : source_automata) {
         Mata::OnTheFlyAlphabet alphabet{};
         Nfa nfa{};
-        load_automaton(aut_file, nfa, alphabet, SKIP_MINTERMIZATION);
+        load_automaton(aut_file, nfa, alphabet, MINTERMIZE_AUTOMATA);
 
         std::cout << "Processing " << aut_file << std::endl;
 

--- a/tests-integration/src/test-unary-op.cc
+++ b/tests-integration/src/test-unary-op.cc
@@ -6,18 +6,10 @@
 #include "mata/alphabet.hh"
 #include "utils/utils.hh"
 
-#include "mata/parser/inter-aut.hh"
 #include "mata/nfa/nfa.hh"
-#include "mata/nfa/plumbing.hh"
-#include "mata/nfa/algorithms.hh"
-#include "mata/parser/mintermization.hh"
 
 #include <iostream>
-#include <iomanip>
-#include <fstream>
-#include <chrono>
 #include <string>
-#include <cstring>
 
 using namespace Mata::Nfa;
 

--- a/tests-integration/src/test-unary-op.cc
+++ b/tests-integration/src/test-unary-op.cc
@@ -1,6 +1,6 @@
 /**
  * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
- *  - If you want to skip mintermization, set the variable `SKIP_MINTERMIZATION` below to `false`
+ *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
 #include "mata/alphabet.hh"
@@ -13,7 +13,7 @@
 
 using namespace Mata::Nfa;
 
-const bool SKIP_MINTERMIZATION = false;
+const bool MINTERMIZE_AUTOMATA = true;
 
 int main(int argc, char *argv[]) {
     if (argc != 2) {
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
 
     Nfa aut;
     Mata::OnTheFlyAlphabet alphabet{};
-    if (load_automaton(filename, aut, alphabet, SKIP_MINTERMIZATION) != EXIT_SUCCESS) {
+    if (load_automaton(filename, aut, alphabet, MINTERMIZE_AUTOMATA) != EXIT_SUCCESS) {
         return EXIT_FAILURE;
     }
 

--- a/tests-integration/src/unary-operations.cc
+++ b/tests-integration/src/unary-operations.cc
@@ -1,14 +1,10 @@
 #include "utils/utils.hh"
 
-#include "mata/parser/inter-aut.hh"
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/plumbing.hh"
 #include "mata/nfa/algorithms.hh"
-#include "mata/parser/mintermization.hh"
 
 #include <iostream>
-#include <iomanip>
-#include <fstream>
 #include <chrono>
 #include <string>
 
@@ -27,93 +23,75 @@ int main(int argc, char *argv[]) {
     load_automaton(filename, aut, alphabet);
 
     Nfa compl_aut;
-    auto start = std::chrono::system_clock::now();
+    TIME_BEGIN(complement);
     // > START OF PROFILED CODE
     // Only complement and its callees will be measured
     Mata::Nfa::Plumbing::complement(&compl_aut, aut, alphabet);
     // > END OF PROFILED CODE
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed = end - start;
-    std::cout << "complement: " << elapsed.count() << "\n";
+    TIME_END(complement);
 
     Nfa min_compl_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(complement_and_minize);
     // > START OF PROFILED CODE
     // Only complement and its callees will be measured
     Mata::Nfa::Plumbing::complement(&min_compl_aut, aut, alphabet, {{"algorithm", "classical"}, {"minimize", "true"}});
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "complement-and-minimize: " << elapsed.count() << "\n";
+    TIME_END(complement_and_minize);
 
     Nfa revert_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(revert);
     // > START OF PROFILED CODE
     // Only revert and its callees will be measured
     Mata::Nfa::Plumbing::revert(&revert_aut, aut);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "revert: " << elapsed.count() << "\n";
+    TIME_END(revert);
 
     Nfa reduced_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(reduce_and_trim);
     // > START OF PROFILED CODE
     // Only reduce and its callees will be measured
     Nfa trimmed{ aut };
     Mata::Nfa::Plumbing::reduce(&reduced_aut, trimmed.trim());
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "reduce-and-trim: " << elapsed.count() << "\n";
+    TIME_END(reduce_and_trim);
 
     Nfa untrimmed_reduced_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(reduce);
     // > START OF PROFILED CODE
     // Only reduce and its callees will be measured
     Mata::Nfa::Plumbing::reduce(&untrimmed_reduced_aut, aut);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "reduce: " << elapsed.count() << "\n";
+    TIME_END(reduce);
 
     Nfa minimized_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(minimize);
     // > START OF PROFILED CODE
     // Only minimize and its callees will be measured
     Mata::Nfa::Plumbing::minimize(&minimized_aut, aut);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "minimize: " << elapsed.count() << "\n";
+    TIME_END(minimize);
 
     Nfa det_aut;
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(determinize);
     // > START OF PROFILED CODE
     // Only determinize and its callees will be measured
     Mata::Nfa::Plumbing::determinize(&det_aut, aut);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "determinize: " << elapsed.count() << "\n";
+    TIME_END(determinize);
 
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(naive_universality);
     // > START OF PROFILED CODE
     // Only universality check and its callees will be measured
     Mata::Nfa::Algorithms::is_universal_naive(aut, alphabet, nullptr);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "naive-universality: " << elapsed.count() << "\n";
+    TIME_END(naive_universality);
 
-    start = std::chrono::system_clock::now();
+    TIME_BEGIN(antichain_universality);
     // > START OF PROFILED CODE
     // Only universality check and its callees will be measured
     Mata::Nfa::Algorithms::is_universal_antichains(aut, alphabet, nullptr);
     // > END OF PROFILED CODE
-    end = std::chrono::system_clock::now();
-    elapsed = end - start;
-    std::cout << "antichains-universality: " << elapsed.count() << "\n";
+    TIME_END(antichain_universality);
 
     return EXIT_SUCCESS;
 }

--- a/tests-integration/src/utils/utils.cc
+++ b/tests-integration/src/utils/utils.cc
@@ -1,7 +1,12 @@
 #include "utils.hh"
 
-int load_automaton(const std::string& filename, Nfa& aut, Mata::OnTheFlyAlphabet& alphabet,
-                   const bool skip_mintermization, const std::string& aut_name) {
+int load_automaton(
+        const std::string& filename,
+        Nfa& aut,
+        Mata::OnTheFlyAlphabet& alphabet,
+        const bool skip_mintermization,
+        const std::string& aut_name
+) {
     std::fstream fs(filename, std::ios::in);
     if (!fs) {
         std::cerr << "Could not open file \'" << filename << "'\n";
@@ -25,7 +30,8 @@ int load_automaton(const std::string& filename, Nfa& aut, Mata::OnTheFlyAlphabet
 
         std::vector<Mata::IntermediateAut> inter_auts = Mata::IntermediateAut::parse_from_mf(parsed);
 
-        if (skip_mintermization or parsed[0].type.compare(parsed[0].type.length() - bits_str.length(), bits_str.length(), bits_str) != 0) {
+        bool is_not_nfa_bits = parsed[0].type.compare(parsed[0].type.length() - bits_str.length(), bits_str.length(), bits_str) != 0;
+        if (skip_mintermization or is_not_nfa_bits) {
             aut = Mata::Nfa::Builder::construct(inter_auts[0], &alphabet);
         } else {
             Mata::Mintermization mintermization;

--- a/tests-integration/src/utils/utils.cc
+++ b/tests-integration/src/utils/utils.cc
@@ -7,7 +7,7 @@ int load_automaton(
         const std::string& filename,
         Nfa& aut,
         Mata::OnTheFlyAlphabet& alphabet,
-        const bool skip_mintermization
+        const bool mintermize_automata
 ) {
     std::vector<Mata::IntermediateAut> inter_auts;
     TIME_BEGIN(parsing);
@@ -17,7 +17,7 @@ int load_automaton(
     }
     TIME_END(parsing);
     try {
-        if (skip_mintermization or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
+        if (!mintermize_automata or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
             aut = Mata::Nfa::Builder::construct(inter_auts[0], &alphabet);
         } else {
             Mata::Mintermization mintermization;
@@ -38,7 +38,7 @@ int load_automata(
         std::vector<std::string>& filenames,
         std::vector<Nfa>& auts,
         Mata::OnTheFlyAlphabet& alphabet,
-        const bool skip_mintermization
+        const bool mintermize_automata
 ) {
     std::vector<Mata::IntermediateAut> inter_auts;
     TIME_BEGIN(parsing);
@@ -50,7 +50,7 @@ int load_automata(
     }
     TIME_END(parsing);
     try {
-        if (skip_mintermization or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
+        if (!mintermize_automata or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
             // This is not foolproof and assumes, that everything is BITVECTOR
             for (Mata::IntermediateAut& inter_aut : inter_auts) {
                 assert(inter_aut.alphabet_type == Mata::IntermediateAut::AlphabetType::BITVECTOR);

--- a/tests-integration/src/utils/utils.cc
+++ b/tests-integration/src/utils/utils.cc
@@ -1,11 +1,13 @@
+#include <string>
 #include "utils.hh"
+#include "mata/nfa/types.hh"
+#include "mata/parser/inter-aut.hh"
 
 int load_automaton(
         const std::string& filename,
         Nfa& aut,
         Mata::OnTheFlyAlphabet& alphabet,
-        const bool skip_mintermization,
-        const std::string& aut_name
+        const bool skip_mintermization
 ) {
     std::fstream fs(filename, std::ios::in);
     if (!fs) {
@@ -14,8 +16,6 @@ int load_automaton(
     }
 
     Mata::Parser::Parsed parsed;
-    const std::string nfa_str = "NFA";
-    const std::string bits_str = "-bits";
     try {
         parsed = Mata::Parser::parse_mf(fs, true);
         fs.close();
@@ -24,24 +24,22 @@ int load_automaton(
             throw std::runtime_error(
                     "The number of sections in the input file is not 1\n");
         }
-        if (parsed[0].type.compare(0, nfa_str.length(), nfa_str) != 0) {
+        if (!parsed[0].type.starts_with(TYPE_NFA)) {
+            std::cout << (parsed[0].type) << std::endl;
             throw std::runtime_error("The type of input automaton is not NFA\n");
         }
 
         std::vector<Mata::IntermediateAut> inter_auts = Mata::IntermediateAut::parse_from_mf(parsed);
 
-        bool is_not_nfa_bits = parsed[0].type.compare(parsed[0].type.length() - bits_str.length(), bits_str.length(), bits_str) != 0;
-        if (skip_mintermization or is_not_nfa_bits) {
+        if (skip_mintermization or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
             aut = Mata::Nfa::Builder::construct(inter_auts[0], &alphabet);
         } else {
             Mata::Mintermization mintermization;
-            auto minterm_start = std::chrono::system_clock::now();
+            TIME_BEGIN(mintermization);
             auto mintermized = mintermization.mintermize(inter_auts);
-            auto minterm_end = std::chrono::system_clock::now();
-            std::chrono::duration<double> elapsed = minterm_end - minterm_start;
+            TIME_END(mintermization);
             assert(mintermized.size() == 1);
             aut = Mata::Nfa::Builder::construct(mintermized[0], &alphabet);
-            std::cout << "mintermization-" << aut_name<< ":" << elapsed.count() << "\n";
         }
         return EXIT_SUCCESS;
     }

--- a/tests-integration/src/utils/utils.cc
+++ b/tests-integration/src/utils/utils.cc
@@ -10,10 +10,12 @@ int load_automaton(
         const bool skip_mintermization
 ) {
     std::vector<Mata::IntermediateAut> inter_auts;
+    TIME_BEGIN(parsing);
     if (load_intermediate_automaton(filename, inter_auts) != EXIT_SUCCESS) {
         std::cerr << "Could not load intermediate autotomaton from \'" << filename << "'\n";
         return EXIT_FAILURE;
     }
+    TIME_END(parsing);
     try {
         if (skip_mintermization or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
             aut = Mata::Nfa::Builder::construct(inter_auts[0], &alphabet);
@@ -23,6 +25,46 @@ int load_automaton(
             Mata::IntermediateAut mintermized = mintermization.mintermize(inter_auts[0]);
             TIME_END(mintermization);
             aut = Mata::Nfa::Builder::construct(mintermized, &alphabet);
+        }
+        return EXIT_SUCCESS;
+    }
+    catch (const std::exception& ex) {
+        std::cerr << "error: " << ex.what() << "\n";
+        return EXIT_FAILURE;
+    }
+}
+
+int load_automata(
+        std::vector<std::string>& filenames,
+        std::vector<Nfa>& auts,
+        Mata::OnTheFlyAlphabet& alphabet,
+        const bool skip_mintermization
+) {
+    std::vector<Mata::IntermediateAut> inter_auts;
+    TIME_BEGIN(parsing);
+    for (const std::string filename : filenames) {
+        if (load_intermediate_automaton(filename, inter_auts) != EXIT_SUCCESS) {
+            std::cerr << "Could not load intermediate autotomaton from \'" << filename << "'\n";
+            return EXIT_FAILURE;
+        }
+    }
+    TIME_END(parsing);
+    try {
+        if (skip_mintermization or inter_auts[0].alphabet_type != Mata::IntermediateAut::AlphabetType::BITVECTOR) {
+            // This is not foolproof and assumes, that everything is BITVECTOR
+            for (Mata::IntermediateAut& inter_aut : inter_auts) {
+                assert(inter_aut.alphabet_type == Mata::IntermediateAut::AlphabetType::BITVECTOR);
+                auts.push_back(Mata::Nfa::Builder::construct(inter_aut, &alphabet));
+            }
+        } else {
+            Mata::Mintermization mintermization;
+            TIME_BEGIN(mintermization);
+            std::vector<Mata::IntermediateAut> mintermized = mintermization.mintermize(inter_auts);
+            TIME_END(mintermization);
+            for (Mata::IntermediateAut& inter_aut : mintermized) {
+                assert(inter_aut.alphabet_type == Mata::IntermediateAut::AlphabetType::BITVECTOR);
+                auts.push_back(Mata::Nfa::Builder::construct(inter_aut, &alphabet));
+            }
         }
         return EXIT_SUCCESS;
     }

--- a/tests-integration/src/utils/utils.hh
+++ b/tests-integration/src/utils/utils.hh
@@ -25,12 +25,28 @@ using namespace Mata::Nfa;
  * @param[out] aut Automaton instance to load into.
  * @param[out] alphabet Alphabet to use for symbols on transitions.
  * @param[in] skip_mintermization Whether to skip mirmization of the loaded automaton.
- * @param[in] aut_name Automaton name to print in logging outputs.
  * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
  */ 
 int load_automaton(
         const std::string& filename,
         Nfa& aut,
+        Mata::OnTheFlyAlphabet& alphabet,
+        const bool skip_mintermization = false
+);
+
+/**
+ * @brief Load automata from list of files at @p filename into list of automata @p aut,
+ * using @p alphabet for symbols on transitions.
+ *
+ * @param[in] filenames Paths to the file with automaton to load.
+ * @param[out] auts Vector of instances to load into.
+ * @param[out] alphabet Alphabet to use for symbols on transitions.
+ * @param[in] skip_mintermization Whether to skip mirmization of the loaded automaton.
+ * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
+ */
+int load_automata(
+        std::vector<std::string>& filenames,
+        std::vector<Nfa>& auts,
         Mata::OnTheFlyAlphabet& alphabet,
         const bool skip_mintermization = false
 );

--- a/tests-integration/src/utils/utils.hh
+++ b/tests-integration/src/utils/utils.hh
@@ -28,8 +28,13 @@ using namespace Mata::Nfa;
  * @param[in] aut_name Automaton name to print in logging outputs.
  * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
  */ 
-int load_automaton(const std::string& filename, Nfa& aut, Mata::OnTheFlyAlphabet& alphabet,
-                   const bool skip_mintermization = false, const std::string& aut_name = "unnamed");
+int load_automaton(
+        const std::string& filename,
+        Nfa& aut,
+        Mata::OnTheFlyAlphabet& alphabet,
+        const bool skip_mintermization = false
+);
+
 /*
  * Use to print elapsed time of set of timers with user-defined prefix `timer`
  */

--- a/tests-integration/src/utils/utils.hh
+++ b/tests-integration/src/utils/utils.hh
@@ -35,6 +35,18 @@ int load_automaton(
         const bool skip_mintermization = false
 );
 
+/**
+ * @brief Load automaton from file at @p filename into @p inter_aut
+ *
+ * @param[in] filename Path to the file with automaton to load.
+ * @param[out] inter_aut Intermediate automaton instance to load into.
+ * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
+ */
+int load_intermediate_automaton(
+        const std::string& filename,
+        std::vector<Mata::IntermediateAut>& out_inter_auts
+);
+
 /*
  * Use to print elapsed time of set of timers with user-defined prefix `timer`
  */

--- a/tests-integration/src/utils/utils.hh
+++ b/tests-integration/src/utils/utils.hh
@@ -24,14 +24,16 @@ using namespace Mata::Nfa;
  * @param[in] filename Path to the file with automaton to load.
  * @param[out] aut Automaton instance to load into.
  * @param[out] alphabet Alphabet to use for symbols on transitions.
- * @param[in] skip_mintermization Whether to skip mirmization of the loaded automaton.
+ * @param[in] mintermize_automata Whether to mintermize the input loaded automaton.
+ *   (Note, that if you want to mintermize multiple automata together, either use `load_automata` or
+ *   `load_intermediate_automaton` and mintermize yourself.)
  * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
  */ 
 int load_automaton(
         const std::string& filename,
         Nfa& aut,
         Mata::OnTheFlyAlphabet& alphabet,
-        const bool skip_mintermization = false
+        const bool mintermize_automata = true
 );
 
 /**
@@ -41,14 +43,14 @@ int load_automaton(
  * @param[in] filenames Paths to the file with automaton to load.
  * @param[out] auts Vector of instances to load into.
  * @param[out] alphabet Alphabet to use for symbols on transitions.
- * @param[in] skip_mintermization Whether to skip mirmization of the loaded automaton.
+ * @param[in] mintermize_automata Whether to mintermize the input loaded automaton.
  * @return 0 if loading the automaton succeeded. Otherwise value != 0 if loading failed.
  */
 int load_automata(
         std::vector<std::string>& filenames,
         std::vector<Nfa>& auts,
         Mata::OnTheFlyAlphabet& alphabet,
-        const bool skip_mintermization = false
+        const bool mintermize_automata = true
 );
 
 /**


### PR DESCRIPTION
This PR addresses some issues and bugs found by @kilohsakul and addresses issues raised in  #302 

So far, this PR:
  1. Simplifies some code in `tests-integration` sources,
  2. Introduces `TIMER` macros where they were not used,
  3. Introduces `load_automata` function, which loads vector of automata and mintermizes them together.