### PR TITLE
Nft inclusion

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -62,24 +62,22 @@ public:
 
 public:
     explicit Nft(Delta delta = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 1,
+                 utils::SparseSet<State> final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 0,
                  Alphabet* alphabet = nullptr)
-        : mata::nfa::Nfa(std::move(delta), std::move(initial_states), std::move(final_states), alphabet),
-        levels(std::move(levels)), levels_cnt(levels_cnt) {}
-
+        : mata::nfa::Nfa(std::move(delta), std::move(initial_states), std::move(final_states), alphabet), levels(levels), levels_cnt(levels_cnt) {}
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
      *
      * @param[in] num_of_states Number of states for which to preallocate Delta.
      */
     explicit Nft(const unsigned long num_of_states, StateSet initial_states = {},
-                 StateSet final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 1, Alphabet*
+                 StateSet final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 0, Alphabet*
                  alphabet = nullptr)
-        : mata::nfa::Nfa(num_of_states, std::move(initial_states), std::move(final_states), alphabet), levels(std::move(levels)), levels_cnt(levels_cnt) {}
+        : mata::nfa::Nfa(num_of_states, std::move(initial_states), std::move(final_states), alphabet), levels(levels), levels_cnt(levels_cnt) {}
 
     explicit Nft(const mata::nfa::Nfa& other)
         : mata::nfa::Nfa(other.delta, other.initial, other.final, other.alphabet),
-          levels(std::vector<Level>(other.num_of_states(), 0)), levels_cnt(1) {}
+          levels(std::vector<Level>()), levels_cnt(0) {}
 
     /**
      * @brief Construct a new explicit NFT from other NFT.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -51,7 +51,7 @@ struct Nft : public mata::nfa::Nfa {
 public:
     /// @brief For state q, levels[q] gives the state a level.
     std::vector<Level> levels{};
-    Level levels_cnt = 0;
+    Level levels_cnt = 1;
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
     /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
@@ -62,22 +62,24 @@ public:
 
 public:
     explicit Nft(Delta delta = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 0,
+                 utils::SparseSet<State> final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 1,
                  Alphabet* alphabet = nullptr)
-        : mata::nfa::Nfa(std::move(delta), std::move(initial_states), std::move(final_states), alphabet), levels(levels), levels_cnt(levels_cnt) {}
+        : mata::nfa::Nfa(std::move(delta), std::move(initial_states), std::move(final_states), alphabet),
+          levels(levels.size() ? std::move(levels) : std::vector<Level>(delta.num_of_states(), 0)), levels_cnt(levels_cnt) {}
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
      *
      * @param[in] num_of_states Number of states for which to preallocate Delta.
      */
     explicit Nft(const unsigned long num_of_states, StateSet initial_states = {},
-                 StateSet final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 0, Alphabet*
+                 StateSet final_states = {}, std::vector<Level> levels = {}, const Level levels_cnt = 1, Alphabet*
                  alphabet = nullptr)
-        : mata::nfa::Nfa(num_of_states, std::move(initial_states), std::move(final_states), alphabet), levels(levels), levels_cnt(levels_cnt) {}
+        : mata::nfa::Nfa(num_of_states, std::move(initial_states), std::move(final_states), alphabet),
+        levels(levels.size() ? std::move(levels) : std::vector<Level>(num_of_states, 0)), levels_cnt(levels_cnt) {}
 
     explicit Nft(const mata::nfa::Nfa& other)
         : mata::nfa::Nfa(other.delta, other.initial, other.final, other.alphabet),
