### PR TITLE
Optimize sync iterator

### DIFF
--- a/include/mata/utils/synchronized-iterator.hh
+++ b/include/mata/utils/synchronized-iterator.hh
@@ -215,11 +215,12 @@ public:
             if (position_i_it == end_i_it) {
                 // If there is nothing left at the position, it is removed, that is,
                 // swapped with a position from the end of the vector,
-                // and shorten the vector.
+                // and the vector is shortened.
                 // The same is done with ends.
                 while (position_i_it == end_i_it && i < positions_size) {
                     position_i_it = this->positions[positions_size - 1];
                     end_i_it = this->ends[positions_size - 1];
+                    // This must be here, because in the next call, position_size is set again with positions.size().
                     this->positions.pop_back();
                     this->ends.pop_back();
                     --positions_size;
@@ -242,7 +243,7 @@ public:
                 this->next_minimum = position_i_it;
             }
 
-            ++i;
+            ++i; // This cannot be in the for statement line, because of the continue in the if body above.
         }
         return !currently_synchronized.empty();
     }; // advance().

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -684,7 +684,7 @@ StateSet SynchronizedExistentialSymbolPostIterator::unify_targets() const {
     static utils::SynchronizedExistentialIterator<StateSet::const_iterator> sync_iterator;
     sync_iterator.reset();
     size_t all_targets_size{ 0 };
-    std::vector<StatePost::const_iterator> current_symbol_post_its{ this->get_current() };
+    const std::vector<StatePost::const_iterator>& current_symbol_post_its{ this->get_current() };
     sync_iterator.reserve(current_symbol_post_its.size());
     for (const auto symbol_post_it: current_symbol_post_its) {
         sync_iterator.push_back(symbol_post_it->cbegin(), symbol_post_it->cend());
@@ -692,7 +692,7 @@ StateSet SynchronizedExistentialSymbolPostIterator::unify_targets() const {
     }
     StateSet unified_targets{};
     unified_targets.reserve(all_targets_size);
-    while (sync_iterator.advance()) { unified_targets.push_back(*(sync_iterator.get_current()[0])); }
+    while (sync_iterator.advance()) { unified_targets.push_back(*sync_iterator.get_current_minimum()); }
     return unified_targets;
 }
 

--- a/src/nfa/intersection.cc
+++ b/src/nfa/intersection.cc
@@ -193,7 +193,7 @@ Nfa mata::nfa::algorithms::product(
         mata::utils::push_back(sync_iterator, rhs.delta[rhs_source]);
 
         while (sync_iterator.advance()) {
-            std::vector<StatePost::const_iterator> same_symbol_posts = sync_iterator.get_current();
+            const std::vector<StatePost::const_iterator>& same_symbol_posts{ sync_iterator.get_current() };
             assert(same_symbol_posts.size() == 2); // One move per state in the pair.
 
             // Compute product for state transitions with same symbols.
@@ -202,7 +202,7 @@ Nfa mata::nfa::algorithms::product(
             //  and states to which second one goes.
             Symbol symbol = same_symbol_posts[0]->symbol;
             if (symbol < first_epsilon) {
-                SymbolPost product_symbol_post{symbol};
+                SymbolPost product_symbol_post{ symbol };
                 for (const State lhs_target: same_symbol_posts[0]->targets) {
                     for (const State rhs_target: same_symbol_posts[1]->targets) {
                         create_product_state_and_symbol_post(lhs_target, rhs_target, product_symbol_post);

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -731,7 +731,7 @@ Nfa mata::nfa::determinize(
         while (synchronized_iterator.advance()) {
 
             // extract post from the sychronized_iterator iterator
-            std::vector<Iterator> moves = synchronized_iterator.get_current();
+            const std::vector<Iterator>& moves = synchronized_iterator.get_current();
             Symbol currentSymbol = (*moves.begin())->symbol;
             StateSet T = synchronized_iterator.unify_targets();
 


### PR DESCRIPTION
This PR slightly optimizes `SynchronizedIterator` and its uses.