### PR TITLE
Simplifying get_useful_states with move iterator

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -218,6 +218,7 @@ public:
     const_iterator(const_iterator&&) = default;
 
     const Move& operator*() const { return move_; }
+    const Move* operator->() const { return &move_; }
 
     // Prefix increment
     const_iterator& operator++();
@@ -545,6 +546,7 @@ public:
     const_iterator(const_iterator&&) = default;
 
     const Transition& operator*() const { return transition_; }
+    const Transition* operator->() const { return &transition_; }
 
     // Prefix increment
     const_iterator& operator++();

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -162,8 +162,12 @@ namespace {
 
         TarjanNodeData() = default;
 
-        TarjanNodeData(State q, const Delta & delta, unsigned long index)
-            : current_move(delta[q].moves().begin()), end_move(delta[q].moves().end()), index(index), lowlink(index), initilized(true), on_stack(true) {};
+        TarjanNodeData(State q, const Delta& delta, unsigned long index)
+            : index(index), lowlink(index), initilized(true), on_stack(true) {
+            const StatePost::Moves moves{ delta[q].moves() };
+            current_move = moves.begin();
+            end_move = moves.end();
+        };
     };
 };
 
@@ -474,4 +478,3 @@ bool Nfa::is_identical(const Nfa& aut) const {
     }
     return delta == aut.delta;
 }
-

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -163,8 +163,7 @@ namespace {
         TarjanNodeData() = default;
 
         TarjanNodeData(State q, const Delta & delta, unsigned long index)
-            : current_move(delta[q].moves().begin()), end_move(delta[q].moves().end()), index(index), lowlink(index), initilized(true), on_stack(true) {
-        };
+            : current_move(delta[q].moves().begin()), end_move(delta[q].moves().end()), index(index), lowlink(index), initilized(true), on_stack(true) {};
     };
 };
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -242,7 +242,7 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
             State act_succ = (*act_state_data.current_move).target;
             act_state_data.lowlink = std::min(act_state_data.lowlink, node_info[act_succ].lowlink);
             // act_succ is the state that cased the recursive call. Move to another successor.
-            act_state_data.current_move++;
+            ++act_state_data.current_move;
         }
 
         // iterate through outgoing edges

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -242,7 +242,7 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
                 if (stop_at_first_useful_state) { return useful; }
             }
         } else { // return from the recursive call
-            State act_succ = (*act_state_data.current_move).target;
+            State act_succ = act_state_data.current_move->target;
             act_state_data.lowlink = std::min(act_state_data.lowlink, node_info[act_succ].lowlink);
             // act_succ is the state that cased the recursive call. Move to another successor.
             ++act_state_data.current_move;
@@ -253,8 +253,8 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
         // rec_call simulates call of the strongconnect. Since c++ cannot do continue over
         // multiple loops, we use rec_call to jump to the main loop
         bool rec_call = false;
-        for(;act_state_data.current_move != act_state_data.end_move;++act_state_data.current_move) {
-            next_state = (*act_state_data.current_move).target;
+        for(; act_state_data.current_move != act_state_data.end_move; ++act_state_data.current_move) {
+            next_state = act_state_data.current_move->target;
             // if successor is useful, act_state is useful as well
             if(useful[next_state]) {
                 useful[act_state] = true;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -250,7 +250,7 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
         // rec_call simulates call of the strongconnect. Since c++ cannot do continue over
         // multiple loops, we use rec_call to jump to the main loop
         bool rec_call = false;
-        while(act_state_data.current_move != act_state_data.end_move) {
+        for(;act_state_data.current_move != act_state_data.end_move;act_state_data.current_move++) {
             next_state = (*act_state_data.current_move).target;
             // if successor is useful, act_state is useful as well
             if(useful[next_state]) {
@@ -263,7 +263,6 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
             } else if(node_info[next_state].on_stack) {
                 act_state_data.lowlink = std::min(act_state_data.lowlink, node_info[next_state].index);
             }
-            act_state_data.current_move++;
         }
         if(rec_call) continue;
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -249,7 +249,7 @@ BoolVector Nfa::get_useful_states(const bool stop_at_first_useful_state) const {
         // rec_call simulates call of the strongconnect. Since c++ cannot do continue over
         // multiple loops, we use rec_call to jump to the main loop
         bool rec_call = false;
-        for(;act_state_data.current_move != act_state_data.end_move;act_state_data.current_move++) {
+        for(;act_state_data.current_move != act_state_data.end_move;++act_state_data.current_move) {
             next_state = (*act_state_data.current_move).target;
             // if successor is useful, act_state is useful as well
             if(useful[next_state]) {


### PR DESCRIPTION
Look at this to see an ultimate demonstration of the coolness of the davids move iterator.

Although, I am wandering whether it can be used anywhere else then here. I did not come with a good usage in the intersection for instance, because I wanted to get the vectors ot targets with the same symbol and then merge them. Maybe it is just my fault, but maybe we actually need something a bit different, I don't know. 
For instance, iterator through symbol_post that skips over symbols where there are no targets ... 
Just thinking.