### PR TITLE
Different handling of jump transition in projection

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -435,9 +435,9 @@ Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
  *
  * @param aut The automaton for projection.
  * @param levels_to_project A non-empty ordered vector of levels to be projected out from the automaton.
- * * @return A new automaton after the projection.
+ * @return A new automaton after the projection.
  */
-Nft project_levels(const Nft& aut, const utils::OrdVector<Level>& levels_to_project);
+Nft project_out(const Nft& aut, const utils::OrdVector<Level>& levels_to_project);
 
 /**
  * @brief Projects out specified level in the given automaton.
@@ -448,7 +448,7 @@ Nft project_levels(const Nft& aut, const utils::OrdVector<Level>& levels_to_proj
  * @param level_to_project A level that is going to be projected out from the automaton.
  * @return A new automaton after the projection.
  */
-Nft project_levels(const Nft& aut, const Level level_to_project);
+Nft project_out(const Nft& aut, const Level level_to_project);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -435,9 +435,11 @@ Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
  *
  * @param aut The automaton for projection.
  * @param levels_to_project A non-empty ordered vector of levels to be projected out from the automaton.
+ * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of DONT_CAREs.
  * @return A new automaton after the projection.
  */
-Nft project_out(const Nft& aut, const utils::OrdVector<Level>& levels_to_project);
+Nft project_out(const Nft& aut, const utils::OrdVector<Level>& levels_to_project, const bool repeat_jump_symbol = true);
 
 /**
  * @brief Projects out specified level in the given automaton.
@@ -446,9 +448,11 @@ Nft project_out(const Nft& aut, const utils::OrdVector<Level>& levels_to_project
  *
  * @param aut The automaton for projection.
  * @param level_to_project A level that is going to be projected out from the automaton.
+ * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of DONT_CAREs.
  * @return A new automaton after the projection.
  */
-Nft project_out(const Nft& aut, const Level level_to_project);
+Nft project_out(const Nft& aut, const Level level_to_project, const bool repeat_jump_symbol = true);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -176,7 +176,7 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
     return result;
 }
 
