### PR TITLE
Warn about not handling epsilons

### DIFF
--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -468,6 +468,7 @@ StateSet Nfa::post(const StateSet& states, const Symbol& symbol) const {
 
     for (const State state: states) {
         const StatePost& post{ delta[state] };
+        // TODO: This does not handle epsilons.
         const auto move_it{ post.find(symbol) };
         if (move_it != post.end()) {
             res.insert(move_it->targets);


### PR DESCRIPTION
This PR adds a warning that `Nfa::post()` does not handle epsilons. `Nfa::post()` is a relict from VATA, but is still used in `is_in_lang()` and elsewhere.