### PR TITLE
Rewrite opening files to fix compilation errors

### DIFF
--- a/bindings/python/libmata/parser.pxd
+++ b/bindings/python/libmata/parser.pxd
@@ -13,6 +13,7 @@ cdef extern from "<fstream>" namespace "std":
     cdef cppclass ifstream(istream):
         ifstream() except+
         ifstream(const char*) except +
+        void open(const char*)
 
 cdef extern from "mata/parser/re2parser.hh" namespace "mata::parser":
     cdef void create_nfa(CNfa*, string) except +

--- a/bindings/python/libmata/parser.pyx
+++ b/bindings/python/libmata/parser.pyx
@@ -44,7 +44,7 @@ def from_mata(src, alph.Alphabet alphabet):
 
     # either load single automata
     if isinstance(src, str):
-        fs = parser.ifstream(src.encode('utf-8'))
+        fs.open(src.encode('utf-8'))
         res_inter_aut = parser.parse_from_mf(parser.parse_mf(fs, True))
         result = mata_nfa.Nfa()
         if res_inter_aut[0].is_bitvector():
@@ -64,9 +64,9 @@ def from_mata(src, alph.Alphabet alphabet):
     else:
         automata = []
         for file in src:
-            fs = parser.ifstream(file.encode('utf-8'))
+            fs.open(file.encode('utf-8'))
             res_inter_aut = parser.parse_from_mf(parser.parse_mf(fs, True))
-            inter_aut.emplace_back(res_inter_aut[0])
+            inter_aut.push_back(res_inter_aut[0])
         if inter_aut[0].is_bitvector():
             mintermized_inter_aut = mintermization.c_mintermize_vec(inter_aut)
         else:


### PR DESCRIPTION
This PR rewrites opening files in Cython which for some unknown reason fails on my system. Both changes are necessary for the binding to compile. The performance should not be affected.