### PR TITLE
Implement class `Levels` inheriting from `std::vector<Level>`

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -43,9 +43,9 @@
 namespace mata::nfa {
 
 /**
- * A struct representing an NFA.
+ * A class representing an NFA.
  */
-struct Nfa {
+class Nfa {
 public:
     /**
      * @brief For state q, delta[q] keeps the list of transitions ordered by symbols.
@@ -398,7 +398,7 @@ public:
      * @return True if some new transition (and sink state) was added to the automaton.
      */
     bool make_complete(const Alphabet& alphabet) { return this->make_complete(alphabet, this->num_of_states()); }
-}; // struct Nfa.
+}; // class Nfa.
 
 // Allow variadic number of arguments of the same type.
 //

--- a/include/mata/nfa/types.hh
+++ b/include/mata/nfa/types.hh
@@ -43,7 +43,7 @@ public:
     static const Symbol max_symbol = std::numeric_limits<Symbol>::max();
 };
 
-struct Nfa; ///< A non-deterministic finite automaton.
+class Nfa; ///< A non-deterministic finite automaton.
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = Limits::max_symbol;

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -44,6 +44,15 @@
  */
 namespace mata::nft {
 
+class Levels: public std::vector<Level> {
+    using super = std::vector<Level>;
+public:
+    Levels& set(State state, Level level = DEFAULT_LEVEL);
+    using super::vector;
+    Levels(const std::vector<Level>& levels): super(levels) {}
+    Levels(std::vector<Level>&& levels): super(std::move(levels)) {}
+};
+
 /**
  * A struct representing an NFT.
  */

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -70,7 +70,7 @@ inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAut
  * Both automata can contain ε-transitions. Epsilons will be handled as alphabet symbols.
  *
  * Transducers must share alphabets. //TODO: this is not implemented yet.
- * Transducers must have equal values of @c levels_cnt.
+ * Transducers must have equal values of @c num_of_levels.
  *
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -38,14 +38,14 @@ using ParameterMap = mata::nfa::ParameterMap;
 
 using Limits = mata::nfa::Limits;
 
-struct Nft; ///< A non-deterministic finite automaton.
+class Nft; ///< A non-deterministic finite automaton.
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = mata::nfa::EPSILON;
 constexpr Symbol DONT_CARE = EPSILON - 1;
 
 constexpr Level DEFAULT_LEVEL{ 0 };
-constexpr Level DEFAULT_LEVEL_CNT{ 1 };
+constexpr Level DEFAULT_NUM_OF_LEVELS{ 1 };
 
 } // namespace mata::nfa.
 

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -15,7 +15,6 @@
 #include <cassert>
 #include <unordered_map>
 #include <vector>
-#include <ranges>
 #include <cstdint>
 
 /// macro for debug outputs

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -108,7 +108,7 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
             if (level < 0) {
                 throw std::runtime_error("Bad format of levels: level " + it->second[0] + " is out of range.");
             }
