### PR TITLE
Refactoring of SCC-based Algorithms

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -303,6 +303,13 @@ public:
     bool is_complete(Alphabet const* alphabet = nullptr) const;
 
     /**
+     * @brief Is the automaton graph acyclic? Used for checking language finiteness.
+     * 
+     * @return true <-> Automaton graph is acyclic.
+     */
+    bool is_acyclic() const;
+
+    /**
      * Fill @p alphabet with symbols from @p nfa.
      * @param[in] nfa NFA with symbols to fill @p alphabet with.
      * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -275,7 +275,8 @@ public:
     StateSet post(const StateSet& states, const Symbol& symbol) const;
 
     /**
-     * Check whether the language of NFA is empty.
+     * Check whether the language of NFA is empty. 
+     * Currently calls is_lang_empty_scc if cex is null 
      * @param[out] cex Counter-example path for a case the language is not empty.
      * @return True if the language is empty, false otherwise.
      */

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -171,15 +171,13 @@ public:
      */
     struct SCCCrawlExe {
         // event handler for the first-time state discovery
-        virtual bool state_discover(State) { return false; };
+        std::function<bool(State)> state_discover;
         // event handler for SCC discovery (together with the whole Tarjan stack)
-        virtual bool scc_discover(const std::vector<State>&, const std::vector<State>&) { return false; };
+        std::function<bool(const std::vector<State>&, const std::vector<State>&)> scc_discover;
         // event handler for state in SCC discovery
-        virtual void scc_state_discover(State) {};
+        std::function<void(State)> scc_state_discover;
         // event handler for visiting of the state successors
-        virtual void succ_state_discover(State, State) {};
-
-        virtual ~SCCCrawlExe() = default;
+        std::function<void(State,State)> succ_state_discover;
     };
 
     /**
@@ -187,7 +185,7 @@ public:
      * 
      * @param crawl Instance of the crawling class.
      */
-    void scc_crawl(SCCCrawlExe& crawl) const;
+    void scc_crawl(const SCCCrawlExe& crawl) const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -166,10 +166,10 @@ public:
     BoolVector get_useful_states() const;
 
     /**
-     * @brief Structure for utilizing Tarjan's SCC discover.
-     * 
+     * @brief Structure for storing callback functions (event handlers) utilizing 
+     * Tarjan's SCC discover algorithm.
      */
