### PR TITLE
Implement NFT operations for solving string constraints `replace(_re)()` and `replace(_re)_all()`

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -116,6 +116,7 @@ public:
     using super::front;
     using super::back;
     using super::filter;
+    using super::clear;
 
     void erase(const SymbolPost& s) {super::erase(s);}
     void erase(const_iterator first, const_iterator last) {super::erase(first,last);}

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -366,7 +366,7 @@ public:
      * you can get all words by calling
      *      get_words(aut.num_of_states())
      */
-    std::set<Word> get_words(unsigned max_length);
+    std::set<Word> get_words(size_t max_length) const;
 
     /**
      * @brief Make NFA complete in place.

--- a/include/mata/nfa/strings.hh
+++ b/include/mata/nfa/strings.hh
@@ -117,6 +117,15 @@ std::set<Symbol> get_accepted_symbols(const Nfa& nfa);
 std::set<std::pair<int, int>> get_word_lengths(const Nfa& aut);
 
 /**
+ * @brief Modify @p nfa in-place to remove outgoing transitions from final states.
+ *
+ * If @p nfa accepts empty string, returned NFA will accept only the empty string.
+ * @param nfa NFA to modify.
+ * @return The reluctant version of @p nfa.
+ */
+Nfa reluctant_nfa(Nfa nfa);
+
+/**
  * @brief Checks if the automaton @p nfa accepts only a single word \eps.
  *
  * @param nfa Input automaton

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -101,10 +101,12 @@ Simlib::Util::BinaryRelation compute_relation(
  *   because this one is too slow.
  * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states can not form a product state.
  * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states con not form a product state.
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
  * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,
-            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr,
+            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
             const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
 
 /**

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -99,10 +99,10 @@ Simlib::Util::BinaryRelation compute_relation(
  * @param[out] prod_map Can be used to get the mapping of the pairs of the original states to product states.
  *   Mostly useless, it is only filled in and returned if !=nullptr, but the algorithm internally uses another data structures,
  *   because this one is too slow.
- * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states can not form a product state.
- * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states con not form a product state.
  * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states can not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states con not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -106,7 +106,7 @@ Simlib::Util::BinaryRelation compute_relation(
  * @return NFT as a product of NFTs @p lhs and @p rhs with ε handled as regular symbols.
  */
 Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)> && final_condition,
-            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
+            std::unordered_map<std::pair<State,State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::RepeatSymbol,
             const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
 
 /**

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -6,6 +6,7 @@
 #include "mata/nfa/builder.hh"
 #include "nft.hh"
 
+#include <optional>
 #include <filesystem>
 
 /**
@@ -103,7 +104,7 @@ Nft parse_from_mata(const std::filesystem::path& nft_file);
  * @param epsilons Which symbols handle as epsilons.
  * @return NFT representing @p nfa_state with @p level_cnt number of levels.
  */
-Nft create_from_nfa(const mata::nfa::Nfa& nfa_state, Level level_cnt = 2, const std::set<Symbol>& epsilons = { EPSILON });
+Nft create_from_nfa(const mata::nfa::Nfa& nfa_state, Level level_cnt = 2, std::optional<Symbol> next_level_symbol = {}, const std::set<Symbol>& epsilons = { EPSILON });
 
 } // namespace mata::nft::builder.
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -367,9 +367,12 @@ Nft uni(const Nft &lhs, const Nft &rhs);
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
  * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
  * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
-Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr,
+Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>,
+                 State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
                  const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
 
 
@@ -386,9 +389,13 @@ Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<St
  * @param[in] rhs Second transducer to compose.
  * @param[in] lhs_sync_levels Ordered vector of synchronization levels of the @p lhs.
  * @param[in] rhs_sync_levels Ordered vector of synchronization levels of the @p rhs.
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
  * @return A new NFT after the composition.
  */
