### PR TITLE
Reluctant replace NFT

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -116,6 +116,7 @@ public:
     using super::front;
     using super::back;
     using super::filter;
+    using super::clear;
 
     void erase(const SymbolPost& s) {super::erase(s);}
     void erase(const_iterator first, const_iterator last) {super::erase(first,last);}

--- a/include/mata/nfa/strings.hh
+++ b/include/mata/nfa/strings.hh
@@ -117,6 +117,15 @@ std::set<Symbol> get_accepted_symbols(const Nfa& nfa);
 std::set<std::pair<int, int>> get_word_lengths(const Nfa& aut);
 
 /**
+ * @brief Modify @p nfa in-place to remove outgoing transitions from final states.
+ *
+ * If @p nfa accepts empty string, returned NFA will accept only the empty string.
+ * @param nfa NFA to modify.
+ * @return The reluctant version of @p nfa.
+ */
+Nfa reluctant_nfa(Nfa nfa);
+
+/**
  * @brief Checks if the automaton @p nfa accepts only a single word \eps.
  *
  * @param nfa Input automaton

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -103,7 +103,7 @@ Nft parse_from_mata(const std::filesystem::path& nft_file);
  * @param epsilons Which symbols handle as epsilons.
  * @return NFT representing @p nfa_state with @p level_cnt number of levels.
  */
-Nft create_from_nfa(const mata::nfa::Nfa& nfa_state, Level level_cnt = 2, const std::set<Symbol>& epsilons = { EPSILON });
+Nft create_from_nfa(const mata::nfa::Nfa& nfa_state, Level level_cnt = 2, std::optional<Symbol> next_level_symbol = {}, const std::set<Symbol>& epsilons = { EPSILON });
 
 } // namespace mata::nft::builder.
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -223,6 +223,14 @@ public:
     /// Checks whether the prefix of a string is in the language of an automaton
     bool is_prfx_in_lang(const Run& word) const;
 
+    /**
+     * @brief Checks whether track words are in the language of the transducer.
+     *
+     * That is, the function checks whether a tuple @p track_words (word1, word2, word3, ..., wordn) is in the regular
+     *  relation accepted by the transducer with 'n' levels (tracks).
+     */
+    bool is_tuple_in_lang(const std::vector<Word>& word_begin_end_it);
+
     std::pair<Run, bool> get_word_for_path(const Run& run) const;
 
     /**

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -38,8 +38,8 @@ Nft replace_reluctant(
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
 Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
 
-nfa::Nfa generic_end_marker_dfa(const std::string& regex, Alphabet* alphabet);
-nfa::Nfa generic_end_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
+nfa::Nfa generic_marker_dfa(const std::string& regex, Alphabet* alphabet);
+nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -49,7 +49,7 @@ nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
-Nft begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker);
+Nft begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -46,6 +46,7 @@ nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
 Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
+nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -49,7 +49,7 @@ nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
-Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
+Nft begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -19,20 +19,25 @@ Nft create_identity(mata::Alphabet* alphabet, Level level_cnt = 2);
  */
 Nft create_identity_with_single_replace(mata::Alphabet* alphabet, Symbol from_symbol, Symbol to_symbol);
 
+enum class ReplaceMode {
+    Single,
+    All,
+};
+
 Nft replace_reluctant(
     const std::string& regex,
-    const std::string& replacement,
+    const Word& replacement,
     Alphabet* alphabet,
-    // TODO: Change into constants?
-    Symbol begin_marker = EPSILON - 101,
-    Symbol end_marker = EPSILON - 100
+    // TODO(nft): Change into constants?
+    ReplaceMode replace_mode,
+    Symbol begin_marker = EPSILON - 100
 );
 Nft replace_reluctant(
     nfa::Nfa regex,
-    const std::string& replacement,
+    const Word& replacement,
     Alphabet* alphabet,
-    Symbol begin_marker = EPSILON - 101,
-    Symbol end_marker = EPSILON - 100
+    ReplaceMode replace_mode,
+    Symbol begin_marker = EPSILON - 100
 );
 
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
@@ -47,6 +52,9 @@ nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
+
+Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
+Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -790,3 +790,89 @@ std::set<mata::Word> mata::nft::Nft::get_words(unsigned max_length) {
 
     return result;
 }