-    struct SCCCrawlExe {
+    struct TarjanDiscoverCallback {
         // event handler for the first-time state discovery
         std::function<bool(State)> state_discover;
         // event handler for SCC discovery (together with the whole Tarjan stack)
@@ -181,11 +181,11 @@ public:
     };
 
     /**
-     * @brief Tarjan-based SCC crawler.
+     * @brief Tarjan's SCC discover algorihm.
      * 
-     * @param crawl Instance of the crawling class.
+     * @param callback Callbacks class to instantiate callbacks for the Tarjan's algorithm.
      */
-    void scc_crawl(const SCCCrawlExe& crawl) const;
+    void tarjan_scc_discover(const TarjanDiscoverCallback& callback) const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.
@@ -282,7 +282,7 @@ public:
     bool is_lang_empty(Run* cex = nullptr) const;
 
     /**
-     * @brief Check if the language is empty using SCC crawling.
+     * @brief Check if the language is empty using Tarjan's SCC discover algorithm.
      * 
      * @return Language empty <-> True
      */

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -161,12 +161,29 @@ public:
      * @brief Get the useful states using a modified Tarjan's algorithm. A state
      * is useful if it is reachable from an initial state and can reach a final state.
      *
-     * @param state_at_first_useful_state Whether only the first found useful state is set to true. Useful when
-     *  checking whether the set of useful states is empty.
-     *
      * @return BoolVector Bool vector whose ith value is true iff the state i is useful.
      */
-    BoolVector get_useful_states(const bool stop_at_first_useful_state = false) const;
+    BoolVector get_useful_states() const;
+
+    /**
+     * @brief Structure for utilizing Tarjan's SCC discover.
+     * 
+     */
+    struct SCCCrawlExe {
+        virtual bool state_discover(State) { return false; };
+        virtual bool scc_discover(const std::vector<State>&, const std::vector<State>&) { return false; };
+        virtual void scc_state_discover(State) {};
+        virtual void succ_state_discover(State, State) {};
+
+        virtual ~SCCCrawlExe() = default;
+    };
+
+    /**
+     * @brief Tarjan-based SCC crawler.
+     * 
+     * @param crawl Instance of the crawling class.
+     */
+    void scc_crawl(SCCCrawlExe& crawl) const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.
@@ -261,6 +278,13 @@ public:
      * @return True if the language is empty, false otherwise.
      */
     bool is_lang_empty(Run* cex = nullptr) const;
+
+    /**
+     * @brief Check if the language is empty using SCC crawling.
+     * 
+     * @return Language empty <-> True
+     */
+    bool is_lang_empty_scc() const;
 
     /**
      * @brief Test whether an automaton is deterministic.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -170,9 +170,13 @@ public:
      * 
      */
     struct SCCCrawlExe {
+        // event handler for the first-time state discovery
         virtual bool state_discover(State) { return false; };
+        // event handler for SCC discovery (together with the whole Tarjan stack)
         virtual bool scc_discover(const std::vector<State>&, const std::vector<State>&) { return false; };
+        // event handler for state in SCC discovery
         virtual void scc_state_discover(State) {};
+        // event handler for visiting of the state successors
         virtual void succ_state_discover(State, State) {};
 
         virtual ~SCCCrawlExe() = default;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -365,6 +365,25 @@ bool Nfa::is_lang_empty_scc() const {
     return !crawl.accepting_state;
 }
 
+bool Nfa::is_acyclic() const {
+    struct SCCCrawlAcyclic : SCCCrawlExe {
+        bool acyclic {true};
+
+        inline bool scc_discover(const std::vector<State>& scc, const std::vector<State>& tarjan_stack) {
+            (void)tarjan_stack;
+            if(scc.size() > 1) {
+                this->acyclic = false;
+                return true;
+            }
+            return false;
+        }
+    };
+
+    SCCCrawlAcyclic crawl;
+    scc_crawl(crawl);
+    return !crawl.acyclic;
+}
+
 std::string Nfa::print_to_DOT() const {
     std::stringstream output;
     print_to_DOT(output);

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -505,11 +505,7 @@ bool mata::nfa::Nfa::is_lang_empty(Run* cex) const {
     //TOOD: hot fix for performance reasons for TACAS.
     // Perhaps make the get_useful_states return a witness on demand somehow.
     if (!cex) {
-        BoolVector useful_states = get_useful_states(true);
-        for (State is_state_useful: useful_states)
-            if (is_state_useful)
-                return false;
-        return true;
+        return is_lang_empty_scc();
     }
 
     std::list<State> worklist(initial.begin(), initial.end());

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -263,6 +263,64 @@ TEST_CASE("mata::nfa::is_lang_empty()")
     }
 } // }}}
 
+TEST_CASE("mata::nfa::is_acyclic")
+{ // {{{
+    Nfa aut(14);
+
+    SECTION("An empty automaton is acyclic")
+    {
+        REQUIRE(aut.is_acyclic());
+    }
+
+    SECTION("An automaton with a state that is both initial and final is acyclic")
+    {
+        aut.initial = {1, 2};
+        aut.final = {2, 3};
+        REQUIRE(aut.is_acyclic());
+    }
+
+    SECTION("More complicated automaton")
+    {
+        aut.initial = {1, 2};
+        aut.delta.add(1, 'a', 2);
+        aut.delta.add(1, 'a', 3);
+        aut.delta.add(1, 'b', 4);
+        aut.delta.add(2, 'a', 3);
+        aut.delta.add(2, 'b', 4);
+        aut.delta.add(3, 'b', 4);
+        aut.delta.add(3, 'c', 7);
+        aut.delta.add(7, 'a', 8);
+
+        SECTION("without final states")
+        {
+            REQUIRE(aut.is_lang_empty());
+        }
+    }
+
+    SECTION("Cyclic automaton")
+    {
+        aut.initial = {1, 2};
+        aut.final = {8, 9};
+        aut.delta.add(1, 'c', 2);
+        aut.delta.add(2, 'a', 4);
+        aut.delta.add(2, 'c', 1);
+        aut.delta.add(2, 'c', 3);
+        aut.delta.add(3, 'e', 5);
+        aut.delta.add(4, 'c', 8);
+        REQUIRE(!aut.is_acyclic());
+    }
+
+    SECTION("Automaton with self-loops")
+    {
+        Nfa aut(2);
+        aut.initial = {0};
+        aut.final = {1};
+        aut.delta.add(0, 'c', 1);
+        aut.delta.add(1, 'a', 1);
+        REQUIRE(!aut.is_acyclic());
+    }
+} // }}}
+
 TEST_CASE("mata::nfa::get_word_for_path()")
 { // {{{
     Nfa aut(5);


### PR DESCRIPTION
This PR refactors SCC-based algorithms to be more generic. In particular,

- SCC-based crawler: Generic Tarjan's algorithm instantiated with event handlers. Generic enough to cover emptiness checking, useful states computation.
- Implementation of another instantiation for a checking if the NFA graph is acyclic (useful for language finiteness checking in `Z3-Noodler`).