### PR TITLE
Nfa compose

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -107,9 +107,9 @@ public:
      * Inserts a @p word into the NFA from a source state @p src to a target state @p tgt.
      * Creates new states along the path of the @p word.
      *
-     * @param src The source state where the word begins.
-     * @param word The word to be inserted into the NFA.
-     * @param tgt The target state where the word ends.
+     * @param src The source state where the word begins. It must already be a part of the automaton.
+     * @param word The nonempty word to be inserted into the NFA.
+     * @param tgt The target state where the word ends. It must already be a part of the automaton.
      */
     void insert_word(const State src, const Word &word, const State tgt);
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -104,6 +104,16 @@ public:
     State add_state(State state);
 
     /**
+     * Inserts a @p word into the NFA from a source state @p src to a target state @p tgt.
+     * Creates new states along the path of the @p word.
+     *
+     * @param src The source state where the word begins.
+     * @param word The word to be inserted into the NFA.
+     * @param tgt The target state where the word ends.
+     */
+    void insert_word(const State src, const Word &word, const State tgt);
+
+    /**
      * @brief Get the current number of states in the whole automaton.
      *
      * This includes the initial and final states as well as states in the transition relation.

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -99,10 +99,13 @@ Simlib::Util::BinaryRelation compute_relation(
  * @param[out] prod_map Can be used to get the mapping of the pairs of the original states to product states.
  *   Mostly useless, it is only filled in and returned if !=nullptr, but the algorithm internally uses another data structures,
  *   because this one is too slow.
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,
-            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr);
+            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr,
+            const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
 
 /**
  * @brief Concatenate two NFTs.

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -99,8 +99,8 @@ Simlib::Util::BinaryRelation compute_relation(
  * @param[out] prod_map Can be used to get the mapping of the pairs of the original states to product states.
  *   Mostly useless, it is only filled in and returned if !=nullptr, but the algorithm internally uses another data structures,
  *   because this one is too slow.
- * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
- * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states can not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states con not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -91,19 +91,18 @@ Simlib::Util::BinaryRelation compute_relation(
         const ParameterMap&  params = {{ "relation", "simulation"}, { "direction", "forward"}});
 
 /**
- * @brief Compute product of two NFTs, final condition is to be specified, with a possibility of using multiple epsilons.
+ * @brief Compute product of two NFTs, final condition is to be specified.
  *
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
- * @param[in] first_epsilons The smallest epsilon.
  * @param[in] final_condition The predicate that tells whether a pair of states is final (conjunction for intersection).
  * @param[out] prod_map Can be used to get the mapping of the pairs of the original states to product states.
  *   Mostly useless, it is only filled in and returned if !=nullptr, but the algorithm internally uses another data structures,
  *   because this one is too slow.
- * @return NFT as a product of NFTs @p lhs and @p rhs with ε-transitions preserved.
+ * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,
-            const Symbol first_epsilon = EPSILON, std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr);
+            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr);
 
 /**
  * @brief Concatenate two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -149,6 +149,14 @@ public:
     void insert_word_by_parts(const State src, const std::vector<Word> &word_part_on_level, const State tgt);
 
     /**
+    * Inserts an identity transition into the NFT.
+    *
+    * @param state The state where the identity transition will be inserted. This serves as both the source and target state.
+    * @param symbol The symbol used for the identity transition.
+    */
+    void insert_identity(const State state, const Symbol symbol);
+
+    /**
      * @brief Clear the underlying NFT to a blank NFT.
      *
      * The whole NFT is cleared, each member is set to its zero value.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -297,9 +297,43 @@ Nft uni(const Nft &lhs, const Nft &rhs);
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
-Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr);
+Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr,
+                 const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
+
+
+/**
+ * @brief Composes two NFTs.
+ *
+ * Takes two NFTs and their corresponding synchronization levels as input,
+ * and returns a new NFT that represents their composition.
+ *
+ * Vectors of synchronization levels have to be non-empty and of the the same size.
+ *
+ * @param[in] lhs First transducer to compose.
+ * @param[in] rhs Second transducer to compose.
+ * @param[in] lhs_sync_levels Ordered vector of synchronization levels of the @p lhs.
+ * @param[in] rhs_sync_levels Ordered vector of synchronization levels of the @p rhs.
+ * @return A new NFT after the composition.
+ */
+Nft compose(const Nft& lhs, const Nft& rhs, const utils::OrdVector<Level>& lhs_sync_levels, const utils::OrdVector<Level>& rhs_sync_levels);
+
+/**
+ * @brief Composes two NFTs.
+ *
+ * Takes two NFTs and their corresponding synchronization levels as input,
+ * and returns a new NFT that represents their composition.
+ *
+ * @param[in] lhs First transducer to compose.
+ * @param[in] rhs Second transducer to compose.
+ * @param[in] lhs_sync_level The synchronization level of the @p lhs.
+ * @param[in] rhs_sync_level The synchronization level of the @p rhs.
+ * @return A new NFT after the composition.
+ */
+Nft compose(const Nft& lhs, const Nft& rhs, const Level& lhs_sync_level = 1, const Level rhs_sync_level = 0);
 
 /**
  * @brief Concatenate two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -252,19 +252,16 @@ Nft uni(const Nft &lhs, const Nft &rhs);
 /**
  * @brief Compute intersection of two NFTs.
  *
- * Both automata can contain ε-transitions. The product preserves the ε-transitions, i.e.,
- * for each each product state `(s, t)` with`s -ε-> p`, `(s, t) -ε-> (p, t)` is created, and vice versa.
+ * Both automata can contain ε-transitions. Epsilons will be handled a normal symbols.
  *
  * Automata must share alphabets. //TODO: this is not implemented yet.
  *
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
- * @param[in] first_epsilon smallest epsilon. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
- * @return NFT as a product of NFTs @p lhs and @p rhs with ε-transitions preserved.
+ * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
-Nft intersection(const Nft& lhs, const Nft& rhs,
-                 const Symbol first_epsilon = EPSILON, std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr);
+Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr);
 
 /**
  * @brief Concatenate two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -124,6 +124,31 @@ public:
     State add_state_with_level(State state, Level level);
 
     /**
+     * Inserts a @p word into the NFT from a source state @p src to a target state @p tgt.
+     * Creates new states along the path of the @p word.
+     *
+     * @param src The source state where the word begins. It must already be a part of the transducer.
+     * @param word The nonempty word to be inserted into the NFA.
+     * @param tgt The target state where the word ends. It must already be a part of the transducer.
+     */
+    void insert_word(const State src, const Word &word, const State tgt);
+
+    /**
+     * Inserts a word, which is created by interleaving parts from @p word_part_on_level, into the NFT
+     * from a source state @p src to a target state @p tgt, creating new states along its path.
+     *
+     * The length of the inserted word equals @c levels_cnt * the maximum word length in the vector @p word_part_on_level.
+     * At least one Word in @p word_part_on_level must be nonempty.
+     * The vector @p word_part_on_level must have a size equal to @c levels_cnt.
+     * Words shorter than the maximum word length are interpreted as words followed by a sequence of epsilons to match the maximum length.
+     *
+     * @param src The source state where the word begins. This state must already exist in the transducer.
+     * @param word_part_on_level The vector of word parts, with each part corresponding to a different level.
+     * @param tgt The target state where the word ends. This state must already exist in the transducer.
+     */
+    void insert_word_by_parts(const State src, const std::vector<Word> &word_part_on_level, const State tgt);
+
+    /**
      * @brief Clear the underlying NFT to a blank NFT.
      *
      * The whole NFT is cleared, each member is set to its zero value.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -475,9 +475,43 @@ Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project,
  * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
- * @return A new projectedtransducer.
+ * @return A new projected transducer.
  */
 Nft project_to(const Nft& nft, Level level_to_project, bool repeat_jump_symbol = true);
+
+/**
+ * @brief Inserts new levels, as specified by the mask @p new_levels_mask, into the given transducer @p nft.
+ *
+ * @c levels_cnt must be greater than 0.
+ * The vector @c new_levels_mask must be nonempty, its length must be greater than @c levels_cnt,
+ * and it must contain exactly @c levels_cnt occurrences of false.
+ *
+ * @param nft The original transducer.
+ * @param new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
+ *  that one level is inserted before level 0 and two levels are inserted before level 1.
+ * @param default_symbol The default symbol to be used for transitions at the inserted levels.
+ * @param repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
+ *  of @c DONT_CARE symbols.
+ */
+Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol = DONT_CARE, bool repeat_jump_symbol = true);
+
+/**
+ * @brief Inserts a new level @p new_level into the given transducer @p nft.
+ *
+ * @c levels_cnt must be greater than 0.
+ *
+ * @param nft The original transducer.
+ * @param new_level Specifies the new level to be inserted into the transducer.
+ *  If @p new_level is 0, then it is inserted before the 0-th level.
+ *  If @p new_level is less than @c levels_cnt, then it is inserted before the level @c new_level-1.
+ *  If @p new_level is greater than or equal to @c levels_cnt, then all levels from @c levels_cnt through @p new_level are appended after the last level.
+ * @param default_symbol The default symbol to be used for transitions at the inserted levels.
+ * @param repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
+ *  of @c DONT_CARE symbols.
+ */
+Nft insert_level(const Nft& nft, const Level new_level, const Symbol default_symbol = DONT_CARE, bool repeat_jump_symbol = true);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -127,6 +127,10 @@ public:
      * Inserts a @p word into the NFT from a source state @p src to a target state @p tgt.
      * Creates new states along the path of the @p word.
      *
+     * If the length of @p word is less than @c levels_cnt, then the last symbol of @p word
+     * will form a transition going directly from the last inner state to @p tgt. The level
+     * of the state @p tgt must be 0 or greater than the level of the last inner state.
+     *
      * @param src The source state where the word begins. It must already be a part of the transducer.
      * @param word The nonempty word to be inserted into the NFA.
      * @param tgt The target state where the word ends. It must already be a part of the transducer.
@@ -142,9 +146,9 @@ public:
      * The vector @p word_part_on_level must have a size equal to @c levels_cnt.
      * Words shorter than the maximum word length are interpreted as words followed by a sequence of epsilons to match the maximum length.
      *
-     * @param src The source state where the word begins. This state must already exist in the transducer.
+     * @param src The source state where the word begins. This state must already exist in the transducer and must be of a level 0.
      * @param word_part_on_level The vector of word parts, with each part corresponding to a different level.
