### PR TITLE
Fix parsing copy constructor

### DIFF
--- a/include/mata/parser/inter-aut.hh
+++ b/include/mata/parser/inter-aut.hh
@@ -123,7 +123,7 @@ public:
  */
 struct FormulaGraph {
     FormulaNode node{};
-    std::deque<FormulaGraph> children{};
+    std::vector<FormulaGraph> children{};
 
     FormulaGraph() = default;
     FormulaGraph(const FormulaNode& n) : node(n), children() {}

--- a/include/mata/parser/inter-aut.hh
+++ b/include/mata/parser/inter-aut.hh
@@ -125,10 +125,12 @@ struct FormulaGraph {
 
     FormulaGraph() = default;
     FormulaGraph(const FormulaNode& n) : node(n), children() {}
+    FormulaGraph(FormulaNode&& n) : node(std::move(n)), children() {}
     FormulaGraph(const FormulaGraph& g) : node(g.node), children(g.children) {}
+    FormulaGraph(FormulaGraph&& g) : node(std::move(g.node)), children(std::move(g.children)) {}
 
-    FormulaGraph& operator=(const mata::FormulaGraph& other) = default;
-    FormulaGraph& operator=(mata::FormulaGraph&& other) noexcept = default;
+    FormulaGraph& operator=(const mata::FormulaGraph&) = default;
+    FormulaGraph& operator=(mata::FormulaGraph&&) noexcept = default;
 
     std::unordered_set<std::string> collect_node_names() const;
     void print_tree(std::ostream& os) const;

--- a/include/mata/parser/inter-aut.hh
+++ b/include/mata/parser/inter-aut.hh
@@ -108,6 +108,8 @@ public:
     FormulaNode(const FormulaNode& n)
         : type(n.type), raw(n.raw), name(n.name), operator_type(n.operator_type), operand_type(n.operand_type) {}
 
+    FormulaNode(FormulaNode&&) = default;
+
     FormulaNode& operator=(const FormulaNode& other) = default;
     FormulaNode& operator=(FormulaNode&& other) = default;
 };

--- a/include/mata/parser/inter-aut.hh
+++ b/include/mata/parser/inter-aut.hh
@@ -121,7 +121,7 @@ public:
  */
 struct FormulaGraph {
     FormulaNode node{};
-    std::vector<FormulaGraph> children{};
+    std::deque<FormulaGraph> children{};
 
     FormulaGraph() = default;
     FormulaGraph(const FormulaNode& n) : node(n), children() {}

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -279,10 +279,11 @@ namespace {
                             break;
                         default:
                             assert(opstack.size() > 1);
+                            mata::FormulaGraph second_child{ std::move(opstack.back()) };
+                            opstack.pop_back();
                             gr.children.emplace_back(std::move(opstack.back()));
                             opstack.pop_back();
-                            gr.children.emplace_front(std::move(opstack.back()));
-                            opstack.pop_back();
+                            gr.children.emplace_back(std::move(second_child));
                             opstack.emplace_back(std::move(gr));
                     }
                     break;

--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -92,9 +92,15 @@ namespace {
         return std::find(vec.begin(), vec.end(), item) != vec.end();
     }
 
-    bool no_operators(const std::vector<mata::FormulaNode>& nodes)
-    {
-        return std::ranges::all_of(nodes, [](const mata::FormulaNode& node){ return !node.is_operator();});
+    bool no_operators(const std::vector<mata::FormulaNode>& nodes) {
+        // Refactor using all_of() when Clang adds support for it.
+        // return std::ranges::all_of(nodes, [](const mata::FormulaNode& node){ return !node.is_operator();});
+        for (const auto& node: nodes) {
+            if (node.is_operator()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     std::string serialize_graph(const mata::FormulaGraph& graph)
@@ -179,7 +185,6 @@ namespace {
         }
 
         throw std::runtime_error("Unknown token " + token);
-        assert(false);
     }
 
     /**

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -63,12 +63,10 @@ bool is_logical_operator(char ch)
  *
  * The function assumes that the stream does not span lines
  */
-std::string get_token_from_line(std::istream& input, bool* quoted)
-{ // {{{
+std::string get_token_from_line(std::istream& input, bool* quoted) {
 	assert(nullptr != quoted);
 
-	enum class TokenizerState
-	{
+	enum class TokenizerState {
 		INIT,
 		UNQUOTED,
 		QUOTED,
@@ -199,35 +197,35 @@ std::vector<std::pair<std::string, bool>> tokenize_line(const std::string& line)
 	return result;
 } // tokenize_line(string) }}}
 
-std::vector<std::pair<std::string, bool>> split_tokens(const std::vector<std::pair<std::string, bool>>& tokens)
-{ // {{{
+std::vector<std::pair<std::string, bool>> split_tokens(std::vector<std::pair<std::string, bool>> tokens) {
     std::vector<std::pair<std::string, bool>> result;
     for (const auto& token : tokens) {
         if (token.second) { // is quoted?
-            result.push_back(token);
+            result.push_back(std::move(token));
             continue;
         }
 
-        const std::string& token_string = token.first;
+        const std::string_view token_string = token.first;
         size_t last_operator = 0;
-        const size_t size = token_string.size();
-        for (size_t i = 0; i < size; ++i) {
+        for (size_t i = 0, token_string_size{ token_string.size() }; i < token_string_size; ++i) {
             if (is_logical_operator(token_string[i])) {
-                const std::string token_candidate = token_string.substr(last_operator, i - last_operator);
+                const std::string_view token_candidate = token_string.substr(last_operator, i - last_operator);
 
                 // there is token before logical operator (this is case of binary operators, e.g., a&b)
-                if (!token_candidate.empty())
+                if (!token_candidate.empty()) {
                     result.emplace_back(token_candidate, false);
+								}
                 result.emplace_back(std::string(1,token_string[i]), false);
-                last_operator = i+1;
+                last_operator = i + 1;
             }
         }
 
-        const size_t length = token_string.length();
+				const size_t length{ token_string.length() };
         if (last_operator == 0) {
-            result.push_back(token);
-        } else if (last_operator != length){ // operator was not last, we need parse rest of token
-            result.emplace_back(token_string.substr(last_operator, length-last_operator), false); }
+            result.emplace_back(std::move(token));
+        } else if (last_operator != length) { // operator was not last, we need parse rest of token
+            result.emplace_back(token_string.substr(last_operator, length-last_operator), false);
+        }
     }
 
     return result;
@@ -351,7 +349,7 @@ ParsedSection mata::parser::parse_mf_section(
 		    continue;
 		}
 
-		token_line = split_tokens(token_line);
+		token_line = split_tokens(std::move(token_line));
 
 		const std::string& maybe_key = token_line[0].first;
 		const bool& quoted = token_line[0].second;


### PR DESCRIPTION
This PR optimizes parsing by introducing move assignment operator and move constructor for `FormulaGraph` and requiring some moves to happen during the parsing. It is just a quick improvement for now. Modifications to the overall algorithms are needed which will probably completely rewrite these functions.

@martinhruska Feel free to give me your input on these changes. As discussed privately, this helps, but is not enough.