-Nft compose(const Nft& lhs, const Nft& rhs, const utils::OrdVector<Level>& lhs_sync_levels, const utils::OrdVector<Level>& rhs_sync_levels);
+Nft compose(const Nft& lhs, const Nft& rhs,
+            const utils::OrdVector<Level>& lhs_sync_levels, const utils::OrdVector<Level>& rhs_sync_levels,
+            const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Composes two NFTs.
@@ -401,9 +408,11 @@ Nft compose(const Nft& lhs, const Nft& rhs, const utils::OrdVector<Level>& lhs_s
  * @param[in] rhs Second transducer to compose.
  * @param[in] lhs_sync_level The synchronization level of the @p lhs.
  * @param[in] rhs_sync_level The synchronization level of the @p rhs.
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
  * @return A new NFT after the composition.
  */
-Nft compose(const Nft& lhs, const Nft& rhs, Level lhs_sync_level = 1, Level rhs_sync_level = 0);
+Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level = 1, const Level rhs_sync_level = 0, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Concatenate two NFTs.
@@ -572,12 +581,12 @@ Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
  * @param[in] nft The transducer for projection.
  * @param[in] levels_to_project A non-empty ordered vector of levels to be projected out from the transducer. It must
  *  contain only values that are greater than or equal to 0 and smaller than @c num_of_levels.
- * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @p DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, bool repeat_jump_symbol = true);
+Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Projects out specified level @p level_to_project in the given transducer @p nft.
@@ -585,12 +594,12 @@ Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project
  * @param[in] nft The transducer for projection.
  * @param[in] level_to_project A level that is going to be projected out from the transducer. It has to be greater than or
  *  equal to 0 and smaller than @c num_of_levels.
- * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_out(const Nft& nft, Level level_to_project, bool repeat_jump_symbol = true);
+Nft project_out(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Projects to specified levels @p levels_to_project in the given transducer @p nft.
@@ -598,12 +607,12 @@ Nft project_out(const Nft& nft, Level level_to_project, bool repeat_jump_symbol 
  * @param[in] nft The transducer for projection.
  * @param[in] levels_to_project A non-empty ordered vector of levels the transducer is going to be projected to.
  *  It must contain only values greater than or equal to 0 and smaller than @c num_of_levels.
- * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, bool repeat_jump_symbol = true);
+Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Projects to a specified level @p level_to_project in the given transducer @p nft.
@@ -611,12 +620,12 @@ Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project,
  * @param[in] nft The transducer for projection.
  * @param[in] level_to_project A level the transducer is going to be projected to. It has to be greater than or equal to 0
  *  and smaller than @c num_of_levels.
- * @param[in] repeat_jump_symbol Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_to(const Nft& nft, Level level_to_project, bool repeat_jump_symbol = true);
+Nft project_to(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Inserts new levels, as specified by the mask @p new_levels_mask, into the given transducer @p nft.
@@ -629,11 +638,11 @@ Nft project_to(const Nft& nft, Level level_to_project, bool repeat_jump_symbol =
  * @param[in] new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
  *  that one level is inserted before level 0 and two levels are inserted before level 1.
  * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
- * @param[in] repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol = DONT_CARE, bool repeat_jump_symbol = true);
+Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /**
  * @brief Inserts a new level @p new_level into the given transducer @p nft.
@@ -646,11 +655,11 @@ Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbo
  *  If @p new_level is less than @c num_of_levels, then it is inserted before the level @c new_level-1.
  *  If @p new_level is greater than or equal to @c num_of_levels, then all levels from @c num_of_levels through @p new_level are appended after the last level.
  * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
- * @param[in] repeat_jump_symbol Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
+ * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_level(const Nft& nft, const Level new_level, const Symbol default_symbol = DONT_CARE, bool repeat_jump_symbol = true);
+Nft insert_level(const Nft& nft, const Level new_level, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -320,6 +320,14 @@ public:
     /// Checks whether the prefix of a string is in the language of an automaton
     bool is_prfx_in_lang(const Run& word) const;
 
+    /**
+     * @brief Checks whether track words are in the language of the transducer.
+     *
+     * That is, the function checks whether a tuple @p track_words (word1, word2, word3, ..., wordn) is in the regular
+     *  relation accepted by the transducer with 'n' levels (tracks).
+     */
+    bool is_tuple_in_lang(const std::vector<Word>& track_words);
+
     std::pair<Run, bool> get_word_for_path(const Run& run) const;
 
     /**

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -365,10 +365,10 @@ Nft uni(const Nft &lhs, const Nft &rhs);
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
- * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
- * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
+ * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
+ * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
 Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>,

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -337,7 +337,7 @@ public:
      * you can get all words by calling
      *      get_words(aut.num_of_states())
      */
-    std::set<Word> get_words(unsigned max_length);
+    std::set<Word> get_words(size_t max_length) const;
 
 }; // class Nft.
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -376,8 +376,9 @@ Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<St
 /**
  * @brief Composes two NFTs.
  *
- * Takes two NFTs and their corresponding synchronization levels as input,
- * and returns a new NFT that represents their composition.
+ * Takes two NFTs and their corresponding synchronization levels as input, and returns a new NFT that represents their
+ *  composition as `lhs || rhs` where `a || b` (read as "a pipe b", or "b after a") means apply `a` on input and then apply `b` on
+ *  output of `a`.
  *
  * Vectors of synchronization levels have to be non-empty and of the the same size.
  *
@@ -392,8 +393,9 @@ Nft compose(const Nft& lhs, const Nft& rhs, const utils::OrdVector<Level>& lhs_s
 /**
  * @brief Composes two NFTs.
  *
- * Takes two NFTs and their corresponding synchronization levels as input,
- * and returns a new NFT that represents their composition.
+ * Takes two NFTs and their corresponding synchronization levels as input, and returns a new NFT that represents their
+ *  composition as `lhs || rhs` where `a || b` (read as "a pipe b", or "b after a") means apply `a` on input and then apply `b` on
+ *  output of `a`.
  *
  * @param[in] lhs First transducer to compose.
  * @param[in] rhs Second transducer to compose.
@@ -401,7 +403,7 @@ Nft compose(const Nft& lhs, const Nft& rhs, const utils::OrdVector<Level>& lhs_s
  * @param[in] rhs_sync_level The synchronization level of the @p rhs.
  * @return A new NFT after the composition.
  */
-Nft compose(const Nft& lhs, const Nft& rhs, const Level& lhs_sync_level = 1, const Level rhs_sync_level = 0);
+Nft compose(const Nft& lhs, const Nft& rhs, Level lhs_sync_level = 1, Level rhs_sync_level = 0);
 
 /**
  * @brief Concatenate two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -372,7 +372,7 @@ Nft uni(const Nft &lhs, const Nft &rhs);
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
 Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<State, State>,
-                 State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
+                 State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::RepeatSymbol,
                  const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state);
 
 
@@ -395,7 +395,7 @@ Nft intersection(const Nft& lhs, const Nft& rhs, std::unordered_map<std::pair<St
  */
 Nft compose(const Nft& lhs, const Nft& rhs,
             const utils::OrdVector<Level>& lhs_sync_levels, const utils::OrdVector<Level>& rhs_sync_levels,
-            const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+            const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Composes two NFTs.
@@ -412,7 +412,7 @@ Nft compose(const Nft& lhs, const Nft& rhs,
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE.
  * @return A new NFT after the composition.
  */
-Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level = 1, const Level rhs_sync_level = 0, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level = 1, const Level rhs_sync_level = 0, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Concatenate two NFTs.
@@ -586,7 +586,7 @@ Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
  *  of @p DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Projects out specified level @p level_to_project in the given transducer @p nft.
@@ -599,7 +599,7 @@ Nft project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_out(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft project_out(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Projects to specified levels @p levels_to_project in the given transducer @p nft.
@@ -612,7 +612,7 @@ Nft project_out(const Nft& nft, Level level_to_project, const JumpMode jump_mode
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Projects to a specified level @p level_to_project in the given transducer @p nft.
@@ -625,7 +625,7 @@ Nft project_to(const Nft& nft, const utils::OrdVector<Level>& levels_to_project,
  *  of @c DONT_CARE symbols.
  * @return A new projected transducer.
  */
-Nft project_to(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft project_to(const Nft& nft, Level level_to_project, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Inserts new levels, as specified by the mask @p new_levels_mask, into the given transducer @p nft.
@@ -642,7 +642,7 @@ Nft project_to(const Nft& nft, Level level_to_project, const JumpMode jump_mode 
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Inserts a new level @p new_level into the given transducer @p nft.
@@ -659,7 +659,7 @@ Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const Symbo
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_level(const Nft& nft, const Level new_level, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL);
+Nft insert_level(const Nft& nft, const Level new_level, const Symbol default_symbol = DONT_CARE, const JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -82,7 +82,7 @@ inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAut
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
 inline void intersection(Nft* res, const Nft& lhs, const Nft& rhs,
-                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
+                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::RepeatSymbol,
                   const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state) {
     *res = intersection(lhs, rhs, prod_map, jump_mode, lhs_first_aux_state, rhs_first_aux_state);
 }

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -75,14 +75,16 @@ inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAut
  * @param[in] lhs First NFT to compute intersection for.
  * @param[in] rhs Second NFT to compute intersection for.
  * @param[out] prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence of @c DONT_CARE
  * @param[in] lhs_first_aux_state The first auxiliary state in @p lhs. Two auxiliary states does not form a product state.
  * @param[in] rhs_first_aux_state The first auxiliary state in @p rhs. Two auxiliary states does not form a product state.
  * @return NFT as a product of NFTs @p lhs and @p rhs.
  */
 inline void intersection(Nft* res, const Nft& lhs, const Nft& rhs,
-                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr,
+                  std::unordered_map<std::pair<State, State>, State> *prod_map = nullptr, const JumpMode jump_mode = JumpMode::REPEAT_SYMBOL,
                   const State lhs_first_aux_state = Limits::max_state, const State rhs_first_aux_state = Limits::max_state) {
-    *res = intersection(lhs, rhs, prod_map, lhs_first_aux_state, rhs_first_aux_state);
+    *res = intersection(lhs, rhs, prod_map, jump_mode, lhs_first_aux_state, rhs_first_aux_state);
 }
 
 /**

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -9,6 +9,9 @@
 
 namespace mata::nft::strings {
 
+constexpr Symbol BEGIN_MARKER{ EPSILON - 100 };
+constexpr Symbol END_MARKER{ EPSILON - 99 };
+
 /**
  * How many occurrences of the regex to replace, in order from left to right?
  */
@@ -42,7 +45,7 @@ Nft replace_reluctant(
     Alphabet* alphabet,
     // TODO(nft): Change into constants?
     ReplaceMode replace_mode,
-    Symbol begin_marker = EPSILON - 100
+    Symbol begin_marker = BEGIN_MARKER
 );
 
 Nft replace_reluctant(
@@ -51,7 +54,7 @@ Nft replace_reluctant(
     Alphabet* alphabet,
     // TODO(nft): Change into constants?
     ReplaceMode replace_mode,
-    Symbol begin_marker = EPSILON - 100
+    Symbol begin_marker = BEGIN_MARKER
 );
 
 Nft replace_reluctant(
@@ -59,14 +62,11 @@ Nft replace_reluctant(
     const Word& replacement,
     Alphabet* alphabet,
     ReplaceMode replace_mode,
-    Symbol begin_marker = EPSILON - 100
+    Symbol begin_marker = BEGIN_MARKER
 );
 
-Nft replace_reluctant_finite(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
-                             ReplaceMode replace_mode, Symbol end_marker = EPSILON - 99);
-
 Nft replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
-                              ReplaceMode replace_mode, Symbol end_marker = EPSILON - 99);
+                              ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
 
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
 Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -9,8 +9,8 @@
 
 namespace mata::nft::strings {
 
-constexpr Symbol BEGIN_MARKER{ EPSILON - 100 };
-constexpr Symbol END_MARKER{ EPSILON - 99 };
+constexpr Symbol BEGIN_MARKER{ EPSILON - 100 }; ///< Marker marking the beginning of the regex to be replaced.
+constexpr Symbol END_MARKER{ EPSILON - 99 }; ///< Marker marking the end of the regex to be replaced.
 
 /**
  * How many occurrences of the regex to replace, in order from left to right?
@@ -38,25 +38,32 @@ Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol 
  */
 Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
                                                ReplaceMode replace_mode = ReplaceMode::All);
-
-Nft replace_reluctant(
-    const Word& literal,
-    const Word& replacement,
-    Alphabet* alphabet,
-    // TODO(nft): Change into constants?
-    ReplaceMode replace_mode,
-    Symbol begin_marker = BEGIN_MARKER
-);
-
+/**
+ * Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ * @param regex A string containing regex to be replaced.
+ * @param replacement Literal to be replaced with.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
+ * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
+ * @return The reluctant leftmost replace NFT.
+ */
 Nft replace_reluctant(
     const std::string& regex,
     const Word& replacement,
     Alphabet* alphabet,
-    // TODO(nft): Change into constants?
     ReplaceMode replace_mode,
     Symbol begin_marker = BEGIN_MARKER
 );
 
+/**
+ * Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ * @param regex NFA representing regex to be replaced.
+ * @param replacement Literal to be replaced with.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
+ * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
+ * @return The reluctant leftmost replace NFT.
+ */
 Nft replace_reluctant(
     nfa::Nfa regex,
     const Word& replacement,
@@ -65,8 +72,53 @@ Nft replace_reluctant(
     Symbol begin_marker = BEGIN_MARKER
 );
 
+/**
+ * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
+ * @param literal Literal to replace.
+ * @param replacement Literal to be replaced with.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p literal.
+ * @param end_marker Symbol to be used internally as an end marker marking the end of the replaced literal.
+ * @return The reluctant leftmost replace NFT.
+ */
 Nft replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
                               ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
+
+/**
+ * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
+ * @param literal Literal to replace.
+ * @param replacement Literal to be replaced with.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p literal.
+ * @param end_marker Symbol to be used internally as an end marker marking the end of the replaced literal.
+ * @return The reluctant leftmost replace NFT.
+ */
+Nft replace_reluctant_single_symbol(const Word& literal, const Word& replacement, Alphabet* alphabet,
+                                    ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
+
+/**
+ * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param from_symbol Symbol to replace.
+ * @param replacement Symbol to replace with.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
+ * @return The reluctant leftmost replace NFT.
+ */
+Nft replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, Symbol replacement,
+                                    ReplaceMode replace_mode = ReplaceMode::All);
+
+/**
+ * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
+ * @param alphabet Alphabet over which to create the NFT.
+ * @param from_symbol Symbol to replace.
+ * @param replacement Literal to replace with.
+ * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
+ * @return The reluctant leftmost replace NFT.
+ */
+Nft replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
+                                    ReplaceMode replace_mode = ReplaceMode::All);
+
+// Internal functions.
 
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
 Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
@@ -84,7 +136,7 @@ nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphab
 Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 
-Nft replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet, const Symbol end_marker,
+Nft replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet, Symbol end_marker,
                         ReplaceMode replace_mode = ReplaceMode::All);
 } // Namespace mata::nft::strings.
 

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -38,8 +38,8 @@ Nft replace_reluctant(
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
 Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
 
-nfa::Nfa generic_end_marker_dfa(const std::string& regex, Alphabet* alphabet);
-nfa::Nfa generic_end_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
+nfa::Nfa generic_marker_dfa(const std::string& regex, Alphabet* alphabet);
+nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -51,10 +51,12 @@ Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol 
  * @return The reluctant leftmost replace NFT.
  */
 Nft replace_reluctant_regex(const std::string& regex, const Word& replacement, Alphabet* alphabet,
-                            ReplaceMode replace_mode, Symbol begin_marker = BEGIN_MARKER);
+                            ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
 
 /**
- * Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ * @brief Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ *
+ * The most general replace operation, handling any regex as the part to be replaced.
  * @param regex NFA representing regex to be replaced.
  * @param replacement Literal to replace with.
  * @param alphabet Alphabet over which to create the NFT.
@@ -62,8 +64,8 @@ Nft replace_reluctant_regex(const std::string& regex, const Word& replacement, A
  * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet, ReplaceMode replace_mode,
-                            Symbol begin_marker = BEGIN_MARKER);
+Nft replace_reluctant_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+                            ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
@@ -75,50 +77,100 @@ Nft replace_reluctant_regex(nfa::Nfa regex, const Word& replacement, Alphabet* a
  * @return The reluctant leftmost replace NFT.
  */
 Nft replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
-                              ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
+                              ReplaceMode replace_mode = ReplaceMode::All, Symbol end_marker = END_MARKER);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
- * @param alphabet Alphabet over which to create the NFT.
  * @param from_symbol Symbol to replace.
  * @param replacement Symbol to replace with.
+ * @param alphabet Alphabet over which to create the NFT.
  * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, Symbol replacement,
+Nft replace_reluctant_single_symbol(Symbol from_symbol, Symbol replacement, mata::Alphabet* alphabet,
                                     ReplaceMode replace_mode = ReplaceMode::All);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
- * @param alphabet Alphabet over which to create the NFT.
  * @param from_symbol Symbol to replace.
  * @param replacement Literal to replace with.
+ * @param alphabet Alphabet over which to create the NFT.
  * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
+Nft replace_reluctant_single_symbol(Symbol from_symbol, const Word& replacement, mata::Alphabet* alphabet,
                                     ReplaceMode replace_mode = ReplaceMode::All);
 
-// Internal functions.
+/**
+ * @brief Implementation of all reluctant replace versions.
+ */
+class ReluctantReplace {
+public:
+    /**
+     * @brief Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+     *
+     * The most general replace operation, handling any regex as the part to be replaced.
+     * @param regex NFA representing regex to be replaced.
+     * @param replacement Literal to replace with.
+     * @param alphabet Alphabet over which to create the NFT.
+     * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
+     * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
+     * @return The reluctant leftmost replace NFT.
+     */
+    static Nft replace_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+                             ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
+    /**
+     * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
+     * @param literal Literal to replace.
+     * @param replacement Literal to replace with.
+     * @param alphabet Alphabet over which to create the NFT.
+     * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p literal.
+     * @param end_marker Symbol to be used internally as an end marker marking the end of the replaced literal.
+     * @return The reluctant leftmost replace NFT.
+     */
+    static Nft replace_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
+                                            ReplaceMode replace_mode = ReplaceMode::All, Symbol end_marker = END_MARKER);
+    /**
+     * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
+     * @param from_symbol Symbol to replace.
+     * @param replacement Symbol to replace with.
+     * @param alphabet Alphabet over which to create the NFT.
+     * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
+     * @return The reluctant leftmost replace NFT.
+     */
+    static Nft replace_symbol(Symbol from_symbol, Symbol replacement, mata::Alphabet* alphabet,
+                                           ReplaceMode replace_mode = ReplaceMode::All);
+    /**
+     * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.
+     * @param from_symbol Symbol to replace.
+     * @param replacement Literal to replace with.
+     * @param alphabet Alphabet over which to create the NFT.
+     * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p from_symbol.
+     * @return The reluctant leftmost replace NFT.
+     */
+    static Nft replace_symbol(Symbol from_symbol, const Word& replacement, mata::Alphabet* alphabet,
+                                           ReplaceMode replace_mode = ReplaceMode::All);
+protected:
+    nfa::Nfa end_marker_dfa(nfa::Nfa regex);
+    Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
 
-nfa::Nfa end_marker_dfa(nfa::Nfa regex);
-Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
+    nfa::Nfa generic_marker_dfa(const std::string& regex, Alphabet* alphabet);
+    nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 
-nfa::Nfa generic_marker_dfa(const std::string& regex, Alphabet* alphabet);
-nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
+    nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
+    nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
-nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
-nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
+    Nft begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker);
+    Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
+    nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 
-Nft begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker);
-Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
-nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
+    Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
+    Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 
-Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
-Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
+    Nft replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet, Symbol end_marker,
+                            ReplaceMode replace_mode = ReplaceMode::All);
+};
 
-Nft replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet, Symbol end_marker,
-                        ReplaceMode replace_mode = ReplaceMode::All);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -49,7 +49,7 @@ nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
-Nft begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker);
+Nft begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -46,6 +46,7 @@ nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
 Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
+nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -49,7 +49,7 @@ nfa::Nfa generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(const std::string& regex, Alphabet* alphabet);
 nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 
-Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
+Nft begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
 

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -19,20 +19,25 @@ Nft create_identity(mata::Alphabet* alphabet, Level level_cnt = 2);
  */
 Nft create_identity_with_single_replace(mata::Alphabet* alphabet, Symbol from_symbol, Symbol to_symbol);
 
+enum class ReplaceMode {
+    Single,
+    All,
+};
+
 Nft replace_reluctant(
     const std::string& regex,
-    const std::string& replacement,
+    const Word& replacement,
     Alphabet* alphabet,
-    // TODO: Change into constants?
-    Symbol begin_marker = EPSILON - 101,
-    Symbol end_marker = EPSILON - 100
+    // TODO(nft): Change into constants?
+    ReplaceMode replace_mode,
+    Symbol begin_marker = EPSILON - 100
 );
 Nft replace_reluctant(
     nfa::Nfa regex,
-    const std::string& replacement,
+    const Word& replacement,
     Alphabet* alphabet,
-    Symbol begin_marker = EPSILON - 101,
-    Symbol end_marker = EPSILON - 100
+    ReplaceMode replace_mode,
+    Symbol begin_marker = EPSILON - 100
 );
 
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
@@ -47,6 +52,9 @@ nfa::Nfa begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet);
 Nft begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker);
 Nft end_marker_dft(const nfa::Nfa& end_marker_dfa, Symbol end_marker);
 nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphabet);
+
+Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
+Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -8,6 +8,15 @@
 #include "nft.hh"
 
 namespace mata::nft::strings {
+
+/**
+ * How many occurrences of the regex to replace, in order from left to right?
+ */
+enum class ReplaceMode {
+    Single, ///< Replace only the first occurrence of the regex.
+    All, ///< Replace all occurrences of the regex.
+};
+
 /**
  * Create identity transducer over the @p alphabet with @p level_cnt levels.
  */
@@ -17,12 +26,16 @@ Nft create_identity(mata::Alphabet* alphabet, Level level_cnt = 2);
  * Create identity input/output transducer with 2 levels over the @p alphabet with @p level_cnt levels with single
  *  symbol @p from_symbol replaced with @to_symbol.
  */
-Nft create_identity_with_single_replace(mata::Alphabet* alphabet, Symbol from_symbol, Symbol to_symbol);
+Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol from_symbol, Symbol replacement,
+                                               ReplaceMode replace_mode = ReplaceMode::All);
 
-enum class ReplaceMode {
-    Single,
-    All,
-};
+/**
+ * Create identity input/output transducer with 2 levels over the @p alphabet with @p level_cnt levels with single
+ *  symbol @p from_symbol replaced with word @p replacement.
+ */
+Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
+                                               ReplaceMode replace_mode = ReplaceMode::All);
+
 
 Nft replace_reluctant(
     const std::string& regex,

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -38,8 +38,11 @@ Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol 
  */
 Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
                                                ReplaceMode replace_mode = ReplaceMode::All);
+
 /**
- * Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ * @brief Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ *
+ * The most general replace operation, handling any regex as the part to be replaced.
  * @param regex A string containing regex to be replaced.
  * @param replacement Literal to be replaced with.
  * @param alphabet Alphabet over which to create the NFT.
@@ -47,35 +50,25 @@ Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol 
  * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant(
-    const std::string& regex,
-    const Word& replacement,
-    Alphabet* alphabet,
-    ReplaceMode replace_mode,
-    Symbol begin_marker = BEGIN_MARKER
-);
+Nft replace_reluctant_regex(const std::string& regex, const Word& replacement, Alphabet* alphabet,
+                            ReplaceMode replace_mode, Symbol begin_marker = BEGIN_MARKER);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
  * @param regex NFA representing regex to be replaced.
- * @param replacement Literal to be replaced with.
+ * @param replacement Literal to replace with.
  * @param alphabet Alphabet over which to create the NFT.
  * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
  * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant(
-    nfa::Nfa regex,
-    const Word& replacement,
-    Alphabet* alphabet,
-    ReplaceMode replace_mode,
-    Symbol begin_marker = BEGIN_MARKER
-);
+Nft replace_reluctant_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet, ReplaceMode replace_mode,
+                            Symbol begin_marker = BEGIN_MARKER);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
  * @param literal Literal to replace.
- * @param replacement Literal to be replaced with.
+ * @param replacement Literal to replace with.
  * @param alphabet Alphabet over which to create the NFT.
  * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p literal.
  * @param end_marker Symbol to be used internally as an end marker marking the end of the replaced literal.
@@ -83,18 +76,6 @@ Nft replace_reluctant(
  */
 Nft replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
                               ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
-
-/**
- * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.
- * @param literal Literal to replace.
- * @param replacement Literal to be replaced with.
- * @param alphabet Alphabet over which to create the NFT.
- * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p literal.
- * @param end_marker Symbol to be used internally as an end marker marking the end of the replaced literal.
- * @return The reluctant leftmost replace NFT.
- */
-Nft replace_reluctant_single_symbol(const Word& literal, const Word& replacement, Alphabet* alphabet,
-                                    ReplaceMode replace_mode, Symbol end_marker = END_MARKER);
 
 /**
  * Create NFT modelling a reluctant leftmost replace of symbol @p from_symbol to @p replacement.

--- a/include/mata/nft/strings.hh
+++ b/include/mata/nft/strings.hh
@@ -36,6 +36,14 @@ Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol 
 Nft create_identity_with_single_symbol_replace(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
                                                ReplaceMode replace_mode = ReplaceMode::All);
 
+Nft replace_reluctant(
+    const Word& literal,
+    const Word& replacement,
+    Alphabet* alphabet,
+    // TODO(nft): Change into constants?
+    ReplaceMode replace_mode,
+    Symbol begin_marker = EPSILON - 100
+);
 
 Nft replace_reluctant(
     const std::string& regex,
@@ -45,6 +53,7 @@ Nft replace_reluctant(
     ReplaceMode replace_mode,
     Symbol begin_marker = EPSILON - 100
 );
+
 Nft replace_reluctant(
     nfa::Nfa regex,
     const Word& replacement,
@@ -52,6 +61,12 @@ Nft replace_reluctant(
     ReplaceMode replace_mode,
     Symbol begin_marker = EPSILON - 100
 );
+
+Nft replace_reluctant_finite(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+                             ReplaceMode replace_mode, Symbol end_marker = EPSILON - 99);
+
+Nft replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
+                              ReplaceMode replace_mode, Symbol end_marker = EPSILON - 99);
 
 nfa::Nfa end_marker_dfa(nfa::Nfa regex);
 Nft marker_nft(const nfa::Nfa& marker_dfa, Symbol marker);
@@ -68,6 +83,9 @@ nfa::Nfa reluctant_nfa_with_marker(nfa::Nfa nfa, Symbol marker, Alphabet* alphab
 
 Nft reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
 Nft reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker, const Word& replacement, ReplaceMode replace_mode);
+
+Nft replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet, const Symbol end_marker,
+                        ReplaceMode replace_mode = ReplaceMode::All);
 } // Namespace mata::nft::strings.
 
 #endif // MATA_NFT_STRING_SOLVING_HH_.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -41,8 +41,8 @@ using Limits = mata::nfa::Limits;
 class Nft; ///< A non-deterministic finite transducer.
 
 enum class JumpMode {
-    REPEAT_SYMBOL, ///< Repeat the symbol on the jump.
-    APPEND_DONT_CAREs ///< Append a sequence of DONT_CAREs to the symbol on the jump.
+    RepeatSymbol, ///< Repeat the symbol on the jump.
+    AppendDontCares ///< Append a sequence of DONT_CAREs to the symbol on the jump.
 };
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -38,7 +38,12 @@ using ParameterMap = mata::nfa::ParameterMap;
 
 using Limits = mata::nfa::Limits;
 
-class Nft; ///< A non-deterministic finite automaton.
+class Nft; ///< A non-deterministic finite transducer.
+
+enum class JumpMode {
+    REPEAT_SYMBOL, ///< Repeat the symbol on the jump.
+    APPEND_DONT_CAREs ///< Append a sequence of DONT_CAREs to the symbol on the jump.
+};
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = mata::nfa::EPSILON;
@@ -47,6 +52,6 @@ constexpr Symbol DONT_CARE = EPSILON - 1;
 constexpr Level DEFAULT_LEVEL{ 0 };
 constexpr Level DEFAULT_NUM_OF_LEVELS{ 1 };
 
-} // namespace mata::nfa.
+} // namespace mata::nft.
 
 #endif //MATA_TYPES_HH

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -545,9 +545,8 @@ State Nfa::add_state(State state) {
 
 State Nfa::insert_word(const State source, const Word &word, const State target) {
     assert(!word.empty());
-    const size_t num_of_states_orig{ num_of_states() };
-    assert(source < num_of_states_orig);
-    assert(target < num_of_states_orig);
+    assert(source < num_of_states());
+    assert(target < num_of_states());
 
     const size_t word_len = word.size();
     if (word_len == 1) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -788,7 +788,7 @@ Run mata::nfa::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return { .word = alphabet->translate_word(input) };
 }
 
-std::set<mata::Word> mata::nfa::Nfa::get_words(unsigned max_length) {
+std::set<mata::Word> mata::nfa::Nfa::get_words(size_t max_length) const {
     std::set<mata::Word> result;
 
     // contains a pair: a state s and the word with which we got to the state s

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -12,7 +12,7 @@ using namespace mata::utils;
 namespace mata::nft
 {
 
-Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_levels, const OrdVector<Level>& rhs_sync_levels) {
+Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_levels, const OrdVector<Level>& rhs_sync_levels, const JumpMode jump_mode) {
     assert(!lhs_sync_levels.empty());
     assert(lhs_sync_levels.size() == rhs_sync_levels.size());
 
@@ -82,8 +82,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), biggest_suffix_len - lhs_suffix_len, true);
     rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), biggest_suffix_len - rhs_suffix_len, true);
 
-    Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, DONT_CARE, false);
-    Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, DONT_CARE, false);
+    Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, DONT_CARE, jump_mode);
+    Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, DONT_CARE, jump_mode);
 
     // Two auxiliary states (states from inserted loops) can not create a product state.
     const State lhs_first_aux_state = lhs_synced.num_of_states();
@@ -92,13 +92,13 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     insert_self_loops(lhs_synced, lhs_new_levels_mask);
     insert_self_loops(rhs_synced, rhs_new_levels_mask);
 
-    Nft result{ intersection(lhs_synced, rhs_synced, nullptr, lhs_first_aux_state, rhs_first_aux_state) };
-    result = project_out(result, levels_to_project_out, false);
+    Nft result{ intersection(lhs_synced, rhs_synced, nullptr, jump_mode, lhs_first_aux_state, rhs_first_aux_state) };
+    result = project_out(result, levels_to_project_out, jump_mode);
     return result;
 }
 
-Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level, const Level rhs_sync_level) {
-    return compose(lhs, rhs, OrdVector{ lhs_sync_level }, OrdVector{ rhs_sync_level });
+Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level, const Level rhs_sync_level, const JumpMode jump_mode) {
+    return compose(lhs, rhs, OrdVector{ lhs_sync_level }, OrdVector{ rhs_sync_level }, jump_mode);
 }
 
 } // mata::nft

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -98,7 +98,7 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     return result;
 }
 
-Nft compose(const Nft& lhs, const Nft& rhs, const Level& lhs_sync_level, const Level rhs_sync_level) {
+Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level, const Level rhs_sync_level) {
     return compose(lhs, rhs, OrdVector{ lhs_sync_level }, OrdVector{ rhs_sync_level });
 }
 

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -92,9 +92,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     insert_self_loops(lhs_synced, lhs_new_levels_mask);
     insert_self_loops(rhs_synced, rhs_new_levels_mask);
 
-    Nft result = intersection(lhs_synced, rhs_synced, nullptr, lhs_first_aux_state, rhs_first_aux_state);
+    Nft result{ intersection(lhs_synced, rhs_synced, nullptr, lhs_first_aux_state, rhs_first_aux_state) };
     result = project_out(result, levels_to_project_out, false);
-
     return result;
 }
 

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -22,7 +22,7 @@ bool mata::nft::algorithms::is_included_naive(
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
-    Nft nft_isect = intersection(smaller, bigger_cmpl);
+    Nft nft_isect = intersection(smaller, bigger_cmpl, nullptr, JumpMode::APPEND_DONT_CAREs);
 
     return nft_isect.is_lang_empty(cex);
 } // is_included_naive }}}

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -22,7 +22,7 @@ bool mata::nft::algorithms::is_included_naive(
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
-    Nft nft_isect = intersection(smaller, bigger_cmpl, nullptr, JumpMode::APPEND_DONT_CAREs);
+    Nft nft_isect = intersection(smaller, bigger_cmpl, nullptr, JumpMode::AppendDontCares);
 
     return nft_isect.is_lang_empty(cex);
 } // is_included_naive }}}

--- a/src/nft/intersection.cc
+++ b/src/nft/intersection.cc
@@ -115,9 +115,9 @@ Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::fu
         }
         State product_target = get_state_from_product_storage(lhs_target, rhs_target );
 
-        if ( product_target == Limits::max_state )
+        if (product_target == Limits::max_state)
         {
-            product_target = product.add_state_with_level((jump_mode == JumpMode::REPEAT_SYMBOL || lhs.levels[lhs_target] == 0 || rhs.levels[rhs_target] == 0) ?
+            product_target = product.add_state_with_level((jump_mode == JumpMode::RepeatSymbol || lhs.levels[lhs_target] == 0 || rhs.levels[rhs_target] == 0) ?
                                                           std::max(lhs.levels[lhs_target], rhs.levels[rhs_target]) :
                                                           std::min(lhs.levels[lhs_target], rhs.levels[rhs_target]));
             assert(product_target < Limits::max_state);
@@ -158,13 +158,15 @@ Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::fu
                     const bool dcare_target_is_deeper = specific_target_level != 0 && (specific_target_level < dcare_target_level || dcare_target_level == 0);
                     const bool specific_target_is_deeper = dcare_target_level != 0 && (dcare_target_level < specific_target_level || specific_target_level == 0);
 
+                    // If jump_mode is AppendDONT_CAREs, we should wait in the deeper state.
+                    // If jump_mode is RepeatSymbol, we should wait in the source state that has a deeper target.
                     State lhs_target, rhs_target;
                     if (dcare_on_lhs) {
-                        lhs_target = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || specific_target_is_deeper) ? dcare_target : dcare_src;
-                        rhs_target = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || dcare_target_is_deeper) ? specific_target : specific_src;
+                        lhs_target = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || specific_target_is_deeper) ? dcare_target : dcare_src;
+                        rhs_target = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || dcare_target_is_deeper) ? specific_target : specific_src;
                     } else {
-                        lhs_target = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || dcare_target_is_deeper) ? specific_target : specific_src;
-                        rhs_target = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || specific_target_is_deeper) ? dcare_target : dcare_src;
+                        lhs_target = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || dcare_target_is_deeper) ? specific_target : specific_src;
+                        rhs_target = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || specific_target_is_deeper) ? dcare_target : dcare_src;
                     }
                     create_product_state_and_symbol_post(lhs_target, rhs_target, product_symbol_post);
                 }
@@ -205,7 +207,7 @@ Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::fu
         const bool sources_are_on_the_same_level = lhs.levels[lhs_source] == rhs.levels[rhs_source];
         const bool rhs_source_is_deeper = (lhs.levels[lhs_source] < rhs.levels[rhs_source] && lhs.levels[lhs_source] != 0) || (lhs.levels[lhs_source] != 0 && rhs.levels[rhs_source] == 0);
 
-        if (sources_are_on_the_same_level || jump_mode == JumpMode::REPEAT_SYMBOL) {
+        if (sources_are_on_the_same_level || jump_mode == JumpMode::RepeatSymbol) {
             // Compute classic product for current state pair.
             mata::utils::SynchronizedUniversalIterator<mata::utils::OrdVector<SymbolPost>::const_iterator> sync_iterator(2);
             mata::utils::push_back(sync_iterator, lhs.delta[lhs_source]);
@@ -226,8 +228,10 @@ Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::fu
                         const bool lhs_target_is_deeper = rhs.levels[rhs_target] != 0 && (rhs.levels[rhs_target] < lhs.levels[lhs_target] || lhs.levels[lhs_target] == 0);
                         const bool rhs_target_is_deeper = lhs.levels[lhs_target] != 0 && (lhs.levels[lhs_target] < rhs.levels[rhs_target] || rhs.levels[rhs_target] == 0);
 
-                        const State lhs_state = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || rhs_target_is_deeper) ? lhs_target : lhs_source;
-                        const State rhs_state = (jump_mode == JumpMode::APPEND_DONT_CAREs || targets_are_on_the_same_level || lhs_target_is_deeper) ? rhs_target : rhs_source;
+                        // If jump_mode is AppendDONT_CAREs, we should wait in the deeper state.
+                        // If jump_mode is RepeatSymbol, we should wait in the source state that has a deeper target.
+                        const State lhs_state = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || rhs_target_is_deeper) ? lhs_target : lhs_source;
+                        const State rhs_state = (jump_mode == JumpMode::AppendDontCares || targets_are_on_the_same_level || lhs_target_is_deeper) ? rhs_target : rhs_source;
 
                         create_product_state_and_symbol_post(lhs_state, rhs_state, product_symbol_post);
                     }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -332,9 +332,8 @@ State Nft::insert_word(const State source, const Word &word) { return insert_wor
 State Nft::insert_word_by_parts(const State source, const std::vector<Word> &word_parts_on_levels, const State target) {
     assert(0 < num_of_levels);
     assert(word_parts_on_levels.size() == num_of_levels);
-    const size_t num_of_states_orig{ num_of_states() };
-    assert(source < num_of_states_orig);
-    assert(target < num_of_states_orig);
+    assert(source < num_of_states());
+    assert(target < num_of_states());
     assert(levels[source] == 0);
     assert(levels[target] == 0);
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -384,7 +384,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     }
 
     // Construct an empty automaton with updated levels.
-    Nft result(Delta{}, nft.initial, nft.final, new_state_levels, static_cast<unsigned int>(new_levels_mask.size()), nft.alphabet);
+    Nft result(Delta(nft.num_of_states()), nft.initial, nft.final, new_state_levels, static_cast<unsigned int>(new_levels_mask.size()), nft.alphabet);
 
     // Function to create a transition between source and target states.
     // The transition symbol is determined based on the parameters:

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -864,7 +864,7 @@ Run mata::nft::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return mata::nfa::encode_word(alphabet, input);
 }
 
-std::set<mata::Word> mata::nft::Nft::get_words(unsigned max_length) {
+std::set<mata::Word> mata::nft::Nft::get_words(size_t max_length) const {
     std::set<mata::Word> result;
 
     // contains a pair: a state s and the word with which we got to the state s

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -931,9 +931,7 @@ bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
        return true;
     };
 
-    if (are_all_track_words_read(track_words_begins)) {
-        return final.intersects_with(initial);
-    }
+    if (are_all_track_words_read(track_words_begins) && final.intersects_with(initial)) { return true; }
 
     using StateWordBeginsPair = std::pair<State, std::vector<Word::const_iterator>>;
     std::deque<StateWordBeginsPair> worklist{};

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -297,7 +297,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
                     if (is_projected_out(cls_state)) {
                         // If there are remaining levels between cls_state and tgt_state
                         // on a transition with a length greater than 1, then these levels must be preserved.
-                        if (jump_mode == JumpMode::REPEAT_SYMBOL) {
+                        if (jump_mode == JumpMode::RepeatSymbol) {
                             result.delta.add(src_state, move.symbol, tgt_state);
                         } else {
                             result.delta.add(src_state, DONT_CARE, tgt_state);
@@ -393,7 +393,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
         if (is_inserted_level) { // Transition over the inserted level
             result.delta.add(src, default_symbol, tgt);
         } else { // Transition over existing (old) level
-            if (jump_mode == JumpMode::REPEAT_SYMBOL || !is_old_level_processed) {
+            if (jump_mode == JumpMode::RepeatSymbol || !is_old_level_processed) {
                 result.delta.add(src, symb, tgt);
             } else {
                 result.delta.add(src, DONT_CARE, tgt);

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -156,12 +156,12 @@ namespace {
     }
 
     /// Add transitions, optionally add @p source to @p dfa_generic_end_marker.final, and update @p labeling and @p labeling_inv functions.
-    void process_source(const nfa::Nfa& regex, const Alphabet* alphabet, nfa::Nfa& dfa_generic_end_marker,
+    void process_source(const nfa::Nfa& regex, const utils::OrdVector<Symbol>& alphabet_symbols, nfa::Nfa& dfa_generic_end_marker,
                         std::map<State, StateSet>& labeling,
                         std::unordered_map<StateSet, State>& labeling_inv, State source,
                         StateSet& source_label, std::vector<State>& worklist) {
-        const State generic_initial_state{ *dfa_generic_end_marker.initial.begin() };
-        for (const Symbol symbol: alphabet->get_alphabet_symbols()) {
+        const State generic_initial_state{ *regex.initial.begin() };
+        for (const Symbol symbol: alphabet_symbols) {
             StateSet target_label{ generic_initial_state };
             for (const State regex_state: source_label) {
                 const StatePost& state_post{ regex.delta[regex_state] };
@@ -335,6 +335,7 @@ nfa::Nfa ReluctantReplace::generic_marker_dfa(const std::string& regex, Alphabet
 nfa::Nfa ReluctantReplace::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
     if (!regex.is_deterministic()) { regex = determinize(regex); }
 
+    const utils::OrdVector<Symbol> alphabet_symbols{ alphabet->get_alphabet_symbols() };
     nfa::Nfa dfa_generic_end_marker{};
     dfa_generic_end_marker.initial.insert(0);
     std::map<State, StateSet> labeling{};
@@ -351,10 +352,10 @@ nfa::Nfa ReluctantReplace::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet
         if (regex.final.intersects_with(source_label)) {
             const State end_marker_target{ dfa_generic_end_marker.add_state() };
             dfa_generic_end_marker.delta.add(source, EPSILON, end_marker_target);
-            process_source(regex, alphabet, dfa_generic_end_marker, labeling, labeling_inv, end_marker_target,
+            process_source(regex, alphabet_symbols, dfa_generic_end_marker, labeling, labeling_inv, end_marker_target,
                            source_label, worklist);
         } else {
-            process_source(regex, alphabet, dfa_generic_end_marker, labeling, labeling_inv, source, source_label,
+            process_source(regex, alphabet_symbols, dfa_generic_end_marker, labeling, labeling_inv, source, source_label,
                            worklist);
         }
 

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -518,15 +518,6 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
     return nft_reluctant_leftmost;
 }
 
-Nft nft::strings::replace_reluctant_finite(Nfa regex, const Word& replacement, Alphabet* alphabet,
-                                           const ReplaceMode replace_mode, const Symbol end_marker) {
-    assert(regex.is_acyclic());
-    regex = mata::strings::reluctant_nfa(std::move(regex));
-    const std::set<Word> regex_words{ regex.get_words(regex.num_of_states()) };
-
-    return Nft();
-}
-
 Nft nft::strings::replace_reluctant_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,
                                             strings::ReplaceMode replace_mode, Symbol end_marker) {
     Nft nft_end_marker{ [&]() {
@@ -547,8 +538,7 @@ Nft nft::strings::replace_reluctant_literal(const Word& literal, const Word& rep
 }
 
 Nft nft::strings::replace_literal_nft(const Word& literal, const Word& replacement, const Alphabet* alphabet,
-                                      const Symbol end_marker,
-                                      ReplaceMode replace_mode) {
+                                      const Symbol end_marker, ReplaceMode replace_mode) {
     Nft nft{};
     nft.levels_cnt = 2;
     State init_state{ nft.add_state_with_level(0) };
@@ -572,6 +562,3 @@ Nft nft::strings::replace_literal_nft(const Word& literal, const Word& replaceme
     add_end_marker_transitions_from_literal_states(end_marker, state_word_pairs, nft);
     return nft;
 }
-
-
-

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -480,6 +480,7 @@ Nft ReluctantReplace::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, S
             break;
         };
         case ReplaceMode::Single: {
+            nft_reluctant_leftmost.levels.resize(nft_reluctant_leftmost.levels.size() + alphabet_symbols.size() + 1);
             const State final{ curr_state };
             nft_reluctant_leftmost.final.insert(final);
             ++curr_state;

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -290,7 +290,7 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
     // Move to replace mode when begin marker is encountered.
     initial_state_post.insert({ begin_marker, curr_state });
     nft_reluctant_leftmost.delta.mutable_state_post(curr_state).push_back(
-        SymbolPost{ EPSILON, StateSet{ nft_reluctant_leftmost.initial }}
+        SymbolPost{ EPSILON, StateSet{ nft_reluctant_leftmost.initial } }
     );
     nft_reluctant_leftmost.levels[curr_state] = 1;
     ++curr_state;

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -8,7 +8,8 @@
 #include "mata/nft/nft.hh"
 #include "mata/nft/builder.hh"
 
-//using mata::nft::Nft;
+using mata::nft::Nft;
+using mata::nfa::Nfa;
 using namespace mata;
 using mata::nft::Level;
 using mata::Symbol;
@@ -111,10 +112,7 @@ Nft mata::nft::strings::replace_reluctant(
     Symbol begin_marker,
     Symbol end_marker
 ) {
-    nfa::Nfa dfa_generic_marker{ generic_end_marker_dfa(std::move(regex), alphabet) };
-    Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_marker, end_marker) };
-    Nft dft_begin_marker{ begin_marker_nft(dfa_generic_marker, begin_marker) };
-
+    Nft dft_begin_marker{ begin_marker_nft(generic_marker_dfa(regex, alphabet), begin_marker) };
     return Nft{};
 }
 
@@ -158,13 +156,13 @@ Nft mata::nft::strings::marker_nft(const nfa::Nfa& marker_dfa, Symbol marker) {
     return dft_marker;
 }
 
-nfa::Nfa nft::strings::generic_end_marker_dfa(const std::string& regex, Alphabet* alphabet) {
+nfa::Nfa nft::strings::generic_marker_dfa(const std::string& regex, Alphabet* alphabet) {
     nfa::Nfa nfa{};
     parser::create_nfa(&nfa, regex);
-    return generic_end_marker_dfa(std::move(nfa), alphabet);
+    return generic_marker_dfa(std::move(nfa), alphabet);
 }
 
-nfa::Nfa nft::strings::generic_end_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
+nfa::Nfa nft::strings::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
     if (!regex.is_deterministic()) {
         regex = determinize(regex);
     }
@@ -204,7 +202,7 @@ nfa::Nfa nft::strings::begin_marker_nfa(const std::string& regex, Alphabet* alph
 }
 
 nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
-    nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa(std::move(regex), alphabet) };
+    nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa(std::move(regex), alphabet) };
     dfa_generic_end_marker = revert(dfa_generic_end_marker);
     std::swap(dfa_generic_end_marker.initial, dfa_generic_end_marker.final);
     return dfa_generic_end_marker;

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -372,14 +372,12 @@ nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
 
 Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker) {
     Nft begin_marker_nft{ marker_nft(marker_nfa, begin_marker) };
-    const State new_initial{ begin_marker_nft.add_state() };
+    const State new_initial{ begin_marker_nft.add_state_with_level(0) };
     for (const State orig_final: begin_marker_nft.final) {
         begin_marker_nft.delta.add(new_initial, EPSILON, orig_final);
     }
     begin_marker_nft.final = begin_marker_nft.initial;
     begin_marker_nft.initial = { new_initial };
-    begin_marker_nft.levels.resize(new_initial + 1);
-    begin_marker_nft.levels[new_initial] = 0;
     return begin_marker_nft;
 }
 
@@ -432,11 +430,9 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
     const utils::OrdVector<Symbol> alphabet_symbols{ alphabet->get_alphabet_symbols() };
     nft_reluctant_leftmost.levels.resize(
         regex_num_of_states + replacement.size() * 2 + alphabet_symbols.size() + 4);
-    State curr_state{ regex_num_of_states };
     // Create self-loop on the new initial state.
-    const State initial{ regex_num_of_states };
-    nft_reluctant_leftmost.levels[initial] = 0;
-    ++curr_state;
+    const State initial{ nft_reluctant_leftmost.add_state_with_level(0) };
+    State curr_state{ regex_num_of_states + 1 };
     StatePost& initial_state_post{ nft_reluctant_leftmost.delta.mutable_state_post(initial) };
     for (const Symbol symbol: alphabet_symbols) {
         initial_state_post.push_back({ symbol, curr_state });

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -19,10 +19,11 @@ using mata::nfa::SymbolPost;
 using namespace mata::nft;
 
 namespace {
-    bool is_subvector(const Word& subvector, const Word& vector) {
-        assert(subvector.size() <= vector.size());
-        for (size_t i{ 0 }; const Symbol symbol: subvector) {
-            if (symbol != vector[i]) { return false; }
+    template<class Sequence>
+    bool is_subsequence(const Sequence& subsequence, const Sequence& sequence) {
+        assert(subsequence.size() <= sequence.size());
+        for (size_t i{ 0 }; const Symbol symbol: subsequence) {
+            if (symbol != sequence[i]) { return false; }
             ++i;
         }
         return true;
@@ -465,7 +466,7 @@ Nft nft::strings::replace_literal_nft(const Word& literal, const Word& replaceme
                 auto subword_next_symbol_it{ subword_next_symbol_begin };
                 while (subword_next_symbol_it != subword_next_symbol_end) {
                     const Word subsubword{ subword_next_symbol_it, subword_next_symbol_end };
-                    if (is_subvector(subsubword, literal)) {
+                    if (is_subsequence(subsubword, literal)) {
                         // it...end is a valid literal subvector. Transition should therefore lead to the corresponding
                         //  subvector init_state.
                         target_state = subsubword.size();

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -206,23 +206,24 @@ nfa::Nfa nft::strings::begin_marker_nfa(const std::string& regex, Alphabet* alph
 }
 
 nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
+    regex = revert(regex);
     nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa(std::move(regex), alphabet) };
     dfa_generic_end_marker = revert(dfa_generic_end_marker);
     std::swap(dfa_generic_end_marker.initial, dfa_generic_end_marker.final);
     return dfa_generic_end_marker;
 }
 
-Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker) {
-    Nft begin_marker_dft{ marker_nft(marker_dfa, begin_marker) };
-    const State new_initial{ begin_marker_dft.add_state() };
-    for (const State orig_final: begin_marker_dft.final) {
-        begin_marker_dft.delta.add(new_initial, EPSILON, orig_final);
+Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_nfa, Symbol begin_marker) {
+    Nft begin_marker_nft{ marker_nft(marker_nfa, begin_marker) };
+    const State new_initial{ begin_marker_nft.add_state() };
+    for (const State orig_final: begin_marker_nft.final) {
+        begin_marker_nft.delta.add(new_initial, EPSILON, orig_final);
     }
-    begin_marker_dft.final = begin_marker_dft.initial;
-    begin_marker_dft.initial = { new_initial };
-    begin_marker_dft.levels.resize(new_initial + 1);
-    begin_marker_dft.levels[new_initial] = 0;
-    return begin_marker_dft;
+    begin_marker_nft.final = begin_marker_nft.initial;
+    begin_marker_nft.initial = { new_initial };
+    begin_marker_nft.levels.resize(new_initial + 1);
+    begin_marker_nft.levels[new_initial] = 0;
+    return begin_marker_nft;
 }
 
 Nft nft::strings::end_marker_dft(const nfa::Nfa& end_marker_dfa, const Symbol end_marker) {

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -91,8 +91,7 @@ namespace {
         }
     }
 
-    void
-    add_generic_literal_transitions(const Word& literal, const std::vector<std::pair<State, Word>>& state_word_pairs,
+    void add_generic_literal_transitions(const Word& literal, const std::vector<std::pair<State, Word>>& state_word_pairs,
                                     Nft& nft, const utils::OrdVector<Symbol>& alphabet_symbols) {
         const size_t literal_size{ literal.size() };
         Symbol literal_symbol;
@@ -257,11 +256,6 @@ Nft nft::strings::create_identity_with_single_symbol_replace(Alphabet* alphabet,
     return nft;
 }
 
-Nft nft::strings::replace_reluctant(const Word& literal, const Word& replacement, Alphabet* alphabet,
-                                    strings::ReplaceMode replace_mode, Symbol begin_marker) {
-    return Nft();
-}
-
 Nft mata::nft::strings::replace_reluctant(
     const std::string& regex,
     const Word& replacement,
@@ -290,10 +284,7 @@ Nft mata::nft::strings::replace_reluctant(
 }
 
 nfa::Nfa mata::nft::strings::end_marker_dfa(nfa::Nfa regex) {
-    if (!regex.is_deterministic()) {
-        regex = determinize(regex);
-    }
-
+    if (!regex.is_deterministic()) { regex = determinize(regex); }
     State new_final;
     for (State orig_final: regex.final) {
         new_final = regex.add_state();
@@ -311,7 +302,6 @@ nfa::Nfa mata::nft::strings::end_marker_dfa(nfa::Nfa regex) {
 }
 
 Nft mata::nft::strings::marker_nft(const nfa::Nfa& marker_dfa, Symbol marker) {
-
     Nft dft_marker{ nft::builder::create_from_nfa(marker_dfa) };
     const size_t dft_marker_num_of_states{ dft_marker.num_of_states() };
     for (State source{ 0 }; source < dft_marker_num_of_states; ++source) {
@@ -336,9 +326,7 @@ nfa::Nfa nft::strings::generic_marker_dfa(const std::string& regex, Alphabet* al
 }
 
 nfa::Nfa nft::strings::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
-    if (!regex.is_deterministic()) {
-        regex = determinize(regex);
-    }
+    if (!regex.is_deterministic()) { regex = determinize(regex); }
 
     nfa::Nfa dfa_generic_end_marker{};
     dfa_generic_end_marker.initial.insert(0);
@@ -530,9 +518,7 @@ Nft nft::strings::replace_reluctant_literal(const Word& literal, const Word& rep
         nft_end_marker.final.insert(end_marker_state);
         return nft_end_marker;
     }() };
-
     Nft nft_literal_replace{ replace_literal_nft(literal, replacement, alphabet, end_marker, replace_mode) };
-
 //    return nft_end_marker.compose(nft_replace_reluctant_literal);
     return Nft{};
 }
@@ -561,4 +547,14 @@ Nft nft::strings::replace_literal_nft(const Word& literal, const Word& replaceme
     add_replacement_transitions(replacement, end_marker, replace_mode, state_word_pairs, nft, alphabet_symbols);
     add_end_marker_transitions_from_literal_states(end_marker, state_word_pairs, nft);
     return nft;
+}
+
+Nft nft::strings::replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, const Word& replacement,
+                                                  ReplaceMode replace_mode) {
+    return create_identity_with_single_symbol_replace(alphabet, from_symbol, replacement, replace_mode);
+}
+
+Nft nft::strings::replace_reluctant_single_symbol(mata::Alphabet* alphabet, Symbol from_symbol, Symbol replacement,
+                                                  ReplaceMode replace_mode) {
+    return create_identity_with_single_symbol_replace(alphabet, from_symbol, replacement, replace_mode);
 }

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -425,8 +425,6 @@ Nft nft::strings::reluctant_leftmost_nft(const std::string& regex, Alphabet* alp
 Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker,
                                          const Word& replacement, ReplaceMode replace_mode) {
     nfa = reluctant_nfa_with_marker(std::move(nfa), begin_marker, alphabet);
-    std::ostringstream stream;
-    stream << EPSILON;
     Nft nft_reluctant_leftmost{
         nft::builder::create_from_nfa(nfa, 2, { EPSILON }, { EPSILON }) };
     const size_t regex_num_of_states{ nft_reluctant_leftmost.num_of_states() };

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -561,8 +561,7 @@ Nft ReluctantReplace::replace_literal(const Word& literal, const Word& replaceme
         return nft_end_marker;
     }() };
     Nft nft_literal_replace{ reluctant_replace.replace_literal_nft(literal, replacement, alphabet, end_marker, replace_mode) };
-//    return nft_end_marker.compose(nft_replace_reluctant_literal);
-    return Nft{};
+    return compose(nft_end_marker, nft_literal_replace);
 }
 
 Nft ReluctantReplace::replace_symbol(Symbol from_symbol, Symbol replacement, mata::Alphabet* alphabet,

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -554,8 +554,7 @@ Nft ReluctantReplace::replace_regex(nfa::Nfa regex, const Word& replacement, Alp
     Nft dft_begin_marker{ reluctant_replace.begin_marker_nft(reluctant_replace.begin_marker_nfa(regex, alphabet), begin_marker) };
     Nft nft_reluctant_replace{
         reluctant_replace.reluctant_leftmost_nft(std::move(regex), alphabet, begin_marker, replacement, replace_mode) };
-//    return dft_begin_marker.compose(nft_reluctant_replace);
-    return Nft{};
+    return compose(dft_begin_marker, nft_reluctant_replace);
 }
 
 Nft ReluctantReplace::replace_literal(const Word& literal, const Word& replacement, Alphabet* alphabet,

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -320,6 +320,7 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
         };
         case ReplaceMode::Single: {
             const State final{ curr_state };
+            nft_reluctant_leftmost.final.insert(final);
             ++curr_state;
             for (const Symbol symbol: alphabet_symbols) {
                 nft_reluctant_leftmost.delta.add(final, symbol, curr_state);
@@ -329,7 +330,7 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
             }
 
             nft_reluctant_leftmost.delta.add(final, begin_marker, curr_state);
-            nft_reluctant_leftmost.delta.add(curr_state, begin_marker, final);
+            nft_reluctant_leftmost.delta.add(curr_state, EPSILON, final);
             nft_reluctant_leftmost.levels[curr_state] = 1;
             ++curr_state;
             break;
@@ -345,6 +346,3 @@ Nft nft::strings::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbo
 
     return nft_reluctant_leftmost;
 }
-
-
-

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -256,24 +256,24 @@ Nft nft::strings::create_identity_with_single_symbol_replace(Alphabet* alphabet,
     return nft;
 }
 
-Nft mata::nft::strings::replace_reluctant(
+Nft mata::nft::strings::replace_reluctant_regex(
     const std::string& regex,
     const Word& replacement,
     Alphabet* alphabet,
-    const ReplaceMode replace_mode,
-    const Symbol begin_marker
+    ReplaceMode replace_mode,
+    Symbol begin_marker
 ) {
     nfa::Nfa regex_nfa{};
     parser::create_nfa(&regex_nfa, regex);
-    return replace_reluctant(std::move(regex_nfa), replacement, alphabet, replace_mode, begin_marker);
+    return replace_reluctant_regex(std::move(regex_nfa), replacement, alphabet, replace_mode, begin_marker);
 }
 
-Nft mata::nft::strings::replace_reluctant(
+Nft mata::nft::strings::replace_reluctant_regex(
     nfa::Nfa regex,
     const Word& replacement,
     Alphabet* alphabet,
-    const ReplaceMode replace_mode,
-    const Symbol begin_marker
+    ReplaceMode replace_mode,
+    Symbol begin_marker
 ) {
     // TODO(nft): Add optional bool parameter to revert whether to swap initial and final states.
     Nft dft_begin_marker{ begin_marker_nft(begin_marker_nfa(regex, alphabet), begin_marker) };

--- a/src/nft/strings.cc
+++ b/src/nft/strings.cc
@@ -112,7 +112,8 @@ Nft mata::nft::strings::replace_reluctant(
     ReplaceMode replace_mode,
     Symbol begin_marker
 ) {
-    Nft dft_begin_marker{ begin_marker_nft(generic_marker_dfa(regex, alphabet), begin_marker) };
+    // TODO(nft): Add optional bool parameter to revert whether to swap initial and final states.
+    Nft dft_begin_marker{ begin_marker_nft(begin_marker_nfa(regex, alphabet), begin_marker) };
     Nft nft_reluctant_replace{
         reluctant_leftmost_nft(std::move(regex), alphabet, begin_marker, replacement, replace_mode) };
 //    return dft_begin_marker.compose(nft_reluctant_replace);
@@ -211,8 +212,8 @@ nfa::Nfa nft::strings::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
     return dfa_generic_end_marker;
 }
 
-Nft nft::strings::begin_marker_nft(const nfa::Nfa& begin_marker_dfa, Symbol begin_marker) {
-    Nft begin_marker_dft{ marker_nft(begin_marker_dfa, begin_marker) };
+Nft nft::strings::begin_marker_nft(const nfa::Nfa& marker_dfa, Symbol begin_marker) {
+    Nft begin_marker_dft{ marker_nft(marker_dfa, begin_marker) };
     const State new_initial{ begin_marker_dft.add_state() };
     for (const State orig_final: begin_marker_dft.final) {
         begin_marker_dft.delta.add(new_initial, EPSILON, orig_final);

--- a/src/strings/nfa-strings.cc
+++ b/src/strings/nfa-strings.cc
@@ -210,3 +210,10 @@ bool mata::strings::is_lang_eps(const Nfa& aut) {
     }
     return true;
 }
+
+Nfa mata::strings::reluctant_nfa(Nfa nfa) {
+    for (const State final: nfa.final) {
+        nfa.delta.mutable_state_post(final).clear();
+    }
+    return nfa;
+}

--- a/tests/nft/builder.cc
+++ b/tests/nft/builder.cc
@@ -55,6 +55,40 @@ TEST_CASE("nft::create_from_nfa()") {
         expected.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
+
+    SECTION("regex cb+a+") {
+        constexpr Level NUM_OF_LEVELS{ 2 };
+        nfa.initial = { 0 };
+        nfa.final = { 3 };
+        nfa.delta.add(0, 'c', 1);
+        nfa.delta.add(1, 'b', 1);
+        nfa.delta.add(1, 'b', 2);
+        nfa.delta.add(2, 'a', 2);
+        nfa.delta.add(2, 'a', 3);
+        nft = builder::create_from_nfa(nfa, NUM_OF_LEVELS);
+        expected = mata::nft::builder::parse_from_mata(
+            std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsCnt 2\nq0 99 q1\nq1 99 q2\nq2 98 q3\nq3 98 q2\nq3 98 q4\nq4 97 q5\nq5 97 q4\nq5 97 q6\n")
+        );
+        expected.num_of_levels = NUM_OF_LEVELS;
+        CHECK(mata::nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("regex cb+a+ with epsilon on added levels") {
+        constexpr Level NUM_OF_LEVELS{ 2 };
+        nfa.initial = { 0 };
+        nfa.final = { 3 };
+        nfa.delta.add(0, 'c', 1);
+        nfa.delta.add(1, 'b', 1);
+        nfa.delta.add(1, 'b', 2);
+        nfa.delta.add(2, 'a', 2);
+        nfa.delta.add(2, 'a', 3);
+        nft = builder::create_from_nfa(nfa, NUM_OF_LEVELS, { EPSILON }, { EPSILON });
+        expected = mata::nft::builder::parse_from_mata(
+            std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsCnt 2\nq0 99 q1\nq1 4294967295 q2\nq2 98 q3\nq3 4294967295 q2\nq3 4294967295 q4\nq4 97 q5\nq5 4294967295 q4\nq5 4294967295 q6\n")
+        );
+        expected.num_of_levels = NUM_OF_LEVELS;
+        CHECK(mata::nft::are_equivalent(nft, expected));
+    }
 }
 
 TEST_CASE("nft::parse_from_mata()") {

--- a/tests/nft/nft-intersection.cc
+++ b/tests/nft/nft-intersection.cc
@@ -54,14 +54,14 @@ using namespace mata::parser;
 
 // }}}
 
-TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAREs")
+TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares")
 { // {{{
     Nft a, b, res;
     std::unordered_map<std::pair<State, State>, State> prod_map;
 
     SECTION("Intersection of empty automata")
     {
-        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -71,7 +71,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
 
     SECTION("Intersection of empty automata 2")
     {
-        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -94,7 +94,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
         REQUIRE(!a.final.empty());
         REQUIRE(!b.final.empty());
 
-        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
         REQUIRE(!res.initial.empty());
         REQUIRE(!res.final.empty());
@@ -113,7 +113,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
         FILL_WITH_AUT_A(a);
         FILL_WITH_AUT_B(b);
 
-        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial[prod_map[{1, 4}]]);
         REQUIRE(res.initial[prod_map[{3, 4}]]);
@@ -164,7 +164,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
         FILL_WITH_AUT_B(b);
         b.final = {12};
 
-        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial[prod_map[{1, 4}]]);
         REQUIRE(res.initial[prod_map[{3, 4}]]);
@@ -182,7 +182,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             b.delta.add(0, 'b', 1);
             b.delta.add(1, EPSILON, 2);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(!res.initial.empty());
             CHECK(res.final.empty());
@@ -210,7 +210,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(1, 'a', 3);
             expected.delta.add(2, 'a', 3);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -233,7 +233,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(2, 'b', 3);
             expected.delta.add(3, 'c', 4);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -248,7 +248,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
 
             expected = b;
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -266,7 +266,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             b.delta.add(3, 'a', 4);
 
             std::unordered_map<std::pair<State, State>, State> prod_map;
-            Nft res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+            Nft res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
             REQUIRE(!res.initial.empty());
             REQUIRE(res.final.empty());
@@ -317,7 +317,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
         expected.delta.add(8, 'a', 9);
         expected.delta.add(10, 'b', 11);
 
-        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
         CHECK(are_equivalent(res, expected));
     }
@@ -347,7 +347,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(5, 'c', 8);
             expected.delta.add(6, 'c', 9);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -374,7 +374,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(3, 'c', 6);
             expected.delta.add(4, 'c', 7);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -403,7 +403,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(5, DONT_CARE, 8);
             expected.delta.add(6, DONT_CARE, 9);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -422,7 +422,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
             expected.delta.add(1, DONT_CARE, 2);
             expected.delta.add(2, DONT_CARE, 3);
 
-            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+            res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
             CHECK(are_equivalent(res, expected));
         }
@@ -430,13 +430,13 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAR
 } // }}}
 
 
-TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::REPEAT_SYMBOL") {
+TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") {
     Nft a, b, res;
     std::unordered_map<std::pair<State, State>, State> prod_map;
 
     SECTION("Intersection of empty automata")
     {
-        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -446,7 +446,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::REPEAT_SYMBOL")
 
     SECTION("Intersection of empty automata 2")
     {
-        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+        res = intersection(a, b, nullptr, JumpMode::AppendDontCares);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -849,7 +849,7 @@ TEST_CASE("mata::nft::intersection() for profiling", "[.profiling],[intersection
     b.delta.add(3, 'a', 7);
 
     for (size_t i{ 0 }; i < 10000; ++i) {
-        Nft result{intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs) };
+        Nft result{intersection(a, b, nullptr, JumpMode::AppendDontCares) };
     }
 }
 

--- a/tests/nft/nft-intersection.cc
+++ b/tests/nft/nft-intersection.cc
@@ -54,14 +54,14 @@ using namespace mata::parser;
 
 // }}}
 
-TEST_CASE("mata::nft::intersection()")
+TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::APPEND_DONT_CAREs")
 { // {{{
     Nft a, b, res;
     std::unordered_map<std::pair<State, State>, State> prod_map;
 
     SECTION("Intersection of empty automata")
     {
-        res = intersection(a, b, &prod_map);
+        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -71,7 +71,382 @@ TEST_CASE("mata::nft::intersection()")
 
     SECTION("Intersection of empty automata 2")
     {
-        res = intersection(a, b);
+        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+        REQUIRE(res.initial.empty());
+        REQUIRE(res.final.empty());
+        REQUIRE(res.delta.empty());
+    }
+
+    a.add_state(5);
+    b.add_state(6);
+
+    SECTION("Intersection of automata with no transitions")
+    {
+        a.initial = {1, 3};
+        a.final = {3, 5};
+
+        b.initial = {4, 6};
+        b.final = {4, 2};
+
+        REQUIRE(!a.initial.empty());
+        REQUIRE(!b.initial.empty());
+        REQUIRE(!a.final.empty());
+        REQUIRE(!b.final.empty());
+
+        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+
+        REQUIRE(!res.initial.empty());
+        REQUIRE(!res.final.empty());
+
+        State init_fin_st = prod_map[{3, 4}];
+
+        REQUIRE(res.initial[init_fin_st]);
+        REQUIRE(res.final[init_fin_st]);
+    }
+
+    a.add_state(10);
+    b.add_state(14);
+
+    SECTION("Intersection of automata with some transitions")
+    {
+        FILL_WITH_AUT_A(a);
+        FILL_WITH_AUT_B(b);
+
+        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+
+        REQUIRE(res.initial[prod_map[{1, 4}]]);
+        REQUIRE(res.initial[prod_map[{3, 4}]]);
+        REQUIRE(res.final[prod_map[{5, 2}]]);
+
+        //for (const auto& c : prod_map) std::cout << c.first.first << "," << c.first.second << " -> " << c.second << "\n";
+        //std::cout << prod_map[{7, 2}] << " " <<  prod_map[{1, 2}] << '\n';
+        REQUIRE(res.delta.contains(prod_map[{1, 4}], 'a', prod_map[{3, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 4}], 'a', prod_map[{10, 8}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 4}], 'a', prod_map[{10, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 4}], 'b', prod_map[{7, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{3, 6}], 'a', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 2}], 'a', prod_map[{3, 0}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 2}], 'a', prod_map[{5, 0}]));
+        // REQUIRE(res.delta.contains(prod_map[{7, 2}], 'b', prod_map[{1, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{3, 0}], 'a', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 2}], 'a', prod_map[{10, 0}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 2}], 'a', prod_map[{3, 0}]));
+        // REQUIRE(res.delta.contains(prod_map[{1, 2}], 'b', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{10, 0}], 'a', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{5, 0}], 'a', prod_map[{5, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{5, 2}], 'a', prod_map[{5, 0}]));
+        REQUIRE(res.delta.contains(prod_map[{10, 6}], 'a', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 6}], 'a', prod_map[{5, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 6}], 'a', prod_map[{3, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{10, 8}], 'b', prod_map[{7, 4}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 4}], 'a', prod_map[{3, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 4}], 'a', prod_map[{3, 8}]));
+        // REQUIRE(res.delta.contains(prod_map[{7, 4}], 'b', prod_map[{1, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 4}], 'a', prod_map[{5, 6}]));
+        // REQUIRE(res.delta.contains(prod_map[{7, 4}], 'b', prod_map[{1, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 6}], 'a', prod_map[{3, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{1, 6}], 'a', prod_map[{10, 2}]));
+        // REQUIRE(res.delta.contains(prod_map[{10, 2}], 'b', prod_map[{7, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{10, 2}], 'a', prod_map[{7, 0}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 0}], 'a', prod_map[{5, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 0}], 'a', prod_map[{3, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{3, 2}], 'a', prod_map[{7, 0}]));
+        REQUIRE(res.delta.contains(prod_map[{5, 6}], 'a', prod_map[{5, 2}]));
+        REQUIRE(res.delta.contains(prod_map[{3, 4}], 'a', prod_map[{7, 6}]));
+        REQUIRE(res.delta.contains(prod_map[{3, 4}], 'a', prod_map[{7, 8}]));
+        REQUIRE(res.delta.contains(prod_map[{7, 8}], 'b', prod_map[{1, 4}]));
+    }
+
+    SECTION("Intersection of automata with some transitions but without a final state")
+    {
+        FILL_WITH_AUT_A(a);
+        FILL_WITH_AUT_B(b);
+        b.final = {12};
+
+        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+
+        REQUIRE(res.initial[prod_map[{1, 4}]]);
+        REQUIRE(res.initial[prod_map[{3, 4}]]);
+        REQUIRE(res.is_lang_empty());
+    }
+
+    Nft expected;
+    SECTION("Intersection of transducers with epsilon transitions.") {
+        SECTION("The intersection results in an empty language.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            a.delta.add(0, EPSILON, 1);
+            a.delta.add(1, 'b', 2);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            b.delta.add(0, 'b', 1);
+            b.delta.add(1, EPSILON, 2);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(!res.initial.empty());
+            CHECK(res.final.empty());
+            CHECK(res.is_lang_empty());
+        }
+
+        SECTION("Epsilon is treated as an alphabet symbol.") {
+            a = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 1, 0, 0 }, 2);
+            a.delta.add(0, EPSILON, 1);
+            a.delta.add(0, 'b', 2);
+            a.delta.add(1, 'a', 3);
+            a.delta.add(2, 'a', 4);
+            a.delta.add(4, EPSILON, 4);
+
+            b = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            b.delta.add(0, EPSILON, 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(1, 'a', 3);
+            b.delta.add(1, 'b', 3);
+            b.delta.add(2, 'a', 3);
+
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            expected.delta.add(0, EPSILON, 1);
+            expected.delta.add(0, 'b', 2);
+            expected.delta.add(1, 'a', 3);
+            expected.delta.add(2, 'a', 3);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+    }
+
+    SECTION("Intersection of linear transducers with multiple levels.") {
+        SECTION("Intersection 1") {
+            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'b', 2);
+            a.delta.add(2, 'c', 3);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'b', 2);
+
+            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(3, 'c', 4);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 2") {
+            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a.delta.add(0, 'a', 1);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'b', 2);
+
+            expected = b;
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 3") {
+            a = Nft(4, { 0 }, { 3 }, { 0, 2, 3, 0 }, 5);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'b', 2);
+            a.delta.add(2, 'a', 3);
+
+            b = Nft(5, { 0 }, { 4 }, { 0, 1, 3, 4, 0 }, 5);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'c', 2);
+            b.delta.add(2, 'b', 3);
+            b.delta.add(3, 'a', 4);
+
+            std::unordered_map<std::pair<State, State>, State> prod_map;
+            Nft res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+
+            REQUIRE(!res.initial.empty());
+            REQUIRE(res.final.empty());
+            REQUIRE(res.delta.contains(prod_map[{0, 0}], 'a', prod_map[{1, 1}]));
+            REQUIRE(res.delta.contains(prod_map[{1, 1}], 'c', prod_map[{1, 2}]));
+            REQUIRE(res.delta.contains(prod_map[{1, 2}], 'b', prod_map[{2, 2}]));
+            CHECK(res.is_lang_empty());
+        }
+    }
+
+    SECTION("Intersection of complex transducers with multiple levels and an epsilon transition") {
+        a = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 1, 2, 2, 0, 0, 0 }, 3);
+        a.delta.add(0, 'a', 1);
+        a.delta.add(0, 'b', 2);
+        a.delta.add(0, 'a', 4);
+        a.delta.add(1, 'c', 3);
+        a.delta.add(2, 'a', 4);
+        a.delta.add(2, 'c', 7);
+        a.delta.add(3, 'a', 5);
+        a.delta.add(4, 'b', 6);
+        a.delta.add(5, 'a', 3);
+        a.delta.add(6, EPSILON, 4);
+        a.delta.add(7, 'c', 2);
+
+        b = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 2, 0, 0 }, 3);
+        b.delta.add(0, 'a', 1);
+        b.delta.add(0, 'b', 1);
+        b.delta.add(0, 'a', 3);
+        b.delta.add(1, 'a', 2);
+        b.delta.add(1, 'c', 4);
+        b.delta.add(2, 'b', 4);
+        b.delta.add(3, 'c', 3);
+        b.delta.add(4, EPSILON, 4);
+
+        expected = Nft(12, { 0 }, { 4, 5, 9, 11 }, { 0, 1, 1, 2, 0, 0, 2, 1, 2, 0, 2, 0 }, 3);
+        expected.delta.add(0, 'b', 1);
+        expected.delta.add(0, 'a', 2);
+        expected.delta.add(0, 'a', 7);
+        expected.delta.add(0, 'a', 10);
+        expected.delta.add(1, 'a', 3);
+        expected.delta.add(1, 'c', 4);
+        expected.delta.add(2, 'a', 3);
+        expected.delta.add(2, 'c', 6);
+        expected.delta.add(3, 'b', 5);
+        expected.delta.add(5, EPSILON, 6);
+        expected.delta.add(6, 'b', 5);
+        expected.delta.add(7, 'c', 8);
+        expected.delta.add(8, 'a', 9);
+        expected.delta.add(10, 'b', 11);
+
+        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+        CHECK(are_equivalent(res, expected));
+    }
+
+    SECTION("Intersection of transducers with the DONT_CARE symbol") {
+        SECTION("DONT_CARE is in the lhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, DONT_CARE, 1);
+            a.delta.add(1, 'c', 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(0, 'a', 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(0, 'b', 2);
+            expected.delta.add(0, 'a', 3);
+            expected.delta.add(1, 'c', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'e', 6);
+            expected.delta.add(4, 'c', 7);
+            expected.delta.add(5, 'c', 8);
+            expected.delta.add(6, 'c', 9);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in the rhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'c', 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, DONT_CARE, 1);
+            b.delta.add(0, DONT_CARE, 2);
+            b.delta.add(0, DONT_CARE, 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(1, 'd', 3);
+            expected.delta.add(1, 'e', 4);
+            expected.delta.add(2, 'c', 5);
+            expected.delta.add(3, 'c', 6);
+            expected.delta.add(4, 'c', 7);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a higher level than it is in rhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, DONT_CARE, 1);
+            a.delta.add(1, DONT_CARE, 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, DONT_CARE, 1);
+            b.delta.add(0, DONT_CARE, 2);
+            b.delta.add(0, DONT_CARE, 3);
+            b.delta.add(1, 'c', 4);
+            b.delta.add(2, 'd', 5);
+            b.delta.add(3, 'e', 6);
+
+            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected.delta.add(0, DONT_CARE, 1);
+            expected.delta.add(0, DONT_CARE, 2);
+            expected.delta.add(0, DONT_CARE, 3);
+            expected.delta.add(1, 'c', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'e', 6);
+            expected.delta.add(4, DONT_CARE, 7);
+            expected.delta.add(5, DONT_CARE, 8);
+            expected.delta.add(6, DONT_CARE, 9);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in the rhs at a higher level than it is in the lhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 3);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, DONT_CARE, 2);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, DONT_CARE, 2);
+
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, DONT_CARE, 2);
+            expected.delta.add(2, DONT_CARE, 3);
+
+            res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
+
+            CHECK(are_equivalent(res, expected));
+        }
+    }
+} // }}}
+
+
+TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::REPEAT_SYMBOL") {
+    Nft a, b, res;
+    std::unordered_map<std::pair<State, State>, State> prod_map;
+
+    SECTION("Intersection of empty automata")
+    {
+        res = intersection(a, b, &prod_map, JumpMode::APPEND_DONT_CAREs);
+
+        REQUIRE(res.initial.empty());
+        REQUIRE(res.final.empty());
+        REQUIRE(res.delta.empty());
+        REQUIRE(prod_map.empty());
+    }
+
+    SECTION("Intersection of empty automata 2")
+    {
+        res = intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs);
 
         REQUIRE(res.initial.empty());
         REQUIRE(res.final.empty());
@@ -235,10 +610,32 @@ TEST_CASE("mata::nft::intersection()")
 
             res = intersection(a, b);
 
-            CHECK(are_equivalent(res, expected));
+            CHECK(res.is_lang_empty());
+            CHECK(!are_equivalent(res, expected));
         }
 
         SECTION("Intersection 2") {
+            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, 'a', 2);
+            a.delta.add(2, 'a', 3);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'a', 2);
+
+            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(3, 'a', 4);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 3") {
             a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
             a.delta.add(0, 'a', 1);
 
@@ -250,30 +647,46 @@ TEST_CASE("mata::nft::intersection()")
 
             res = intersection(a, b);
 
+            CHECK(!are_equivalent(res, expected));
+        }
+
+        SECTION("Intersection 4") {
+            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a.delta.add(0, 'a', 1);
+
+            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(1, 'a', 2);
+
+            expected = b;
+
+            res = intersection(a, b);
+
             CHECK(are_equivalent(res, expected));
         }
 
-        SECTION("Intersection 3") {
+        SECTION("Intersection 5") {
             a = Nft(4, { 0 }, { 3 }, { 0, 2, 3, 0 }, 5);
             a.delta.add(0, 'a', 1);
-            a.delta.add(1, 'b', 2);
-            a.delta.add(2, 'a', 3);
+            a.delta.add(1, 'a', 2);
+            a.delta.add(2, 'b', 3);
 
             b = Nft(5, { 0 }, { 4 }, { 0, 1, 3, 4, 0 }, 5);
             b.delta.add(0, 'a', 1);
-            b.delta.add(1, 'c', 2);
+            b.delta.add(1, 'a', 2);
             b.delta.add(2, 'b', 3);
-            b.delta.add(3, 'a', 4);
+            b.delta.add(3, 'b', 4);
 
-            std::unordered_map<std::pair<State, State>, State> prod_map;
-            Nft res = intersection(a, b, &prod_map);
+            expected = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(3, 'b', 4);
+            expected.delta.add(4, 'b', 5);
 
-            REQUIRE(!res.initial.empty());
-            REQUIRE(res.final.empty());
-            REQUIRE(res.delta.contains(prod_map[{0, 0}], 'a', prod_map[{1, 1}]));
-            REQUIRE(res.delta.contains(prod_map[{1, 1}], 'c', prod_map[{1, 2}]));
-            REQUIRE(res.delta.contains(prod_map[{1, 2}], 'b', prod_map[{2, 2}]));
-            CHECK(res.is_lang_empty());
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
         }
     }
 
@@ -298,24 +711,17 @@ TEST_CASE("mata::nft::intersection()")
         b.delta.add(1, 'a', 2);
         b.delta.add(1, 'c', 4);
         b.delta.add(2, 'b', 4);
-        b.delta.add(3, 'c', 3);
-        b.delta.add(4, EPSILON, 4);
+        b.delta.add(3, EPSILON, 3);
+        b.delta.add(4, 'c', 4);
 
-        expected = Nft(12, { 0 }, { 4, 5, 9, 11 }, { 0, 1, 1, 2, 0, 0, 2, 1, 2, 0, 2, 0 }, 3);
+        expected = Nft(6, { 0 }, { 3, 5 }, { 0, 1, 2, 0, 1, 0}, 3);
+        expected.delta.add(0, 'a', 1);
         expected.delta.add(0, 'b', 1);
-        expected.delta.add(0, 'a', 2);
-        expected.delta.add(0, 'a', 7);
-        expected.delta.add(0, 'a', 10);
-        expected.delta.add(1, 'a', 3);
-        expected.delta.add(1, 'c', 4);
-        expected.delta.add(2, 'a', 3);
-        expected.delta.add(2, 'c', 6);
-        expected.delta.add(3, 'b', 5);
-        expected.delta.add(5, EPSILON, 6);
-        expected.delta.add(6, 'b', 5);
-        expected.delta.add(7, 'c', 8);
-        expected.delta.add(8, 'a', 9);
-        expected.delta.add(10, 'b', 11);
+        expected.delta.add(0, 'b', 4);
+        expected.delta.add(1, 'a', 2);
+        expected.delta.add(2, 'b', 3);
+        expected.delta.add(4, 'c', 5);
+        expected.delta.add(5, 'c', 4);
 
         res = intersection(a, b);
 
@@ -336,16 +742,10 @@ TEST_CASE("mata::nft::intersection()")
             b.delta.add(2, 'd', 5);
             b.delta.add(3, 'e', 6);
 
-            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
             expected.delta.add(0, 'a', 1);
-            expected.delta.add(0, 'b', 2);
-            expected.delta.add(0, 'a', 3);
-            expected.delta.add(1, 'c', 4);
-            expected.delta.add(2, 'd', 5);
-            expected.delta.add(3, 'e', 6);
-            expected.delta.add(4, 'c', 7);
-            expected.delta.add(5, 'c', 8);
-            expected.delta.add(6, 'c', 9);
+            expected.delta.add(1, 'c', 2);
+            expected.delta.add(2, 'c', 3);
 
             res = intersection(a, b);
 
@@ -358,68 +758,63 @@ TEST_CASE("mata::nft::intersection()")
             a.delta.add(1, 'c', 2);
 
             b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
-            b.delta.add(0, DONT_CARE, 1);
-            b.delta.add(0, DONT_CARE, 2);
-            b.delta.add(0, DONT_CARE, 3);
-            b.delta.add(1, 'c', 4);
-            b.delta.add(2, 'd', 5);
-            b.delta.add(3, 'e', 6);
-
-            expected = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 2, 2, 2, 0, 0, 0 }, 3);
-            expected.delta.add(0, 'a', 1);
-            expected.delta.add(1, 'c', 2);
-            expected.delta.add(1, 'd', 3);
-            expected.delta.add(1, 'e', 4);
-            expected.delta.add(2, 'c', 5);
-            expected.delta.add(3, 'c', 6);
-            expected.delta.add(4, 'c', 7);
-
-            res = intersection(a, b);
-
-            CHECK(are_equivalent(res, expected));
-        }
-
-        SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a higher level than it is in rhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
-            a.delta.add(0, DONT_CARE, 1);
-            a.delta.add(1, DONT_CARE, 2);
-
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
-            b.delta.add(0, DONT_CARE, 1);
-            b.delta.add(0, DONT_CARE, 2);
-            b.delta.add(0, DONT_CARE, 3);
-            b.delta.add(1, 'c', 4);
-            b.delta.add(2, 'd', 5);
-            b.delta.add(3, 'e', 6);
-
-            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
-            expected.delta.add(0, DONT_CARE, 1);
-            expected.delta.add(0, DONT_CARE, 2);
-            expected.delta.add(0, DONT_CARE, 3);
-            expected.delta.add(1, 'c', 4);
-            expected.delta.add(2, 'd', 5);
-            expected.delta.add(3, 'e', 6);
-            expected.delta.add(4, DONT_CARE, 7);
-            expected.delta.add(5, DONT_CARE, 8);
-            expected.delta.add(6, DONT_CARE, 9);
-
-            res = intersection(a, b);
-
-            CHECK(are_equivalent(res, expected));
-        }
-
-        SECTION("DONT_CARE is in the rhs at a higher level than it is in the lhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 3);
-            a.delta.add(0, 'a', 1);
-            a.delta.add(1, DONT_CARE, 2);
-
-            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
             b.delta.add(0, 'a', 1);
-            b.delta.add(1, DONT_CARE, 2);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(0, 'a', 3);
+            b.delta.add(1, DONT_CARE, 4);
+            b.delta.add(2, DONT_CARE, 5);
+            b.delta.add(3, DONT_CARE, 6);
 
             expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
             expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'c', 3);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a smaller level than it is in rhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, DONT_CARE, 1);
+            a.delta.add(1, 'c', 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(0, 'a', 3);
+            b.delta.add(1, DONT_CARE, 4);
+            b.delta.add(2, DONT_CARE, 5);
+            b.delta.add(3, DONT_CARE, 6);
+
+            expected = Nft(3, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(0, 'b', 1);
             expected.delta.add(1, DONT_CARE, 2);
+            expected.delta.add(2, 'c', 3);
+
+            res = intersection(a, b);
+
+            CHECK(are_equivalent(res, expected));
+        }
+
+        SECTION("DONT_CARE is in the rhs at a smaller level than it is in the lhs.") {
+            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a.delta.add(0, 'a', 1);
+            a.delta.add(1, DONT_CARE, 2);
+
+            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b.delta.add(0, 'a', 1);
+            b.delta.add(0, 'b', 2);
+            b.delta.add(0, 'a', 3);
+            b.delta.add(1, DONT_CARE, 4);
+            b.delta.add(2, DONT_CARE, 5);
+            b.delta.add(3, DONT_CARE, 6);
+
+            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected.delta.add(0, 'a', 1);
+            expected.delta.add(1, 'a', 2);
             expected.delta.add(2, DONT_CARE, 3);
 
             res = intersection(a, b);
@@ -427,7 +822,7 @@ TEST_CASE("mata::nft::intersection()")
             CHECK(are_equivalent(res, expected));
         }
     }
-} // }}}
+}
 
 
 TEST_CASE("mata::nft::intersection() for profiling", "[.profiling],[intersection]")
@@ -454,7 +849,7 @@ TEST_CASE("mata::nft::intersection() for profiling", "[.profiling],[intersection
     b.delta.add(3, 'a', 7);
 
     for (size_t i{ 0 }; i < 10000; ++i) {
-        Nft result{intersection(a, b) };
+        Nft result{intersection(a, b, nullptr, JumpMode::APPEND_DONT_CAREs) };
     }
 }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3146,7 +3146,7 @@ TEST_CASE("mata::nft::Nft::add_state()") {
 }
 
 
-TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
+TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3157,7 +3157,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0 = project_out(atm, OrdVector<Level>{ 0 }, false);
+            Nft proj0 = project_out(atm, OrdVector<Level>{ 0 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_expected.delta.add(0, 1, 1);
             proj0_expected.delta.add(1, 2, 2);
@@ -3166,7 +3166,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 1") {
-            Nft proj1 = project_out(atm, 1, false);
+            Nft proj1 = project_out(atm, 1, JumpMode::APPEND_DONT_CAREs);
             Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_expected.delta.add(0, 0, 1);
             proj1_expected.delta.add(1, 2, 2);
@@ -3174,7 +3174,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 2") {
-            Nft proj2 = project_out(atm, 2, false);
+            Nft proj2 = project_out(atm, 2, JumpMode::APPEND_DONT_CAREs);
             Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_expected.delta.add(0, 0, 1);
             proj2_expected.delta.add(1, 1, 2);
@@ -3194,7 +3194,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_loop = project_out(atm_loop, 0, false);
+            Nft proj0_loop = project_out(atm_loop, 0, JumpMode::APPEND_DONT_CAREs);
             Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_loop_expected.delta.add(0, DONT_CARE, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
@@ -3204,7 +3204,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 1") {
-            Nft proj1_loop = project_out(atm_loop, 1, false);
+            Nft proj1_loop = project_out(atm_loop, 1, JumpMode::APPEND_DONT_CAREs);
             Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_loop_expected.delta.add(0, 3, 0);
             proj1_loop_expected.delta.add(0, 0, 1);
@@ -3214,7 +3214,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 2") {
-            Nft proj2_loop = project_out(atm_loop, 2, false);
+            Nft proj2_loop = project_out(atm_loop, 2, JumpMode::APPEND_DONT_CAREs);
             Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_loop_expected.delta.add(0, 3, 0);
             proj2_loop_expected.delta.add(0, 0, 1);
@@ -3225,7 +3225,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
 
         SECTION("project 0, 1, 2") {
             Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
-            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, false);
+            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, JumpMode::APPEND_DONT_CAREs);
             CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0)));
         }
     }
@@ -3241,7 +3241,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         Nft nft_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_complex = project_out(nft_complex, 0, false);
+            Nft proj0_complex = project_out(nft_complex, 0, JumpMode::APPEND_DONT_CAREs);
             Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_complex_expected.delta.add(0, 1, 1);
             proj0_complex_expected.delta.add(0, DONT_CARE, 2);
@@ -3251,7 +3251,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 1") {
-            Nft proj1_complex = project_out(nft_complex, 1, false);
+            Nft proj1_complex = project_out(nft_complex, 1, JumpMode::APPEND_DONT_CAREs);
             Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_complex_expected.delta.add(0, 0, 1);
             proj1_complex_expected.delta.add(0, 3, 2);
@@ -3261,7 +3261,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 2") {
-            Nft proj2_complex = project_out(nft_complex, OrdVector<Level>{ 2 }, false);
+            Nft proj2_complex = project_out(nft_complex, OrdVector<Level>{ 2 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_complex_expected.delta.add(0, 0, 1);
             proj2_complex_expected.delta.add(0, 3, 2);
@@ -3280,7 +3280,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 0, 1") {
-            Nft proj01_complex = project_out(nft_complex, { 0, 1 }, false);
+            Nft proj01_complex = project_out(nft_complex, { 0, 1 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj01_complex_expected.delta.add(0, 2, 1);
             proj01_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3289,7 +3289,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 0, 2") {
-            Nft proj02_complex = project_out(nft_complex, { 0, 2 }, false);
+            Nft proj02_complex = project_out(nft_complex, { 0, 2 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj02_complex_expected.delta.add(0, 1, 1);
             proj02_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3298,7 +3298,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 1, 2") {
-            Nft proj12_complex = project_out(nft_complex, { 1, 2 }, false);
+            Nft proj12_complex = project_out(nft_complex, { 1, 2 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj12_complex_expected.delta.add(0, 0, 1);
             proj12_complex_expected.delta.add(0, 3, 1);
@@ -3307,7 +3307,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, false);
+            Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, JumpMode::APPEND_DONT_CAREs);
             Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
             CHECK(are_equivalent(proj012_complex, proj012_complex_expected));
         }
@@ -3327,7 +3327,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
         atm_hard.delta.add(6, 8, 7);
         atm_hard.delta.add(7, 9, 2);
 
-        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, false);
+        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, JumpMode::APPEND_DONT_CAREs);
 
         Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
         proj_hard_expected.delta.add(0, 0, 2);
@@ -3343,7 +3343,7 @@ TEST_CASE("mata::nft::project_out(repeat_jump_symbol = false)") {
     }
 }
 
-TEST_CASE("mata::nft::project_out(repeat_jump_symbol = true)") {
+TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::REPEAT_SYMBOL)") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3662,7 +3662,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
     Delta delta;
     Nft input_nft, output_nft, expected_nft;
 
-    SECTION("Linear - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
@@ -3670,7 +3670,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3680,7 +3680,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
@@ -3690,7 +3690,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3700,7 +3700,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3710,7 +3710,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 4") {
-            output_nft = insert_level(input_nft, 4, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 4, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3721,7 +3721,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 100011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, false);
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3733,7 +3733,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Linear - default_symbol = DONT_CARE, repeat_jump_symbol = true") {
+    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::REPEAT_SYMBOL") {
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
@@ -3804,7 +3804,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Linear - default_symbol = 42, repeat_jump_symbol = false") {
+    SECTION("Linear - default_symbol = 42, jump_mode == JumpMode::APPEND_DONT_CAREs") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
@@ -3876,7 +3876,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("loop - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+    SECTION("loop - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
         delta.clear();
         delta.add(0, 4, 0);
         delta.add(0, 0, 1);
@@ -3887,7 +3887,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 4, 0);
@@ -3901,7 +3901,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 7);
@@ -3919,7 +3919,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(9, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 2, 3, 2, 3 }, 4);
             expected_nft.delta.add(0, 4, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
@@ -3935,7 +3935,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3 }, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 0);
@@ -3949,7 +3949,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, false);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 8);
             expected_nft.delta.add(8, 4, 9);
@@ -3976,7 +3976,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("loop - default_symbol = 42, repeat_jump_symbol = true") {
+    SECTION("loop - default_symbol = 42, jump_mode == JumpMode::REPEAT_SYMBOL") {
         delta.clear();
         delta.add(0, 4, 0);
         delta.add(0, 0, 1);
@@ -4086,7 +4086,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("complex - default_symbol = DONT_CARE, repeat_jump_symbol = false") {
+    SECTION("complex - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);
@@ -4098,7 +4098,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 3 }, { 0, 2, 3, 0, 1, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
@@ -4113,7 +4113,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(8, { 0 }, { 3 }, { 0, 1, 3, 0, 2, 2, 2, 2 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 6);
@@ -4129,7 +4129,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 2, 3, 2 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4144,7 +4144,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, false);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 3, 3, 3 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4159,7 +4159,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, false);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
             expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 0, 1);
@@ -4188,7 +4188,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Complex - default_symbol = 42, repeat_jump_symbol = false") {
+    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::APPEND_DONT_CAREs") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);
@@ -4199,7 +4199,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
-        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, false);
+        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, JumpMode::APPEND_DONT_CAREs);
         expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
         expected_nft.delta.add(0, 42, 5);
         expected_nft.delta.add(5, 0, 1);
@@ -4227,7 +4227,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         CHECK(are_equivalent(output_nft, expected_nft));
     }
 
-    SECTION("Complex - default_symbol = 42, repeat_jump_symbol = true") {
+    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::REPEAT_SYMBOL") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3146,7 +3146,7 @@ TEST_CASE("mata::nft::Nft::add_state()") {
 }
 
 
-TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
+TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3157,7 +3157,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0 = project_out(atm, OrdVector<Level>{ 0 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj0 = project_out(atm, OrdVector<Level>{ 0 }, JumpMode::AppendDontCares);
             Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_expected.delta.add(0, 1, 1);
             proj0_expected.delta.add(1, 2, 2);
@@ -3166,7 +3166,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 1") {
-            Nft proj1 = project_out(atm, 1, JumpMode::APPEND_DONT_CAREs);
+            Nft proj1 = project_out(atm, 1, JumpMode::AppendDontCares);
             Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_expected.delta.add(0, 0, 1);
             proj1_expected.delta.add(1, 2, 2);
@@ -3174,7 +3174,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 2") {
-            Nft proj2 = project_out(atm, 2, JumpMode::APPEND_DONT_CAREs);
+            Nft proj2 = project_out(atm, 2, JumpMode::AppendDontCares);
             Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_expected.delta.add(0, 0, 1);
             proj2_expected.delta.add(1, 1, 2);
@@ -3194,7 +3194,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_loop = project_out(atm_loop, 0, JumpMode::APPEND_DONT_CAREs);
+            Nft proj0_loop = project_out(atm_loop, 0, JumpMode::AppendDontCares);
             Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_loop_expected.delta.add(0, DONT_CARE, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
@@ -3204,7 +3204,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 1") {
-            Nft proj1_loop = project_out(atm_loop, 1, JumpMode::APPEND_DONT_CAREs);
+            Nft proj1_loop = project_out(atm_loop, 1, JumpMode::AppendDontCares);
             Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_loop_expected.delta.add(0, 3, 0);
             proj1_loop_expected.delta.add(0, 0, 1);
@@ -3214,7 +3214,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 2") {
-            Nft proj2_loop = project_out(atm_loop, 2, JumpMode::APPEND_DONT_CAREs);
+            Nft proj2_loop = project_out(atm_loop, 2, JumpMode::AppendDontCares);
             Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_loop_expected.delta.add(0, 3, 0);
             proj2_loop_expected.delta.add(0, 0, 1);
@@ -3225,7 +3225,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
 
         SECTION("project 0, 1, 2") {
             Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
-            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, JumpMode::AppendDontCares);
             CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0)));
         }
     }
@@ -3241,7 +3241,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         Nft nft_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("project 0") {
-            Nft proj0_complex = project_out(nft_complex, 0, JumpMode::APPEND_DONT_CAREs);
+            Nft proj0_complex = project_out(nft_complex, 0, JumpMode::AppendDontCares);
             Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj0_complex_expected.delta.add(0, 1, 1);
             proj0_complex_expected.delta.add(0, DONT_CARE, 2);
@@ -3251,7 +3251,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 1") {
-            Nft proj1_complex = project_out(nft_complex, 1, JumpMode::APPEND_DONT_CAREs);
+            Nft proj1_complex = project_out(nft_complex, 1, JumpMode::AppendDontCares);
             Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj1_complex_expected.delta.add(0, 0, 1);
             proj1_complex_expected.delta.add(0, 3, 2);
@@ -3261,7 +3261,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 2") {
-            Nft proj2_complex = project_out(nft_complex, OrdVector<Level>{ 2 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj2_complex = project_out(nft_complex, OrdVector<Level>{ 2 }, JumpMode::AppendDontCares);
             Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
             proj2_complex_expected.delta.add(0, 0, 1);
             proj2_complex_expected.delta.add(0, 3, 2);
@@ -3280,7 +3280,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 0, 1") {
-            Nft proj01_complex = project_out(nft_complex, { 0, 1 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj01_complex = project_out(nft_complex, { 0, 1 }, JumpMode::AppendDontCares);
             Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj01_complex_expected.delta.add(0, 2, 1);
             proj01_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3289,7 +3289,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 0, 2") {
-            Nft proj02_complex = project_out(nft_complex, { 0, 2 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj02_complex = project_out(nft_complex, { 0, 2 }, JumpMode::AppendDontCares);
             Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj02_complex_expected.delta.add(0, 1, 1);
             proj02_complex_expected.delta.add(0, DONT_CARE, 1);
@@ -3298,7 +3298,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 1, 2") {
-            Nft proj12_complex = project_out(nft_complex, { 1, 2 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj12_complex = project_out(nft_complex, { 1, 2 }, JumpMode::AppendDontCares);
             Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
             proj12_complex_expected.delta.add(0, 0, 1);
             proj12_complex_expected.delta.add(0, 3, 1);
@@ -3307,7 +3307,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, JumpMode::APPEND_DONT_CAREs);
+            Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, JumpMode::AppendDontCares);
             Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
             CHECK(are_equivalent(proj012_complex, proj012_complex_expected));
         }
@@ -3327,7 +3327,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
         atm_hard.delta.add(6, 8, 7);
         atm_hard.delta.add(7, 9, 2);
 
-        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, JumpMode::APPEND_DONT_CAREs);
+        Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, JumpMode::AppendDontCares);
 
         Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
         proj_hard_expected.delta.add(0, 0, 2);
@@ -3343,7 +3343,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::APPEND_DONT_CAREs)") {
     }
 }
 
-TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::REPEAT_SYMBOL)") {
+TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
     SECTION("LINEAR") {
         Delta delta;
@@ -3662,7 +3662,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
     Delta delta;
     Nft input_nft, output_nft, expected_nft;
 
-    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
+    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::AppendDontCares") {
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
@@ -3670,7 +3670,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3680,7 +3680,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
@@ -3690,7 +3690,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3700,7 +3700,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3710,7 +3710,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 4") {
-            output_nft = insert_level(input_nft, 4, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 4, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3721,7 +3721,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 100011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3733,7 +3733,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::REPEAT_SYMBOL") {
+    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::RepeatSymbol") {
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
@@ -3804,7 +3804,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Linear - default_symbol = 42, jump_mode == JumpMode::APPEND_DONT_CAREs") {
+    SECTION("Linear - default_symbol = 42, jump_mode == JumpMode::AppendDontCares") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
@@ -3876,7 +3876,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("loop - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
+    SECTION("loop - default_symbol = DONT_CARE, jump_mode == JumpMode::AppendDontCares") {
         delta.clear();
         delta.add(0, 4, 0);
         delta.add(0, 0, 1);
@@ -3887,7 +3887,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 4, 0);
@@ -3901,7 +3901,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 7);
@@ -3919,7 +3919,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(9, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 2, 3, 2, 3 }, 4);
             expected_nft.delta.add(0, 4, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
@@ -3935,7 +3935,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3 }, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 0);
@@ -3949,7 +3949,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 8);
             expected_nft.delta.add(8, 4, 9);
@@ -3976,7 +3976,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("loop - default_symbol = 42, jump_mode == JumpMode::REPEAT_SYMBOL") {
+    SECTION("loop - default_symbol = 42, jump_mode == JumpMode::RepeatSymbol") {
         delta.clear();
         delta.add(0, 4, 0);
         delta.add(0, 0, 1);
@@ -4086,7 +4086,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("complex - default_symbol = DONT_CARE, jump_mode == JumpMode::APPEND_DONT_CAREs") {
+    SECTION("complex - default_symbol = DONT_CARE, jump_mode == JumpMode::AppendDontCares") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);
@@ -4098,7 +4098,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, { 0, 2, 3, 0, 1, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
@@ -4113,7 +4113,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(8, { 0 }, { 3 }, { 0, 1, 3, 0, 2, 2, 2, 2 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 6);
@@ -4129,7 +4129,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 2, 3, 2 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4144,7 +4144,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 3, 3, 3 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4159,7 +4159,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::APPEND_DONT_CAREs);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
             expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 0, 1);
@@ -4188,7 +4188,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::APPEND_DONT_CAREs") {
+    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::AppendDontCares") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);
@@ -4199,7 +4199,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
-        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, JumpMode::APPEND_DONT_CAREs);
+        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, JumpMode::AppendDontCares);
         expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
         expected_nft.delta.add(0, 42, 5);
         expected_nft.delta.add(5, 0, 1);
@@ -4227,7 +4227,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         CHECK(are_equivalent(output_nft, expected_nft));
     }
 
-    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::REPEAT_SYMBOL") {
+    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::RepeatSymbol") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(0, 4, 2);

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -803,41 +803,41 @@ TEST_CASE("mata::nft::strings::replace_reluctant_symbol()") {
     }
 }
 
-TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
-    Nft nft{};
-    Nft expected{};
-    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+// TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
+//     Nft nft{};
+//     Nft expected{};
+//     EnumAlphabet alphabet{ 'a', 'b', 'c' };
 
-    SECTION("'a+b+c' replace with 'dd' replace all") {
-        // Use replace symbol with symbol.
-        nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
-                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
-                                     {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
-                                     { 'a', 'a', 'a', 'b', 'd', 'c', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
-                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
-                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
-//        expected = nft::builder::parse_from_mata(std::string(
-//        ));
-//        CHECK(nft::are_equivalent(nft, expected));
-    }
+//     SECTION("'a+b+c' replace with 'dd' replace all") {
+//         // Use replace symbol with symbol.
+//         nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
+//         nft.print_to_DOT(std::cout);
+//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+//                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+//         CHECK(nft.is_tuple_in_lang({ {},
+//                                      {} }));
+//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
+//                                      { 'a', 'a', 'a', 'b', 'd', 'c', 'a', 'a' } }));
+//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
+//                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
+//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
+//                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
+// //        expected = nft::builder::parse_from_mata(std::string(
+// //        ));
+// //        CHECK(nft::are_equivalent(nft, expected));
+//     }
 
-    SECTION("'a' replace with 'd' replace all") {
-        // Use replace symbol with symbol.
-        nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
-                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
-                                     {} }));
-//        expected = nft::builder::parse_from_mata(std::string(
-//        ));
-//        CHECK(nft::are_equivalent(nft, expected));
-    }
-    // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
-}
+//     SECTION("'a' replace with 'd' replace all") {
+//         // Use replace symbol with symbol.
+//         nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
+//         nft.print_to_DOT(std::cout);
+//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+//                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
+//         CHECK(nft.is_tuple_in_lang({ {},
+//                                      {} }));
+// //        expected = nft::builder::parse_from_mata(std::string(
+// //        ));
+// //        CHECK(nft::are_equivalent(nft, expected));
+//     }
+//     // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
+// }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -470,7 +470,7 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
     constexpr Symbol MARKER{ EPSILON - 100 };
 
-    SECTION("'cb+a+' replaced with 'ddd'") {
+    SECTION("all 'cb+a+' replaced with 'ddd'") {
         nft = reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
@@ -478,11 +478,29 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
         CHECK(nft::are_equivalent(nft, expected));
     }
 
-    SECTION("'a+b+c' replaced with '' (empty string)") {
+    SECTION("single 'a+b+c' replaced with '' (empty string)") {
         nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{}, ReplaceMode::Single);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
+    }
+
+    SECTION("All 'a+b+c' replaced with 'd'") {
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{ 'd' }, ReplaceMode::All);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 100 q20\nq20 4294967295 q21\nq21 4294967295 q22\nq22 4294967295 q14\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
     }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -466,16 +466,23 @@ TEST_CASE("mata::nft::strings::reluctant_nfa_with_marker()") {
 
 TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     Nft nft{};
-    nfa::Nfa regex{};
+    Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
     constexpr Symbol MARKER{ EPSILON - 100 };
 
     SECTION("'cb+a+' replaced with 'ddd'") {
-        Nft nft_reluctant_replace{
-            reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All)
-        };
-        nft::Nft expected{ nft::builder::parse_from_mata(std::string(
-            "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n")) };
-        CHECK(nft::are_equivalent(nft_reluctant_replace, expected));
+        nft = reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'a+b+c' replaced with '' (empty string)") {
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{}, ReplaceMode::Single);
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
     }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -565,3 +565,41 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
         CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
     }
 }
+
+TEST_CASE("mata::nft::literal_replace_nft()") {
+    Nft nft{};
+    Nft expected{};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    Symbol end_marker{ EPSILON - 99 };
+
+    SECTION("'abcc' replace with 'a' replace all") {
+        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, end_marker, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', end_marker },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'abcc' replace with 'bbb' replace single") {
+        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, end_marker, ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', end_marker },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'aabac' replace with 'd' replace all") {
+        nft = replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, end_marker,
+                                  ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', end_marker },
+                                     { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+}

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -93,48 +93,140 @@ TEST_CASE("nft::create_identity()") {
     }
 }
 
-TEST_CASE("nft::create_identity_with_single_replace()") {
-    Nft nft{};
-    nft.initial = { 0 };
-    nft.final = { 0 };
+TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
+    Nft expected{};
+    expected.initial = { 0 };
+    expected.final = { 0 };
     SECTION("small identity nft") {
         EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        nft.alphabet = &alphabet;
-        nft.delta.add(0, 0, 1);
-        nft.delta.add(1, 0, 0);
-        nft.delta.add(0, 1, 2);
-        nft.delta.add(2, 3, 0);
-        nft.delta.add(0, 2, 3);
-        nft.delta.add(3, 2, 0);
-        nft.delta.add(0, 3, 4);
-        nft.delta.add(4, 3, 0);
-        nft.num_of_levels = 2;
-        nft.levels.resize(5);
-        nft.levels[0] = 0;
-        nft.levels[1] = 1;
-        nft.levels[2] = 1;
-        nft.levels[3] = 1;
-        nft.levels[4] = 1;
-        Nft nft_identity_with_replace{ create_identity_with_single_replace(&alphabet, 1, 3) };
-        CHECK(nft_identity_with_replace.is_identical(nft));
+        expected.alphabet = &alphabet;
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(1, 0, 0);
+        expected.delta.add(0, 1, 2);
+        expected.delta.add(2, 3, 0);
+        expected.delta.add(0, 2, 3);
+        expected.delta.add(3, 2, 0);
+        expected.delta.add(0, 3, 4);
+        expected.delta.add(4, 3, 0);
+        expected.num_of_levels = 2;
+        expected.levels.resize(5);
+        expected.levels[0] = 0;
+        expected.levels[1] = 1;
+        expected.levels[2] = 1;
+        expected.levels[3] = 1;
+        expected.levels[4] = 1;
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, 3) };
+        CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
     }
 
     SECTION("identity nft no symbols") {
         EnumAlphabet alphabet{};
-        CHECK_THROWS(create_identity_with_single_replace(&alphabet, 1, 2));
+        CHECK_THROWS(create_identity_with_single_symbol_replace(&alphabet, 1, 2));
     }
 
     SECTION("identity nft one symbol") {
         EnumAlphabet alphabet{ 0 };
-        nft.alphabet = &alphabet;
-        nft.num_of_levels = 2;
-        nft.levels.resize(2);
-        nft.levels[0] = 0;
-        nft.levels[1] = 1;
-        nft.delta.add(0, 0, 1);
-        nft.delta.add(1, 1, 0);
-        Nft nft_identity{ create_identity_with_single_replace(&alphabet, 0, 1) };
-        CHECK(nft_identity.is_identical(nft));
+        expected.alphabet = &alphabet;
+        expected.num_of_levels = 2;
+        expected.levels.resize(2);
+        expected.levels[0] = 0;
+        expected.levels[1] = 1;
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(1, 1, 0);
+        Nft nft_identity{ create_identity_with_single_symbol_replace(&alphabet, 0, 1) };
+        CHECK(nft::are_equivalent(nft_identity, expected));
+    }
+
+    SECTION("small identity expected longer replace") {
+        EnumAlphabet alphabet{ 0, 1, 2, 3 };
+        expected.alphabet = &alphabet;
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(1, 0, 0);
+        expected.delta.add(0, 1, 2);
+        expected.delta.add(2, 5, 5);
+        expected.delta.add(5, EPSILON, 6);
+        expected.delta.add(6, 6, 7);
+        expected.delta.add(7, EPSILON, 8);
+        expected.delta.add(8, 7, 0);
+        expected.delta.add(0, 2, 3);
+        expected.delta.add(3, 2, 0);
+        expected.delta.add(0, 3, 4);
+        expected.delta.add(4, 3, 0);
+        expected.num_of_levels = 2;
+        expected.levels.resize(9);
+        expected.levels[0] = 0;
+        expected.levels[1] = 1;
+        expected.levels[2] = 1;
+        expected.levels[3] = 1;
+        expected.levels[4] = 1;
+        expected.levels[5] = 0;
+        expected.levels[6] = 1;
+        expected.levels[7] = 0;
+        expected.levels[8] = 1;
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{ 5, 6, 7 }) };
+        CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
+    }
+
+    SECTION("small identity expected replace symbol with empty string") {
+        EnumAlphabet alphabet{ 0, 1, 2, 3 };
+        expected.alphabet = &alphabet;
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(1, 0, 0);
+        expected.delta.add(0, 1, 2);
+        expected.delta.add(2, EPSILON, 0);
+        expected.delta.add(0, 2, 3);
+        expected.delta.add(3, 2, 0);
+        expected.delta.add(0, 3, 4);
+        expected.delta.add(4, 3, 0);
+        expected.num_of_levels = 2;
+        expected.levels.resize(5);
+        expected.levels[0] = 0;
+        expected.levels[1] = 1;
+        expected.levels[2] = 1;
+        expected.levels[3] = 1;
+        expected.levels[4] = 1;
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{}) };
+        CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
+    }
+
+    SECTION("identity expected one symbol with word replace") {
+        EnumAlphabet alphabet{ 0 };
+        expected.alphabet = &alphabet;
+        expected.num_of_levels = 2;
+        expected.levels.resize(2);
+        expected.levels[0] = 0;
+        expected.levels[1] = 1;
+        expected.delta.add(0, 0, 1);
+        expected.delta.add(1, 0, 0);
+        Nft nft_identity{ create_identity_with_single_symbol_replace(&alphabet, 0, Word{ 0 }) };
+        CHECK(nft::are_equivalent(nft_identity, expected));
+    }
+
+    SECTION("small identity expected longer replace single replacement") {
+        EnumAlphabet alphabet{ 0, 1, 2, 3 };
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q9\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:1 q7:0 q8:1 q9:0 q10:1 q11:1 q12:1 q13:1\n%LevelsCnt 2\nq0 0 q1\nq0 1 q2\nq0 2 q3\nq0 3 q4\nq1 0 q0\nq2 5 q5\nq3 2 q0\nq4 3 q0\nq5 4294967295 q6\nq6 6 q7\nq7 4294967295 q8\nq8 7 q9\nq9 0 q10\nq9 1 q11\nq9 2 q12\nq9 3 q13\nq10 0 q9\nq11 1 q9\nq12 2 q9\nq13 3 q9\n"
+        ));
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{ 5, 6, 7 }, ReplaceMode::Single) };
+        CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
+    }
+
+    SECTION("small identity expected replace symbol with empty string single replace") {
+        EnumAlphabet alphabet{ 0, 1, 2, 3 };
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:1 q7:1 q8:1 q9:1\n%LevelsCnt 2\nq0 0 q1\nq0 1 q2\nq0 2 q3\nq0 3 q4\nq1 0 q0\nq2 4294967295 q5\nq3 2 q0\nq4 3 q0\nq5 0 q6\nq5 1 q7\nq5 2 q8\nq5 3 q9\nq6 0 q5\nq7 1 q5\nq8 2 q5\nq9 3 q5\n"
+        ));
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{}, ReplaceMode::Single) };
+        CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
+    }
+
+    SECTION("identity expected one symbol with word replace single replace") {
+        EnumAlphabet alphabet{ 0 };
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q2\n%Levels q0:0 q1:1 q2:0 q3:1\n%LevelsCnt 2\nq0 0 q1\nq1 0 q2\nq2 0 q3\nq3 0 q2\n"
+        ));
+        Nft nft_identity{ create_identity_with_single_symbol_replace(&alphabet, 0, Word{ 0 }, ReplaceMode::Single) };
+        CHECK(nft::are_equivalent(nft_identity, expected));
     }
 }
 

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -322,7 +322,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::begin_marker_nft() regex a+b+c") {
-        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("cb+a+", &alphabet) };
+        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("a+b+c", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(0, 'a', 0);
         nfa_expected.delta.add(0, 'b', 0);
@@ -396,58 +396,21 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(0, 'b', 0);
         nfa_expected.delta.add(0, 'c', 0);
         nfa_expected.delta.add(1, 'a', 1);
+        nfa_expected.delta.add(1, 'a', 4);
         nfa_expected.delta.add(2, 'b', 1);
         nfa_expected.delta.add(0, 'c', 1);
         nfa_expected.delta.add(3, 'a', 2);
         nfa_expected.delta.add(2, 'b', 2);
         nfa_expected.delta.add(0, 'c', 2);
         nfa_expected.delta.add(4, EPSILON, 3);
-        nfa_expected.delta.add(3, 'a', 4);
         nfa_expected.delta.add(2, 'b', 4);
         nfa_expected.delta.add(0, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
         Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, MARKER) };
-        Nft nft_expected{};
-        nft_expected.initial.insert(0);
-        nft_expected.final.insert(1);
-        nft_expected.num_of_levels = 2;
-        nft_expected.delta.add(0, EPSILON, 1);
-        nft_expected.delta.add(0, EPSILON, 2);
-        nft_expected.delta.add(0, EPSILON, 3);
-        nft_expected.delta.add(0, EPSILON, 5);
-        nft_expected.delta.add(1, 'b', 6);
-        nft_expected.delta.add(6, 'b', 1);
-        nft_expected.delta.add(1, 'c', 7);
-        nft_expected.delta.add(7, 'c', 1);
-        nft_expected.delta.add(7, 'c', 2);
-        nft_expected.delta.add(7, 'c', 3);
-        nft_expected.delta.add(7, 'c', 5);
-        nft_expected.delta.add(2, 'a', 8);
-        nft_expected.delta.add(8, 'a', 2);
-        nft_expected.delta.add(8, 'a', 1);
-        nft_expected.delta.add(3, 'b', 9);
-        nft_expected.delta.add(9, 'b', 3);
-        nft_expected.delta.add(9, 'b', 2);
-        nft_expected.delta.add(9, 'b', 5);
-        nft_expected.delta.add(4, 'a', 10);
-        nft_expected.delta.add(10, 'a', 5);
-        nft_expected.delta.add(10, 'a', 3);
-        nft_expected.delta.add(5, EPSILON, 11);
-        nft_expected.delta.add(11, MARKER, 4);
-        nft_expected.levels.resize(12);
-        nft_expected.levels[0] = 0;
-        nft_expected.levels[1] = 0;
-        nft_expected.levels[2] = 0;
-        nft_expected.levels[3] = 0;
-        nft_expected.levels[4] = 0;
-        nft_expected.levels[5] = 0;
-        nft_expected.levels[6] = 1;
-        nft_expected.levels[7] = 1;
-        nft_expected.levels[8] = 1;
-        nft_expected.levels[9] = 1;
-        nft_expected.levels[10] = 1;
-        nft_expected.levels[11] = 1;
+        Nft nft_expected{ nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q11\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:0 q4:0 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0\n%LevelsCnt 2\nq0 98 q1\nq0 99 q2\nq1 98 q0\nq2 99 q0\nq2 99 q3\nq2 99 q4\nq2 99 q5\nq3 97 q6\nq4 98 q7\nq5 4294967295 q10\nq6 97 q0\nq6 97 q3\nq6 97 q5\nq7 98 q3\nq7 98 q4\nq7 98 q5\nq8 97 q9\nq9 97 q4\nq10 4294967195 q8\nq11 4294967295 q0\nq11 4294967295 q3\nq11 4294967295 q4\nq11 4294967295 q5\n"
+        )) };
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
     }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -574,7 +574,7 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     }
 }
 
-TEST_CASE("mata::nft::literal_replace_nft()") {
+TEST_CASE("mata::nft::strings::literal_replace_nft()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
@@ -612,7 +612,7 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     }
 }
 
-TEST_CASE("mata::nft::replace_reluctant_literal()") {
+TEST_CASE("mata::nft::strings::replace_reluctant_literal()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
@@ -703,7 +703,7 @@ TEST_CASE("mata::nft::replace_reluctant_literal()") {
     }
 }
 
-TEST_CASE("mata::nft::replace_reluctant_symbol()") {
+TEST_CASE("mata::nft::strings::replace_reluctant_symbol()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
@@ -801,4 +801,30 @@ TEST_CASE("mata::nft::replace_reluctant_symbol()") {
         ));
         CHECK(nft::are_equivalent(nft, expected));
     }
+}
+
+TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
+    Nft nft{};
+    Nft expected{};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+
+    SECTION("'a' replace with 'b' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'd', 'c', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
+                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
+                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+    // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -234,7 +234,6 @@ TEST_CASE("nft::reluctant_replacement()") {
     Nft nft{};
     nfa::Nfa regex{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    constexpr Symbol MARKER{ EPSILON - 100 };
     SECTION("nft::end_marker_dfa()") {
         parser::create_nfa(&regex, "cb+a+");
         nfa::Nfa dfa_end_marker{ nft::strings::end_marker_dfa(regex) };
@@ -249,7 +248,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected_end_marker.delta.add(4, 'a', 3);
         CHECK(dfa_end_marker.is_deterministic());
         CHECK(nfa::are_equivalent(dfa_end_marker, dfa_expected_end_marker));
-        Nft dft_end_marker{ end_marker_dft(dfa_end_marker, MARKER) };
+        Nft dft_end_marker{ end_marker_dft(dfa_end_marker, END_MARKER) };
         Nft dft_expected_end_marker{};
         dft_expected_end_marker.num_of_levels = 2;
         dft_expected_end_marker.levels = { 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1 };
@@ -264,7 +263,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dft_expected_end_marker.delta.add(4, 'a', 6);
         dft_expected_end_marker.delta.add(6, 'a', 7);
         dft_expected_end_marker.delta.add(7, EPSILON, 8);
-        dft_expected_end_marker.delta.add(8, MARKER, 9);
+        dft_expected_end_marker.delta.add(8, END_MARKER, 9);
         dft_expected_end_marker.delta.add(9, 'a', 10);
         dft_expected_end_marker.delta.add(10, 'a', 7);
         CHECK(dft_end_marker.is_deterministic());
@@ -289,7 +288,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected.delta.add(4, 'c', 1);
         CHECK(nfa::are_equivalent(dfa_generic_end_marker, dfa_expected));
 
-        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, MARKER) };
+        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, END_MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 4, 7, 14 };
@@ -313,7 +312,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dft_expected.delta.add(7, 'c', 12);
         dft_expected.delta.add(12, 'c', 4);
         dft_expected.delta.add(10, EPSILON, 13);
-        dft_expected.delta.add(13, MARKER, 14);
+        dft_expected.delta.add(13, END_MARKER, 14);
         dft_expected.delta.add(14, 'a', 15);
         dft_expected.delta.add(15, 'a', 10);
         dft_expected.delta.add(14, 'b', 16);
@@ -360,7 +359,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected.delta.add(4, 'c', 0);
         CHECK(nfa::are_equivalent(dfa_generic_end_marker, dfa_expected));
 
-        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, MARKER) };
+        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, END_MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 2, 7, 14 };
@@ -384,7 +383,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dft_expected.delta.add(7, 'c', 12);
         dft_expected.delta.add(12, 'c', 0);
         dft_expected.delta.add(10, EPSILON, 13);
-        dft_expected.delta.add(13, MARKER, 14);
+        dft_expected.delta.add(13, END_MARKER, 14);
         dft_expected.delta.add(14, 'a', 15);
         dft_expected.delta.add(15, 'a', 10);
         dft_expected.delta.add(14, 'b', 16);
@@ -431,7 +430,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(1, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
-        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, MARKER) };
+        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
         Nft nft_expected{};
         nft_expected.initial.insert(0);
         nft_expected.final.insert(1);
@@ -458,7 +457,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         nft_expected.delta.add(10, 'a', 3);
         nft_expected.delta.add(10, 'a', 5);
         nft_expected.delta.add(5, EPSILON, 11);
-        nft_expected.delta.add(11, MARKER, 4);
+        nft_expected.delta.add(11, BEGIN_MARKER, 4);
         nft_expected.levels.resize(12);
         nft_expected.levels[0] = 0;
         nft_expected.levels[1] = 0;
@@ -473,12 +472,12 @@ TEST_CASE("nft::reluctant_replacement()") {
         nft_expected.levels[10] = 1;
         nft_expected.levels[11] = 1;
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'c' }, Word{ MARKER, 'a', 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'c' } }));
         CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'b', 'c' }, Word{ 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', MARKER, 'a', 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'b', 'b', 'c', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c' } }));
     }
 
     SECTION("nft::begin_marker_nft() regex ab+a+") {
@@ -499,7 +498,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(0, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
-        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, MARKER) };
+        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
         Nft nft_expected{ nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q11\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:0 q4:0 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0\n%LevelsCnt 2\nq0 98 q1\nq0 99 q2\nq1 98 q0\nq2 99 q0\nq2 99 q3\nq2 99 q4\nq2 99 q5\nq3 97 q6\nq4 98 q7\nq5 4294967295 q10\nq6 97 q0\nq6 97 q3\nq6 97 q5\nq7 98 q3\nq7 98 q4\nq7 98 q5\nq8 97 q9\nq9 97 q4\nq10 4294967195 q8\nq11 4294967295 q0\nq11 4294967295 q3\nq11 4294967295 q4\nq11 4294967295 q5\n"
         )) };
@@ -511,13 +510,12 @@ TEST_CASE("mata::nft::strings::reluctant_nfa_with_marker()") {
     Nft nft{};
     nfa::Nfa regex{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    constexpr Symbol MARKER{ EPSILON - 100 };
 
     SECTION("regex cb+a+") {
         nfa::Nfa nfa{ [&]() {
             nfa::Nfa nfa{};
             mata::parser::create_nfa(&nfa, "cb+a+");
-            return reluctant_nfa_with_marker(nfa, MARKER, &alphabet);
+            return reluctant_nfa_with_marker(nfa, BEGIN_MARKER, &alphabet);
         }() };
         nfa::Nfa expected{ nfa::builder::parse_from_mata(std::string(
             "@NFA-explicit\n%Alphabet-auto\n%Initial q0\n%Final q3\nq0 99 q1\nq0 4294967195 q0\nq1 98 q2\nq1 4294967195 q1\nq2 97 q3\nq2 98 q2\nq2 4294967195 q2\n")) };
@@ -529,10 +527,9 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    constexpr Symbol MARKER{ EPSILON - 100 };
 
     SECTION("all 'cb+a+' replaced with 'ddd'") {
-        nft = reluctant_leftmost_nft("cb+a+", &alphabet, MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
+        nft = reluctant_leftmost_nft("cb+a+", &alphabet, BEGIN_MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
         ));
@@ -540,29 +537,29 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     }
 
     SECTION("single 'a+b+c' replaced with '' (empty string)") {
-        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{}, ReplaceMode::Single);
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{}, ReplaceMode::Single);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
-        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
     }
 
     SECTION("All 'a+b+c' replaced with 'd'") {
-        nft = reluctant_leftmost_nft("a+b+c", &alphabet, MARKER, Word{ 'd' }, ReplaceMode::All);
+        nft = reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{ 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 100 q20\nq20 4294967295 q21\nq21 4294967295 q22\nq22 4294967295 q14\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
-        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ Word{ MARKER, 'a', MARKER, 'a', MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', MARKER, 'a', 'b', 'c', MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
     }
 }
 
@@ -570,11 +567,10 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    Symbol end_marker{ EPSILON - 99 };
 
     SECTION("'abcc' replace with 'a' replace all") {
-        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, end_marker, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', end_marker },
+        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, END_MARKER, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
@@ -583,8 +579,8 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     }
 
     SECTION("'abcc' replace with 'bbb' replace single") {
-        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, end_marker, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', end_marker },
+        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
@@ -593,9 +589,9 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     }
 
     SECTION("'aabac' replace with 'd' replace all") {
-        nft = replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, end_marker,
+        nft = replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
                                   ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', end_marker },
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -616,59 +616,189 @@ TEST_CASE("mata::nft::replace_reluctant_literal()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    ReluctantReplaceSUT reluctant_replace;
 
     SECTION("'abcc' replace with 'a' replace all") {
         nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, ReplaceMode::All);
-
         CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c', 'c' },
-                                     { 'a' } }));
+                                   { 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'b', 'c', 'c' },
-                                     { 'a', 'a' } }));
+                                   { 'a', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c' },
-                                     { 'c', 'a' } }));
+                                   { 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a' },
-                                     { 'c', 'a', 'a' } }));
+                                   { 'c', 'a', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
-                                     { 'c', 'a', 'a', 'a' } }));
+                                   { 'c', 'a', 'a', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
-                                     { 'a', 'c', 'a', 'a', 'a' } }));
+                                   { 'a', 'c', 'a', 'a', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
-                                        { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
+                                   { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { }, { } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c' },
+                                   { 'a', 'b', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c' },
+                                   { 'a', 'b', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'c', 'c', 'c' },
+                                   { 'c', 'c', 'c' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967295 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967295 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967295 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967295 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
         ));
-
-        // NOTE(nft): It appears that the END_MARKER is left in the resulting transducer.
-        // This transducer should not contain END_MARKER, as it exists only at the synchronization
-        // levels (of lhs and rhs) and will be projected out at the end of the composition.
-        // Moreover, this transducer represents the ReplaceAll procedure, therefore it should not contain any END_MARKER.
-        //
-        // expected = nft::builder::parse_from_mata(std::string(
-        //     "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
-        // ));
-
         CHECK(nft::are_equivalent(nft, expected));
     }
 
-   SECTION("'abcc' replace with 'bbb' replace single") {
-       nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
-                                    { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
+   SECTION("'abcc' replace with 'dd' replace single") {
+       nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'd', 'd' },  &alphabet, ReplaceMode::Single);
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
+                                  { 'a', 'a', 'a', 'b', 'a', 'a', 'd', 'd', 'a', 'a', 'b', 'c', 'c', 'a' } }));
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c' },
+                                  { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c' } }));
        expected = nft::builder::parse_from_mata(std::string(
-           "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
+         "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:0 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:0 q32:1 q33:0 q34:1 q35:1 q36:1 q37:1 q38:0 q39:1 q40:0 q41:1 q42:0 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:0 q53:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 97 q6\nq8 4294967295 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967295 q17\nq14 97 q52\nq15 97 q48\nq16 4294967295 q20\nq17 97 q18\nq18 4294967295 q19\nq19 98 q5\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967295 q24\nq21 97 q44\nq22 97 q38\nq23 4294967295 q29\nq24 97 q25\nq25 4294967295 q26\nq26 98 q27\nq27 4294967295 q28\nq28 99 q5\nq29 4294967295 q30\nq30 100 q31\nq31 4294967295 q32\nq32 100 q33\nq33 97 q34\nq33 98 q35\nq33 99 q36\nq33 4294967295 q37\nq34 97 q33\nq35 98 q33\nq36 99 q33\nq37 4294967295 q5\nq38 4294967295 q39\nq39 98 q40\nq40 4294967295 q41\nq41 99 q42\nq42 4294967295 q43\nq43 98 q0\nq44 4294967295 q45\nq45 98 q46\nq46 4294967295 q47\nq47 99 q6\nq48 4294967295 q49\nq49 98 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q53\nq53 98 q6\n"
        ));
        CHECK(nft::are_equivalent(nft, expected));
    }
 
    SECTION("'aabac' replace with 'd' replace all") {
-       nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
+       nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet,
                                                    ReplaceMode::All);
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
-                                    { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                  { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
+       CHECK(nft.is_tuple_in_lang({ { }, { } }));
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                  { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
        expected = nft::builder::parse_from_mata(std::string(
-           "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
+          "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:0 q63:1 q64:0 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q68\nq49 97 q60\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 100 q0\nq60 4294967295 q61\nq61 97 q62\nq62 4294967295 q63\nq63 98 q64\nq64 4294967295 q65\nq65 97 q66\nq66 4294967295 q67\nq67 98 q0\nq68 4294967295 q69\nq69 97 q70\nq70 4294967295 q71\nq71 98 q15\n"
        ));
        CHECK(nft::are_equivalent(nft, expected));
    }
+
+    SECTION("drop all 'aabac'") {
+        nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{}, &alphabet,
+                                                      ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
+                                     { 'a', 'a', 'a', 'b', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { }, { } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:0 q63:1 q64:0 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q68\nq49 97 q60\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 4294967295 q0\nq60 4294967295 q61\nq61 97 q62\nq62 4294967295 q63\nq63 98 q64\nq64 4294967295 q65\nq65 97 q66\nq66 4294967295 q67\nq67 98 q0\nq68 4294967295 q69\nq69 97 q70\nq70 4294967295 q71\nq71 98 q15\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop single 'aabac'") {
+        nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{}, &alphabet,
+                                                      ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c'} }));
+        CHECK(nft.is_tuple_in_lang({ { }, { } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:1 q63:1 q64:1 q65:0 q66:1 q67:0 q68:1 q69:0 q70:1 q71:0 q72:1 q73:0 q74:1 q75:0 q76:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q73\nq49 97 q65\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 4294967295 q60\nq60 97 q61\nq60 98 q62\nq60 99 q63\nq60 4294967295 q64\nq61 97 q60\nq62 98 q60\nq63 99 q60\nq64 4294967295 q5\nq65 4294967295 q66\nq66 97 q67\nq67 4294967295 q68\nq68 98 q69\nq69 4294967295 q70\nq70 97 q71\nq71 4294967295 q72\nq72 98 q0\nq73 4294967295 q74\nq74 97 q75\nq75 4294967295 q76\nq76 98 q15\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+}
+
+TEST_CASE("mata::nft::replace_reluctant_symbol()") {
+    Nft nft{};
+    Nft expected{};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+
+    SECTION("'a' replace with 'b' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_single_symbol('a', 'd', &alphabet, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'd' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 100 q0\nq2 98 q0\nq3 99 q0\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+
+        // Use replace symbol with literal containing a single symbol.
+        nft = nft::strings::replace_reluctant_single_symbol('a', Word{ 'd' }, &alphabet, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'd' } }));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'a' replace with 'b' replace single") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_single_symbol('a', 'd', &alphabet, ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q4\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1 q6:1 q7:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 100 q4\nq2 98 q0\nq3 99 q0\nq4 97 q5\nq4 98 q6\nq4 99 q7\nq5 97 q4\nq6 98 q4\nq7 99 q4\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+
+        // Use replace symbol with literal containing a single symbol.
+        nft = nft::strings::replace_reluctant_single_symbol('a', Word{ 'd' }, &alphabet, ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+                                     { 'b', 'b', 'b', 'b', 'd', 'a', 'a', 'b', 'a', 'a' } }));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'a' replace with 'bb' replace all") {
+        nft = nft::strings::replace_reluctant_single_symbol('a', Word{ 'b', 'b' }, &alphabet, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'c', 'b', 'b' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+                                     { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 98 q4\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq5 98 q0\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop all 'a'") {
+        nft = nft::strings::replace_reluctant_single_symbol('a', Word{}, &alphabet, ReplaceMode::All);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'b', 'b', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+                                     { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 4294967295 q0\nq2 98 q0\nq3 99 q0\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop single 'a'") {
+        nft = nft::strings::replace_reluctant_single_symbol('a', Word{}, &alphabet, ReplaceMode::Single);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+                                     { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q4\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1 q6:1 q7:1\n%LevelsCnt 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 4294967295 q4\nq2 98 q0\nq3 99 q0\nq4 97 q5\nq4 98 q6\nq4 99 q7\nq5 97 q4\nq6 98 q4\nq7 99 q4\n"
+        ));
+        CHECK(nft::are_equivalent(nft, expected));
+    }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -611,3 +611,55 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
         CHECK(nft::are_equivalent(nft, expected));
     }
 }
+
+TEST_CASE("mata::nft::replace_reluctant_literal()") {
+    Nft nft{};
+    Nft expected{};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+
+    SECTION("'abcc' replace with 'a' replace all") {
+        nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, ReplaceMode::All);
+//        std::cout << "result\n";
+//        std::cout << nft.print_to_DOT();
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c', 'c' },
+                                     { 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'b', 'c', 'c' },
+                                     { 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c' },
+                                     { 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a' },
+                                     { 'c', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
+                                     { 'c', 'a', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
+                                     { 'a', 'c', 'a', 'a', 'a' } }));
+        // FIXME(nft): Bug in `is_tuple_in_lang()`: infinite loop.
+//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
+//                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+//    SECTION("'abcc' replace with 'bbb' replace single") {
+//        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
+//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
+//                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+//    }
+
+//    SECTION("'aabac' replace with 'd' replace all") {
+//        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
+//                                                    ReplaceMode::All);
+//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
+//                                     { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+//    }
+}

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -803,29 +803,29 @@ TEST_CASE("mata::nft::strings::replace_reluctant_symbol()") {
     }
 }
 
-// TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
-//     Nft nft{};
-//     Nft expected{};
-//     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
+    Nft nft{};
+    Nft expected{};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
 
-//     SECTION("'a+b+c' replace with 'dd' replace all") {
-//         // Use replace symbol with symbol.
-//         nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-//         nft.print_to_DOT(std::cout);
-//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
-//                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-//         CHECK(nft.is_tuple_in_lang({ {},
-//                                      {} }));
-//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
-//                                      { 'a', 'a', 'a', 'b', 'd', 'c', 'a', 'a' } }));
-//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
-//                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
-//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
-//                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
-// //        expected = nft::builder::parse_from_mata(std::string(
-// //        ));
-// //        CHECK(nft::are_equivalent(nft, expected));
-//     }
+    SECTION("'a+b+c' replace with 'dd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'd', 'd', 'c', 'a', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
+                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
+                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
 
 //     SECTION("'a' replace with 'd' replace all") {
 //         // Use replace symbol with symbol.
@@ -839,5 +839,5 @@ TEST_CASE("mata::nft::strings::replace_reluctant_symbol()") {
 // //        ));
 // //        CHECK(nft::are_equivalent(nft, expected));
 //     }
-//     // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
-// }
+    // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
+}

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -811,7 +811,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("'a+b+c' replace with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -830,7 +829,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("'a' replace with 'd' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -843,7 +841,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("drop 'a' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'b', 'b', 'c' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -856,7 +853,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("drop 'a' replace single") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::Single);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -869,7 +865,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("drop 'a+b' replace single") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::Single);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -882,7 +877,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("drop 'a+b' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -895,7 +889,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("replace 'a+b' with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'd', 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -908,7 +901,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("replace 'a+b' with 'dd' replace single") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::Single);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
@@ -921,7 +913,6 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     SECTION("replace 'a*b*c' with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a*b*c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'd', 'd', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'a' },

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -840,4 +840,82 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
 // //        CHECK(nft::are_equivalent(nft, expected));
 //     }
     // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
+
+    SECTION("drop 'a' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'b', 'b', 'c' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop 'a' replace single") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::Single);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop 'a+b' replace single") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::Single);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("drop 'a+b' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("replace 'a+b' with 'dd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'd', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("replace 'a+b' with 'dd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::Single);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -19,6 +19,14 @@ using IntAlphabet = mata::IntAlphabet;
 using OnTheFlyAlphabet = mata::OnTheFlyAlphabet;
 using mata::EnumAlphabet;
 
+class ReluctantReplaceSUT: public nft::strings::ReluctantReplace {
+    using super = nft::strings::ReluctantReplace;
+public:
+    using super::reluctant_nfa_with_marker, super::replace_literal_nft, super::generic_marker_dfa, super::end_marker_dfa,
+          super::marker_nft, super::reluctant_leftmost_nft, super::begin_marker_nfa, super::begin_marker_nft,
+          super::end_marker_dft;
+};
+
 TEST_CASE("nft::create_identity()") {
     Nft nft{};
     nft.initial = { 0 };
@@ -234,9 +242,10 @@ TEST_CASE("nft::reluctant_replacement()") {
     Nft nft{};
     nfa::Nfa regex{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    ReluctantReplaceSUT reluctant_replace{};
     SECTION("nft::end_marker_dfa()") {
         parser::create_nfa(&regex, "cb+a+");
-        nfa::Nfa dfa_end_marker{ nft::strings::end_marker_dfa(regex) };
+        nfa::Nfa dfa_end_marker{ reluctant_replace.end_marker_dfa(regex) };
         nfa::Nfa dfa_expected_end_marker{};
         dfa_expected_end_marker.initial = { 0 };
         dfa_expected_end_marker.final = { 4 };
@@ -248,7 +257,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected_end_marker.delta.add(4, 'a', 3);
         CHECK(dfa_end_marker.is_deterministic());
         CHECK(nfa::are_equivalent(dfa_end_marker, dfa_expected_end_marker));
-        Nft dft_end_marker{ end_marker_dft(dfa_end_marker, END_MARKER) };
+        Nft dft_end_marker{ reluctant_replace.end_marker_dft(dfa_end_marker, END_MARKER) };
         Nft dft_expected_end_marker{};
         dft_expected_end_marker.num_of_levels = 2;
         dft_expected_end_marker.levels = { 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1 };
@@ -271,7 +280,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex cb+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("cb+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ reluctant_replace.generic_marker_dfa("cb+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 0);
         dfa_expected.delta.add(0, 'b', 0);
@@ -288,7 +297,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected.delta.add(4, 'c', 1);
         CHECK(nfa::are_equivalent(dfa_generic_end_marker, dfa_expected));
 
-        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, END_MARKER) };
+        Nft dft_generic_end_marker{ reluctant_replace.end_marker_dft(dfa_generic_end_marker, END_MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 4, 7, 14 };
@@ -342,7 +351,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex ab+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("ab+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ reluctant_replace.generic_marker_dfa("ab+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 1);
         dfa_expected.delta.add(0, 'b', 0);
@@ -359,7 +368,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         dfa_expected.delta.add(4, 'c', 0);
         CHECK(nfa::are_equivalent(dfa_generic_end_marker, dfa_expected));
 
-        Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, END_MARKER) };
+        Nft dft_generic_end_marker{ reluctant_replace.end_marker_dft(dfa_generic_end_marker, END_MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 2, 7, 14 };
@@ -413,7 +422,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::begin_marker_nft() regex a+b+c") {
-        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("a+b+c", &alphabet) };
+        nfa::Nfa nfa_begin_marker{ reluctant_replace.begin_marker_nfa("a+b+c", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(0, 'a', 0);
         nfa_expected.delta.add(0, 'b', 0);
@@ -430,7 +439,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(1, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
-        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
+        Nft nft_begin_marker{ reluctant_replace.begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
         Nft nft_expected{};
         nft_expected.initial.insert(0);
         nft_expected.final.insert(1);
@@ -481,7 +490,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::begin_marker_nft() regex ab+a+") {
-        nfa::Nfa nfa_begin_marker{ begin_marker_nfa("ab+a+", &alphabet) };
+        nfa::Nfa nfa_begin_marker{ reluctant_replace.begin_marker_nfa("ab+a+", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(1, 'a', 0);
         nfa_expected.delta.add(0, 'b', 0);
@@ -498,7 +507,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         nfa_expected.delta.add(0, 'c', 4);
         CHECK(nfa::are_equivalent(nfa_begin_marker, nfa_expected));
 
-        Nft nft_begin_marker{ begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
+        Nft nft_begin_marker{ reluctant_replace.begin_marker_nft(nfa_begin_marker, BEGIN_MARKER) };
         Nft nft_expected{ nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q11\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:0 q4:0 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0\n%LevelsCnt 2\nq0 98 q1\nq0 99 q2\nq1 98 q0\nq2 99 q0\nq2 99 q3\nq2 99 q4\nq2 99 q5\nq3 97 q6\nq4 98 q7\nq5 4294967295 q10\nq6 97 q0\nq6 97 q3\nq6 97 q5\nq7 98 q3\nq7 98 q4\nq7 98 q5\nq8 97 q9\nq9 97 q4\nq10 4294967195 q8\nq11 4294967295 q0\nq11 4294967295 q3\nq11 4294967295 q4\nq11 4294967295 q5\n"
         )) };
@@ -510,12 +519,13 @@ TEST_CASE("mata::nft::strings::reluctant_nfa_with_marker()") {
     Nft nft{};
     nfa::Nfa regex{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    ReluctantReplaceSUT reluctant_replace{};
 
     SECTION("regex cb+a+") {
         nfa::Nfa nfa{ [&]() {
             nfa::Nfa nfa{};
             mata::parser::create_nfa(&nfa, "cb+a+");
-            return reluctant_nfa_with_marker(nfa, BEGIN_MARKER, &alphabet);
+            return reluctant_replace.reluctant_nfa_with_marker(nfa, BEGIN_MARKER, &alphabet);
         }() };
         nfa::Nfa expected{ nfa::builder::parse_from_mata(std::string(
             "@NFA-explicit\n%Alphabet-auto\n%Initial q0\n%Final q3\nq0 99 q1\nq0 4294967195 q0\nq1 98 q2\nq1 4294967195 q1\nq2 97 q3\nq2 98 q2\nq2 4294967195 q2\n")) };
@@ -527,9 +537,10 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    ReluctantReplaceSUT reluctant_replace{};
 
     SECTION("all 'cb+a+' replaced with 'ddd'") {
-        nft = reluctant_leftmost_nft("cb+a+", &alphabet, BEGIN_MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
+        nft = reluctant_replace.reluctant_leftmost_nft("cb+a+", &alphabet, BEGIN_MARKER, Word{ 'd', 'd', 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q13\n%Final q13\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:0 q6:1 q7:1 q8:0 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:0 q24:1 q25:0\n%LevelsCnt 2\nq0 99 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 98 q4\nq2 4294967195 q6\nq3 4294967295 q0\nq4 4294967295 q5\nq5 97 q7\nq5 98 q9\nq5 4294967195 q10\nq6 4294967295 q2\nq7 4294967295 q8\nq8 4294967295 q18\nq9 4294967295 q5\nq10 4294967295 q5\nq11 4294967195 q12\nq12 4294967295 q11\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967195 q17\nq14 97 q13\nq15 98 q13\nq16 99 q13\nq17 4294967295 q0\nq18 100 q19\nq19 4294967295 q20\nq20 100 q21\nq21 4294967295 q22\nq22 100 q23\nq23 4294967295 q24\nq24 4294967295 q25\nq25 4294967295 q13\n"
         ));
@@ -537,7 +548,7 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     }
 
     SECTION("single 'a+b+c' replaced with '' (empty string)") {
-        nft = reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{}, ReplaceMode::Single);
+        nft = reluctant_replace.reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{}, ReplaceMode::Single);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q20 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q20\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967195 q24\nq21 97 q20\nq22 98 q20\nq23 99 q20\nq24 4294967295 q20\n"
         ));
@@ -550,7 +561,7 @@ TEST_CASE("mata::nft::strings::reluctant_leftmost_nft()") {
     }
 
     SECTION("All 'a+b+c' replaced with 'd'") {
-        nft = reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{ 'd' }, ReplaceMode::All);
+        nft = reluctant_replace.reluctant_leftmost_nft("a+b+c", &alphabet, BEGIN_MARKER, Word{ 'd' }, ReplaceMode::All);
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0\n%LevelsCnt 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 100 q20\nq20 4294967295 q21\nq21 4294967295 q22\nq22 4294967295 q14\n"
         ));
@@ -567,9 +578,10 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    ReluctantReplaceSUT reluctant_replace{};
 
     SECTION("'abcc' replace with 'a' replace all") {
-        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, END_MARKER, ReplaceMode::All);
+        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, END_MARKER, ReplaceMode::All);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
@@ -579,7 +591,7 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     }
 
     SECTION("'abcc' replace with 'bbb' replace single") {
-        nft = replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
+        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
         expected = nft::builder::parse_from_mata(std::string(
@@ -589,7 +601,7 @@ TEST_CASE("mata::nft::literal_replace_nft()") {
     }
 
     SECTION("'aabac' replace with 'd' replace all") {
-        nft = replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
+        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
                                   ReplaceMode::All);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -827,19 +827,18 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
 //        CHECK(nft::are_equivalent(nft, expected));
     }
 
-//     SECTION("'a' replace with 'd' replace all") {
-//         // Use replace symbol with symbol.
-//         nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
-//         nft.print_to_DOT(std::cout);
-//         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
-//                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
-//         CHECK(nft.is_tuple_in_lang({ {},
-//                                      {} }));
-// //        expected = nft::builder::parse_from_mata(std::string(
-// //        ));
-// //        CHECK(nft::are_equivalent(nft, expected));
-//     }
-    // TODO(nft): Test dropping regex, correctly replacing shortest/longest match, ...
+    SECTION("'a' replace with 'd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
 
     SECTION("drop 'a' replace all") {
         // Use replace symbol with symbol.
@@ -906,12 +905,29 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
 //        CHECK(nft::are_equivalent(nft, expected));
     }
 
-    SECTION("replace 'a+b' with 'dd' replace all") {
+    SECTION("replace 'a+b' with 'dd' replace single") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::Single);
         nft.print_to_DOT(std::cout);
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("replace 'a*b*c' with 'dd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a*b*c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'd', 'd', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'a' },
+                                     { 'a', 'a', 'a', 'b', 'd', 'd', 'a' } }));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'd', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -808,7 +808,7 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
 
-    SECTION("'a' replace with 'b' replace all") {
+    SECTION("'a+b+c' replace with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = nft::strings::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
         nft.print_to_DOT(std::cout);
@@ -822,6 +822,19 @@ TEST_CASE("mata::nft::strings::replace_reluctant_regex()") {
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
+//        expected = nft::builder::parse_from_mata(std::string(
+//        ));
+//        CHECK(nft::are_equivalent(nft, expected));
+    }
+
+    SECTION("'a' replace with 'd' replace all") {
+        // Use replace symbol with symbol.
+        nft = nft::strings::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
+        nft.print_to_DOT(std::cout);
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+                                     { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
+        CHECK(nft.is_tuple_in_lang({ {},
+                                     {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
 //        CHECK(nft::are_equivalent(nft, expected));

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -616,11 +616,11 @@ TEST_CASE("mata::nft::replace_reluctant_literal()") {
     Nft nft{};
     Nft expected{};
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    ReluctantReplaceSUT reluctant_replace;
 
     SECTION("'abcc' replace with 'a' replace all") {
         nft = nft::strings::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, ReplaceMode::All);
-//        std::cout << "result\n";
-//        std::cout << nft.print_to_DOT();
+
         CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c', 'c' },
                                      { 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'b', 'c', 'c' },
@@ -633,33 +633,42 @@ TEST_CASE("mata::nft::replace_reluctant_literal()") {
                                      { 'c', 'a', 'a', 'a' } }));
         CHECK(nft.is_tuple_in_lang({ { 'a', 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
                                      { 'a', 'c', 'a', 'a', 'a' } }));
-        // FIXME(nft): Bug in `is_tuple_in_lang()`: infinite loop.
-//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
-//                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
-//        expected = nft::builder::parse_from_mata(std::string(
-//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
-//        ));
-//        CHECK(nft::are_equivalent(nft, expected));
+        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
+                                        { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
+        expected = nft::builder::parse_from_mata(std::string(
+            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967295 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967295 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967295 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967295 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
+        ));
+
+        // NOTE(nft): It appears that the END_MARKER is left in the resulting transducer.
+        // This transducer should not contain END_MARKER, as it exists only at the synchronization
+        // levels (of lhs and rhs) and will be projected out at the end of the composition.
+        // Moreover, this transducer represents the ReplaceAll procedure, therefore it should not contain any END_MARKER.
+        //
+        // expected = nft::builder::parse_from_mata(std::string(
+        //     "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
+        // ));
+
+        CHECK(nft::are_equivalent(nft, expected));
     }
 
-//    SECTION("'abcc' replace with 'bbb' replace single") {
-//        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
-//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
-//                                     { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
-//        expected = nft::builder::parse_from_mata(std::string(
-//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
-//        ));
-//        CHECK(nft::are_equivalent(nft, expected));
-//    }
+   SECTION("'abcc' replace with 'bbb' replace single") {
+       nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
+                                    { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
+       expected = nft::builder::parse_from_mata(std::string(
+           "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsCnt 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
+       ));
+       CHECK(nft::are_equivalent(nft, expected));
+   }
 
-//    SECTION("'aabac' replace with 'd' replace all") {
-//        nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
-//                                                    ReplaceMode::All);
-//        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
-//                                     { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
-//        expected = nft::builder::parse_from_mata(std::string(
-//            "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
-//        ));
-//        CHECK(nft::are_equivalent(nft, expected));
-//    }
+   SECTION("'aabac' replace with 'd' replace all") {
+       nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
+                                                   ReplaceMode::All);
+       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
+                                    { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
+       expected = nft::builder::parse_from_mata(std::string(
+           "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsCnt 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
+       ));
+       CHECK(nft::are_equivalent(nft, expected));
+   }
 }

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -321,7 +321,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         CHECK(nft::are_equivalent(dft_generic_end_marker, dft_expected));
     }
 
-    SECTION("nft::begin_marker_nft() regex cb+a+") {
+    SECTION("nft::begin_marker_nft() regex a+b+c") {
         nfa::Nfa nfa_begin_marker{ begin_marker_nfa("cb+a+", &alphabet) };
         nfa::Nfa nfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         nfa_expected.delta.add(0, 'a', 0);
@@ -381,6 +381,12 @@ TEST_CASE("nft::reluctant_replacement()") {
         nft_expected.levels[10] = 1;
         nft_expected.levels[11] = 1;
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'c' }, Word{ MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'b', 'c' }, Word{ 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ MARKER, 'a', MARKER, 'a', 'b', 'b', 'b', 'c', MARKER, 'a', 'b', 'c' } }));
     }
 
     SECTION("nft::begin_marker_nft() regex ab+a+") {

--- a/tests/nft/strings.cc
+++ b/tests/nft/strings.cc
@@ -1,6 +1,5 @@
 // TODO: some header
 
-#include <unordered_set>
 #include <vector>
 #include <fstream>
 
@@ -179,7 +178,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex cb+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa("cb+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("cb+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 0);
         dfa_expected.delta.add(0, 'b', 0);
@@ -250,7 +249,7 @@ TEST_CASE("nft::reluctant_replacement()") {
     }
 
     SECTION("nft::generic_end_marker_dft() regex ab+a+") {
-        nfa::Nfa dfa_generic_end_marker{ generic_end_marker_dfa("ab+a+", &alphabet) };
+        nfa::Nfa dfa_generic_end_marker{ generic_marker_dfa("ab+a+", &alphabet) };
         nfa::Nfa dfa_expected{ nfa::Delta{}, { 0 }, { 0, 1, 2, 4 }};
         dfa_expected.delta.add(0, 'a', 1);
         dfa_expected.delta.add(0, 'b', 0);
@@ -270,7 +269,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_generic_end_marker{ end_marker_dft(dfa_generic_end_marker, MARKER) };
         Nft dft_expected{};
         dft_expected.initial.insert(0);
-        dft_expected.final = { 0, 2, 7, 14};
+        dft_expected.final = { 0, 2, 7, 14 };
         dft_expected.num_of_levels = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 2);


### PR DESCRIPTION
This PR implements the first part of implementation of reluctant replace operations for string solving. This PR includes implementation of functions to create reluctant NFAs and NFTs which perform the reluctant match of a regex, and reluctant replacement operations (for replace_re_all() and replace_re() operations), respectively. Furthermore, the PR implements creation of begin marker DFT which precedes the reluctant replace NFT in reluctant replace modelling.

This PR implements creation of NFTs for reluctant replace of:
- general regular expression (expected to be the slowest, but handles all regular expression cases) being replaced with a literal,
- literal being replaced with a literal, and
- single symbol being replaced with a literal (including a single symbol).

Further implementation except for optimization of the current methods may include generation of NFTs for finite regular language replacement. However, I believe that in our implementation (using data structure `Delta`), the NFT's state space would explode