-     * @param tgt The target state where the word ends. This state must already exist in the transducer.
+     * @param tgt The target state where the word ends. This state must already exist in the transducer and must be of a level 0.
      */
     void insert_word_by_parts(const State src, const std::vector<Word> &word_part_on_level, const State tgt);
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -499,10 +499,10 @@ Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
 /**
  * @brief Projects out specified levels @p levels_to_project in the given transducer @p nft.
  *
- * @param nft The transducer for projection.
- * @param levels_to_project A non-empty ordered vector of levels to be projected out from the transducer. It must
+ * @param[in] nft The transducer for projection.
+ * @param[in] levels_to_project A non-empty ordered vector of levels to be projected out from the transducer. It must
  *  contain only values that are greater than or equal to 0 and smaller than @c levels_cnt.
- * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @p DONT_CARE symbols.
  * @return A new projected transducer.
@@ -512,10 +512,10 @@ Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project
 /**
  * @brief Projects out specified level @p level_to_project in the given transducer @p nft.
  *
- * @param nft The transducer for projection.
- * @param level_to_project A level that is going to be projected out from the transducer. It has to be greater than or
+ * @param[in] nft The transducer for projection.
+ * @param[in] level_to_project A level that is going to be projected out from the transducer. It has to be greater than or
  *  equal to 0 and smaller than @c levels_cnt.
- * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
@@ -525,10 +525,10 @@ Nft project_out(const Nft& nft, Level level_to_project, bool repeat_jump_symbol 
 /**
  * @brief Projects to specified levels @p levels_to_project in the given transducer @p nft.
  *
- * @param nft The transducer for projection.
- * @param levels_to_project A non-empty ordered vector of levels the transducer is going to be projected to.
+ * @param[in] nft The transducer for projection.
+ * @param[in] levels_to_project A non-empty ordered vector of levels the transducer is going to be projected to.
  *  It must contain only values greater than or equal to 0 and smaller than @c levels_cnt.
- * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
@@ -538,10 +538,10 @@ Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project,
 /**
  * @brief Projects to a specified level @p level_to_project in the given transducer @p nft.
  *
- * @param nft The transducer for projection.
- * @param level_to_project A level the transducer is going to be projected to. It has to be greater than or equal to 0
+ * @param[in] nft The transducer for projection.
+ * @param[in] level_to_project A level the transducer is going to be projected to. It has to be greater than or equal to 0
  *  and smaller than @c levels_cnt.
- * @param repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
@@ -555,11 +555,11 @@ Nft project_to(const Nft& nft, Level level_to_project, bool repeat_jump_symbol =
  * The vector @c new_levels_mask must be nonempty, its length must be greater than @c levels_cnt,
  * and it must contain exactly @c levels_cnt occurrences of false.
  *
- * @param nft The original transducer.
- * @param new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
+ * @param[in] nft The original transducer.
+ * @param[in] new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
  *  that one level is inserted before level 0 and two levels are inserted before level 1.
- * @param default_symbol The default symbol to be used for transitions at the inserted levels.
- * @param repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
+ * @param[in] repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
@@ -570,13 +570,13 @@ Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbo
  *
  * @c levels_cnt must be greater than 0.
  *
- * @param nft The original transducer.
- * @param new_level Specifies the new level to be inserted into the transducer.
+ * @param[in] nft The original transducer.
+ * @param[in] new_level Specifies the new level to be inserted into the transducer.
  *  If @p new_level is 0, then it is inserted before the 0-th level.
  *  If @p new_level is less than @c levels_cnt, then it is inserted before the level @c new_level-1.
  *  If @p new_level is greater than or equal to @c levels_cnt, then all levels from @c levels_cnt through @p new_level are appended after the last level.
- * @param default_symbol The default symbol to be used for transitions at the inserted levels.
- * @param repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
+ * @param[in] repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -252,9 +252,10 @@ Nft uni(const Nft &lhs, const Nft &rhs);
 /**
  * @brief Compute intersection of two NFTs.
  *
- * Both automata can contain ε-transitions. Epsilons will be handled a normal symbols.
+ * Both automata can contain ε-transitions. Epsilons will be handled as alphabet symbols.
  *
  * Automata must share alphabets. //TODO: this is not implemented yet.
+ * Transducers must have equal values of @c levels_cnt.
  *
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -67,9 +67,10 @@ inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAut
 /**
  * @brief Compute intersection of two NFTs.
  *
- * Both automata can contain ε-transitions. Epsilons will be handled a normal symbols.
+ * Both automata can contain ε-transitions. Epsilons will be handled as alphabet symbols.
  *
- * Automata must share alphabets. //TODO: this is not implemented yet.
+ * Transducers must share alphabets. //TODO: this is not implemented yet.
+ * Transducers must have equal values of @c levels_cnt.
  *
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -65,23 +65,20 @@ void construct(Nft* result, const ParsedObject& parsed, Alphabet* alphabet = nul
 inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAutomaton = uni(lhs, rhs); }
 
 /**
- * @brief Compute intersection of two NFAs.
+ * @brief Compute intersection of two NFTs.
  *
- * Both automata can contain ε-transitions. The product preserves the ε-transitions, i.e.,
- * for each each product state `(s, t)` with`s -ε-> p`, `(s, t) -ε-> (p, t)` is created, and vice versa.
+ * Both automata can contain ε-transitions. Epsilons will be handled a normal symbols.
  *
- * Automata must share alphabets.
+ * Automata must share alphabets. //TODO: this is not implemented yet.
  *
- * @param[out] res The resulting intersection NFA.
- * @param[in] lhs Input NFA.
- * @param[in] rhs Input NFA.
- * @param[in] first_epsilon smallest epsilon.
+ * @param[in] lhs First NFT to compute intersection for.
+ * @param[in] rhs Second NFT to compute intersection for.
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
- * @return NFA as a product of NFAs @p lhs and @p rhs with ε-transitions preserved.
+ * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
-inline void intersection(Nft* res, const Nft& lhs, const Nft& rhs, Symbol first_epsilon = EPSILON,
+inline void intersection(Nft* res, const Nft& lhs, const Nft& rhs,
                   std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr) {
-    *res = intersection(lhs, rhs, first_epsilon, prod_map);
+    *res = intersection(lhs, rhs, prod_map);
 }
 
 /**

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -75,11 +75,14 @@ inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAut
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
 inline void intersection(Nft* res, const Nft& lhs, const Nft& rhs,
-                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr) {
-    *res = intersection(lhs, rhs, prod_map);
+                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr,
+                  const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state) {
+    *res = intersection(lhs, rhs, prod_map, lhs_first_aux_state, rhs_first_aux_state);
 }
 
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(libmata STATIC
 	nft/inclusion.cc
 	nft/universal.cc
 	nft/complement.cc
+	nft/composition.cc
 	nft/intersection.cc
 	nft/concatenation.cc
 	nft/operations.cc

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -543,14 +543,13 @@ void Nfa::insert_word(const State src, const Word &word, const State tgt) {
     }
 
     // Remember the first state that comes right after src.
-    // The add_state method is not used because it allocates StatePost in delta,
+    // The add method is not used currently because it allocates StatePost in delta,
     // which would prevent the use of the append operation.
-    State first_after_src = num_of_states();
+    State first_state_after_src = num_of_states();
 
     // Append transitions inner_state --> inner_state
-    State inner_state = first_after_src;
-    for (size_t idx{ 1 }; idx < word_len - 1; idx++) {
-        inner_state++;
+    State inner_state = first_state_after_src + 1;
+    for (size_t idx{ 1 }; idx < word_len - 1; idx++, inner_state++) {
         delta.append({StatePost({SymbolPost(word[idx], {inner_state})})});
     }
 
@@ -560,7 +559,7 @@ void Nfa::insert_word(const State src, const Word &word, const State tgt) {
     // Insert transition src --> inner_state.
     // This must be done as the last operation, because the add method allocates StatePost
     // in delta, which would prevent the use of the append operation.
-    delta.add(src, word[0], first_after_src);
+    delta.add(src, word[0], first_state_after_src);
 
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -542,6 +542,12 @@ void Nfa::insert_word(const State src, const Word &word, const State tgt) {
         return;
     }
 
+    // Ensure the size of delta matches the number of states in the transducer.
+    // This allows for further use of the append method.
+    if (delta.num_of_states() < num_of_states()) {
+        delta.allocate(num_of_states());
+    }
+
     // Remember the first state that comes right after src.
     // The add method is not used currently because it allocates StatePost in delta,
     // which would prevent the use of the append operation.

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -531,6 +531,39 @@ State Nfa::add_state(State state) {
     return state;
 }
 
+void Nfa::insert_word(const State src, const Word &word, const State tgt) {
+    assert(!word.empty());
+    assert(src < num_of_states());
+    assert(tgt < num_of_states());
+
+    const size_t word_len = word.size();
+    if (word_len == 1) {
+        delta.add(src, word[0], tgt);
+        return;
+    }
+
+    // Remember the first state that comes right after src.
+    // The add_state method is not used because it allocates StatePost in delta,
+    // which would prevent the use of the append operation.
+    State first_after_src = num_of_states();
+
+    // Append transitions inner_state --> inner_state
+    State inner_state = first_after_src;
+    for (size_t idx{ 1 }; idx < word_len - 1; idx++) {
+        inner_state++;
+        delta.append({StatePost({SymbolPost(word[idx], {inner_state})})});
+    }
+
+    // Append transition inner_state --> tgt
+    delta.append({StatePost({SymbolPost(word[word_len - 1], {tgt})})});
+
+    // Insert transition src --> inner_state.
+    // This must be done as the last operation, because the add method allocates StatePost
+    // in delta, which would prevent the use of the append operation.
+    delta.add(src, word[0], first_after_src);
+
+}
+
 size_t Nfa::num_of_states() const {
     return std::max({
         static_cast<size_t>(initial.domain_size()),

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -1,0 +1,107 @@
+/* composition.cc -- Composition of two NFTs
+ */
+
+// MATA headers
+#include "mata/nft/nft.hh"
+#include <cassert>
+#include <functional>
+
+
+using namespace mata::utils;
+
+
+namespace mata::nft
+{
+
+Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_levels, const OrdVector<Level>& rhs_sync_levels) {
+    assert(!lhs_sync_levels.empty());
+    assert(lhs_sync_levels.size() == rhs_sync_levels.size());
+
+    // Inserts loop into the given Nft for each state with level 0.
+    // The loop word is constructed using the EPSILON symbol for all levels, except for the levels
+    // where is_dcare_on_transition is true, in which case the DONT_CARE symbol is used.
+    auto insert_self_loops = [&](Nft &nft, const BoolVector &is_dcare_on_transition) {
+        Word loop_word(nft.levels_cnt, EPSILON);
+        for (size_t i{ 0 }; i < nft.levels_cnt; i++) {
+            if (is_dcare_on_transition[i]) {
+                loop_word[i] = DONT_CARE;
+            }
+        }
+
+        for (State s{ 0 }; s < nft.num_of_states(); s++) {
+            if (nft.levels[s]== 0) {
+                nft.insert_word(s, loop_word, s);
+            }
+        }
+    };
+
+    // Calculate new_levels_mask, which is used for inserting levels to match the synchronization
+    // transitions in lhs and rhs. It also calculates the vector levels_to_project_out, which contains
+    // levels of synchronized transitions. These levels will be projected out from the Nft after the composition.
+    // Example:
+    // lhs_sync_levels: 1 4
+    // rhs_sync_levels: 2 3
+    // lhs_new_levels_mask: 0 1 0 0 0
+    // rhs_new_levels_mask: 0 0 1 1 0
+    // levels_to_project_out: 2 5
+    Level min_level = std::min(*lhs_sync_levels.begin(), *rhs_sync_levels.begin());
+    size_t lhs_suffix_len = lhs.levels_cnt - 1 - *--lhs_sync_levels.end();
+    size_t rhs_suffix_len = rhs.levels_cnt - 1 - *--rhs_sync_levels.end();
+    size_t biggest_suffix_len = std::max(lhs_suffix_len, rhs_suffix_len);
+    BoolVector lhs_new_levels_mask(min_level, false);
+    BoolVector rhs_new_levels_mask(min_level, false);
+    OrdVector<Level> levels_to_project_out;
+    Level lhs_offset{ 0 };
+    Level rhs_offset{ 0 };
+    Level lhs_lvl{ 0 };
+    Level rhs_lvl{ 0 };
+    for (auto lhs_sync_levels_it{ lhs_sync_levels.begin() }, rhssync_levels_it{ rhs_sync_levels.begin ()};
+         lhs_sync_levels_it != lhs_sync_levels.end();
+         ++lhs_sync_levels_it, ++rhssync_levels_it)
+    {
+        lhs_lvl = *lhs_sync_levels_it + lhs_offset;
+        rhs_lvl = *rhssync_levels_it + rhs_offset;
+        if (lhs_lvl < rhs_lvl) {
+            lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), rhs_lvl - lhs_lvl, true);
+            rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), rhs_lvl - lhs_lvl, false);
+            lhs_offset += rhs_lvl - lhs_lvl ;
+        } else if (lhs_lvl > rhs_lvl) {
+            lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), lhs_lvl - rhs_lvl, false);
+            rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), lhs_lvl - rhs_lvl, true);
+            rhs_offset = lhs_lvl - rhs_lvl;
+        } else {
+            lhs_new_levels_mask.resize(lhs_lvl, false);
+            rhs_new_levels_mask.resize(rhs_lvl, false);
+        }
+        lhs_new_levels_mask.push_back(false);
+        rhs_new_levels_mask.push_back(false);
+        levels_to_project_out.push_back(static_cast<Level>(lhs_new_levels_mask.size() - 1));
+    }
+    // Match the size of vectors and levels_cnt in lhs and rhs after the insertion of new levels.
+    lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), lhs_suffix_len, false);
+    rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), rhs_suffix_len, false);
+    lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), biggest_suffix_len - lhs_suffix_len, true);
+    rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), biggest_suffix_len - rhs_suffix_len, true);
+
+    Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, DONT_CARE, false);
+    Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, DONT_CARE, false);
+
+    // Two auxiliary states (states from inserted loops) can not create a product state.
+    const State lhs_first_aux_state = lhs_synced.num_of_states();
+    const State rhs_first_aux_state = rhs_synced.num_of_states();
+
+    insert_self_loops(lhs_synced, lhs_new_levels_mask);
+    insert_self_loops(rhs_synced, rhs_new_levels_mask);
+
+    Nft result = intersection(lhs_synced, rhs_synced, nullptr, lhs_first_aux_state, rhs_first_aux_state);
+    result = project_out(result, levels_to_project_out, false);
+
+    return result;
+}
+
+Nft compose(const Nft& lhs, const Nft& rhs, const Level& lhs_sync_level, const Level rhs_sync_level) {
+    return compose(lhs, rhs, OrdVector{ lhs_sync_level }, OrdVector{ rhs_sync_level });
+}
+
+} // mata::nft
+

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -4,7 +4,6 @@
 // MATA headers
 #include "mata/nft/nft.hh"
 #include <cassert>