+
+bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
+    if (track_words.size() != levels_cnt) {
+        throw std::runtime_error("Invalid number of tracks. Expected " + std::to_string(levels_cnt) + ".");
+    }
+    std::vector<Word::const_iterator> track_words_begins(levels_cnt);
+    for (size_t track{ 0 }; track < levels_cnt; ++track) {
+        track_words_begins[track] = track_words[track].begin();
+    }
+
+    const std::vector<Word::const_iterator> track_words_ends{
+        [&](){
+            std::vector<Word::const_iterator> track_words_ends(levels_cnt);
+            for (size_t track{ 0 }; track < levels_cnt; ++track) {
+                track_words_ends[track] = track_words[track].end();
+            }
+            return track_words_ends;
+        }()
+    };
+
+    auto are_all_track_words_read = [&](const std::vector<Word::const_iterator>& word_begins){
+       for (size_t i{ 0 }; Word::const_iterator word_it: word_begins) {
+           if (word_it != track_words_ends[i]) { return false; }
+           ++i;
+       }
+       return true;
+    };
+
+    if (are_all_track_words_read(track_words_begins)) {
+        return final.intersects_with(initial);
+    }
+
+    using StateWordBeginsPair = std::pair<State, std::vector<Word::const_iterator>>;
+    std::deque<StateWordBeginsPair> worklist{};
+    for (const State state: initial) {
+        worklist.emplace_back(state, track_words_begins);
+    }
+    Level level;
+    while (!worklist.empty()) {
+        const auto [state, words_its]{ worklist.front() };
+        worklist.pop_front();
+        level = levels[state];
+        const StatePost& state_post{ delta[state] };
+        const auto state_post_end{ state_post.end() };
+        const Word::const_iterator word_symbol_it{ words_its[level] };
+        if (word_symbol_it != track_words_ends[level]) {
+                auto symbol_post_it{ state_post.find(*word_symbol_it) };
+                if (symbol_post_it != state_post_end) {
+                    for (State target: symbol_post_it->targets) {
+                        std::vector<Word::const_iterator> next_words_its{ words_its };
+                        ++next_words_its[level];
+                        if (are_all_track_words_read(next_words_its) && final.contains(target)) { return true; }
+                        worklist.emplace_back(target, next_words_its);
+                    }
+                }
+
+            symbol_post_it = state_post.find(DONT_CARE);
+            if (symbol_post_it != state_post_end) {
+                for (const State target: symbol_post_it->targets) {
+                    bool continue_to_next_target{ false };
+                    std::vector<Word::const_iterator> next_words_its{ words_its };
+                    Level level_in_transition{ level };
+                    do {
+                        if (next_words_its[level_in_transition] == track_words_ends[level_in_transition]) {
+                            continue_to_next_target = true;
+                        }
+                        ++next_words_its[level_in_transition];
+                        level_in_transition = (level_in_transition + 1) % levels_cnt;
+                    } while(level_in_transition % levels_cnt != levels[target] && !continue_to_next_target);
+                    if (continue_to_next_target) { continue; }
+                    if (are_all_track_words_read(next_words_its) && final.contains(target)) { return true; }
+                    worklist.emplace_back(target, next_words_its);
+                }
+            }
+        }
+
+        auto symbol_post_it{ state_post.find(EPSILON) };
+        if (symbol_post_it != state_post_end) {
+            for (State target: symbol_post_it->targets) {
+                if (are_all_track_words_read(words_its) && final.contains(target)) { return true; }
+                worklist.emplace_back(target, words_its);
+            }
+        }
+    }
+    return false;
+}

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -8,7 +8,8 @@
 #include "mata/nft/nft.hh"
 #include "mata/nft/builder.hh"
 
-//using mata::nft::Nft;
+using mata::nft::Nft;
+using mata::nfa::Nfa;
 using namespace mata;
 using mata::nft::Level;
 using mata::Symbol;
@@ -111,10 +112,7 @@ Nft mata::nft::strings::replace_reluctant(
     Symbol begin_marker,
     Symbol end_marker
 ) {
-    nfa::Nfa dfa_generic_marker{ generic_end_marker_dfa(std::move(regex), alphabet) };
-    Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_marker, end_marker) };
-    Nft dft_begin_marker{ begin_marker_nft(dfa_generic_marker, begin_marker) };
-
+    Nft dft_begin_marker{ begin_marker_nft(generic_marker_dfa(regex, alphabet), begin_marker) };
     return Nft{};
 }
 