-            aut.levels_cnt = static_cast<Level>(level);
+            aut.num_of_levels = static_cast<Level>(level);
         } catch (const std::invalid_argument &ex) {
             throw std::runtime_error("Bad format of levels: unsupported level " + it->second[0]);
         } catch (const std::out_of_range &ex) {
@@ -299,7 +299,7 @@ Nft builder::create_from_nfa(const mata::nfa::Nfa& nfa, Level level_cnt, const s
     const Level num_of_additional_states_per_nfa_trans{ level_cnt - 1 };
     Nft nft{};
     size_t nfa_num_of_states{ nfa.num_of_states() };
-    nft.levels_cnt = level_cnt;
+    nft.num_of_levels = level_cnt;
     nft.levels.resize(nfa_num_of_states + nfa.delta.num_of_transitions() * num_of_additional_states_per_nfa_trans);
     std::unordered_map<State, State> state_mapping{};
     state_mapping.reserve(nfa_num_of_states);

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -337,9 +337,11 @@ Nft builder::create_from_nfa(const mata::nfa::Nfa& nfa, Level level_cnt, const s
         }
     }
     nft.initial.reserve(nfa.initial.size());
-    std::ranges::for_each(nfa.initial, [&](const State nfa_state){ nft.initial.insert(state_mapping[nfa_state]); });
+    std::for_each(nfa.initial.begin(), nfa.initial.end(),
+                  [&](const State nfa_state) { nft.initial.insert(state_mapping[nfa_state]); });
     nft.final.reserve(nfa.final.size());
-    std::ranges::for_each(nfa.final, [&](const State nfa_state){ nft.final.insert(state_mapping[nfa_state]); });
+    std::for_each(nfa.final.begin(), nfa.final.end(),
+                  [&](const State nfa_state) { nft.final.insert(state_mapping[nfa_state]); });
 
     // TODO(nft): HACK. Levels do not work if the size of delta differs from the size of the vector level.
     nft.levels.resize(nft.delta.num_of_states());

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -20,8 +20,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     // The loop word is constructed using the EPSILON symbol for all levels, except for the levels
     // where is_dcare_on_transition is true, in which case the DONT_CARE symbol is used.
     auto insert_self_loops = [&](Nft &nft, const BoolVector &is_dcare_on_transition) {
-        Word loop_word(nft.levels_cnt, EPSILON);
-        for (size_t i{ 0 }; i < nft.levels_cnt; i++) {
+        Word loop_word(nft.num_of_levels, EPSILON);
+        for (size_t i{ 0 }; i < nft.num_of_levels; i++) {
             if (is_dcare_on_transition[i]) {
                 loop_word[i] = DONT_CARE;
             }
@@ -44,8 +44,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     // rhs_new_levels_mask: 0 0 1 1 0
     // levels_to_project_out: 2 5
     Level min_level = std::min(*lhs_sync_levels.begin(), *rhs_sync_levels.begin());
-    size_t lhs_suffix_len = lhs.levels_cnt - 1 - *--lhs_sync_levels.end();
-    size_t rhs_suffix_len = rhs.levels_cnt - 1 - *--rhs_sync_levels.end();
+    size_t lhs_suffix_len = lhs.num_of_levels - 1 - *--lhs_sync_levels.end();
+    size_t rhs_suffix_len = rhs.num_of_levels - 1 - *--rhs_sync_levels.end();
     size_t biggest_suffix_len = std::max(lhs_suffix_len, rhs_suffix_len);
     BoolVector lhs_new_levels_mask(min_level, false);
     BoolVector rhs_new_levels_mask(min_level, false);
@@ -76,7 +76,7 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
         rhs_new_levels_mask.push_back(false);
         levels_to_project_out.push_back(static_cast<Level>(lhs_new_levels_mask.size() - 1));
     }
-    // Match the size of vectors and levels_cnt in lhs and rhs after the insertion of new levels.
+    // Match the size of vectors and num_of_levels in lhs and rhs after the insertion of new levels.
     lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), lhs_suffix_len, false);
     rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), rhs_suffix_len, false);
     lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), biggest_suffix_len - lhs_suffix_len, true);

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -36,7 +36,7 @@ bool mata::nft::algorithms::is_included_antichains(
     const Alphabet* const  alphabet, //TODO: this parameter is not used
     Run*                   cex)
 { // {{{
-    if (smaller.levels_cnt != bigger.levels_cnt) { return false; }
+    if (smaller.num_of_levels != bigger.num_of_levels) { return false; }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {
@@ -93,7 +93,7 @@ bool mata::nft::is_included(
 
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *alphabet, const ParameterMap& params)
 {
-    if (lhs.levels_cnt != rhs.levels_cnt) { return false; }
+    if (lhs.num_of_levels != rhs.num_of_levels) { return false; }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {

--- a/src/nft/intersection.cc
+++ b/src/nft/intersection.cc
@@ -40,7 +40,7 @@ Nft intersection(const Nft& lhs, const Nft& rhs, ProductMap *prod_map, const Sta
 Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)>&& final_condition, ProductMap *product_map, const State lhs_first_aux_state, const State rhs_first_aux_state) {
 
     Nft product{}; // The product automaton.
-    product.levels_cnt = lhs.levels_cnt;
+    product.num_of_levels = lhs.num_of_levels;
 
     // Set of product states to process.
     std::deque<State> worklist{};
@@ -55,7 +55,7 @@ Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::fu
     const bool large_product = lhs.num_of_states() * rhs.num_of_states() > MAX_PRODUCT_MATRIX_SIZE;
     assert(lhs.num_of_states() < Limits::max_state);
     assert(rhs.num_of_states() < Limits::max_state);
-    assert(lhs.levels_cnt == rhs.levels_cnt);
+    assert(lhs.num_of_levels == rhs.num_of_levels);
 
     //Two variants of storage for the mapping from pairs of lhs and rhs states to product state, for large and non-large products.
     MatrixProductStorage matrix_product_storage;

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -289,8 +289,6 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
     const State first_new_state = num_of_states();
     Nfa::insert_word(src, word, tgt);
     const size_t num_of_states_after = num_of_states();
-    const State last_inner_state = num_of_states() - 1;
-
     const Level src_lvl = levels[src];
     Level lvl = (num_of_levels == 1 ) ? src_lvl : (src_lvl + 1);
     State state{ first_new_state };
@@ -298,7 +296,7 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
         add_state_with_level(state, lvl);
     }
 
-    assert(levels[tgt] == 0 || levels[last_inner_state] < levels[tgt]);
+    assert(levels[tgt] == 0 || levels[num_of_states_after - 1] < levels[tgt]);
 }
 
 void Nft::insert_identity(const State state, const Symbol symbol) {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -160,7 +160,7 @@ void Nft::print_to_mata(std::ostream &output) const {
             }
         }
         output << std::endl;
-        output << "%LevelsCnt " << levels_cnt << std::endl;
+        output << "%LevelsCnt " << num_of_levels << std::endl;
     }
 
     for (const Transition& trans: delta.transitions()) {
@@ -184,10 +184,10 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements)
     auto add_inner_transitions = [&](State src, Symbol symbol, State trg) {
         if (symbol == DONT_CARE && !dcare_for_dcare) {
             for (const Symbol replace_symbol : dcare_replacements) {
-                transitions_to_add.push_back({ src, replace_symbol, trg });
+                transitions_to_add.emplace_back( src, replace_symbol, trg );
             }
         } else {
-            transitions_to_add.push_back({ src, symbol, trg });
+            transitions_to_add.emplace_back( src, symbol, trg );
         }
     };
 
@@ -195,12 +195,12 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements)
     for (const auto &transition : delta.transitions()) {
         src_lvl = levels[transition.source];
         trg_lvl = levels[transition.target];
-        diff_lvl = (trg_lvl == 0) ? (levels_cnt - src_lvl) : trg_lvl - src_lvl;
+        diff_lvl = (trg_lvl == 0) ? (static_cast<Level>(num_of_levels) - src_lvl) : trg_lvl - src_lvl;
 
         if (diff_lvl == 1 && transition.symbol == DONT_CARE && !dcare_for_dcare) {
             transitions_to_del.push_back(transition);
             for (const Symbol replace_symbol : dcare_replacements) {
-                transitions_to_add.push_back({ transition.source, replace_symbol, transition.target });
+                transitions_to_add.emplace_back( transition.source, replace_symbol, transition.target );
             }
         } else if (diff_lvl > 1) {
             transitions_to_del.push_back(transition);
@@ -217,7 +217,7 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements)
             inner_trg_lvl++;
 
             // Iterations 1 to n-1 connecting inner states.
-            Level pre_trg_lvl = (trg_lvl == 0) ? (levels_cnt - 1) : (trg_lvl - 1);
+            Level pre_trg_lvl = (trg_lvl == 0) ? (static_cast<Level>(num_of_levels) - 1) : (trg_lvl - 1);
             for (; inner_src_lvl < pre_trg_lvl; inner_src_lvl++, inner_trg_lvl++) {
                 inner_trg = add_state();
                 levels[inner_trg] = inner_trg_lvl;
@@ -238,62 +238,53 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements)
     }
 }
 