-#include <functional>
 
 
 using namespace mata::utils;

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -300,7 +300,7 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
     const State last_inner_state = num_of_states() - 1;
 
     const Level src_lvl = levels[src];
-    Level lvl = (levels_cnt == 1 ) ? src_lvl : (src_lvl + 1) ;
+    Level lvl = (levels_cnt == 1 ) ? src_lvl : (src_lvl + 1);
     State state{ first_new_state };
     for (; state < num_of_states_after; state++, lvl = (lvl + 1) % levels_cnt){
         add_state_with_level(state, lvl);
@@ -363,19 +363,17 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
     // Append transition inner_state --> inner_state
     State prev_state = first_state_after_src;
     State inner_state = first_state_after_src + 1;
-    Level prev_lvl = 0;
-    Level lvl = 1;
+    Level lvl = (levels_cnt == 1 ) ? 0 : 1;
     for (size_t symbol_idx{ 1 }; symbol_idx < word_total_len - 1; symbol_idx++, inner_state++, lvl = (lvl + 1) % levels_cnt) {
         delta.append({StatePost({SymbolPost(get_next_symbol(lvl), {inner_state})})});
         // The level of the previous state can now be set, because the state is already in delta.
-        add_state_with_level(prev_state, prev_lvl);
-        prev_lvl = lvl;
+        add_state_with_level(prev_state, lvl);
         prev_state = inner_state;
     }
 
     // Append a transition that goes from the last inner state to the tgt and set its level.
     delta.append({StatePost({SymbolPost(get_next_symbol(lvl), {tgt})})});
-    add_state_with_level(prev_state, prev_lvl);
+    add_state_with_level(prev_state, lvl);
 
     // Insert transition src --> inner_state.
     // This must be done as the last operation, because the add method allocates StatePost

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -297,12 +297,16 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
     const State first_new_state = num_of_states();
     Nfa::insert_word(src, word, tgt);
     const size_t num_of_states_after = num_of_states();
+    const State last_inner_state = num_of_states() - 1;
 
-    Level lvl = (levels_cnt == 1 ) ? 0 : 1 ;
+    const Level src_lvl = levels[src];
+    Level lvl = (levels_cnt == 1 ) ? src_lvl : (src_lvl + 1) ;
     State state{ first_new_state };
     for (; state < num_of_states_after; state++, lvl = (lvl + 1) % levels_cnt){
         add_state_with_level(state, lvl);
     }
+
+    assert(levels[tgt] == 0 || levels[last_inner_state] < levels[tgt]);
 }
 
 void Nft::insert_identity(const State state, const Symbol symbol) {
@@ -314,6 +318,8 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
     assert(word_part_on_level.size() == levels_cnt);
     assert(src < num_of_states());
     assert(tgt < num_of_states());
+    assert(levels[src] == 0);
+    assert(levels[tgt] == 0);
 
     if (levels_cnt == 1) {
         Nft::insert_word(src, word_part_on_level[0], tgt);

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -293,6 +293,7 @@ State Nft::add_state_with_level(const State state, const Level level) {
 }
 
 void Nft::insert_word(const State src, const Word &word, const State tgt) {
+    assert(0 < levels_cnt);
     const State first_new_state = num_of_states();
     Nfa::insert_word(src, word, tgt);
     const size_t num_of_states_after = num_of_states();
@@ -304,12 +305,17 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
     }
 }
 
+void Nft::insert_identity(const State state, const Symbol symbol) {
+    insert_word(state, Word(levels_cnt, symbol), state);
+}
+
 void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_part_on_level, const State tgt) {
+    assert(0 < levels_cnt);
     assert(word_part_on_level.size() == levels_cnt);
     assert(src < num_of_states());
     assert(tgt < num_of_states());
 
-    if (word_part_on_level.size() == 1) {
+    if (levels_cnt == 1) {
         Nft::insert_word(src, word_part_on_level[0], tgt);
         return;
     }
@@ -335,6 +341,12 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
         }
         return *(word_part_it_v[lvl]++);
     };
+
+    // Ensure the size of delta matches the number of states in the transducer.
+    // This allows for further use of the append method.
+    if (delta.num_of_states() < num_of_states()) {
+        delta.allocate(num_of_states());
+    }
 
     // Remember the first state and symbol that come right after src.
     // The add method is not used currently because it allocates StatePost in delta,

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -233,8 +233,9 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     Level lvl_sub{ 0 };
     for (Level lvl_old{ 0 }; lvl_old < seq_start_idx; lvl_old++) {
         new_levels[lvl_old] = static_cast<Level>(lvl_old - lvl_sub);
-        if (is_projected_out(lvl_old))
+        if (levels_to_project.find(lvl_old) != levels_to_project.end()) {
             lvl_sub++;
+        }
     }
 
     // cannot use multimap, because it can contain multiple occurrences of (a -> a), (a -> a)
@@ -344,8 +345,12 @@ Nft mata::nft::project_to(const Nft& nft, Level level_to_project, const bool rep
 
 Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol, bool repeat_jump_symbol) {
     assert(0 < nft.levels_cnt);
-    assert(nft.levels_cnt < new_levels_mask.size());
+    assert(nft.levels_cnt <= new_levels_mask.size());
     assert(std::count(new_levels_mask.begin(), new_levels_mask.end(), false) == nft.levels_cnt);
+
+    if (nft.levels_cnt == new_levels_mask.size()) {
+         return Nft(nft);
+    }
 
     // Construct a vector of size equal to levels_cnt. Each index k in this vector represents a new level for the original level k.
     // Note: The 0th index always remains zero.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(tests
 		nft/delta.cc
 		nft/nft.cc
 		nft/builder.cc
+		nft/nft-composition.cc
 		nft/nft-concatenation.cc
 		nft/nft-intersection.cc
 		nft/nft-profiling.cc

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2984,3 +2984,230 @@ TEST_CASE("mata::nfa::Nfa::get_words") {
         CHECK(aut.get_words(5) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}, {0,1,0}, {1,0,1}, {0,1,0,1}, {1,0,1,0}, {0,1,0,1,0}, {1,0,1,0,1}});
     }
 }
