### PR TITLE
In place union and concatenation in Python binding

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -139,6 +139,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         CNfa() except +
         CNfa(unsigned long) except +
         CNfa(unsigned long, StateSet, StateSet, CAlphabet*)
+        CNfa(const CNfa&)
 
         # Public Functions
         void make_initial(State)

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -160,6 +160,8 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         State add_state(State)
         void print_to_DOT(ostream)
         CNfa& trim(StateRenaming*)
+        CNfa& concatenate(CNfa&)
+        CNfa& uni(CNfa&)
         void get_one_letter_aut(CNfa&)
         bool is_epsilon(Symbol)
         CBoolVector get_useful_states()

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -533,6 +533,22 @@ cdef class Nfa:
         self.thisptr.get().trim(&state_map)
         return self, {k: v for k, v in state_map}
 
+    def concatenate(self, Nfa other) -> Nfa:
+        """Concatenate 'self' with 'other' in-place.
+
+        :return: Self
+        """
+        self.thisptr.get().concatenate(dereference(other.thisptr.get()))
+        return self
+
+    def union(self, Nfa other) -> Nfa:
+        """Make union of 'self' with 'other' in-place.
+
+        :return: Self
+        """
+        self.thisptr.get().uni(dereference(other.thisptr.get()))
+        return self
+
     def is_lang_empty(self, Run run = None):
         """Check if language of automaton is empty.
 

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -204,6 +204,13 @@ cdef class Nfa:
         )
         self.label = label
 
+    def deepcopy(self):
+        """Deepcopy Nfa using C++ copy constructor."""
+        new = Nfa()
+        cdef CNfa* orig = self.thisptr.get()
+        new.thisptr = make_shared[CNfa](mata_nfa.CNfa(dereference(orig)))
+        return new
+
     @property
     def label(self):
         return self.label

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -340,6 +340,10 @@ def test_concatenate():
     assert len(shortest_words) == 1
     assert [ord('b'), ord('a')] in shortest_words
 
+    lhs_in_place = lhs.deepcopy()
+    result_in_place = lhs_in_place.concatenate(rhs)
+    assert mata_nfa.equivalence_check(result, result_in_place)
+
     result = mata_nfa.concatenate(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
@@ -348,6 +352,11 @@ def test_concatenate():
     assert result.has_transition(1, mata_nfa.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
 
+    lhs_in_place = lhs.deepcopy()
+    result_in_place = lhs_in_place.concatenate(rhs)
+    result.remove_epsilon_inplace()
+    assert mata_nfa.equivalence_check(result, result_in_place)
+
     result, _, rhs_map = mata_nfa.concatenate_with_result_state_maps(lhs, rhs, True)
     assert result.has_initial_state(0)
     assert result.has_final_state(3)
@@ -355,6 +364,11 @@ def test_concatenate():
     assert result.has_transition(0, ord('b'), 1)
     assert result.has_transition(1, mata_nfa.epsilon(), 2)
     assert result.has_transition(2, ord('a'), 3)
+
+    lhs_in_place = lhs.deepcopy()
+    result_in_place = lhs_in_place.concatenate(rhs)
+    result.remove_epsilon_inplace()
+    assert mata_nfa.equivalence_check(result, result_in_place)
 
 
 def test_completeness(
@@ -422,6 +436,10 @@ def test_union(
 
     assert mata_nfa.is_included(fa_one_divisible_by_two, uni)
     assert mata_nfa.is_included(fa_one_divisible_by_four, uni)
+
+    fa_one_divisible_by_two_in_lace = fa_one_divisible_by_two.deepcopy()
+    uni_in_place = fa_one_divisible_by_two_in_lace.union(fa_one_divisible_by_four)
+    assert mata_nfa.equivalence_check(uni, uni_in_place)
 
 
 def test_intersection(


### PR DESCRIPTION
This PR adds in-place variants of concatenation and union to Python binding. Additionally, it adds a temporary deepcopy function for Python `Nfa` class. Proper deepcopy using Python `copy.deepcopy()` will come in a later PR.