### PR TITLE
Store compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ option(MATA_ENABLE_COVERAGE "Build with coverage compiler flags" OFF)
 
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Store compile commands into 'build/compile_commands.json', which are needed, beside others, for linters.
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
     option(MATA_BUILD_EXAMPLES "Build Mata examples" ON)
 
     message("-- Default C++ compiler: ${CMAKE_CXX_COMPILER}")


### PR DESCRIPTION
This PR reverts the removal of storing compile commands by CMake introduced in #315.

This option creates a `compile_commands.json` compilation database file in `build/` which, beside others, allows linters to work properly with header files and other dependencies of each file.