+
+TEST_CASE("mata::nfa::Nfa::insert_word()") {
+    Delta delta;
+    delta.add(0, 0, 1);
+    delta.add(0, 4, 0);
+    delta.add(1, 1, 2);
+    delta.add(1, 5, 1);
+    delta.add(2, 2, 3);
+    delta.add(2, 6, 2);
+    delta.add(3, 3, 4);
+    delta.add(3, 7, 3);
+
+    Nfa nfa, expected;
+
+    SECTION("Insert 'a'") {
+        SECTION("src < tgt") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("src < tgt && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("tgt < src") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+
+        }
+
+        SECTION("tgt < src && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+    }
+
+    SECTION("Insert 'ab'") {
+        SECTION("src < tgt") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a', 'b'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("src < tgt && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a', 'b'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("tgt < src") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a', 'b'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+
+        }
+
+        SECTION("tgt < src && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a', 'b'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 5);
+            expected.delta.add(5, 'b', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a', 'b'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a', 'b'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 5);
+            expected.delta.add(5, 'b', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+    }
+
+    SECTION("Insert 'abcd'") {
+        SECTION("src < tgt") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("src < tgt && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(1, {'a', 'b', 'c', 'd'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("tgt < src") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a', 'b', 'c', 'd'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+
+        }
+
+        SECTION("tgt < src && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a', 'b', 'c', 'd'}, 1);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 1);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+
+        SECTION("self-loop && final.contains(tgt)") {
+            nfa = Nfa(delta, { 0 }, { 4 });
+            nfa.insert_word(4, {'a', 'b', 'c', 'd'}, 4);
+
+            expected = Nfa(delta, { 0 }, { 4 });
+            expected.delta.add(4, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 4);
+
+            CHECK(are_equivalent(nfa, expected));
+        }
+    }
+}

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -1,0 +1,422 @@
+/* tests-nft-concatenation.cc -- Tests for concatenation of NFAs
+ */
+
+#include <catch2/catch.hpp>
+
+#include "mata/nft/nft.hh"
+#include "mata/utils/ord-vector.hh"
+
+
+using namespace mata::nft;
+using namespace mata::utils;
+
+
+TEST_CASE("Mata::nft::compose()") {
+
+    Nft lhs, rhs, expected, result;
+    SECTION("levelsl_cnt == 2") {
+
+        SECTION("Linear structure") {
+
+            SECTION("Epsilon free") {
+                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs.delta.add(0, 'e', 1);
+                lhs.delta.add(1, 'a', 2);
+                lhs.delta.add(2, 'g', 3);
+                lhs.delta.add(3, 'b', 4);
+                lhs.delta.add(4, 'i', 5);
+                lhs.delta.add(5, 'c', 6);
+
+                rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                rhs.delta.add(0, 'a', 1);
+                rhs.delta.add(1, 'f', 2);
+                rhs.delta.add(2, 'b', 3);
+                rhs.delta.add(3, 'h', 4);
+                rhs.delta.add(4, 'c', 5);
+                rhs.delta.add(5, 'j', 6);
+
+                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected.delta.add(0, 'e', 1);
+                expected.delta.add(1, 'f', 2);
+                expected.delta.add(2, 'g', 3);
+                expected.delta.add(3, 'h', 4);
+                expected.delta.add(4, 'i', 5);
+                expected.delta.add(5, 'j', 6);
+
+                result = compose(lhs, rhs);
+
+                CHECK(are_equivalent(result, expected));
+            }
+
+            SECTION("Epsilon perfectly matches.") {
+                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs.delta.add(0, 'e', 1);
+                lhs.delta.add(1, 'a', 2);
+                lhs.delta.add(2, 'g', 3);
+                lhs.delta.add(3, EPSILON, 4);
+                lhs.delta.add(4, EPSILON, 5);
+                lhs.delta.add(5, 'c', 6);
+
+                rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                rhs.delta.add(0, 'a', 1);
+                rhs.delta.add(1, EPSILON, 2);
+                rhs.delta.add(2, EPSILON, 3);
+                rhs.delta.add(3, 'h', 4);
+                rhs.delta.add(4, 'c', 5);
+                rhs.delta.add(5, 'j', 6);
+
+                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected.delta.add(0, 'e', 1);
+                expected.delta.add(1, EPSILON, 2);
+                expected.delta.add(2, 'g', 3);
+                expected.delta.add(3, 'h', 4);
+                expected.delta.add(4, EPSILON, 5);
+                expected.delta.add(5, 'j', 6);
+                expected.delta.add(2, EPSILON, 7);
+                expected.delta.add(7, 'h', 8);
+                expected.delta.add(8, 'g', 9);
+                expected.delta.add(9, EPSILON, 4);
+                expected.delta.add(2, 'g', 10);
+                expected.delta.add(10, EPSILON, 11);
+                expected.delta.add(11, EPSILON, 12);
+                expected.delta.add(12, 'h', 4);
+
+                result = compose(lhs, rhs, 1, 0);
+
+                CHECK(are_equivalent(result, expected));
+            }
+        }
+
+        SECTION("Branching") {
+
+            SECTION("Epsilon free") {
+                lhs = Nft(8, { 0 }, { 6, 7 }, { 0, 1, 0, 0, 1, 1, 0, 0 }, 2);
+                lhs.delta.add(0, 'e', 1);
+                lhs.delta.add(1, 'a', 2);
+                lhs.delta.add(2, 'c', 4);
+                lhs.delta.add(4, 'e', 6);
+                lhs.delta.add(1, 'b', 3);
+                lhs.delta.add(3, 'd', 5);
+                lhs.delta.add(5, 'f', 7);
+
+                rhs = Nft(11, { 0 }, { 8, 9, 10 }, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 }, 2);
+                rhs.delta.add(0, 'e', 1);
+                rhs.delta.add(1, 'a', 3);
+                rhs.delta.add(3, 'c', 5);
+                rhs.delta.add(5, 'e', 8);
+                rhs.delta.add(0, 'b', 2);
+                rhs.delta.add(2, 'd', 4);
+                rhs.delta.add(4, 'f', 6);
+                rhs.delta.add(6, 'g', 9);
+                rhs.delta.add(4, 'f', 7);
+                rhs.delta.add(7, 'h', 10);
+
+                expected = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                expected.delta.add(0, 'e', 1);
+                expected.delta.add(1, 'd', 2);
+                expected.delta.add(2, 'd', 3);
+                expected.delta.add(3, 'g', 4);
+                expected.delta.add(3, 'h', 4);
+
+                result = compose(lhs, rhs, OrdVector<Level>{ 1 }, OrdVector<Level>{ 0 });
+
+                CHECK(are_equivalent(result, expected));
+            }
+
+            SECTION("Epsilon perfectly matches.") {
+                lhs = Nft(8, { 0 }, { 6, 7 }, { 0, 1, 0, 0, 1, 1, 0, 0 }, 2);
+                lhs.delta.add(0, 'e', 1);
+                lhs.delta.add(1, 'a', 2);
+                lhs.delta.add(2, 'c', 4);
+                lhs.delta.add(4, EPSILON, 6);
+                lhs.delta.add(1, 'b', 3);
+                lhs.delta.add(3, EPSILON, 5);
+                lhs.delta.add(5, 'f', 7);
+
+                rhs = Nft(11, { 0 }, { 8, 9, 10 }, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 }, 2);
+                rhs.delta.add(0, EPSILON, 1);
+                rhs.delta.add(1, 'a', 3);
+                rhs.delta.add(3, 'c', 5);
+                rhs.delta.add(5, 'e', 8);
+                rhs.delta.add(0, 'b', 2);
+                rhs.delta.add(2, 'd', 4);
+                rhs.delta.add(4, 'f', 6);
+                rhs.delta.add(6, 'g', 9);
+                rhs.delta.add(4, 'f', 7);
+                rhs.delta.add(7, 'h', 10);
+
+                expected = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                expected.delta.add(0, 'e', 1);
+                expected.delta.add(1, 'd', 2);
+                expected.delta.add(2, EPSILON, 3);
+                expected.delta.add(3, 'g', 4);
+                expected.delta.add(3, 'h', 4);
+
+                result = compose(lhs, rhs, OrdVector<Level>{ 1 }, OrdVector<Level>{ 0 });
+
+                CHECK(are_equivalent(result, expected));
+            }
+        }
+
+        SECTION("Cycle") {
+            lhs = Nft(5, { 0 }, { 2, 4 }, { 0, 1, 0, 1, 0 }, 2);
+            lhs.delta.add(0, 'a', 1);
+            lhs.delta.add(1, 'b', 2);
+            lhs.delta.add(2, 'c', 3);
+            lhs.delta.add(3, 'e', 4);
+            lhs.delta.add(3, 'd', 2);
+
+            rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+            rhs.delta.add(0, 'b', 1);
+            rhs.delta.add(1, 'x', 2);
+            rhs.delta.add(2, 'd', 3);
+            rhs.delta.add(3, 'y', 4);
+            rhs.delta.add(4, 'f', 4);
+            rhs.delta.add(4, 'd', 5);
+            rhs.delta.add(5, 'z', 6);
+
+            expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'x', 2);
+            expected.delta.add(2, 'c', 3);
+            expected.delta.add(3, 'y', 4);
+            expected.delta.add(4, 'c', 5);
+            expected.delta.add(5, 'z', 6);
+
+            result = compose(lhs, rhs);
+
+            CHECK(are_equivalent(result, expected));
+
+        }
+
+        SECTION("Epsilon does not match on synchronization level.") {
+
+            SECTION("Epsilon only on synchronization levels") {
+                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs.delta.add(0, 'x', 1);
+                lhs.delta.add(1, EPSILON, 2);
+                lhs.delta.add(2, 'y', 3);
+                lhs.delta.add(3, 'a', 4);
+                lhs.delta.add(4, 'x', 5);
+                lhs.delta.add(5, 'c', 6);
+
+                rhs = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                rhs.delta.add(0, 'a', 1);
+                rhs.delta.add(1, 'b', 2);
+                rhs.delta.add(2, 'c', 3);
+                rhs.delta.add(3, 'd', 4);
+
+                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected.delta.add(0, 'x', 1);
+                expected.delta.add(1, EPSILON, 2);
+                expected.delta.add(2, 'y', 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, 'x', 5);
+                expected.delta.add(5, 'd', 6);
+
+                result = compose(lhs, rhs);
+
+                CHECK(are_equivalent(result, expected));
+
+            }
+
+            SECTION("Epsilon is even on non-synchronization levels") {
+                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs.delta.add(0, 'x', 1);
+                lhs.delta.add(1, EPSILON, 2);
+                lhs.delta.add(2, EPSILON, 3);
+                lhs.delta.add(3, 'a', 4);
+                lhs.delta.add(4, 'x', 5);
+                lhs.delta.add(5, EPSILON, 6);
+
+                rhs = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                rhs.delta.add(0, 'a', 1);
+                rhs.delta.add(1, 'b', 2);
+                rhs.delta.add(2, EPSILON, 3);
+                rhs.delta.add(3, 'd', 4);
+
+                expected = Nft(13, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1 }, 2);
+                expected.delta.add(0, 'x', 1);
+                expected.delta.add(1, EPSILON, 2);
+                expected.delta.add(2, EPSILON, 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, 'x', 5);
+                expected.delta.add(4, EPSILON, 10);
+                expected.delta.add(10, 'd', 11);
+                expected.delta.add(11, 'x', 12);
+                expected.delta.add(12, EPSILON, 6);
+                expected.delta.add(4, 'x', 7);
+                expected.delta.add(7, EPSILON, 8);
+                expected.delta.add(8, EPSILON, 9);
+                expected.delta.add(9, 'd', 6);
+                expected.delta.add(5, 'd', 6);
+
+                result = compose(lhs, rhs);
+
+                CHECK(are_equivalent(result, expected));
+            }
+
+        }
+    }
+
+    SECTION("lhs.levels_cnt != rhs.levels_cnt") {
+        SECTION("lhs.levels_cnt > rhs.levels_cnt") {
+            lhs = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            lhs.delta.add(0, 'a', 1);
+            lhs.delta.add(1, 'b', 2);
+            lhs.delta.add(2, 'c', 3);
+            lhs.delta.add(3, 'e', 4);
+            lhs.delta.add(4, 'd', 5);
+
+            rhs = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            rhs.delta.add(0, 'b', 1);
+            rhs.delta.add(1, 'd', 2);
+            rhs.delta.add(2, 'f', 3);
+
+            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(2, 'e', 3);
+            expected.delta.add(3, 'f', 4);
+
+            result = compose(lhs, rhs, { 1, 4 }, { 0, 1 });
+
+            CHECK(are_equivalent(result, expected));
+        }
+
+        SECTION("lhs.levels_cnt < rhs.levels_cnt") {
+            lhs = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            lhs.delta.add(0, 'b', 1);
+            lhs.delta.add(1, 'd', 2);
+            lhs.delta.add(2, 'f', 3);
+
+            rhs = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            rhs.delta.add(0, 'a', 1);
+            rhs.delta.add(1, 'b', 2);
+            rhs.delta.add(2, 'c', 3);
+            rhs.delta.add(3, 'e', 4);
+            rhs.delta.add(4, 'd', 5);
+
+            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(2, 'e', 3);
+            expected.delta.add(3, 'f', 4);
+
+            result = compose(lhs, rhs, { 0, 1 }, { 1, 4 });
+
+            CHECK(are_equivalent(result, expected));
+        }
+    }
+
+    SECTION("levels_cnt == 4") {
+
+        SECTION("Epsilon free") {
+            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs.delta.add(0, 'i', 1);
+            lhs.delta.add(1, 'b', 2);
+            lhs.delta.add(2, 'c', 3);
+            lhs.delta.add(3, 'j', 4);
+            lhs.delta.add(4, 'k', 5);
+            lhs.delta.add(5, 'f', 6);
+            lhs.delta.add(6, 'g', 7);
+            lhs.delta.add(7, 'l', 8);
+
+            rhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs.delta.add(0, 'a', 1);
+            rhs.delta.add(1, 'i', 2);
+            rhs.delta.add(2, 'j', 3);
+            rhs.delta.add(3, 'd', 4);
+            rhs.delta.add(4, 'e', 5);
+            rhs.delta.add(5, 'k', 6);
+            rhs.delta.add(6, 'l', 7);
+            rhs.delta.add(7, 'h', 8);
+
+            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'c', 3);
+            expected.delta.add(3, 'd', 4);
+            expected.delta.add(4, 'e', 5);
+            expected.delta.add(5, 'f', 6);
+            expected.delta.add(6, 'g', 7);
+            expected.delta.add(7, 'h', 8);
+
+            result = compose(lhs, rhs, { 0, 3 }, { 1, 2 });
+
+            CHECK(are_equivalent(result, expected));
+        }
+
+        SECTION("Epsilon perfectly matches") {
+            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs.delta.add(0, 'i', 1);
+            lhs.delta.add(1, 'b', 2);
+            lhs.delta.add(2, 'c', 3);
+            lhs.delta.add(3, EPSILON, 4);
+            lhs.delta.add(4, 'k', 5);
+            lhs.delta.add(5, 'f', 6);
+            lhs.delta.add(6, 'g', 7);
+            lhs.delta.add(7, 'l', 8);
+
+            rhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs.delta.add(0, 'a', 1);
+            rhs.delta.add(1, 'i', 2);
+            rhs.delta.add(2, EPSILON, 3);
+            rhs.delta.add(3, EPSILON, 4);
+            rhs.delta.add(4, 'e', 5);
+            rhs.delta.add(5, 'k', 6);
+            rhs.delta.add(6, 'l', 7);
+            rhs.delta.add(7, 'h', 8);
+
+            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'c', 3);
+            expected.delta.add(3, EPSILON, 4);
+            expected.delta.add(4, 'e', 5);
+            expected.delta.add(5, 'f', 6);
+            expected.delta.add(6, 'g', 7);
+            expected.delta.add(7, 'h', 8);
+
+            result = compose(lhs, rhs, { 0, 3 }, { 1, 2 });
+
+            CHECK(are_equivalent(result, expected));
+        }
+
+        SECTION("Epsilon only on synchronization levels") {
+            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs.delta.add(0, EPSILON, 1);
+            lhs.delta.add(1, 'c', 2);
+            lhs.delta.add(2, 'd', 3);
+            lhs.delta.add(3, EPSILON, 4);
+            lhs.delta.add(4, 'b', 5);
+            lhs.delta.add(5, 'g', 6);
+            lhs.delta.add(6, 'h', 7);
+            lhs.delta.add(7, 'a', 8);
+
+            rhs = Nft(9, { 0 }, { 4, 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs.delta.add(0, 'e', 1);
+            rhs.delta.add(1, 'b', 2);
+            rhs.delta.add(2, 'a', 3);
+            rhs.delta.add(3, 'f', 4);
+            rhs.delta.add(4, 'i', 5);
+            rhs.delta.add(5, 'x', 6);
+            rhs.delta.add(6, 'y', 7);
+            rhs.delta.add(7, 'j', 8);
+
+            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, EPSILON, 1);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(2, 'd', 3);
+            expected.delta.add(3, EPSILON, 4);
+            expected.delta.add(4, 'e', 5);
+            expected.delta.add(5, 'g', 6);
+            expected.delta.add(6, 'h', 7);
+            expected.delta.add(7, 'f', 8);
+
+            result = compose(lhs, rhs, { 0, 3 }, { 1, 2 });
+
+            CHECK(are_equivalent(result, expected));
+        }
+    }
+}