-Nft mata::nft::project_levels(const Nft& aut, const utils::OrdVector<Level>& levels_to_proj) {
+Nft mata::nft::project_out(const Nft& aut, const utils::OrdVector<Level>& levels_to_proj) {
     assert(!levels_to_proj.empty());
     assert(*std::max_element(levels_to_proj.begin(), levels_to_proj.end()) < aut.levels_cnt);
 
@@ -321,8 +321,8 @@ Nft mata::nft::project_levels(const Nft& aut, const utils::OrdVector<Level>& lev
     return result;
 }
 
-Nft mata::nft::project_levels(const Nft& aut, const Level level_to_project) {
-    return project_levels(aut, utils::OrdVector{ level_to_project });
+Nft mata::nft::project_out(const Nft& aut, const Level level_to_project) {
+    return project_out(aut, utils::OrdVector{ level_to_project });
 }
 
 Nft mata::nft::fragile_revert(const Nft& aut) {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3146,7 +3146,7 @@ TEST_CASE("mata::nft::Nft::add_state()") {
 }
 
 
-TEST_CASE("mata::nft::project_levels()") {
+TEST_CASE("mata::nft::project_out()") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3157,7 +3157,7 @@ TEST_CASE("mata::nft::project_levels()") {
         Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0 = project_levels(atm, { 0 });
+            Nft proj0 = project_out(atm, 0);
             Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_expected.delta.add(0, 1, 1);
             proj0_expected.delta.add(1, 2, 2);
@@ -3166,7 +3166,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 1") {
-            Nft proj1 = project_levels(atm, { 1 });
+            Nft proj1 = project_out(atm, 1);
             Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_expected.delta.add(0, 0, 1);
             proj1_expected.delta.add(1, 2, 2);
@@ -3174,7 +3174,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 2") {
-            Nft proj2 = project_levels(atm, { 2 });
+            Nft proj2 = project_out(atm, 2);
             Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_expected.delta.add(0, 0, 1);
             proj2_expected.delta.add(1, 1, 2);
@@ -3194,7 +3194,7 @@ TEST_CASE("mata::nft::project_levels()") {
         Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_loop = project_levels(atm_loop, { 0 });
+            Nft proj0_loop = project_out(atm_loop, 0);
             Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_loop_expected.delta.add(0, DONT_CARE, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
@@ -3204,7 +3204,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 1") {
-            Nft proj1_loop = project_levels(atm_loop, { 1 });
+            Nft proj1_loop = project_out(atm_loop, 1);
             Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_loop_expected.delta.add(0, 3, 0);
             proj1_loop_expected.delta.add(0, 0, 1);
@@ -3214,7 +3214,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 2") {
-            Nft proj2_loop = project_levels(atm_loop, { 2 });
+            Nft proj2_loop = project_out(atm_loop, 2);
             Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_loop_expected.delta.add(0, 3, 0);
             proj2_loop_expected.delta.add(0, 0, 1);
@@ -3225,7 +3225,7 @@ TEST_CASE("mata::nft::project_levels()") {
 
         SECTION("project 0, 1, 2") {
             Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
-            Nft proj012_empty = project_levels(atm_empty, { 0, 1, 2 });
+            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 });
             CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0)));
         }
     }
@@ -3241,7 +3241,7 @@ TEST_CASE("mata::nft::project_levels()") {
         Nft atm_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_complex = project_levels(atm_complex, { 0 });
+            Nft proj0_complex = project_out(atm_complex, 0);
             Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_complex_expected.delta.add(0, 1, 1);
             proj0_complex_expected.delta.add(0, DONT_CARE, 2);
@@ -3251,7 +3251,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 1") {
-            Nft proj1_complex = project_levels(atm_complex, { 1 });
+            Nft proj1_complex = project_out(atm_complex, 1);
             Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_complex_expected.delta.add(0, 0, 1);
             proj1_complex_expected.delta.add(0, 3, 2);
@@ -3261,7 +3261,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 2") {
-            Nft proj2_complex = project_levels(atm_complex, { 2 });
+            Nft proj2_complex = project_out(atm_complex, 2);
             Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_complex_expected.delta.add(0, 0, 1);
             proj2_complex_expected.delta.add(0, 3, 2);
@@ -3271,7 +3271,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 0, 1") {
-            Nft proj01_complex = project_levels(atm_complex, { 0, 1 });
+            Nft proj01_complex = project_out(atm_complex, { 0, 1 });
             Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj01_complex_expected.delta.add(0, 2, 1);
             proj01_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3280,7 +3280,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 0, 2") {
-            Nft proj02_complex = project_levels(atm_complex, { 0, 2 });
+            Nft proj02_complex = project_out(atm_complex, { 0, 2 });
             Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj02_complex_expected.delta.add(0, 1, 1);
             proj02_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3289,7 +3289,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 1, 2") {
-            Nft proj12_complex = project_levels(atm_complex, { 1, 2 });
+            Nft proj12_complex = project_out(atm_complex, { 1, 2 });
             Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj12_complex_expected.delta.add(0, 0, 1);
             proj12_complex_expected.delta.add(0, 3, 1);
@@ -3298,7 +3298,7 @@ TEST_CASE("mata::nft::project_levels()") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft proj012_complex = project_levels(atm_complex, { 0, 1, 2 });
+            Nft proj012_complex = project_out(atm_complex, { 0, 1, 2 });
             Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
             CHECK(are_equivalent(proj012_complex, proj012_complex_expected));
         }
@@ -3318,7 +3318,7 @@ TEST_CASE("mata::nft::project_levels()") {
         atm_hard.delta.add(6, 8, 7);
         atm_hard.delta.add(7, 9, 2);
 
-        Nft proj_hard = project_levels(atm_hard, { 0, 3, 4, 5 });
+        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 });
 
         Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
         proj_hard_expected.delta.add(0, 0, 2);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3146,7 +3146,195 @@ TEST_CASE("mata::nft::Nft::add_state()") {
 }
 
 
-TEST_CASE("mata::nft::project_out()") {
+TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
+
+    SECTION("LINEAR") {
+        Delta delta;
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+
+        Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("project 0") {
+            Nft proj0 = project_out(atm, 0, false);
+            Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj0_expected.delta.add(0, 1, 1);
+            proj0_expected.delta.add(1, 2, 2);
+            CHECK(are_equivalent(proj0, proj0_expected));
+
+        }
+
+        SECTION("project 1") {
+            Nft proj1 = project_out(atm, 1, false);
+            Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj1_expected.delta.add(0, 0, 1);
+            proj1_expected.delta.add(1, 2, 2);
+            CHECK(are_equivalent(proj1, proj1_expected));
+        }
+
+        SECTION("project 2") {
+            Nft proj2 = project_out(atm, 2, false);
+            Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj2_expected.delta.add(0, 0, 1);
+            proj2_expected.delta.add(1, 1, 2);
+            CHECK(are_equivalent(proj2, proj2_expected));
+
+        }
+    }
+
+    SECTION("LOOP") {
+        Delta delta;
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+        delta.add(0, 3, 0);
+        delta.add(3, 4, 3);
+
+        Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("project 0") {
+            Nft proj0_loop = project_out(atm_loop, 0, false);
+            Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj0_loop_expected.delta.add(0, DONT_CARE, 0);
+            proj0_loop_expected.delta.add(0, 1, 1);
+            proj0_loop_expected.delta.add(1, 2, 2);
+            proj0_loop_expected.delta.add(2, DONT_CARE, 2);
+            CHECK(are_equivalent(proj0_loop, proj0_loop_expected));
+        }
+
+        SECTION("project 1") {
+            Nft proj1_loop = project_out(atm_loop, 1, false);
+            Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj1_loop_expected.delta.add(0, 3, 0);
+            proj1_loop_expected.delta.add(0, 0, 1);
+            proj1_loop_expected.delta.add(1, 2, 2);
+            proj1_loop_expected.delta.add(2, 4, 2);
+            CHECK(are_equivalent(proj1_loop, proj1_loop_expected));
+        }
+
+        SECTION("project 2") {
+            Nft proj2_loop = project_out(atm_loop, 2, false);
+            Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj2_loop_expected.delta.add(0, 3, 0);
+            proj2_loop_expected.delta.add(0, 0, 1);
+            proj2_loop_expected.delta.add(1, 1, 2);
+            proj2_loop_expected.delta.add(2, 4, 2);
+            CHECK(are_equivalent(proj2_loop, proj2_loop_expected));
+        }
+
+        SECTION("project 0, 1, 2") {
+            Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
+            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, false);
+            CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0)));
+        }
+    }
+
+    SECTION("COMPLEX") {
+        Delta delta;
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+        delta.add(0, 3, 3);
+        delta.add(3, 4, 2);
+
+        Nft atm_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("project 0") {
+            Nft proj0_complex = project_out(atm_complex, 0, false);
+            Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj0_complex_expected.delta.add(0, 1, 1);
+            proj0_complex_expected.delta.add(0, DONT_CARE, 2);
+            proj0_complex_expected.delta.add(1, 2, 2);
+            proj0_complex_expected.delta.add(2, DONT_CARE, 1);
+            CHECK(are_equivalent(proj0_complex, proj0_complex_expected));
+        }
+
+        SECTION("project 1") {
+            Nft proj1_complex = project_out(atm_complex, 1, false);
+            Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj1_complex_expected.delta.add(0, 0, 1);
+            proj1_complex_expected.delta.add(0, 3, 2);
+            proj1_complex_expected.delta.add(1, 2, 2);
+            proj1_complex_expected.delta.add(2, 4, 1);
+            CHECK(are_equivalent(proj1_complex, proj1_complex_expected));
+        }
+
+        SECTION("project 2") {
+            Nft proj2_complex = project_out(atm_complex, 2, false);
+            Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            proj2_complex_expected.delta.add(0, 0, 1);
+            proj2_complex_expected.delta.add(0, 3, 2);
+            proj2_complex_expected.delta.add(1, 1, 2);
+            proj2_complex_expected.delta.add(2, 4, 2);
+            CHECK(are_equivalent(proj2_complex, proj2_complex_expected));
+        }
+
+        SECTION("project 0, 1") {
+            Nft proj01_complex = project_out(atm_complex, { 0, 1 }, false);
+            Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            proj01_complex_expected.delta.add(0, 2, 1);
+            proj01_complex_expected.delta.add(0, DONT_CARE, 1);
+            proj01_complex_expected.delta.add(1, 2, 1);
+            CHECK(are_equivalent(proj01_complex, proj01_complex_expected));
+        }
+
+        SECTION("project 0, 2") {
+            Nft proj02_complex = project_out(atm_complex, { 0, 2 }, false);
+            Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            proj02_complex_expected.delta.add(0, 1, 1);
+            proj02_complex_expected.delta.add(0, DONT_CARE, 1);
+            proj02_complex_expected.delta.add(1, DONT_CARE, 1);
+            CHECK(are_equivalent(proj02_complex, proj02_complex_expected));
+        }
+
+        SECTION("project 1, 2") {
+            Nft proj12_complex = project_out(atm_complex, { 1, 2 }, false);
+            Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            proj12_complex_expected.delta.add(0, 0, 1);
+            proj12_complex_expected.delta.add(0, 3, 1);
+            proj12_complex_expected.delta.add(1, 4, 1);
+            CHECK(are_equivalent(proj12_complex, proj12_complex_expected));
+        }
+
+        SECTION("project 0, 1, 2") {
+            Nft proj012_complex = project_out(atm_complex, { 0, 1, 2 }, false);
+            Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
+            CHECK(are_equivalent(proj012_complex, proj012_complex_expected));
+        }
+    }
+
+    SECTION("HARD") {
+        Nft atm_hard(Delta{}, { 0 , 2 }, { 7 }, { 0, 1, 0, 2, 3, 4, 5, 0 }, 6);
+        atm_hard.delta.add(0, 1, 1);
+        atm_hard.delta.add(2, 2, 1);
+        atm_hard.delta.add(2, 3, 2);
+        atm_hard.delta.add(1, 0, 3);
+        atm_hard.delta.add(1, 10, 4);
+        atm_hard.delta.add(3, 4, 4);
+        atm_hard.delta.add(4, 5, 5);
+        atm_hard.delta.add(5, 6, 6);
+        atm_hard.delta.add(6, 7, 0);
+        atm_hard.delta.add(6, 8, 7);
+        atm_hard.delta.add(7, 9, 2);
+
+        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, false);
+
+        Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
+        proj_hard_expected.delta.add(0, 0, 2);
+        proj_hard_expected.delta.add(0, 10, 3);
+        proj_hard_expected.delta.add(1, 0, 2);
+        proj_hard_expected.delta.add(1, 10, 3);
+        proj_hard_expected.delta.add(1, DONT_CARE, 1);
+        proj_hard_expected.delta.add(2, 4, 3);
+        proj_hard_expected.delta.add(3, 10, 3);
+        proj_hard_expected.delta.add(3, 0, 2);
+        proj_hard_expected.delta.add(3, DONT_CARE, 1);
+        CHECK(are_equivalent(proj_hard, proj_hard_expected));
+    }
+}
+
+TEST_CASE("mata::nft::project_out(repeat_jump_symbol = true)") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3196,10 +3384,10 @@ TEST_CASE("mata::nft::project_out()") {
         SECTION("project 0") {
             Nft proj0_loop = project_out(atm_loop, 0);
             Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
-            proj0_loop_expected.delta.add(0, DONT_CARE, 0);
+            proj0_loop_expected.delta.add(0, 3, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
             proj0_loop_expected.delta.add(1, 2, 2);
-            proj0_loop_expected.delta.add(2, DONT_CARE, 2);
+            proj0_loop_expected.delta.add(2, 4, 2);
             CHECK(are_equivalent(proj0_loop, proj0_loop_expected));
         }
 
@@ -3244,9 +3432,9 @@ TEST_CASE("mata::nft::project_out()") {
             Nft proj0_complex = project_out(atm_complex, 0);
             Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_complex_expected.delta.add(0, 1, 1);
-            proj0_complex_expected.delta.add(0, DONT_CARE, 2);
+            proj0_complex_expected.delta.add(0, 3, 2);
             proj0_complex_expected.delta.add(1, 2, 2);
-            proj0_complex_expected.delta.add(2, DONT_CARE, 1);
+            proj0_complex_expected.delta.add(2, 4, 1);
             CHECK(are_equivalent(proj0_complex, proj0_complex_expected));
         }
 
@@ -3274,7 +3462,7 @@ TEST_CASE("mata::nft::project_out()") {
             Nft proj01_complex = project_out(atm_complex, { 0, 1 });
             Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj01_complex_expected.delta.add(0, 2, 1);
-            proj01_complex_expected.delta.add(0, DONT_CARE, 1);
+            proj01_complex_expected.delta.add(0, 3, 1);
             proj01_complex_expected.delta.add(1, 2, 1);
             CHECK(are_equivalent(proj01_complex, proj01_complex_expected));
         }
@@ -3283,8 +3471,8 @@ TEST_CASE("mata::nft::project_out()") {
             Nft proj02_complex = project_out(atm_complex, { 0, 2 });
             Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj02_complex_expected.delta.add(0, 1, 1);
-            proj02_complex_expected.delta.add(0, DONT_CARE, 1);
-            proj02_complex_expected.delta.add(1, DONT_CARE, 1);
+            proj02_complex_expected.delta.add(0, 3, 1);
+            proj02_complex_expected.delta.add(1, 4, 1);
             CHECK(are_equivalent(proj02_complex, proj02_complex_expected));
         }
 
@@ -3325,11 +3513,11 @@ TEST_CASE("mata::nft::project_out()") {
         proj_hard_expected.delta.add(0, 10, 3);
         proj_hard_expected.delta.add(1, 0, 2);
         proj_hard_expected.delta.add(1, 10, 3);
-        proj_hard_expected.delta.add(1, DONT_CARE, 1);
+        proj_hard_expected.delta.add(1, 3, 1);
         proj_hard_expected.delta.add(2, 4, 3);
         proj_hard_expected.delta.add(3, 10, 3);
         proj_hard_expected.delta.add(3, 0, 2);
-        proj_hard_expected.delta.add(3, DONT_CARE, 1);
+        proj_hard_expected.delta.add(3, 9, 1);
         CHECK(are_equivalent(proj_hard, proj_hard_expected));
     }
 }


### PR DESCRIPTION
The projection can interpret jump transition (a transition with the length greater than 1)  in two different ways (based on the parameter `repeat_jump_symbol`):
- as a sequence repeating the same symbol
- as a single instance of the symbol followed by a sequence of DONT_CAREs.