### PR TITLE
Dot format ascii

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -256,13 +256,16 @@ public:
     /**
      * @brief Prints the automaton in DOT format
      *
+     * @param[in] ascii Whether to use ASCII characters for the output.
      * @return automaton in DOT format
      */
-    std::string print_to_DOT() const;
+    std::string print_to_DOT(const bool ascii = false) const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
+     *
+     * @param[in] ascii Whether to use ASCII characters for the output.
      */
-    void print_to_DOT(std::ostream &output) const;
+    void print_to_DOT(std::ostream &output, const bool ascii = false) const;
     /**
      * @brief Prints the automaton in mata format
      *

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -240,13 +240,16 @@ public:
     /**
      * @brief Prints the automaton in DOT format
      *
+     * @param[in] ascii Whether to use ASCII characters for the output.
      * @return automaton in DOT format
      */
-    std::string print_to_DOT() const;
+    std::string print_to_DOT(const bool ascii = false) const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
+     *
+     * @param[in] ascii Whether to use ASCII characters for the output.
      */
-    void print_to_DOT(std::ostream &output) const;
+    void print_to_DOT(std::ostream &output, const bool ascii = false) const;
     /**
      * @brief Prints the automaton in mata format
      *

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -379,13 +379,21 @@ bool Nfa::is_acyclic() const {
     return acyclic;
 }
 
-std::string Nfa::print_to_DOT() const {
+std::string Nfa::print_to_DOT(const bool ascii) const {
     std::stringstream output;
-    print_to_DOT(output);
+    print_to_DOT(output, ascii);
     return output.str();
 }
 
-void Nfa::print_to_DOT(std::ostream &output) const {
+void Nfa::print_to_DOT(std::ostream &output, const bool ascii) const {
+    auto to_ascii = [&](const Symbol symbol) {
+        // Translate only printable ASCII characters.
+        if (symbol < 33) {
+            return std::to_string(symbol);
+        }
+        return "\\'" + std::string(1, static_cast<char>(symbol)) + "\\'";
+    };
+
     output << "digraph finiteAutomaton {" << std::endl
                  << "node [shape=circle];" << std::endl;
 
@@ -400,7 +408,11 @@ void Nfa::print_to_DOT(std::ostream &output) const {
             for (State target: move.targets) {
                 output << target << " ";
             }
-            output << "} [label=" << move.symbol << "];" << std::endl;
+            if (ascii) {
+                output << "} [label=\"" << to_ascii(move.symbol) << "\"];" << std::endl;
+            } else {
+                output << "} [label=\"" << move.symbol << "\"];" << std::endl;
+            }
         }
     }
 


### PR DESCRIPTION
This PR includes:
- Modification of the method `Nft::print_to_DOT()`, enabling it to translate `EPSILON` to `<eps>` and `DONT_CARE` to `<dcare>`.
- Added functionality for methods `Nfa::print_to_DOT()` and `Nft::print_to_DOT(), allowing them to translate transition printable symbols (< 33) into ASCII.

I believe these modifications will make DOT graphs easier to understand.