--- a/tests/nft/nft-intersection.cc
+++ b/tests/nft/nft-intersection.cc
@@ -170,7 +170,265 @@ TEST_CASE("mata::nft::intersection()")
         REQUIRE(res.initial[prod_map[{3, 4}]]);
         REQUIRE(res.is_lang_empty());
     }
+
+    Nft expected;
+    SECTION("Intersection of transducers with epsilon transitions.") {
+        SECTION("The intersection results in an empty language.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            a.delta.add(0, EPSILON, 1);
+            a.delta.add(1, 'b', 2);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            b.delta.add(0, 'b', 1);
+            b.delta.add(1, EPSILON, 2);
+
+            res = intersection(a, b);
+
+            CHECK(!res.initial.empty());
+            CHECK(res.final.empty());
+            CHECK(res.is_lang_empty());
+        }
+
+        SECTION("Epsilon is treated as an alphabet symbol.") {
+            a = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 1, 0, 0 }, 2);
+            a.delta.add(0, EPSILON, 1);
+            a.delta.add(0, 'b', 2);
+            a.delta.add(1, 'a', 3);
+            a.delta.add(2, 'a', 4);
+            a.delta.add(4, EPSILON, 4);
+
+            b = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            b.delta.add(0, EPSILON, 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(1, 'a', 3);
+            b.delta.add(1, 'b', 3);
+            b.delta.add(2, 'a', 3);
+
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            expected.delta.add(0, EPSILON, 1);
+            expected.delta.add(0, 'b', 2);
+            expected.delta.add(1, 'a', 3);
+            expected.delta.add(2, 'a', 3);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+    }
+
+    SECTION("Intersection of linear transducers with multiple levels.") {
+        SECTION("Intersection 1") {
+            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'b', 2);
+            a.delta.add(2, 'c', 3);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'b', 2);
+
+            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(3, 'c', 4);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 2") {
+            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a.delta.add(0, 'a', 1);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'b', 2);
+
+            expected = b;
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 3") {
+            a = Nft(4, { 0 }, { 3 }, { 0, 2, 3, 0 }, 5);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'b', 2);
+            a.delta.add(2, 'a', 3);
+
+            b = Nft(5, { 0 }, { 4 }, { 0, 1, 3, 4, 0 }, 5);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'c', 2);
+            b.delta.add(2, 'b', 3);
+            b.delta.add(3, 'a', 4);
+
+            std::unordered_map<std::pair<State, State>, State> prod_map;
+            Nft res = intersection(a, b, &prod_map);
+
+            REQUIRE(!res.initial.empty());
+            REQUIRE(res.final.empty());
+            REQUIRE(res.delta.contains(prod_map[{0, 0}], 'a', prod_map[{1, 1}]));
+            REQUIRE(res.delta.contains(prod_map[{1, 1}], 'c', prod_map[{1, 2}]));
+            REQUIRE(res.delta.contains(prod_map[{1, 2}], 'b', prod_map[{2, 2}]));
+            CHECK(res.is_lang_empty());
+        }
+    }
+
+    SECTION("Intersection of complex transducers with multiple levels and an epsilon transition") {
+        a = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 1, 2, 2, 0, 0, 0 }, 3);
+        a.delta.add(0, 'a', 1);
+        a.delta.add(0, 'b', 2);
+        a.delta.add(0, 'a', 4);
+        a.delta.add(1, 'c', 3);
+        a.delta.add(2, 'a', 4);
+        a.delta.add(2, 'c', 7);
+        a.delta.add(3, 'a', 5);
+        a.delta.add(4, 'b', 6);
+        a.delta.add(5, 'a', 3);
+        a.delta.add(6, EPSILON, 4);
+        a.delta.add(7, 'c', 2);
+
+        b = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 2, 0, 0 }, 3);
+        b.delta.add(0, 'a', 1);
+        b.delta.add(0, 'b', 1);
+        b.delta.add(0, 'a', 3);
+        b.delta.add(1, 'a', 2);
+        b.delta.add(1, 'c', 4);
+        b.delta.add(2, 'b', 4);
+        b.delta.add(3, 'c', 3);
+        b.delta.add(4, EPSILON, 4);
+
+        expected = Nft(12, { 0 }, { 4, 5, 9, 11 }, { 0, 1, 1, 2, 0, 0, 2, 1, 2, 0, 2, 0 }, 3);
+        expected.delta.add(0, 'b', 1);
+        expected.delta.add(0, 'a', 2);
+        expected.delta.add(0, 'a', 7);
+        expected.delta.add(0, 'a', 10);
+        expected.delta.add(1, 'a', 3);
+        expected.delta.add(1, 'c', 4);
+        expected.delta.add(2, 'a', 3);
+        expected.delta.add(2, 'c', 6);
+        expected.delta.add(3, 'b', 5);
+        expected.delta.add(5, EPSILON, 6);
+        expected.delta.add(6, 'b', 5);
+        expected.delta.add(7, 'c', 8);
+        expected.delta.add(8, 'a', 9);
+        expected.delta.add(10, 'b', 11);
+
+        res = intersection(a, b);
+
+        CHECK(are_equivalent(res, expected));
+    }
+
+    SECTION("Intersection of transducers with the DONT_CARE symbol") {
+        SECTION("DONT_CARE is in the lhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, DONT_CARE, 1);
+            a.delta.add(1, 'c', 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(0, 'a', 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(0, 'b', 2);
+            expected.delta.add(0, 'a', 3);
+            expected.delta.add(1, 'c', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'e', 6);
+            expected.delta.add(4, 'c', 7);
+            expected.delta.add(5, 'c', 8);
+            expected.delta.add(6, 'c', 9);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in the rhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'c', 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, DONT_CARE, 1);
+            b.delta.add(0, DONT_CARE, 2);
+            b.delta.add(0, DONT_CARE, 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(1, 'd', 3);
+            expected.delta.add(1, 'e', 4);
+            expected.delta.add(2, 'c', 5);
+            expected.delta.add(3, 'c', 6);
+            expected.delta.add(4, 'c', 7);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a higher level than it is in rhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, DONT_CARE, 1);
+            a.delta.add(1, DONT_CARE, 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, DONT_CARE, 1);
+            b.delta.add(0, DONT_CARE, 2);
+            b.delta.add(0, DONT_CARE, 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, DONT_CARE, 1);
+            expected.delta.add(0, DONT_CARE, 2);
+            expected.delta.add(0, DONT_CARE, 3);
+            expected.delta.add(1, 'c', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'e', 6);
+            expected.delta.add(4, DONT_CARE, 7);
+            expected.delta.add(5, DONT_CARE, 8);
+            expected.delta.add(6, DONT_CARE, 9);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in the rhs at a higher level than it is in the lhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 3);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, DONT_CARE, 2);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, DONT_CARE, 2);
+
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, DONT_CARE, 2);
+            expected.delta.add(2, DONT_CARE, 3);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+    }
 } // }}}