@@ -158,13 +156,13 @@ Nft mata::nft::strings::marker_nft(const nfa::Nfa& marker_dfa, Symbol marker) {
     return dft_marker;
 }
 
-nfa::Nfa nft::strings::generic_end_marker_dfa(const std::string& regex, Alphabet* alphabet) {
+nfa::Nfa nft::strings::generic_marker_dfa(const std::string& regex, Alphabet* alphabet) {
     nfa::Nfa nfa{};
     parser::create_nfa(&nfa, regex);
-    return generic_end_marker_dfa(std::move(nfa), alphabet);
+    return generic_marker_dfa(std::move(nfa), alphabet);
 }
 
-nfa::Nfa nft::strings::generic_end_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
+nfa::Nfa nft::strings::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
     if (!regex.is_deterministic()) {
         regex = determinize(regex);
     }
@@ -204,7 +202,7 @@ nfa::Nfa nft::strings::begin_marker_nfa(const std::string& regex, Alphabet* alph
 }
 
 nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
-    nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa(std::move(regex), alphabet) };
+    nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa(std::move(regex), alphabet) };
     dfa_generic_end_marker = revert(dfa_generic_end_marker);
     std::swap(dfa_generic_end_marker.initial, dfa_generic_end_marker.final);
     return dfa_generic_end_marker;

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -206,23 +206,24 @@ nfa::Nfa nft::strings::begin_marker_nfa(const std::string& regex, Alphabet* alph
 }
 
 nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
+    regex = revert(regex);
     nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa(std::move(regex), alphabet) };
     dfa_generic_end_marker = revert(dfa_generic_end_marker);
     std::swap(dfa_generic_end_marker.initial, dfa_generic_end_marker.final);
     return dfa_generic_end_marker;
 }
 
-Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker) {
-    Nft begin_marker_dft{ marker_nft(marker_dfa, begin_marker) };
-    const State new_initial{ begin_marker_dft.add_state() };
-    for (const State orig_final: begin_marker_dft.final) {
-        begin_marker_dft.delta.add(new_initial, EPSILON, orig_final);
+Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker) {
+    Nft begin_marker_nft{ marker_nft(marker_nfa, begin_marker) };
+    const State new_initial{ begin_marker_nft.add_state() };
+    for (const State orig_final: begin_marker_nft.final) {
+        begin_marker_nft.delta.add(new_initial, EPSILON, orig_final);
     }
-    begin_marker_dft.final = begin_marker_dft.initial;
-    begin_marker_dft.initial = { new_initial };
-    begin_marker_dft.levels.resize(new_initial + 1);
-    begin_marker_dft.levels[new_initial] = 0;
-    return begin_marker_dft;
+    begin_marker_nft.final = begin_marker_nft.initial;
+    begin_marker_nft.initial = { new_initial };
+    begin_marker_nft.levels.resize(new_initial + 1);
+    begin_marker_nft.levels[new_initial] = 0;
+    return begin_marker_nft;
 }
 
 Nft nft::strings::end_marker_dft(const nfa::Nfa& end_marker_dfa, const Symbol end_marker) {

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -320,6 +320,7 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
         };
         case ReplaceMode::Single: {
             const State final{ curr_state };
+            nft_reluctant_leftmost.final.insert(final);
             ++curr_state;
             for (const Symbol symbol: alphabet_symbols) {
                 nft_reluctant_leftmost.delta.add(final, symbol, curr_state);
@@ -329,7 +330,7 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
             }
 
             nft_reluctant_leftmost.delta.add(final, begin_marker, curr_state);
-            nft_reluctant_leftmost.delta.add(curr_state, begin_marker, final);
+            nft_reluctant_leftmost.delta.add(curr_state, EPSILON, final);
             nft_reluctant_leftmost.levels[curr_state] = 1;
             ++curr_state;
             break;
@@ -345,6 +346,3 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
 
     return nft_reluctant_leftmost;
 }
-
-
-

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -112,7 +112,8 @@ Nft mata::nft::strings::replace_reluctant(
     ReplaceMode replace_mode,
     Symbol begin_marker
 ) {
-    Nft dft_begin_marker{ begin_marker_nft(generic_marker_dfa(regex, alphabet), begin_marker) };
+    // TODO(nft): Add optional bool parameter to revert whether to swap initial and final states.
+    Nft dft_begin_marker{ begin_marker_nft(begin_marker_nfa(regex, alphabet), begin_marker) };
     Nft nft_reluctant_replace{
         reluctant_leftmost_nft(std::move(regex), alphabet, begin_marker, replacement, replace_mode) };
 //    return dft_begin_marker.compose(nft_reluctant_replace);
@@ -211,8 +212,8 @@ nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
     return dfa_generic_end_marker;
 }
 
-Nft nft::strings::begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker) {
-    Nft begin_marker_dft{ marker_nft(begin_marker_dfa, begin_marker) };
+Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker) {
+    Nft begin_marker_dft{ marker_nft(marker_dfa, begin_marker) };
     const State new_initial{ begin_marker_dft.add_state() };
     for (const State orig_final: begin_marker_dft.final) {
         begin_marker_dft.delta.add(new_initial, EPSILON, orig_final);

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -226,3 +226,31 @@ Nft nft::strings::begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begi
 Nft nft::strings::end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker) {
     return marker_nft(end_marker_dfa, end_marker);
 }
+
+nfa::Nfa nft::strings::reluctant_nfa_with_marker(nfa::Nfa nfa, const Symbol marker, Alphabet* alphabet) {
+    // Convert to reluctant NFA.
+    nfa = mata::strings::reluctant_nfa(nfa);
+
+    // Add marker self-loops to accept begin markers inside the shortest match.
+    for (State state{ 0 }; state < nfa.num_of_states(); ++state) {
+        nfa.delta.add(state, marker, state);
+    }
+
+    // Intersect with NFA to avoid removing the next begin marker which might be used for the next replace.
+    // TODO(nft): Could be optimised.
+    nfa::Nfa nfa_avoid_removing_next_begin_marker{ 2, { 0 }, { 0 }};
+    StatePost& initial{ nfa_avoid_removing_next_begin_marker.delta.mutable_state_post(0) };
+    const utils::OrdVector<Symbol> alphabet_symbols{ alphabet->get_alphabet_symbols() };
+    for (const Symbol symbol: alphabet_symbols) {
+        initial.push_back({ symbol, 0 });
+    }
+    StatePost& marker_state{ nfa_avoid_removing_next_begin_marker.delta.mutable_state_post(1) };
+    nfa_avoid_removing_next_begin_marker.delta.add(0, marker, 1);
+    for (const Symbol symbol: alphabet_symbols) {
+        marker_state.push_back({ symbol, 0 });
+    }
+    nfa_avoid_removing_next_begin_marker.delta.add(1, marker, 1);
+    // TODO(nft): Leaves a non-terminating begin_marker transitions in a form of a lasso from final states.
+    //  These lassos should be removed to further optimize NFT creation.
+    return mata::strings::reluctant_nfa(reduce(intersection(nfa, nfa_avoid_removing_next_begin_marker)));
+}

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -208,3 +208,10 @@ bool mata::strings::is_lang_eps(const Nfa& aut) {
     }
     return true;
 }
+
+Nfa mata::strings::reluctant_nfa(Nfa nfa) {
+    for (const State final: nfa.final) {
+        nfa.delta.mutable_state_post(final).clear();
+    }
+    return nfa;
+}