-          levels(std::vector<Level>()), levels_cnt(0) {}
+          levels(std::vector<Level>(other.delta.num_of_states(), 0)), levels_cnt(1) {}
 
     /**
      * @brief Construct a new explicit NFT from other NFT.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -79,7 +79,7 @@ public:
 
     explicit Nft(const mata::nfa::Nfa& other)
         : mata::nfa::Nfa(other.delta, other.initial, other.final, other.alphabet),
-          levels(std::vector<Level>(other.delta.num_of_states(), 0)), levels_cnt(1) {}
+          levels(std::vector<Level>(other.num_of_states(), 0)), levels_cnt(1) {}
 
     /**
      * @brief Construct a new explicit NFT from other NFT.

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -340,5 +340,9 @@ Nft builder::create_from_nfa(const mata::nfa::Nfa& nfa, Level level_cnt, const s
     std::ranges::for_each(nfa.initial, [&](const State nfa_state){ nft.initial.insert(state_mapping[nfa_state]); });
     nft.final.reserve(nfa.final.size());
     std::ranges::for_each(nfa.final, [&](const State nfa_state){ nft.final.insert(state_mapping[nfa_state]); });
+
+    // TODO(nft): HACK. Levels do not work if the size of delta differs from the size of the vector level.
+    nft.levels.resize(nft.delta.num_of_states());
+
     return nft;
 }

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -271,18 +271,24 @@ bool mata::nft::is_included(
 
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *alphabet, const ParameterMap& params)
 {
-    if (lhs.levels_cnt != rhs.levels_cnt) { return false; }
-    //TODO: add comment on what this is doing, what is __func__ ...
-    AlgoType algo{ set_algorithm(std::to_string(__func__), params) };
 
-    if (params.at("algorithm") == "naive") {
-        if (alphabet == nullptr) {
-            const auto computed_alphabet{create_alphabet(lhs, rhs) };
-            return compute_equivalence(lhs, rhs, &computed_alphabet, algo);
+    if (lhs.levels_cnt != rhs.levels_cnt) { return false; }
+    if (lhs.levels_cnt == 0) { return nfa::are_equivalent(lhs, rhs, alphabet, params); }
+
+    OrdVector<mata::Symbol> symbols;
+    if (alphabet == nullptr) {
+        symbols = create_alphabet(lhs, rhs).get_alphabet_symbols();
+        if (symbols.contains(DONT_CARE) && symbols.size() > 1) {
+            symbols.erase(DONT_CARE);
         }
+    } else {
+        symbols = alphabet->get_alphabet_symbols();
     }
 
-    return compute_equivalence(lhs, rhs, alphabet, algo);
+    return nfa::are_equivalent(lhs.get_one_level_aut(symbols),
+                               rhs.get_one_level_aut(symbols),
+                               alphabet,
+                               params);
 }
 
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const ParameterMap& params) {

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -37,7 +37,6 @@ bool mata::nft::algorithms::is_included_antichains(
     Run*                   cex)
 { // {{{
     if (smaller.levels_cnt != bigger.levels_cnt) { return false; }
-    if (smaller.levels_cnt == 0) { return nfa::algorithms::is_included_antichains(smaller, bigger, alphabet, cex); }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {
@@ -57,17 +56,6 @@ bool mata::nft::algorithms::is_included_antichains(
 
 namespace {
     using AlgoType = decltype(algorithms::is_included_naive)*;
-
-    bool compute_equivalence(const Nft &lhs, const Nft &rhs, const mata::Alphabet *const alphabet, const AlgoType &algo) {
-        //alphabet should not be needed as input parameter
-        if (algo(lhs, rhs, alphabet, nullptr)) {
-            if (algo(rhs, lhs, alphabet, nullptr)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     AlgoType set_algorithm(const std::string &function_name, const ParameterMap &params) {
         if (!haskey(params, "algorithm")) {
@@ -106,7 +94,6 @@ bool mata::nft::is_included(
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *alphabet, const ParameterMap& params)
 {
     if (lhs.levels_cnt != rhs.levels_cnt) { return false; }
-    if (lhs.levels_cnt == 0) { return nfa::are_equivalent(lhs, rhs, alphabet, params); }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -4,6 +4,7 @@
 // MATA headers
 #include "mata/nft/nft.hh"
 #include "mata/nft/algorithms.hh"
+#include "mata/nfa/algorithms.hh"
 #include "mata/utils/sparse-set.hh"
 
 using namespace mata::nft;
@@ -35,190 +36,23 @@ bool mata::nft::algorithms::is_included_antichains(
     const Alphabet* const  alphabet, //TODO: this parameter is not used
     Run*                   cex)
 { // {{{
-    (void)alphabet;
+    if (smaller.levels_cnt != bigger.levels_cnt) { return false; }
+    if (smaller.levels_cnt == 0) { return nfa::algorithms::is_included_antichains(smaller, bigger, alphabet, cex); }
 
-    // TODO: Decide what is the best optimization for inclusion.
-
-    using ProdStateType = std::tuple<State, StateSet, size_t>;
-    using ProdStatesType = std::vector<ProdStateType>;
-    // ProcessedType is indexed by states of the smaller nft
-    // tailored for pure antichain approach ... the simulation-based antichain will not work (without changes).
-    using ProcessedType = std::vector<ProdStatesType>;
-
-    auto subsumes = [](const ProdStateType& lhs, const ProdStateType& rhs) {
-        if (std::get<0>(lhs) != std::get<0>(rhs)) {
-            return false;
+    OrdVector<mata::Symbol> symbols;
+    if (alphabet == nullptr) {
+        symbols = create_alphabet(smaller, bigger).get_alphabet_symbols();
+        if (symbols.contains(DONT_CARE) && symbols.size() > 1) {
+            symbols.erase(DONT_CARE);
         }
-
-        const StateSet& lhs_bigger = std::get<1>(lhs);
-        const StateSet& rhs_bigger = std::get<1>(rhs);
-
-        //TODO: Can this be done faster using more heuristics? E.g., compare the last elements first ...
-        //TODO: Try BDDs! What about some abstractions?
-        return lhs_bigger.IsSubsetOf(rhs_bigger);
-    };
-
-
-    // initialize
-    ProdStatesType worklist{};//Pairs (q,S) to be processed. It sometimes gives a huge speed-up when they are kept sorted by the size of S,
-    // worklist.reserve(32);
-    // so those with smaller popped for processing first.
-    ProcessedType processed(smaller.num_of_states()); // Allocate to the number of states of the smaller nft.
-    // The pairs of each state are also kept sorted. It allows slightly faster antichain pruning - no need to test inclusion in sets that have less elements.
-
-    //Is |S| < |S'| for the inut pairs (q,S) and (q',S')?
-    // auto smaller_set = [](const ProdStateType & a, const ProdStateType & b) { return std::get<1>(a).size() < std::get<1>(b).size(); };
-
-    std::vector<State> distances_smaller = revert(smaller).distances_from_initial();
-    std::vector<State> distances_bigger = revert(bigger).distances_from_initial();
-
-    // auto closer_dist = [&](const ProdStateType & a, const ProdStateType & b) {
-    //     return distances_smaller[a.first] < distances_smaller[b.first];
-    // };
-
-    // auto closer_smaller = [&](const ProdStateType & a, const ProdStateType & b) {
-    //     if (distances_smaller[a.first] != distances_smaller[b.first])
-    //         return distances_smaller[a.first] < distances_smaller[b.first];
-    //     else
-    //         return a.second.size() < b.second.size();
-    // };
-
-    // auto smaller_closer = [&](const ProdStateType & a, const ProdStateType & b) {
-    //     if (a.second.size() != b.second.size())
-    //         return a.second.size() < b.second.size();
-    //     else
-    //         return distances_smaller[a.first] < distances_smaller[b.first];
-    // };
-
-    auto min_dst = [&](const StateSet& set) {
-        if (set.empty()) return Limits::max_state;
-        return distances_bigger[*std::min_element(set.begin(), set.end(), [&](const State a,const State b){return distances_bigger[a] < distances_bigger[b];})];
-    };
-
-    auto lengths_incompatible = [&](const ProdStateType& pair) {
-        return distances_smaller[std::get<0>(pair)] < std::get<2>(pair);
-    };
-
-    auto insert_to_pairs = [&](ProdStatesType & pairs,const ProdStateType & pair) {
-        // auto it = std::lower_bound(pairs.begin(), pairs.end(), pair, smaller_set);
-        // auto it = std::lower_bound(pairs.begin(), pairs.end(), pair, closer_dist);
-        // auto it = std::lower_bound(pairs.begin(), pairs.end(), pair, smaller_closer);
-        // auto it = std::lower_bound(pairs.begin(), pairs.end(), pair, closer_smaller);
-        // pairs.insert(it,pair);
-        pairs.push_back(pair);
-        // std::sort(pairs.begin(), pairs.end(), smaller_closer);
-    };
-
-    // 'paths[s] == t' denotes that state 's' was accessed from state 't',
-    // 'paths[s] == s' means that 's' is an initial state
-    std::map<ProdStateType, std::pair<ProdStateType, Symbol>> paths;
-
-    // check initial states first // TODO: this would be done in the main loop as the first thing anyway?
-    for (const auto& state : smaller.initial) {
-        if (smaller.final[state] &&
-            are_disjoint(bigger.initial, bigger.final))
-        {
-            if (cex != nullptr) { cex->word.clear(); }
-            return false;
-        }
-
-        StateSet bigger_state_set{ bigger.initial };
-        const ProdStateType st = std::tuple(state, bigger_state_set, min_dst(bigger_state_set));
-        insert_to_pairs(worklist, st);
-        insert_to_pairs(processed[state],st);
-
-        if (cex != nullptr)
-            paths.insert({ st, {st, 0}});
+    } else {
+        symbols = alphabet->get_alphabet_symbols();
     }
 
-    //For synchronised iteration over the set of states
-    SynchronizedExistentialSymbolPostIterator sync_iterator;
-
-    // We use DFS strategy for the worklist processing
-    while (!worklist.empty()) {
-        // get a next product state
-        ProdStateType prod_state = *worklist.rbegin();
-        worklist.pop_back();
-
-        const State& smaller_state = std::get<0>(prod_state);
-        const StateSet& bigger_set = std::get<1>(prod_state);
-
-        sync_iterator.reset();
-        for (State q: bigger_set) {
-            mata::utils::push_back(sync_iterator, bigger.delta[q]);
-        }
-
-        // process transitions leaving smaller_state
-        for (const auto& smaller_move : smaller.delta[smaller_state]) {
-            const Symbol& smaller_symbol = smaller_move.symbol;
-
-            StateSet bigger_succ = {};
-            if(sync_iterator.synchronize_with(smaller_move)) {
-                bigger_succ = sync_iterator.unify_targets();
-            }
-
-            for (const State& smaller_succ : smaller_move.targets) {
-                const ProdStateType succ = {smaller_succ, bigger_succ, min_dst(bigger_succ)};
-
-                if (lengths_incompatible(succ) || (smaller.final[smaller_succ] &&
-                    !bigger.final.intersects_with(bigger_succ)))
-                {
-                    if (cex != nullptr) {
-                        cex->word.clear();
-                        cex->word.push_back(smaller_symbol);
-                        ProdStateType trav = prod_state;
-                        while (paths[trav].first != trav)
-                        { // go back until initial state
-                            cex->word.push_back(paths[trav].second);
-                            trav = paths[trav].first;
-                        }
-
-                        std::reverse(cex->word.begin(), cex->word.end());
-                    }
-
-                    return false;
-                }
-
-                bool is_subsumed = false;
-                for (const auto& anti_state : processed[smaller_succ])
-                { // trying to find in processed a smaller state than the newly created succ
-                    // if (smaller_set(succ,anti_state)) {
-                    //     break;
-                    // }
-                    if (subsumes(anti_state, succ)) {
-                        is_subsumed = true;
-                        break;
-                    }
-                }
-
-                if (is_subsumed) {
-                    continue;
-                }
-
-                for (ProdStatesType* ds: {&processed[smaller_succ], &worklist}) {
-                    //Pruning of processed and the worklist.
-                    //Since they are ordered by the size of the sets, we can iterate from back,
-                    //and as soon as we get to sets larger than succ, we can stop (larger sets cannot be subsets).
-                    std::erase_if(*ds, [&](const auto& d){ return subsumes(succ, d); });
-                    // for (long it = static_cast<long>(ds->size()-1);it>=0;--it) {
-                    //     // if (smaller_set((*ds)[static_cast<size_t>(it)],succ))
-                    //         // break;
-                    //     if (subsumes(succ, (*ds)[static_cast<size_t>(it)])) {
-                    //         //Using index it instead of an iterator since erase could invalidate it (?)
-                    //         ds->erase(ds->begin() + it);
-                    //     }
-                    // }
-                    insert_to_pairs(*ds, succ);
-                }
-
-                if(cex != nullptr) {
-                    // also set that succ was accessed from state
-                    paths[succ] = {prod_state, smaller_symbol};
-                }
-            }
-        }
-    }
-    return true;
+    return nfa::algorithms::is_included_antichains(smaller.get_one_level_aut(symbols),
+                                                   bigger.get_one_level_aut(symbols),
+                                                   alphabet,
+                                                   cex);
 } // }}}
 
 namespace {
@@ -271,7 +105,6 @@ bool mata::nft::is_included(
 
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *alphabet, const ParameterMap& params)
 {
-
     if (lhs.levels_cnt != rhs.levels_cnt) { return false; }
     if (lhs.levels_cnt == 0) { return nfa::are_equivalent(lhs, rhs, alphabet, params); }
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -240,6 +240,13 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements)
 
 Nft Nft::get_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements) const {
     Nft result{ *this };
+
+    // TODO(nft): Create a class for LEVELS with overloaded getter and setter.
+    // HACK. Works only for automata without levels.
+    if (result.levels.size() != result.num_of_states()) {
+        return result;
+    }
+
     result.make_one_level_aut(dcare_replacements);
     return result;
 }
@@ -263,7 +270,12 @@ State Nft::add_state() {
 }
 
 State Nft::add_state(State state) {
-    levels.push_back(0);
+    const size_t levels_size = levels.size();
+    if (state >= levels_size) {
+        levels.resize(state + 1);
+        const size_t begin_idx = (levels_size == 0) ? 0 : levels_size - 1;
+        std::fill(levels.begin() + static_cast<long int>(begin_idx), levels.end(), 0);
+    }
     return mata::nfa::Nfa::add_state(state);
 }
 

--- a/tests/nft/builder.cc
+++ b/tests/nft/builder.cc
@@ -64,7 +64,7 @@ TEST_CASE("nft::parse_from_mata()") {
         delta.add(0, 0, 0);
         delta.add(0, 1, 1);
         delta.add(1, 2, 0);
-        Nft nft{ delta, { 0 }, { 1 }, { 0 }, 1};
+        Nft nft{ delta, { 0 }, { 1 }, { 0, 0 }, 1};
 
         SECTION("from string") {
             Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2997,3 +2997,131 @@ TEST_CASE("mata::nft::Nft::get_words") {
         CHECK(aut.get_words(5) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}, {0,1,0}, {1,0,1}, {0,1,0,1}, {1,0,1,0}, {0,1,0,1,0}, {1,0,1,0,1}});
     }
 }
+
+TEST_CASE("mata::nft::Nft::get_one_level_aut") {
+    #define REPLACE_DONT_CARE(delta, src, trg)\
+                delta.add(src, 0, trg);\
+                delta.add(src, 1, trg);\
+
+    #define SPLIT_TRANSITION(delta, src, symbol, inter, trg)\
+                ((symbol == DONT_CARE) ? (delta.add(src, 0, inter), delta.add(src, 1, inter)) : (delta.add(src, symbol, inter)));\
+                REPLACE_DONT_CARE(delta, inter, trg);\
+
+    SECTION("level_cnt == 1") {
+        Nft aut(5, {0}, {3, 4}, {0, 0, 0, 0, 0}, 1);
+        aut.delta.add(0, 0, 1);
+        aut.delta.add(0, 1, 2);
+        aut.delta.add(1, 0, 1);
+        aut.delta.add(1, DONT_CARE, 3);
+        aut.delta.add(2, DONT_CARE, 2);
+        aut.delta.add(2, DONT_CARE, 4);
+        aut.delta.add(3, 0, 1);
+        aut.delta.add(3, DONT_CARE, 3);
+        aut.delta.add(4, 1, 2);
+        aut.delta.add(4, DONT_CARE, 4);
+
+        Nft expected(5, {0}, {3, 4}, {0, 0, 0, 0, 0}, 1);
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(0, 1, 2);
+        expected.delta.add(1, 0, 1);
+        REPLACE_DONT_CARE(expected.delta, 1, 3);
+        REPLACE_DONT_CARE(expected.delta, 2, 2);
+        REPLACE_DONT_CARE(expected.delta, 2, 4);
+        expected.delta.add(3, 0, 1);
+        REPLACE_DONT_CARE(expected.delta, 3, 3);
+        expected.delta.add(4, 1, 2);
+        REPLACE_DONT_CARE(expected.delta, 4, 4);
+
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut({0, 1}), expected));
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut().get_one_level_aut({0, 1}), expected));
+        CHECK(nft::are_equivalent(aut, expected));
+    }
+
+    SECTION("level_cnt == 2") {
+        Nft aut(7, {0}, {5, 6}, {0, 1, 1, 0, 0, 0, 0}, 2);
+        aut.delta.add(0, 0, 1);
+        aut.delta.add(0, 1, 2);
+        aut.delta.add(1, DONT_CARE, 3);
+        aut.delta.add(2, DONT_CARE, 4);
+        aut.delta.add(3, 0, 3);
+        aut.delta.add(3, 0, 5);
+        aut.delta.add(4, DONT_CARE, 4);
+        aut.delta.add(4, DONT_CARE, 6);
+        aut.delta.add(5, DONT_CARE, 5);
+        aut.delta.add(5, 0, 3);
+        aut.delta.add(6, DONT_CARE, 6);
+        aut.delta.add(6, 1, 4);
+
+        Nft expected(15, {0}, {5, 6}, {0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}, 2);
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(0, 1, 2);
+        REPLACE_DONT_CARE(expected.delta, 1, 3);
+        REPLACE_DONT_CARE(expected.delta, 2, 4);
+        SPLIT_TRANSITION(expected.delta, 3, 0, 7, 3);
+        SPLIT_TRANSITION(expected.delta, 3, 0, 8, 5);
+        SPLIT_TRANSITION(expected.delta, 4, DONT_CARE, 10, 4);
+        SPLIT_TRANSITION(expected.delta, 4, DONT_CARE, 12, 6);
+        SPLIT_TRANSITION(expected.delta, 5, DONT_CARE, 13, 5);
+        SPLIT_TRANSITION(expected.delta, 5, 0, 9, 3);
+        SPLIT_TRANSITION(expected.delta, 6, DONT_CARE, 14, 6);
+        SPLIT_TRANSITION(expected.delta, 6, 1, 11, 4);
+
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut({0, 1}), expected));
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut().get_one_level_aut({0, 1}), expected));
+        CHECK(nft::are_equivalent(aut, expected));
+
+    }
+
+    SECTION("level_cnt == 4") {
+        Nft aut(17, {0}, {15, 16}, {0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0}, 4);
+        aut.delta.add(0, 0, 1);
+        aut.delta.add(0, 1, 2);
+        aut.delta.add(1, 0, 3);
+        aut.delta.add(2, DONT_CARE, 4);
+        aut.delta.add(3, 0, 5);
+        aut.delta.add(4, DONT_CARE, 6);
+        aut.delta.add(5, 0, 5);
+        aut.delta.add(5, 0, 7);
+        aut.delta.add(6, DONT_CARE, 6);
+        aut.delta.add(6, DONT_CARE, 8);
+        aut.delta.add(7, 0, 9);
+        aut.delta.add(8, DONT_CARE, 10);
+        aut.delta.add(9, 0, 11);
+        aut.delta.add(10, DONT_CARE, 12);
+        aut.delta.add(11, 0, 13);
+        aut.delta.add(12, DONT_CARE, 14);
+        aut.delta.add(13, 0, 15);
+        aut.delta.add(14, DONT_CARE, 16);
+
+        Nft expected(31, {0}, {15, 16}, {0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0, 2, 2, 2, 1, 1, 3, 3, 1, 2, 1, 3, 3, 3, 3}, 4);
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(0, 1, 2);
+        SPLIT_TRANSITION(expected.delta, 1, 0, 17, 3);
+        SPLIT_TRANSITION(expected.delta, 2, DONT_CARE, 18, 4);
+        expected.delta.add(3, 0, 5);
+        REPLACE_DONT_CARE(expected.delta, 4, 6);
+        expected.delta.add(5, 0, 20);
+        REPLACE_DONT_CARE(expected.delta, 20, 19);
+        REPLACE_DONT_CARE(expected.delta, 19, 29);
+        REPLACE_DONT_CARE(expected.delta, 29, 5);
+        SPLIT_TRANSITION(expected.delta, 5, 0, 21, 7);
+        REPLACE_DONT_CARE(expected.delta, 6, 24);
+        REPLACE_DONT_CARE(expected.delta, 24, 25);
+        REPLACE_DONT_CARE(expected.delta, 25, 30);
+        REPLACE_DONT_CARE(expected.delta, 30, 6);
+        SPLIT_TRANSITION(expected.delta, 6, DONT_CARE, 26, 8);
+        SPLIT_TRANSITION(expected.delta, 7, 0, 22, 9);
+        SPLIT_TRANSITION(expected.delta, 8, DONT_CARE, 27, 10);
+        expected.delta.add(9, 0, 11);
+        REPLACE_DONT_CARE(expected.delta, 10, 12);
+        expected.delta.add(11, 0, 13);
+        REPLACE_DONT_CARE(expected.delta, 12, 14);
+        SPLIT_TRANSITION(expected.delta, 13, 0, 23, 15);
+        SPLIT_TRANSITION(expected.delta, 14, DONT_CARE, 28, 16);
+
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut({0, 1}), expected));
+        CHECK(nfa::are_equivalent(aut.get_one_level_aut().get_one_level_aut({0, 1}), expected));
+        CHECK(nft::are_equivalent(aut, expected));
+    }
+
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3008,7 +3008,7 @@ TEST_CASE("mata::nft::Nft::get_one_level_aut") {
                 REPLACE_DONT_CARE(delta, inter, trg);\
 
     SECTION("level_cnt == 1") {
-        Nft aut(5, {0}, {3, 4}, {0, 0, 0, 0, 0}, 1);
+        Nft aut(5, {0}, {3, 4});
         aut.delta.add(0, 0, 1);
         aut.delta.add(0, 1, 2);
         aut.delta.add(1, 0, 1);
@@ -3020,7 +3020,7 @@ TEST_CASE("mata::nft::Nft::get_one_level_aut") {
         aut.delta.add(4, 1, 2);
         aut.delta.add(4, DONT_CARE, 4);
 
-        Nft expected(5, {0}, {3, 4}, {0, 0, 0, 0, 0}, 1);
+        Nft expected(5, {0}, {3, 4});
         expected.delta.add(0, 0, 1);
         expected.delta.add(0, 1, 2);
         expected.delta.add(1, 0, 1);


### PR DESCRIPTION
Inclusion testing and equivalence checks on Nft automata have been implemented using the `nft::get_one_level_atm` method, followed by the call of inclusion/equivalence functions from Nfa.