+
 
 TEST_CASE("mata::nft::intersection() for profiling", "[.profiling],[intersection]")
 {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4426,10 +4426,10 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
 
 TEST_CASE("mata::nft::Nft::insert_identity()") {
     Nft nft, expected;
-    SECTION("Creating an identity on two states (both initial and final) with empty delta and empty vector levels.") {
+    SECTION("Creating an identity on two states (both initial and final) with empty delta.") {
         Delta delta{};
         SECTION("levels_cnt == 1") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 1);
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
 
@@ -4441,7 +4441,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         }
 
         SECTION("levels_cnt == 2") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 2);
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
 
@@ -4455,7 +4455,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         }
 
         SECTION("levels_cnt == 4") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 4);
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3657,3 +3657,612 @@ TEST_CASE("mata::nft::project_to()") {
         CHECK(nft::are_equivalent(projection, expected));
     }
 }
+
+TEST_CASE("nft::insert_level() and nft::insert_levels()") {
+    Delta delta;
+    Nft input_nft, output_nft, expected_nft;
+
+    SECTION("Linear - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, DONT_CARE, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, DONT_CARE, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 4") {
+            output_nft = insert_level(input_nft, 4, DONT_CARE, false);
+            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 4);
+            expected_nft.delta.add(4, DONT_CARE, 5);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 100011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, DONT_CARE, 5);
+            expected_nft.delta.add(5, DONT_CARE, 6);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("Linear - default_symbol = DONT_CARE, repeat_jump_symbol = true") {
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, DONT_CARE, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, DONT_CARE, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 4") {
+            output_nft = insert_level(input_nft, 4);
+            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 4);
+            expected_nft.delta.add(4, DONT_CARE, 5);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 100011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 });
+            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, DONT_CARE, 5);
+            expected_nft.delta.add(5, DONT_CARE, 6);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("Linear - default_symbol = 42, repeat_jump_symbol = false") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0, 42);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 42, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1, 42);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 42, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2, 42);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 42, 3);
+            expected_nft.delta.add(3, 2, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3, 42);
+            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, 42, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 4") {
+            output_nft = insert_level(input_nft, 4, 42);
+            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, 42, 4);
+            expected_nft.delta.add(4, 42, 5);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 100011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, 42);
+            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
+            expected_nft.delta.add(0, 42, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 42, 5);
+            expected_nft.delta.add(5, 42, 6);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("loop - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+        delta.clear();
+        delta.add(0, 4, 0);
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+        delta.add(3, 5, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1 }, 4);
+            expected_nft.delta.add(0, DONT_CARE, 5);
+            expected_nft.delta.add(5, 4, 0);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, DONT_CARE, 6);
+            expected_nft.delta.add(6, 5, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
+            expected_nft.delta.add(0, 4, 5);
+            expected_nft.delta.add(5, DONT_CARE, 7);
+            expected_nft.delta.add(7, DONT_CARE, 8);
+            expected_nft.delta.add(8, DONT_CARE, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, DONT_CARE, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 5, 6);
+            expected_nft.delta.add(6, DONT_CARE, 9);
+            expected_nft.delta.add(9, DONT_CARE, 10);
+            expected_nft.delta.add(10, DONT_CARE, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            expected_nft = Nft(9, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 2, 3, 2, 3 }, 4);
+            expected_nft.delta.add(0, 4, 7);
+            expected_nft.delta.add(7, DONT_CARE, 8);
+            expected_nft.delta.add(8, DONT_CARE, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, DONT_CARE, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 5, 5);
+            expected_nft.delta.add(5, DONT_CARE, 6);
+            expected_nft.delta.add(6, DONT_CARE, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3 }, 4);
+            expected_nft.delta.add(0, 4, 5);
+            expected_nft.delta.add(5, DONT_CARE, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 4);
+            expected_nft.delta.add(4, 5, 6);
+            expected_nft.delta.add(6, DONT_CARE, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 1010011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, false);
+            expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
+            expected_nft.delta.add(0, DONT_CARE, 8);
+            expected_nft.delta.add(8, 4, 9);
+            expected_nft.delta.add(9, DONT_CARE, 10);
+            expected_nft.delta.add(10, DONT_CARE, 11);
+            expected_nft.delta.add(11, DONT_CARE, 12);
+            expected_nft.delta.add(12, DONT_CARE, 13);
+            expected_nft.delta.add(13, DONT_CARE, 0);
+            expected_nft.delta.add(0, DONT_CARE, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, DONT_CARE, 3);
+            expected_nft.delta.add(3, 1, 4);
+            expected_nft.delta.add(4, 2, 5);
+            expected_nft.delta.add(5, DONT_CARE, 6);
+            expected_nft.delta.add(6, DONT_CARE, 7);
+            expected_nft.delta.add(7, DONT_CARE, 14);
+            expected_nft.delta.add(14, 5, 15);
+            expected_nft.delta.add(15, DONT_CARE, 16);
+            expected_nft.delta.add(16, DONT_CARE, 17);
+            expected_nft.delta.add(17, DONT_CARE, 18);
+            expected_nft.delta.add(18, DONT_CARE, 19);
+            expected_nft.delta.add(19, DONT_CARE, 7);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("loop - default_symbol = 42, repeat_jump_symbol = true") {
+        delta.clear();
+        delta.add(0, 4, 0);
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 2);
+        delta.add(2, 2, 3);
+        delta.add(3, 5, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0, 42);
+            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3, 1, 1, 2, 2, 3, 3 }, 4);
+            expected_nft.delta.add(0, 42, 5);
+            expected_nft.delta.add(5, 4, 7);
+            expected_nft.delta.add(7, 4, 10);
+            expected_nft.delta.add(10, 4, 0);
+            expected_nft.delta.add(0, 42, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 42, 6);
+            expected_nft.delta.add(6, 5, 8);
+            expected_nft.delta.add(8, 5, 9);
+            expected_nft.delta.add(9, 5, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1, 42);
+            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
+            expected_nft.delta.add(0, 4, 5);
+            expected_nft.delta.add(5, 42, 7);
+            expected_nft.delta.add(7, 4, 8);
+            expected_nft.delta.add(8, 4, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 42, 2);
+            expected_nft.delta.add(2, 1, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 5, 6);
+            expected_nft.delta.add(6, 42, 9);
+            expected_nft.delta.add(9, 5, 10);
+            expected_nft.delta.add(10, 5, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2, 42);
+            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 3, 1, 3, 2, 2 }, 4);
+            expected_nft.delta.add(0, 4, 7);
+            expected_nft.delta.add(7, 4, 10);
+            expected_nft.delta.add(10, 42, 8);
+            expected_nft.delta.add(8, 4, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 42, 3);
+            expected_nft.delta.add(3, 2, 4);
+            expected_nft.delta.add(4, 5, 5);
+            expected_nft.delta.add(5, 5, 9);
+            expected_nft.delta.add(9, 42, 6);
+            expected_nft.delta.add(6, 5, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3, 42);
+            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 2, 3, 1, 2, 3 }, 4);
+            expected_nft.delta.add(0, 4, 5);
+            expected_nft.delta.add(5, 4, 6);
+            expected_nft.delta.add(6, 4, 7);
+            expected_nft.delta.add(7, 42, 0);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, 42, 4);
+            expected_nft.delta.add(4, 5, 8);
+            expected_nft.delta.add(8, 5, 9);
+            expected_nft.delta.add(9, 5, 10);
+            expected_nft.delta.add(10, 42, 4);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 1010011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42);
+            expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
+            expected_nft.delta.add(0, 42, 8);
+            expected_nft.delta.add(8, 4, 9);
+            expected_nft.delta.add(9, 42, 10);
+            expected_nft.delta.add(10, 4, 11);
+            expected_nft.delta.add(11, 4, 12);
+            expected_nft.delta.add(12, 42, 13);
+            expected_nft.delta.add(13, 42, 0);
+            expected_nft.delta.add(0, 42, 1);
+            expected_nft.delta.add(1, 0, 2);
+            expected_nft.delta.add(2, 42, 3);
+            expected_nft.delta.add(3, 1, 4);
+            expected_nft.delta.add(4, 2, 5);
+            expected_nft.delta.add(5, 42, 6);
+            expected_nft.delta.add(6, 42, 7);
+            expected_nft.delta.add(7, 42, 14);
+            expected_nft.delta.add(14, 5, 15);
+            expected_nft.delta.add(15, 42, 16);
+            expected_nft.delta.add(16, 5, 17);
+            expected_nft.delta.add(17, 5, 18);
+            expected_nft.delta.add(18, 42, 19);
+            expected_nft.delta.add(19, 42, 7);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("complex - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(0, 4, 2);
+        delta.add(1, 1, 2);
+        delta.add(1, 5, 3);
+        delta.add(2, 2, 3);
+        delta.add(3, 3, 0);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        SECTION("add level 0") {
+            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 3 }, { 0, 2, 3, 0, 1, 1, 1 }, 4);
+            expected_nft.delta.add(0, DONT_CARE, 4);
+            expected_nft.delta.add(0, DONT_CARE, 5);
+            expected_nft.delta.add(4, 0, 1);
+            expected_nft.delta.add(5, 4, 2);
+            expected_nft.delta.add(1, 5, 3);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, DONT_CARE, 6);
+            expected_nft.delta.add(6, 3, 0);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 1") {
+            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            expected_nft = Nft(8, { 0 }, { 3 }, { 0, 1, 3, 0, 2, 2, 2, 2 }, 4);
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(0, 4, 6);
+            expected_nft.delta.add(1, DONT_CARE, 4);
+            expected_nft.delta.add(1, DONT_CARE, 5);
+            expected_nft.delta.add(4, 1, 2);
+            expected_nft.delta.add(5, 5, 3);
+            expected_nft.delta.add(6, DONT_CARE, 2);
+            expected_nft.delta.add(2, 2, 3);
+            expected_nft.delta.add(3, 3, 7);
+            expected_nft.delta.add(7, DONT_CARE, 0);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 2") {
+            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 2, 3, 2 }, 4 );
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(0, 4, 2);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(1, 5, 4);
+            expected_nft.delta.add(2, DONT_CARE, 5);
+            expected_nft.delta.add(5, 2, 3);
+            expected_nft.delta.add(4, DONT_CARE, 3);
+            expected_nft.delta.add(3, 3, 6);
+            expected_nft.delta.add(6, DONT_CARE, 0);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add level 3") {
+            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 3, 3, 3 }, 4 );
+            expected_nft.delta.add(0, 0, 1);
+            expected_nft.delta.add(0, 4, 2);
+            expected_nft.delta.add(1, 1, 2);
+            expected_nft.delta.add(1, 5, 4);
+            expected_nft.delta.add(2, 2, 5);
+            expected_nft.delta.add(5, DONT_CARE, 3);
+            expected_nft.delta.add(4, DONT_CARE, 3);
+            expected_nft.delta.add(3, 3, 6);
+            expected_nft.delta.add(6, DONT_CARE, 0);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+
+        SECTION("add levels according to the mask 1010011") {
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, false);
+            expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
+            expected_nft.delta.add(0, DONT_CARE, 5);
+            expected_nft.delta.add(5, 0, 1);
+            expected_nft.delta.add(0, DONT_CARE, 4);
+            expected_nft.delta.add(4, 4, 17);
+            expected_nft.delta.add(17, DONT_CARE, 8);
+            expected_nft.delta.add(8, DONT_CARE, 2);
+            expected_nft.delta.add(1, DONT_CARE, 6);
+            expected_nft.delta.add(1, DONT_CARE, 7);
+            expected_nft.delta.add(6, 5, 18);
+            expected_nft.delta.add(18, DONT_CARE, 9);
+            expected_nft.delta.add(9, DONT_CARE, 11);
+            expected_nft.delta.add(11, DONT_CARE, 3);
+            expected_nft.delta.add(7, 1, 2);
+            expected_nft.delta.add(2, 2, 10);
+            expected_nft.delta.add(10, DONT_CARE, 12);
+            expected_nft.delta.add(12, DONT_CARE, 3);
+            expected_nft.delta.add(3, DONT_CARE, 13);
+            expected_nft.delta.add(13, 3, 19);
+            expected_nft.delta.add(19, DONT_CARE, 16);
+            expected_nft.delta.add(16, DONT_CARE, 20);
+            expected_nft.delta.add(20, DONT_CARE, 14);
+            expected_nft.delta.add(14, DONT_CARE, 15);
+            expected_nft.delta.add(15, DONT_CARE, 0);
+            CHECK(are_equivalent(output_nft, expected_nft));
+        }
+    }
+
+    SECTION("Complex - default_symbol = 42, repeat_jump_symbol = false") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(0, 4, 2);
+        delta.add(1, 1, 2);
+        delta.add(1, 5, 3);
+        delta.add(2, 2, 3);
+        delta.add(3, 3, 0);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, false);
+        expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
+        expected_nft.delta.add(0, 42, 5);
+        expected_nft.delta.add(5, 0, 1);
+        expected_nft.delta.add(0, 42, 4);
+        expected_nft.delta.add(4, 4, 17);
+        expected_nft.delta.add(17, 42, 8);
+        expected_nft.delta.add(8, DONT_CARE, 2);
+        expected_nft.delta.add(1, 42, 6);
+        expected_nft.delta.add(1, 42, 7);
+        expected_nft.delta.add(6, 5, 18);
+        expected_nft.delta.add(18, DONT_CARE, 9);
+        expected_nft.delta.add(9, 42, 11);
+        expected_nft.delta.add(11, 42, 3);
+        expected_nft.delta.add(7, 1, 2);
+        expected_nft.delta.add(2, 2, 10);
+        expected_nft.delta.add(10, 42, 12);
+        expected_nft.delta.add(12, 42, 3);
+        expected_nft.delta.add(3, 42, 13);
+        expected_nft.delta.add(13, 3, 19);
+        expected_nft.delta.add(19, 42, 16);
+        expected_nft.delta.add(16, DONT_CARE, 20);
+        expected_nft.delta.add(20, DONT_CARE, 14);
+        expected_nft.delta.add(14, 42, 15);
+        expected_nft.delta.add(15, 42, 0);
+        CHECK(are_equivalent(output_nft, expected_nft));
+    }
+
+    SECTION("Complex - default_symbol = 42, repeat_jump_symbol = true") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(0, 4, 2);
+        delta.add(1, 1, 2);
+        delta.add(1, 5, 3);
+        delta.add(2, 2, 3);
+        delta.add(3, 3, 0);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+
+        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42);
+        expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
+        expected_nft.delta.add(0, 42, 5);
+        expected_nft.delta.add(5, 0, 1);
+        expected_nft.delta.add(0, 42, 4);
+        expected_nft.delta.add(4, 4, 17);
+        expected_nft.delta.add(17, 42, 8);
+        expected_nft.delta.add(8, 4, 2);
+        expected_nft.delta.add(1, 42, 6);
+        expected_nft.delta.add(1, 42, 7);
+        expected_nft.delta.add(6, 5, 18);
+        expected_nft.delta.add(18, 5, 9);
+        expected_nft.delta.add(9, 42, 11);
+        expected_nft.delta.add(11, 42, 3);
+        expected_nft.delta.add(7, 1, 2);
+        expected_nft.delta.add(2, 2, 10);
+        expected_nft.delta.add(10, 42, 12);
+        expected_nft.delta.add(12, 42, 3);
+        expected_nft.delta.add(3, 42, 13);
+        expected_nft.delta.add(13, 3, 19);
+        expected_nft.delta.add(19, 42, 16);
+        expected_nft.delta.add(16, 3, 20);
+        expected_nft.delta.add(20, 3, 14);
+        expected_nft.delta.add(14, 42, 15);
+        expected_nft.delta.add(15, 42, 0);
+        CHECK(are_equivalent(output_nft, expected_nft));
+    }
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4473,7 +4473,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         }
     }
 