--- a/tests/nft/builder.cc
+++ b/tests/nft/builder.cc
@@ -55,6 +55,40 @@ TEST_CASE("nft::create_from_nfa()") {
         expected.levels_cnt = LEVEL_CNT;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
+
+    SECTION("regex cb+a+") {
+        constexpr Level LEVEL_CNT{ 2 };
+        nfa.initial = { 0 };
+        nfa.final = { 3 };
+        nfa.delta.add(0, 'c', 1);
+        nfa.delta.add(1, 'b', 1);
+        nfa.delta.add(1, 'b', 2);
+        nfa.delta.add(2, 'a', 2);
+        nfa.delta.add(2, 'a', 3);
+        nft = builder::create_from_nfa(nfa, LEVEL_CNT);
+        expected = mata::nft::builder::parse_from_mata(
+            std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsCnt 2\nq0 99 q1\nq1 99 q2\nq2 98 q3\nq3 98 q2\nq3 98 q4\nq4 97 q5\nq5 97 q4\nq5 97 q6\n")
+        );
+        expected.levels_cnt = LEVEL_CNT;
+        CHECK(mata::nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("regex cb+a+ with epsilon on added levels") {
+        constexpr Level LEVEL_CNT{ 2 };
+        nfa.initial = { 0 };
+        nfa.final = { 3 };
+        nfa.delta.add(0, 'c', 1);
+        nfa.delta.add(1, 'b', 1);
+        nfa.delta.add(1, 'b', 2);
+        nfa.delta.add(2, 'a', 2);
+        nfa.delta.add(2, 'a', 3);
+        nft = builder::create_from_nfa(nfa, LEVEL_CNT, { EPSILON }, { EPSILON });
+        expected = mata::nft::builder::parse_from_mata(
+            std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsCnt 2\nq0 99 q1\nq1 4294967295 q2\nq2 98 q3\nq3 4294967295 q2\nq3 4294967295 q4\nq4 97 q5\nq5 4294967295 q4\nq5 4294967295 q6\n")
+        );
+        expected.levels_cnt = LEVEL_CNT;
+        CHECK(mata::nft::are_equivalent(nft, expected));
+    }
 }
 
 TEST_CASE("nft::parse_from_mata()") {

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -470,7 +470,7 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
     constexpr Symbol MARKER{ EPSILON - 100 };
 
-    SECTION("'cb+a+' replaced with 'ddd'") {
+    SECTION("all 'cb+a+' replaced with 'ddd'") {
         nft = reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
@@ -478,11 +478,29 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
         CHECK(nft::are_equivalent(nft, expected));
     }
 
-    SECTION("'a+b+c' replaced with '' (empty string)") {
+    SECTION("single 'a+b+c' replaced with '' (empty string)") {
         nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{}, ReplaceMode::Single);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
+    }
+
+    SECTION("All 'a+b+c' replaced with 'd'") {
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{ 'd' }, ReplaceMode::All);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 100 q20\nq20 4294967295 q21\nq21 4294967295 q22\nq22 4294967295 q14\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
     }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -466,16 +466,23 @@ TEST_CASE("mata::nft::strings::reluctant_nfa_with_marker()") {
 
 TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     Nft nft{};
-    nfa::Nfa regex{};
+    Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
     constexpr Symbol MARKER{ EPSILON - 100 };
 
     SECTION("'cb+a+' replaced with 'ddd'") {
-        Nft nft_reluctant_replace{
-            reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All)
-        };
-        nft::Nft expected{ nft::builder::parse_from_mata(std::string(
-            "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n")) };
-        CHECK(nft::are_equivalent(nft_reluctant_replace, expected));
+        nft = reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'a+b+c' replaced with '' (empty string)") {
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{}, ReplaceMode::Single);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
     }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -1,6 +1,5 @@
 // TODO: some header
 
-#include <unordered_set>
 #include <vector>
 #include <fstream>
 
@@ -179,7 +178,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex cb+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa("cb+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("cb+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 0);
         dfa_expected.delta.add(0, 'b', 0);
@@ -250,7 +249,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex ab+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa("ab+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("ab+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 1);
         dfa_expected.delta.add(0, 'b', 0);
@@ -270,7 +269,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
-        dft_expected.final = { 0, 2, 7, 14};
+        dft_expected.final = { 0, 2, 7, 14 };
         dft_expected.levels_cnt = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 2);

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -321,7 +321,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         CHECK(nft::are_equivalent(dft_generic_end_marker, dft_expected));
     }
 