-Nft Nft::get_one_level_aut(const utils::OrdVector<Symbol> &dcare_replacements) const {
+Nft Nft::get_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_replacements) const {
     Nft result{ *this };
-
-    // TODO(nft): Create a class for LEVELS with overloaded getter and setter.
     // HACK. Works only for automata without levels.
     if (result.levels.size() != result.num_of_states()) {
         return result;
     }
-
-    result.make_one_level_aut(dcare_replacements);
+    result.make_one_level_aut(dont_care_symbol_replacements);
     return result;
 }
 
-void Nft::get_one_level_aut(Nft& result, const utils::OrdVector<Symbol> &dcare_replacements) const {
-    result = get_one_level_aut(dcare_replacements);
+void Nft::get_one_level_aut(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements) const {
+    result = get_one_level_aut(dont_care_symbol_replacements);
 }
 
 Nft& Nft::operator=(Nft&& other) noexcept {
     if (this != &other) {
         mata::nfa::Nfa::operator=(other);
         levels = std::move(other.levels);
-        levels_cnt = other.levels_cnt;
+        num_of_levels = other.num_of_levels;
     }
     return *this;
 }
 
 State Nft::add_state() {
-    const size_t required_capacity{ num_of_states() + 1 };
-    if (levels.size() < required_capacity) {
-        levels.resize(required_capacity, DEFAULT_LEVEL);
-    }
-    return mata::nfa::Nfa::add_state();
+    const State state{ Nfa::add_state() };
+    levels.set(state);
+    return state;
 }
 
 State Nft::add_state(const State state) {
-    const size_t required_capacity{ state + 1 };
-    if (levels.size() < required_capacity) {
-        levels.resize(required_capacity, DEFAULT_LEVEL);
-    }
-    return mata::nfa::Nfa::add_state(state);
+    levels.set(state);
+    return Nfa::add_state(state);
 }
 
 State Nft::add_state_with_level(const Level level) {
-    const State state{ add_state() };
-    levels[state] = level;
+    const State state{ Nfa::add_state() };
+    levels.set(state, level);
     return state;
 }
 
 State Nft::add_state_with_level(const State state, const Level level) {
-    add_state(state);
-    levels[state] = level;
-    return state;
+    levels.set(state, level);
+    return Nfa::add_state(state);
 }
 
 void Nft::insert_word(const State src, const Word &word, const State tgt) {
-    assert(0 < levels_cnt);
+    assert(0 < num_of_levels);
 
     const State first_new_state = num_of_states();
     Nfa::insert_word(src, word, tgt);
@@ -301,9 +292,9 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
     const State last_inner_state = num_of_states() - 1;
 
     const Level src_lvl = levels[src];
-    Level lvl = (levels_cnt == 1 ) ? src_lvl : (src_lvl + 1);
+    Level lvl = (num_of_levels == 1 ) ? src_lvl : (src_lvl + 1);
     State state{ first_new_state };
-    for (; state < num_of_states_after; state++, lvl = (lvl + 1) % levels_cnt){
+    for (; state < num_of_states_after; state++, lvl = (lvl + 1) % static_cast<Level>(num_of_levels)){
         add_state_with_level(state, lvl);
     }
 
@@ -311,18 +302,18 @@ void Nft::insert_word(const State src, const Word &word, const State tgt) {
 }
 
 void Nft::insert_identity(const State state, const Symbol symbol) {
-    insert_word(state, Word(levels_cnt, symbol), state);
+    insert_word(state, Word(num_of_levels, symbol), state);
 }
 
 void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_part_on_level, const State tgt) {
-    assert(0 < levels_cnt);
-    assert(word_part_on_level.size() == levels_cnt);
+    assert(0 < num_of_levels);
+    assert(word_part_on_level.size() == num_of_levels);
     assert(src < num_of_states());
     assert(tgt < num_of_states());
     assert(levels[src] == 0);
     assert(levels[tgt] == 0);
 
-    if (levels_cnt == 1) {
+    if (num_of_levels == 1) {
         Nft::insert_word(src, word_part_on_level[0], tgt);
         return;
     }
@@ -333,10 +324,10 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
         [](const Word& a, const Word& b) { return a.size() < b.size(); }
     )->size();
     assert(0 < max_word_part_len);
-    size_t word_total_len = levels_cnt * max_word_part_len;
+    size_t word_total_len = num_of_levels * max_word_part_len;
 
-    std::vector<mata::Word::const_iterator> word_part_it_v(levels_cnt);
-    for (Level lvl{ 0 }; lvl < levels_cnt; lvl++) {
+    std::vector<mata::Word::const_iterator> word_part_it_v(num_of_levels);
+    for (Level lvl{ 0 }; lvl < num_of_levels; lvl++) {
         word_part_it_v[lvl] = word_part_on_level[lvl].begin();
     }
 
@@ -350,7 +341,7 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
     };
 
     // Add transition src --> inner_state.
-    Level inner_lvl = (levels_cnt == 1 ) ? 0 : 1;
+    Level inner_lvl = (num_of_levels == 1 ) ? 0 : 1;
     State inner_state = add_state_with_level(inner_lvl);
     delta.add(src, get_next_symbol(0), inner_state);
 
@@ -358,7 +349,7 @@ void Nft::insert_word_by_parts(const State src, const std::vector<Word> &word_pa
     State prev_state = inner_state;
     Level prev_lvl = inner_lvl;
     for (size_t symbol_idx{ 1 }; symbol_idx < word_total_len - 1; symbol_idx++) {
-        inner_lvl = (prev_lvl + 1) % levels_cnt;
+        inner_lvl = (prev_lvl + 1) % static_cast<Level>(num_of_levels);
         inner_state = add_state_with_level(inner_lvl);
         delta.add(prev_state, get_next_symbol(prev_lvl), inner_state);
         prev_state = inner_state;
@@ -375,5 +366,11 @@ void Nft::clear() {
 }
 
 bool Nft::is_identical(const Nft& aut) const {
-    return levels_cnt == aut.levels_cnt && levels == aut.levels && mata::nfa::Nfa::is_identical(aut);
+    return num_of_levels == aut.num_of_levels && levels == aut.levels && mata::nfa::Nfa::is_identical(aut);
+}
+
+Levels& Levels::set(State state, Level level) {
+    if (size() <= state) { resize(state + 1, DEFAULT_LEVEL); }
+    (*this)[state] = level;
+    return *this;
 }

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -53,7 +53,7 @@ Nft mata::nft::strings::create_identity(mata::Alphabet* alphabet, Level level_cn
     const auto alphabet_symbols{ alphabet->get_alphabet_symbols() };
     const size_t additional_states_per_symbol_num{ level_cnt - 1 };
     const size_t num_of_states{ alphabet_symbols.size() * additional_states_per_symbol_num + 1 };
-    std::vector<Level> levels(num_of_states);
+    Levels levels(num_of_states);
     levels[0] = 0;
     Level level{ 1 };
     for (State state{ 1 }; state < num_of_states; ++state) {

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -4,6 +4,8 @@
 #include "mata/nfa/strings.hh"
 #include "mata/nfa/builder.hh"
 
+#include <optional>
+
 using namespace mata::nfa;
 using namespace mata::strings;
 

--- a/tests/nft/builder.cc
+++ b/tests/nft/builder.cc
@@ -23,7 +23,7 @@ TEST_CASE("nft::create_from_nfa()") {
     Nfa nfa{};
 
     SECTION("small nfa to 2 level NFT") {
-        constexpr Level LEVEL_CNT{ 2 };
+        constexpr Level NUM_OF_LEVELS{ 2 };
         nfa.initial = { 0 };
         nfa.final = { 3 };
         nfa.delta.add(0, 1, 2);
@@ -31,16 +31,16 @@ TEST_CASE("nft::create_from_nfa()") {
         nfa.delta.add(3, 2, 3);
         nfa.delta.add(2, 3, 1);
         nfa.delta.add(2, 3, 0);
-        nft = builder::create_from_nfa(nfa, LEVEL_CNT);
+        nft = builder::create_from_nfa(nfa, NUM_OF_LEVELS);
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q4\n%Levels q0:0 q1:1 q2:0 q3:0 q4:0 q5:1 q6:1\n%LevelsCnt 2\nq0 1 q1\nq1 1 q2\nq2 3 q5\nq3 4294967295 q4\nq4 2 q6\nq5 3 q0\nq5 3 q3\nq6 2 q4\n")
         );
-        expected.levels_cnt = LEVEL_CNT;
+        expected.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 
     SECTION("small nfa to 3 level NFT") {
-        constexpr Level LEVEL_CNT{ 3 };
+        constexpr Level NUM_OF_LEVELS{ 3 };
         nfa.initial = { 0 };
         nfa.final = { 3 };
         nfa.delta.add(0, 1, 2);
@@ -48,11 +48,11 @@ TEST_CASE("nft::create_from_nfa()") {
         nfa.delta.add(3, 2, 3);
         nfa.delta.add(2, 3, 1);
         nfa.delta.add(2, 3, 0);
-        nft = builder::create_from_nfa(nfa, LEVEL_CNT);
+        nft = builder::create_from_nfa(nfa, NUM_OF_LEVELS);
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:2 q3:0 q4:0 q5:0 q6:1 q7:2 q8:1 q9:2\n%LevelsCnt 3\nq0 1 q1\nq1 1 q2\nq2 1 q3\nq3 3 q6\nq4 4294967295 q5\nq5 2 q8\nq6 3 q7\nq7 3 q0\nq7 3 q4\nq8 2 q9\nq9 2 q5\n")
         );
-        expected.levels_cnt = LEVEL_CNT;
+        expected.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 }
@@ -110,19 +110,19 @@ TEST_CASE("nft::parse_from_mata()") {
         nft.delta.add(1, 'b', 40);
         nft.delta.add(51, 'z', 42);
         nft.final = { 3, 103 };
-        nft.levels = std::vector<Level>(nft.num_of_states(), 0);
+        nft.levels = Levels(nft.num_of_states(), 0);
         nft.levels[3] = 42;
         nft.levels[103] = 42;
-        nft.levels_cnt = 43;
+        nft.num_of_levels = 43;
 
         SECTION("from string") {
             Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.levels_cnt == 43);
+            CHECK(parsed.num_of_levels == 43);
 
-            std::vector test_levels(parsed.levels);
+            Levels test_levels(parsed.levels);
             for (const State &s : parsed.final) {
                 CHECK(test_levels[s] == 42);
                 test_levels[s] = 0;
@@ -139,7 +139,7 @@ TEST_CASE("nft::parse_from_mata()") {
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.levels_cnt == 43);
+            CHECK(parsed.num_of_levels == 43);
 
             std::vector test_levels(parsed.levels);
             for (const State &s : parsed.final) {
@@ -162,7 +162,7 @@ TEST_CASE("nft::parse_from_mata()") {
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.levels_cnt == 43);
+            CHECK(parsed.num_of_levels == 43);
 
             std::vector test_levels(parsed.levels);
             for (const State &s : parsed.final) {
@@ -191,14 +191,14 @@ TEST_CASE("nft::parse_from_mata()") {
             nft.initial.insert(0);
             nft.final.insert(10);
             nft.levels = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            nft.levels_cnt = 11;
+            nft.num_of_levels = 11;
 
             SECTION("from string") {
                 Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -220,7 +220,7 @@ TEST_CASE("nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -245,7 +245,7 @@ TEST_CASE("nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -276,14 +276,14 @@ TEST_CASE("nft::parse_from_mata()") {
             nft.initial.insert(0);
             nft.final.insert(10);
             nft.levels = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-            nft.levels_cnt = 11;
+            nft.num_of_levels = 11;
 
             SECTION("from string") {
                 Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {
@@ -305,7 +305,7 @@ TEST_CASE("nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {
@@ -330,7 +330,7 @@ TEST_CASE("nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.levels_cnt == 11);
+                CHECK(parsed.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -259,8 +259,8 @@ TEST_CASE("Mata::nft::compose()") {
         }
     }
 
-    SECTION("lhs.levels_cnt != rhs.levels_cnt") {
-        SECTION("lhs.levels_cnt > rhs.levels_cnt") {
+    SECTION("lhs.num_of_levels != rhs.num_of_levels") {
+        SECTION("lhs.num_of_levels > rhs.num_of_levels") {
             lhs = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
             lhs.delta.add(0, 'a', 1);
             lhs.delta.add(1, 'b', 2);
@@ -284,7 +284,7 @@ TEST_CASE("Mata::nft::compose()") {
             CHECK(are_equivalent(result, expected));
         }
 
-        SECTION("lhs.levels_cnt < rhs.levels_cnt") {
+        SECTION("lhs.num_of_levels < rhs.num_of_levels") {
             lhs = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
             lhs.delta.add(0, 'b', 1);
             lhs.delta.add(1, 'd', 2);
@@ -309,7 +309,7 @@ TEST_CASE("Mata::nft::compose()") {
         }
     }
 
-    SECTION("levels_cnt == 4") {
+    SECTION("num_of_levels == 4") {
 
         SECTION("Epsilon free") {
             lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -30,8 +30,8 @@ using OnTheFlyAlphabet = mata::OnTheFlyAlphabet;
 TEST_CASE("mata::nft::Nft()") {
     Nft nft{};
     nft.levels.resize(3);
-    nft.levels_cnt = 5;
-    CHECK(nft.levels_cnt == 5);
+    nft.num_of_levels = 5;
+    CHECK(nft.num_of_levels == 5);
     CHECK(nft.levels.size() == 3);
     nft.levels[0] = 0;
     nft.levels[1] = 3;
@@ -4281,7 +4281,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     Nft nft, expected;
 
     SECTION("Insert 'a'") {
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
             nft.insert_word(1, {'a'}, 3);
 
@@ -4291,7 +4291,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 3") {
+        SECTION("num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
             nft.insert_word(1, {'a'}, 3);
 
@@ -4301,7 +4301,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 1") {
+        SECTION("self-loop, num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
             nft.insert_word(3, {'a'}, 3);
 
@@ -4311,7 +4311,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 3") {
+        SECTION("self-loop, num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
             nft.insert_word(3, {'a'}, 3);
 
@@ -4324,7 +4324,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     }
 
     SECTION("Insert 'ab'") {
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
             nft.insert_word(1, {'a', 'b'}, 3);
 
@@ -4335,7 +4335,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 3") {
+        SECTION("num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
             nft.insert_word(1, {'a', 'b'}, 3);
 
@@ -4346,7 +4346,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 1") {
+        SECTION("self-loop, num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
             nft.insert_word(3, {'a', 'b'}, 3);
 
@@ -4357,7 +4357,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 3") {
+        SECTION("self-loop, num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
             nft.insert_word(3, {'a', 'b'}, 3);
 
@@ -4370,7 +4370,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     }
 
     SECTION("Insert 'abcd'") {
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
             nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
 
@@ -4383,7 +4383,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 3") {
+        SECTION("num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
             nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
 
@@ -4396,7 +4396,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 1") {
+        SECTION("self-loop, num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
             nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
 
@@ -4409,7 +4409,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, levels_cnt == 3") {
+        SECTION("self-loop, num_of_levels == 3") {
             nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
             nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
 
@@ -4428,7 +4428,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
     Nft nft, expected;
     SECTION("Creating an identity on two states (both initial and final) with empty delta.") {
         Delta delta{};
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
@@ -4440,7 +4440,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 2") {
+        SECTION("num_of_levels == 2") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
@@ -4454,7 +4454,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 4") {
+        SECTION("num_of_levels == 4") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
@@ -4478,7 +4478,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         delta.add(0, 'a', 1);
         delta.add(1, 'b', 2);
 
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
             nft.insert_identity(1, 'c');
 
@@ -4488,7 +4488,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 2") {
+        SECTION("num_of_levels == 2") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
             nft.insert_identity(1, 'c');
 
@@ -4499,7 +4499,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 4") {
+        SECTION("num_of_levels == 4") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
             nft.insert_identity(1, 'c');
 
@@ -4518,7 +4518,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         delta.add(0, 'a', 1);
         delta.add(1, 'b', 2);
 
-        SECTION("levels_cnt == 1") {
+        SECTION("num_of_levels == 1") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
             nft.insert_identity(2, 'c');
 
@@ -4528,7 +4528,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 2") {
+        SECTION("num_of_levels == 2") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
             nft.insert_identity(2, 'c');
 
@@ -4539,7 +4539,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 4") {
+        SECTION("num_of_levels == 4") {
             nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
             nft.insert_identity(2, 'c');
 
@@ -4561,7 +4561,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
         Delta delta{};
 
-        SECTION("levels_cnt == 1 && word_part.size() == 1") {
+        SECTION("num_of_levels == 1 && word_part.size() == 1") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
             nft.insert_word_by_parts(0, { {'a'} } , 1);
 
@@ -4571,7 +4571,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 1 && word_part.size() == 2") {
+        SECTION("num_of_levels == 1 && word_part.size() == 2") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
             nft.insert_word_by_parts(0, { {'a', 'b'} } , 1);
 
@@ -4582,7 +4582,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("levels_cnt == 1 && word_part.size() == 4") {
+        SECTION("num_of_levels == 1 && word_part.size() == 4") {
             nft = Nft(delta, { 0, 1 }, { 0, 1  }, { 0, 0, 0, 0, 0 }, 1);
             nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'} }, 1);
 
@@ -4603,7 +4603,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         delta.add(0, 'y', 1);
         delta.add(1, 'x', 1);
         delta.add(1, 'z', 0);
-        SECTION("levels_cnt == 2") {
+        SECTION("num_of_levels == 2") {
 
             SECTION("word_part.size() == 1") {
                 nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
@@ -4646,7 +4646,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
         }
 
-        SECTION("levels_cnt == 4") {
+        SECTION("num_of_levels == 4") {
 
             SECTION("word_part.size() == 1") {
                 nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
@@ -4712,7 +4712,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         delta.add(1, 'x', 1);
         delta.add(1, 'z', 0);
 
-        SECTION("levels_cnt == 2") {
+        SECTION("num_of_levels == 2") {
             SECTION("word_part.size() == 1") {
                 nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
                 nft.insert_word_by_parts(0, { {}, {'b'} } , 1);
@@ -4755,7 +4755,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
         }
 
-        SECTION("levels_cnt == 4") {
+        SECTION("num_of_levels == 4") {
             SECTION("word_part.size() == 1") {
                 nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
                 nft.insert_word_by_parts(0, { {'a'}, {}, {'c'}, {} }, 1);

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -37,8 +37,8 @@ TEST_CASE("nft::create_identity()") {
         nft.delta.add(0, 3, 7);
         nft.delta.add(7, 3, 8);
         nft.delta.add(8, 3, 0);
-        nft.levels_cnt = 3;
-        nft.levels.resize(nft.levels_cnt * (alphabet.get_number_of_symbols() - 1));
+        nft.num_of_levels = 3;
+        nft.levels.resize(nft.num_of_levels * (alphabet.get_number_of_symbols() - 1));
         nft.levels[0] = 0;
         nft.levels[1] = 1;
         nft.levels[2] = 2;
@@ -55,7 +55,7 @@ TEST_CASE("nft::create_identity()") {
     SECTION("identity nft no symbols") {
         EnumAlphabet alphabet{};
         nft.alphabet = &alphabet;
-        nft.levels_cnt = 3;
+        nft.num_of_levels = 3;
         nft.levels.resize(1);
         nft.levels[0] = 0;
         Nft nft_identity{ create_identity(&alphabet, 3) };
@@ -65,7 +65,7 @@ TEST_CASE("nft::create_identity()") {
     SECTION("identity nft one symbol") {
         EnumAlphabet alphabet{ 0 };
         nft.alphabet = &alphabet;
-        nft.levels_cnt = 2;
+        nft.num_of_levels = 2;
         nft.levels.resize(2);
         nft.levels[0] = 0;
         nft.levels[1] = 1;
@@ -84,7 +84,7 @@ TEST_CASE("nft::create_identity()") {
         nft.delta.add(0, 1, 0);
         nft.delta.add(0, 2, 0);
         nft.delta.add(0, 3, 0);
-        nft.levels_cnt = 1;
+        nft.num_of_levels = 1;
         nft.levels.resize(1);
         nft.levels[0] = 0;
         Nft nft_identity{ create_identity(&alphabet, 1) };
@@ -107,7 +107,7 @@ TEST_CASE("nft::create_identity_with_single_replace()") {
         nft.delta.add(3, 2, 0);
         nft.delta.add(0, 3, 4);
         nft.delta.add(4, 3, 0);
-        nft.levels_cnt = 2;
+        nft.num_of_levels = 2;
         nft.levels.resize(5);
         nft.levels[0] = 0;
         nft.levels[1] = 1;
@@ -126,7 +126,7 @@ TEST_CASE("nft::create_identity_with_single_replace()") {
     SECTION("identity nft one symbol") {
         EnumAlphabet alphabet{ 0 };
         nft.alphabet = &alphabet;
-        nft.levels_cnt = 2;
+        nft.num_of_levels = 2;
         nft.levels.resize(2);
         nft.levels[0] = 0;
         nft.levels[1] = 1;
@@ -158,7 +158,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         CHECK(nfa::are_equivalent(dfa_end_marker, dfa_expected_end_marker));
         Nft dft_end_marker{ end_marker_dft(dfa_end_marker, MARKER) };
         Nft dft_expected_end_marker{};
-        dft_expected_end_marker.levels_cnt = 2;
+        dft_expected_end_marker.num_of_levels = 2;
         dft_expected_end_marker.levels = { 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1 };
         dft_expected_end_marker.initial = { 0 };
         dft_expected_end_marker.final = { 9 };
@@ -200,7 +200,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 4, 7, 14 };
-        dft_expected.levels_cnt = 2;
+        dft_expected.num_of_levels = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 0);
         dft_expected.delta.add(0, 'b', 2);
@@ -271,7 +271,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 2, 7, 14};
-        dft_expected.levels_cnt = 2;
+        dft_expected.num_of_levels = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 2);
         dft_expected.delta.add(0, 'b', 3);
@@ -342,7 +342,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft nft_expected{};
         nft_expected.initial.insert(0);
         nft_expected.final.insert(1);
-        nft_expected.levels_cnt = 2;
+        nft_expected.num_of_levels = 2;
         nft_expected.delta.add(0, EPSILON, 1);
         nft_expected.delta.add(0, EPSILON, 2);
         nft_expected.delta.add(0, EPSILON, 3);
@@ -404,7 +404,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft nft_expected{};
         nft_expected.initial.insert(0);
         nft_expected.final.insert(1);
-        nft_expected.levels_cnt = 2;
+        nft_expected.num_of_levels = 2;
         nft_expected.delta.add(0, EPSILON, 1);
         nft_expected.delta.add(0, EPSILON, 2);
         nft_expected.delta.add(0, EPSILON, 3);


### PR DESCRIPTION
This PR implements class levels inheriting from `std::vector<Level>` which adds a convenience function `Levels::set(State, Level)` which allows for easier setting of levels for new states.

Furthermore, this PR also renames and retypes `Level Nft::levels_cnt` to `size_t Nft::num_of_levels`. I decided to go against the idea of moving this variable into the `Levels` class. It became confusing how to get the number of levels (tracks) in the transducers (`Nft::num_of_levels`) and how to get the number of elements in the `Levels Nft::levels` class (Levels::size()):
```cpp
Nft nft{};
// ...
if (nft.levels.num_of_levels != 2) { 
// ...
} else if (nft.levels.size() != 3) {
// ...
}
```
I think having these separate will make the distinction more clear:

```cpp
Nft nft{};
// ...
if (nft.num_of_levels != 2) { 
// ...
} else if (nft.levels.size() != 3) {
// ...
}
```
What do you think about this? Should `num_of_levels` be a member of `Levels`?

Due to time constraints, the PR will be merged immediately. I ask the reviewers to do their reviews in their own time and any issues raised in the reviews will be resolved in later PRs.

Furthermore, the PR fixes compilation of Mata on GitHub Actions.