-    SECTION("Creating an identity on a state with incoming and oncoming transitions.") {
+    SECTION("Creating an identity on a state with incoming and outcoming transitions.") {
         Delta delta{};
         delta.add(0, 'a', 1);
         delta.add(1, 'b', 2);
@@ -4550,6 +4550,266 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected.delta.add(5, 'c', 2);
 
             CHECK(are_equivalent(nft, expected));
+        }
+    }
+}
+
+TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
+    Nft nft, expected;
+
+    SECTION("Inserting a word between two states (both initial and final) with empty delta.") {
+
+        Delta delta{};
+
+        SECTION("levels_cnt == 1 && word_part.size() == 1") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            nft.insert_word_by_parts(0, { {'a'} } , 1);
+
+            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            expected.delta.add(0, 'a', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 1 && word_part.size() == 2") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            nft.insert_word_by_parts(0, { {'a', 'b'} } , 1);
+
+            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 0 }, 1);
+            expected.delta.add(0, 'a', 2);
+            expected.delta.add(2, 'b', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 1 && word_part.size() == 4") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1  }, { 0, 0, 0, 0, 0 }, 1);
+            nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'} }, 1);
+
+            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 0, 0, 0 }, 1);
+            expected.delta.add(0, 'a', 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(3, 'c', 4);
+            expected.delta.add(4, 'd', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+
+    SECTION("The source sate and target state are in delta.") {
+
+        Delta delta;
+        delta.add(0, 'w', 0);
+        delta.add(0, 'y', 1);
+        delta.add(1, 'x', 1);
+        delta.add(1, 'z', 0);
+        SECTION("levels_cnt == 2") {
+
+            SECTION("word_part.size() == 1") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {'a'}, {'b'} } , 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1 }, 2);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'b', 1);
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 2") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'} } , 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1 }, 2);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'c', 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, 'd', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 4") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1, 0, 1, 0, 1 }, 2);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'e', 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, 'f', 5);
+                expected.delta.add(5, 'c', 6);
+                expected.delta.add(6, 'g', 7);
+                expected.delta.add(7, 'd', 8);
+                expected.delta.add(8, 'h', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+        }
+
+        SECTION("levels_cnt == 4") {
+
+            SECTION("word_part.size() == 1") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {'a'}, {'b'}, {'c'}, {'d'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'b', 3);
+                expected.delta.add(3, 'c', 4);
+                expected.delta.add(4, 'd', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 2") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'c', 3);
+                expected.delta.add(3, 'e', 4);
+                expected.delta.add(4, 'g', 5);
+                expected.delta.add(5, 'b', 6);
+                expected.delta.add(6, 'd', 7);
+                expected.delta.add(7, 'f', 8);
+                expected.delta.add(8, 'h', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 4") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'e', 3);
+                expected.delta.add(3, 'i', 4);
+                expected.delta.add(4, 'm', 5);
+                expected.delta.add(5, 'b', 6);
+                expected.delta.add(6, 'f', 7);
+                expected.delta.add(7, 'j', 8);
+                expected.delta.add(8, 'n', 9);
+                expected.delta.add(9, 'c', 10);
+                expected.delta.add(10, 'g', 11);
+                expected.delta.add(11, 'k', 12);
+                expected.delta.add(12, 'o', 13);
+                expected.delta.add(13, 'd', 14);
+                expected.delta.add(14, 'h', 15);
+                expected.delta.add(15, 'l', 16);
+                expected.delta.add(16, 'p', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+        }
+    }
+
+    SECTION("The lengths of word parts dont have to match.") {
+        Delta delta;
+        delta.add(0, 'w', 0);
+        delta.add(0, 'y', 1);
+        delta.add(1, 'x', 1);
+        delta.add(1, 'z', 0);
+
+        SECTION("levels_cnt == 2") {
+            SECTION("word_part.size() == 1") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {}, {'b'} } , 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1 }, 2);
+                expected.delta.add(0, EPSILON, 2);
+                expected.delta.add(2, 'b', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 2") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {'a', 'b'}, {'c'} } , 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1 }, 2);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'c', 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, EPSILON, 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 4") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1, 0, 1, 0, 1 }, 2);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'e', 3);
+                expected.delta.add(3, 'b', 4);
+                expected.delta.add(4, EPSILON, 5);
+                expected.delta.add(5, 'c', 6);
+                expected.delta.add(6, EPSILON, 7);
+                expected.delta.add(7, 'd', 8);
+                expected.delta.add(8, EPSILON, 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+        }
+
+        SECTION("levels_cnt == 4") {
+            SECTION("word_part.size() == 1") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {'a'}, {}, {'c'}, {} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, EPSILON, 3);
+                expected.delta.add(3, 'c', 4);
+                expected.delta.add(4, EPSILON, 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 2") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {'a'}, {'c', 'd'}, {}, {'g'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, 'a', 2);
+                expected.delta.add(2, 'c', 3);
+                expected.delta.add(3, EPSILON, 4);
+                expected.delta.add(4, 'g', 5);
+                expected.delta.add(5, EPSILON, 6);
+                expected.delta.add(6, 'd', 7);
+                expected.delta.add(7, EPSILON, 8);
+                expected.delta.add(8, EPSILON, 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
+
+            SECTION("word_part.size() == 4") {
+                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft.insert_word_by_parts(0, { {}, {'e', 'f'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
+
+                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected.delta.add(0, EPSILON, 2);
+                expected.delta.add(2, 'e', 3);
+                expected.delta.add(3, 'i', 4);
+                expected.delta.add(4, 'm', 5);
+                expected.delta.add(5, EPSILON, 6);
+                expected.delta.add(6, 'f', 7);
+                expected.delta.add(7, 'j', 8);
+                expected.delta.add(8, 'n', 9);
+                expected.delta.add(9, EPSILON, 10);
+                expected.delta.add(10, EPSILON, 11);
+                expected.delta.add(11, 'k', 12);
+                expected.delta.add(12, 'o', 13);
+                expected.delta.add(13, EPSILON, 14);
+                expected.delta.add(14, EPSILON, 15);
+                expected.delta.add(15, 'l', 16);
+                expected.delta.add(16, 'p', 1);
+
+                CHECK(are_equivalent(nft, expected));
+            }
         }
     }
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4423,3 +4423,133 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
         }
     }
 }