-    SECTION("nft::begin_marker_nft() regex cb+a+") {
+    SECTION("nft::begin_marker_nft() regex a+b+c") {
         nfa::Nfa nfa_begin_marker{ begin_marker_nfa("cb+a+", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(0, 'a', 0);
@@ -381,6 +381,12 @@ TEST_CASE("nft::reluctant_replacement()") {
         nft_expected.levels[10] = 1;
         nft_expected.levels[11] = 1;
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'c' }, Word{ MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'b', 'c' }, Word{ 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'b', 'b', 'c', MARKER, 'a', 'b', 'c' } }));
     }
 
     SECTION("nft::begin_marker_nft() regex ab+a+") {

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -322,7 +322,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::begin_marker_nft() regex a+b+c") {
-        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("cb+a+", &alphabet) };
+        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("a+b+c", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(0, 'a', 0);
         nfa_expected.delta.add(0, 'b', 0);
@@ -396,58 +396,21 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(0, 'b', 0);
         nfa_expected.delta.add(0, 'c', 0);
         nfa_expected.delta.add(1, 'a', 1);
+        nfa_expected.delta.add(1, 'a', 4);
         nfa_expected.delta.add(2, 'b', 1);
         nfa_expected.delta.add(0, 'c', 1);
         nfa_expected.delta.add(3, 'a', 2);
         nfa_expected.delta.add(2, 'b', 2);
         nfa_expected.delta.add(0, 'c', 2);
         nfa_expected.delta.add(4, EPSILON, 3);
-        nfa_expected.delta.add(3, 'a', 4);
         nfa_expected.delta.add(2, 'b', 4);
         nfa_expected.delta.add(0, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
         Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, MARKER) };
-        Nft nft_expected{};
-        nft_expected.initial.insert(0);
-        nft_expected.final.insert(1);
-        nft_expected.levels_cnt = 2;
-        nft_expected.delta.add(0, EPSILON, 1);
-        nft_expected.delta.add(0, EPSILON, 2);
-        nft_expected.delta.add(0, EPSILON, 3);
-        nft_expected.delta.add(0, EPSILON, 5);
-        nft_expected.delta.add(1, 'b', 6);
-        nft_expected.delta.add(6, 'b', 1);
-        nft_expected.delta.add(1, 'c', 7);
-        nft_expected.delta.add(7, 'c', 1);
-        nft_expected.delta.add(7, 'c', 2);
-        nft_expected.delta.add(7, 'c', 3);
-        nft_expected.delta.add(7, 'c', 5);
-        nft_expected.delta.add(2, 'a', 8);
-        nft_expected.delta.add(8, 'a', 2);
-        nft_expected.delta.add(8, 'a', 1);
-        nft_expected.delta.add(3, 'b', 9);
-        nft_expected.delta.add(9, 'b', 3);
-        nft_expected.delta.add(9, 'b', 2);
-        nft_expected.delta.add(9, 'b', 5);
-        nft_expected.delta.add(4, 'a', 10);
-        nft_expected.delta.add(10, 'a', 5);
-        nft_expected.delta.add(10, 'a', 3);
-        nft_expected.delta.add(5, EPSILON, 11);
-        nft_expected.delta.add(11, MARKER, 4);
-        nft_expected.levels.resize(12);
-        nft_expected.levels[0] = 0;
-        nft_expected.levels[1] = 0;
-        nft_expected.levels[2] = 0;
-        nft_expected.levels[3] = 0;
-        nft_expected.levels[4] = 0;
-        nft_expected.levels[5] = 0;
-        nft_expected.levels[6] = 1;
-        nft_expected.levels[7] = 1;
-        nft_expected.levels[8] = 1;
-        nft_expected.levels[9] = 1;
-        nft_expected.levels[10] = 1;
-        nft_expected.levels[11] = 1;
+        Nft nft_expected{ nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q11\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:0 q4:0 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0\n%LevelsCnt 2\nq0 98 q1\nq0 99 q2\nq1 98 q0\nq2 99 q0\nq2 99 q3\nq2 99 q4\nq2 99 q5\nq3 97 q6\nq4 98 q7\nq5 4294967295 q10\nq6 97 q0\nq6 97 q3\nq6 97 q5\nq7 98 q3\nq7 98 q4\nq7 98 q5\nq8 97 q9\nq9 97 q4\nq10 4294967195 q8\nq11 4294967295 q0\nq11 4294967295 q3\nq11 4294967295 q4\nq11 4294967295 q5\n"
+        )) };
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
     }
 }


### PR DESCRIPTION
This PR implements the first part of implementation of reluctant replace operations for string solving. This PR includes implementation of functions to create reluctant NFAs and NFTs which perform the reluctant match of a regex, and reluctant replacement operations (for `replace_re_all()` and `replace_re()` operations), respectively. Furthermore, the PR implements creation of begin marker DFT which precedes the reluctant replace NFT in reluctant replace modelling.