+
+TEST_CASE("mata::nft::Nft::insert_identity()") {
+    Nft nft, expected;
+    SECTION("Creating an identity on two states (both initial and final) with empty delta and empty vector levels.") {
+        Delta delta{};
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 1);
+            nft.insert_identity(0, 'a');
+            nft.insert_identity(1, 'b');
+
+            expected = Nft(2, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            expected.delta.add(0, 'a', 0);
+            expected.delta.add(1, 'b', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 2") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 2);
+            nft.insert_identity(0, 'a');
+            nft.insert_identity(1, 'b');
+
+            expected = Nft(4, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 1 }, 2);
+            expected.delta.add(0, 'a', 2);
+            expected.delta.add(2, 'a', 0);
+            expected.delta.add(1, 'b', 3);
+            expected.delta.add(3, 'b', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 4") {
+            nft = Nft(delta, { 0, 1 }, { 0, 1 }, {}, 4);
+            nft.insert_identity(0, 'a');
+            nft.insert_identity(1, 'b');
+
+            expected = Nft(8, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 1, 2, 2, 3, 3 }, 4);
+            expected.delta.add(0, 'a', 2);
+            expected.delta.add(2, 'a', 4);
+            expected.delta.add(4, 'a', 6);
+            expected.delta.add(6, 'a', 0);
+            expected.delta.add(1, 'b', 3);
+            expected.delta.add(3, 'b', 5);
+            expected.delta.add(5, 'b', 7);
+            expected.delta.add(7, 'b', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+
+    SECTION("Creating an identity on a state with incoming and oncoming transitions.") {
+        Delta delta{};
+        delta.add(0, 'a', 1);
+        delta.add(1, 'b', 2);
+
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+            nft.insert_identity(1, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+            expected.delta.add(1, 'c', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 2") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
+            nft.insert_identity(1, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
+            expected.delta.add(1, 'c', 3);
+            expected.delta.add(3, 'c', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 4") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+            nft.insert_identity(1, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1, 2, 3 }, 4);
+            expected.delta.add(1, 'c', 3);
+            expected.delta.add(3, 'c', 4);
+            expected.delta.add(4, 'c', 5);
+            expected.delta.add(5, 'c', 1);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+
+    SECTION("Creating an identity on a state with only incoming transitions.") {
+        Delta delta{};
+        delta.add(0, 'a', 1);
+        delta.add(1, 'b', 2);
+
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+            nft.insert_identity(2, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+            expected.delta.add(2, 'c', 2);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 2") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
+            nft.insert_identity(2, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
+            expected.delta.add(2, 'c', 3);
+            expected.delta.add(3, 'c', 2);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 4") {
+            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+            nft.insert_identity(2, 'c');
+
+            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1, 2, 3 }, 4);
+            expected.delta.add(2, 'c', 3);
+            expected.delta.add(3, 'c', 4);
+            expected.delta.add(4, 'c', 5);
+            expected.delta.add(5, 'c', 2);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4266,3 +4266,160 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         CHECK(are_equivalent(output_nft, expected_nft));
     }
 }
+
+TEST_CASE("mata::nft::Nft::insert_word()") {
+    Delta delta;
+    delta.add(0, 0, 1);
+    delta.add(0, 4, 0);
+    delta.add(1, 1, 2);
+    delta.add(1, 5, 1);
+    delta.add(2, 2, 3);
+    delta.add(2, 6, 2);
+    delta.add(3, 3, 4);
+    delta.add(3, 7, 3);
+
+    Nft nft, expected;
+
+    SECTION("Insert 'a'") {
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            nft.insert_word(1, {'a'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            expected.delta.add(1, 'a', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            nft.insert_word(1, {'a'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            expected.delta.add(1, 'a', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            nft.insert_word(3, {'a'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            expected.delta.add(3, 'a', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            nft.insert_word(3, {'a'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            expected.delta.add(3, 'a', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+    }
+
+    SECTION("Insert 'ab'") {
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            nft.insert_word(1, {'a', 'b'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0 }, 1);
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            nft.insert_word(1, {'a', 'b'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1 }, 3);
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            nft.insert_word(3, {'a', 'b'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0 }, 1);
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            nft.insert_word(3, {'a', 'b'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1 }, 3);
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+
+    SECTION("Insert 'abcd'") {
+        SECTION("levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
+            nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
+            nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1, 2, 0}, 3);
+            expected.delta.add(1, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 1") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
+            nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+
+        SECTION("self-loop, levels_cnt == 3") {
+            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
+            nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
+
+            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1, 2, 0}, 3);
+            expected.delta.add(3, 'a', 5);
+            expected.delta.add(5, 'b', 6);
+            expected.delta.add(6, 'c', 7);
+            expected.delta.add(7, 'd', 3);
+
+            CHECK(are_equivalent(nft, expected));
+        }
+    }
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3658,7 +3658,7 @@ TEST_CASE("mata::nft::project_to()") {
     }
 }
 
-TEST_CASE("nft::insert_level() and nft::insert_levels()") {
+TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
     Delta delta;
     Nft input_nft, output_nft, expected_nft;
 


### PR DESCRIPTION
This pull request includes:
- Bug fix in the function `nft::project_out()`.
- Methods `Nft::insert_word()`, `Nft::insert_word_by_parts()`, and `Nft::insert_identity()` for inserting a given word (as one word or a vector of its parts, each for a different level) between source and target states (source and target states are equal for the identity).
- Functions `nft::insert_level()` and `nft::insert_levels()` for inserting levels with a `default_symbol` on transitions with newly inserted levels. These functions are utilized in matching levels of synchronization between two transducers.
- Modification of functions `nft::intersection()` and `nft::algorithm::product()` to handle transducers with `EPSILON` and `DONT_CARE` transitions and a set of auxiliary states (two auxiliary states cannot create a product state).
- Function `nft::compose` for computing the composition of two transducers.