### PR TITLE
Insert levels optimize number of inner states

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -674,12 +674,11 @@ Nft project_to(const Nft& nft, Level level_to_project, JumpMode jump_mode = Jump
  * @param[in] nft The original transducer.
  * @param[in] new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
  *  that one level is inserted before level 0 and two levels are inserted before level 1.
- * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
  * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, Symbol default_symbol = DONT_CARE, JumpMode jump_mode = JumpMode::RepeatSymbol);
+Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Inserts a new level @p new_level into the given transducer @p nft.
@@ -691,12 +690,11 @@ Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, Symbol defa
  *  If @p new_level is 0, then it is inserted before the 0-th level.
  *  If @p new_level is less than @c num_of_levels, then it is inserted before the level @c new_level-1.
  *  If @p new_level is greater than or equal to @c num_of_levels, then all levels from @c num_of_levels through @p new_level are appended after the last level.
- * @param[in] default_symbol The default symbol to be used for transitions at the inserted levels.
  * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_level(const Nft& nft, Level new_level, Symbol default_symbol = DONT_CARE, JumpMode jump_mode = JumpMode::RepeatSymbol);
+Nft insert_level(const Nft& nft, Level new_level, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -206,16 +206,22 @@ public:
     *
     * @param state The state where the identity transition will be inserted. This serves as both the source and target state.
     * @param symbol The vector of symbols used for the identity transition. Identity will be created for each symbol in the vector.
+    * @param jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+    * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
+    * of @c DONT_CARE symbols.
     */
-    void insert_identity(State state, const std::vector<Symbol>& symbols);
+    void insert_identity(State state, const std::vector<Symbol>& symbols, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
     * Inserts an identity transition into the NFT.
     *
     * @param state The state where the identity transition will be inserted. This serves as both the source and target state.
     * @param symbol The symbol used for the identity transition.
+    * @param jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+    * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
+    * of @c DONT_CARE symbols.
     */
-    void insert_identity(const State state, const Symbol symbol);
+    void insert_identity(const State state, const Symbol symbol, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
      * @brief Clear the underlying NFT to a blank NFT.

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -82,8 +82,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), biggest_suffix_len - lhs_suffix_len, true);
     rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), biggest_suffix_len - rhs_suffix_len, true);
 
-    Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, DONT_CARE, jump_mode);
-    Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, DONT_CARE, jump_mode);
+    Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, jump_mode);
+    Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, jump_mode);
 
     // Two auxiliary states (states from inserted loops) can not create a product state.
     const State lhs_first_aux_state = lhs_synced.num_of_states();
@@ -102,4 +102,3 @@ Nft compose(const Nft& lhs, const Nft& rhs, const Level lhs_sync_level, const Le
 }
 
 } // mata::nft
-

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -396,6 +396,7 @@ void Nft::insert_identity(const State state, const std::vector<Symbol> &symbols,
 }
 
 void Nft::insert_identity(const State state, const Symbol symbol, const JumpMode jump_mode) {
+    // TODO(nft): Evaluate the performance difference between adding a jump transition and inserting a transition for each level.
     if (jump_mode == JumpMode::RepeatSymbol) {
         delta.add(state, symbol, state);
     } else {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -389,14 +389,18 @@ State Nft::insert_word_by_parts(const State source, const std::vector<Word> &wor
    return insert_word_by_parts(source, word_parts_on_levels, add_state());
 }
 
-void Nft::insert_identity(const State state, const std::vector<Symbol> &symbols) {
+void Nft::insert_identity(const State state, const std::vector<Symbol> &symbols, const JumpMode jump_mode) {
     for (const Symbol symbol : symbols) {
-        insert_identity(state, symbol);
+        insert_identity(state, symbol, jump_mode);
     }
 }
 
-void Nft::insert_identity(const State state, const Symbol symbol) {
-    insert_word(state, Word(num_of_levels, symbol), state);
+void Nft::insert_identity(const State state, const Symbol symbol, const JumpMode jump_mode) {
+    if (jump_mode == JumpMode::RepeatSymbol) {
+        delta.add(state, symbol, state);
+    } else {
+        insert_word(state, Word(num_of_levels, symbol), state);
+    }
 }
 
 void Nft::clear() {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -204,7 +204,7 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_re
     std::vector<Transition> transitions_to_add;
 
     auto add_inner_transitions = [&](State src, Symbol symbol, State trg) {
-        if (jump_mode == JumpMode::AppendDontCares && symbol == DONT_CARE && !dcare_for_dcare) {
+        if (symbol == DONT_CARE && !dcare_for_dcare) {
             for (const Symbol replace_symbol : dont_care_symbol_replacements) {
                 transitions_to_add.emplace_back( src, replace_symbol, trg );
             }
@@ -243,12 +243,13 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_re
             for (; inner_src_lvl < pre_trg_lvl; inner_src_lvl++, inner_trg_lvl++) {
                 inner_trg = add_state();
                 levels[inner_trg] = inner_trg_lvl;
-                add_inner_transitions(inner_src, DONT_CARE, inner_trg);
+
+                add_inner_transitions(inner_src, jump_mode == JumpMode::AppendDontCares ? DONT_CARE : transition.symbol, inner_trg);
                 inner_src = inner_trg;
             }
 
             // The last iteration connecting last inner state with the original target state.
-            add_inner_transitions(inner_src, DONT_CARE, transition.target);
+            add_inner_transitions(inner_src, jump_mode == JumpMode::AppendDontCares ? DONT_CARE : transition.symbol, transition.target);
         }
     }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3662,7 +3662,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
     Delta delta;
     Nft input_nft, output_nft, expected_nft;
 
-    SECTION("Linear - default_symbol = DONT_CARE, jump_mode == JumpMode::AppendDontCares") {
+    SECTION("Linear - jump_mode == JumpMode::AppendDontCares") {
         delta.add(0, 0, 1);
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
@@ -3670,7 +3670,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3680,7 +3680,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
@@ -3690,7 +3690,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3700,7 +3700,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
             expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3710,7 +3710,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 4") {
-            output_nft = insert_level(input_nft, 4, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 4, JumpMode::AppendDontCares);
             expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -3721,7 +3721,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 100011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -3747,7 +3747,8 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(1, 0, 2);
             expected_nft.delta.add(2, 1, 3);
             expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
 
         SECTION("add level 1") {
@@ -3757,7 +3758,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(1, DONT_CARE, 2);
             expected_nft.delta.add(2, 1, 3);
             expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
 
         SECTION("add level 2") {
@@ -3767,7 +3768,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, DONT_CARE, 3);
             expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
 
         SECTION("add level 3") {
@@ -3777,7 +3778,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, 2, 3);
             expected_nft.delta.add(3, DONT_CARE, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
 
         SECTION("add level 4") {
@@ -3788,7 +3789,8 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(2, 2, 3);
             expected_nft.delta.add(3, DONT_CARE, 4);
             expected_nft.delta.add(4, DONT_CARE, 5);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
 
         SECTION("add levels according to the mask 100011") {
@@ -3800,79 +3802,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
             expected_nft.delta.add(3, 2, 4);
             expected_nft.delta.add(4, DONT_CARE, 5);
             expected_nft.delta.add(5, DONT_CARE, 6);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-    }
-
-    SECTION("Linear - default_symbol = 42, jump_mode == JumpMode::AppendDontCares") {
-        delta.clear();
-        delta.add(0, 0, 1);
-        delta.add(1, 1, 2);
-        delta.add(2, 2, 3);
-
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
-
-        SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
-            expected_nft.delta.add(0, 42, 1);
-            expected_nft.delta.add(1, 0, 2);
-            expected_nft.delta.add(2, 1, 3);
-            expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 42, 2);
-            expected_nft.delta.add(2, 1, 3);
-            expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 1, 2);
-            expected_nft.delta.add(2, 42, 3);
-            expected_nft.delta.add(3, 2, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 1, 2);
-            expected_nft.delta.add(2, 2, 3);
-            expected_nft.delta.add(3, 42, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 4") {
-            output_nft = insert_level(input_nft, 4, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 1, 2);
-            expected_nft.delta.add(2, 2, 3);
-            expected_nft.delta.add(3, 42, 4);
-            expected_nft.delta.add(4, 42, 5);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add levels according to the mask 100011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, 42, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
-            expected_nft.delta.add(0, 42, 1);
-            expected_nft.delta.add(1, 0, 2);
-            expected_nft.delta.add(2, 1, 3);
-            expected_nft.delta.add(3, 2, 4);
-            expected_nft.delta.add(4, 42, 5);
-            expected_nft.delta.add(5, 42, 6);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::RepeatSymbol));
         }
     }
 
@@ -3887,7 +3817,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 4, 0);
@@ -3901,7 +3831,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
             expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 7);
@@ -3919,7 +3849,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
             expected_nft = Nft(9, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 2, 3, 2, 3 }, 4);
             expected_nft.delta.add(0, 4, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
@@ -3935,7 +3865,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3 }, 4);
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 0);
@@ -3949,7 +3879,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
             expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 8);
             expected_nft.delta.add(8, 4, 9);
@@ -3976,116 +3906,6 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("loop - default_symbol = 42, jump_mode == JumpMode::RepeatSymbol") {
-        delta.clear();
-        delta.add(0, 4, 0);
-        delta.add(0, 0, 1);
-        delta.add(1, 1, 2);
-        delta.add(2, 2, 3);
-        delta.add(3, 5, 3);
-
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
-
-        SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, 42);
-            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3, 1, 1, 2, 2, 3, 3 }, 4);
-            expected_nft.delta.add(0, 42, 5);
-            expected_nft.delta.add(5, 4, 7);
-            expected_nft.delta.add(7, 4, 10);
-            expected_nft.delta.add(10, 4, 0);
-            expected_nft.delta.add(0, 42, 1);
-            expected_nft.delta.add(1, 0, 2);
-            expected_nft.delta.add(2, 1, 3);
-            expected_nft.delta.add(3, 2, 4);
-            expected_nft.delta.add(4, 42, 6);
-            expected_nft.delta.add(6, 5, 8);
-            expected_nft.delta.add(8, 5, 9);
-            expected_nft.delta.add(9, 5, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, 42);
-            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
-            expected_nft.delta.add(0, 4, 5);
-            expected_nft.delta.add(5, 42, 7);
-            expected_nft.delta.add(7, 4, 8);
-            expected_nft.delta.add(8, 4, 0);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 42, 2);
-            expected_nft.delta.add(2, 1, 3);
-            expected_nft.delta.add(3, 2, 4);
-            expected_nft.delta.add(4, 5, 6);
-            expected_nft.delta.add(6, 42, 9);
-            expected_nft.delta.add(9, 5, 10);
-            expected_nft.delta.add(10, 5, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, 42);
-            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 3, 1, 3, 2, 2 }, 4);
-            expected_nft.delta.add(0, 4, 7);
-            expected_nft.delta.add(7, 4, 10);
-            expected_nft.delta.add(10, 42, 8);
-            expected_nft.delta.add(8, 4, 0);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 1, 2);
-            expected_nft.delta.add(2, 42, 3);
-            expected_nft.delta.add(3, 2, 4);
-            expected_nft.delta.add(4, 5, 5);
-            expected_nft.delta.add(5, 5, 9);
-            expected_nft.delta.add(9, 42, 6);
-            expected_nft.delta.add(6, 5, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, 42);
-            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 2, 3, 1, 2, 3 }, 4);
-            expected_nft.delta.add(0, 4, 5);
-            expected_nft.delta.add(5, 4, 6);
-            expected_nft.delta.add(6, 4, 7);
-            expected_nft.delta.add(7, 42, 0);
-            expected_nft.delta.add(0, 0, 1);
-            expected_nft.delta.add(1, 1, 2);
-            expected_nft.delta.add(2, 2, 3);
-            expected_nft.delta.add(3, 42, 4);
-            expected_nft.delta.add(4, 5, 8);
-            expected_nft.delta.add(8, 5, 9);
-            expected_nft.delta.add(9, 5, 10);
-            expected_nft.delta.add(10, 42, 4);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-
-        SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42);
-            expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
-            expected_nft.delta.add(0, 42, 8);
-            expected_nft.delta.add(8, 4, 9);
-            expected_nft.delta.add(9, 42, 10);
-            expected_nft.delta.add(10, 4, 11);
-            expected_nft.delta.add(11, 4, 12);
-            expected_nft.delta.add(12, 42, 13);
-            expected_nft.delta.add(13, 42, 0);
-            expected_nft.delta.add(0, 42, 1);
-            expected_nft.delta.add(1, 0, 2);
-            expected_nft.delta.add(2, 42, 3);
-            expected_nft.delta.add(3, 1, 4);
-            expected_nft.delta.add(4, 2, 5);
-            expected_nft.delta.add(5, 42, 6);
-            expected_nft.delta.add(6, 42, 7);
-            expected_nft.delta.add(7, 42, 14);
-            expected_nft.delta.add(14, 5, 15);
-            expected_nft.delta.add(15, 42, 16);
-            expected_nft.delta.add(16, 5, 17);
-            expected_nft.delta.add(17, 5, 18);
-            expected_nft.delta.add(18, 42, 19);
-            expected_nft.delta.add(19, 42, 7);
-            CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-        }
-    }
-
     SECTION("complex - default_symbol = DONT_CARE, jump_mode == JumpMode::AppendDontCares") {
         delta.clear();
         delta.add(0, 0, 1);
@@ -4098,7 +3918,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, { 0, 2, 3, 0, 1, 1, 1 }, 4);
             expected_nft.delta.add(0, DONT_CARE, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
@@ -4113,7 +3933,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
             expected_nft = Nft(8, { 0 }, { 3 }, { 0, 1, 3, 0, 2, 2, 2, 2 }, 4);
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 6);
@@ -4129,7 +3949,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 2, 3, 2 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4144,7 +3964,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
             expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 3, 3, 3 }, 4 );
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4159,7 +3979,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, DONT_CARE, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
             expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 0, 1);
@@ -4188,85 +4008,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
     }
 
-    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::AppendDontCares") {
-        delta.clear();
-        delta.add(0, 0, 1);
-        delta.add(0, 4, 2);
-        delta.add(1, 1, 2);
-        delta.add(1, 5, 3);
-        delta.add(2, 2, 3);
-        delta.add(3, 3, 0);
-
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
-
-        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42, JumpMode::AppendDontCares);
-        expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
-        expected_nft.delta.add(0, 42, 5);
-        expected_nft.delta.add(5, 0, 1);
-        expected_nft.delta.add(0, 42, 4);
-        expected_nft.delta.add(4, 4, 17);
-        expected_nft.delta.add(17, 42, 8);
-        expected_nft.delta.add(8, DONT_CARE, 2);
-        expected_nft.delta.add(1, 42, 6);
-        expected_nft.delta.add(1, 42, 7);
-        expected_nft.delta.add(6, 5, 18);
-        expected_nft.delta.add(18, DONT_CARE, 9);
-        expected_nft.delta.add(9, 42, 11);
-        expected_nft.delta.add(11, 42, 3);
-        expected_nft.delta.add(7, 1, 2);
-        expected_nft.delta.add(2, 2, 10);
-        expected_nft.delta.add(10, 42, 12);
-        expected_nft.delta.add(12, 42, 3);
-        expected_nft.delta.add(3, 42, 13);
-        expected_nft.delta.add(13, 3, 19);
-        expected_nft.delta.add(19, 42, 16);
-        expected_nft.delta.add(16, DONT_CARE, 20);
-        expected_nft.delta.add(20, DONT_CARE, 14);
-        expected_nft.delta.add(14, 42, 15);
-        expected_nft.delta.add(15, 42, 0);
-        CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-    }
-
-    SECTION("Complex - default_symbol = 42, jump_mode == JumpMode::RepeatSymbol") {
-        delta.clear();
-        delta.add(0, 0, 1);
-        delta.add(0, 4, 2);
-        delta.add(1, 1, 2);
-        delta.add(1, 5, 3);
-        delta.add(2, 2, 3);
-        delta.add(3, 3, 0);
-
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
-
-        output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, 42);
-        expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
-        expected_nft.delta.add(0, 42, 5);
-        expected_nft.delta.add(5, 0, 1);
-        expected_nft.delta.add(0, 42, 4);
-        expected_nft.delta.add(4, 4, 17);
-        expected_nft.delta.add(17, 42, 8);
-        expected_nft.delta.add(8, 4, 2);
-        expected_nft.delta.add(1, 42, 6);
-        expected_nft.delta.add(1, 42, 7);
-        expected_nft.delta.add(6, 5, 18);
-        expected_nft.delta.add(18, 5, 9);
-        expected_nft.delta.add(9, 42, 11);
-        expected_nft.delta.add(11, 42, 3);
-        expected_nft.delta.add(7, 1, 2);
-        expected_nft.delta.add(2, 2, 10);
-        expected_nft.delta.add(10, 42, 12);
-        expected_nft.delta.add(12, 42, 3);
-        expected_nft.delta.add(3, 42, 13);
-        expected_nft.delta.add(13, 3, 19);
-        expected_nft.delta.add(19, 42, 16);
-        expected_nft.delta.add(16, 3, 20);
-        expected_nft.delta.add(20, 3, 14);
-        expected_nft.delta.add(14, 42, 15);
-        expected_nft.delta.add(15, 42, 0);
-        CHECK(are_equivalent(output_nft, expected_nft, JumpMode::AppendDontCares));
-    }
-
-    SECTION("Testing inner state reusage.") {
+    SECTION("Testing inner state reuse with JumpMode::RepeatSymbol.") {
         delta.clear();
         delta.add(0, 0, 1);
         delta.add(1, 1, 3);
@@ -4276,12 +4018,24 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
 
-        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 });
-        CHECK(output_nft.num_of_states() == 14);
+        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::RepeatSymbol);
+        CHECK(output_nft.num_of_states() == 13);
+    }
 
+    SECTION("Testing inner state reuse with JumpMode::AppendDontCares.") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 3);
+        delta.add(1, 2, 3);
+        delta.add(1, 3, 2);
+        delta.add(2, 4, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+
+        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::AppendDontCares);
+        CHECK(output_nft.num_of_states() == 9);
     }
 }
-
 TEST_CASE("mata::nft::Nft::insert_word()") {
     Delta delta;
     delta.add(0, 0, 1);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4265,6 +4265,21 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         expected_nft.delta.add(15, 42, 0);
         CHECK(are_equivalent(output_nft, expected_nft));
     }
+
+    SECTION("Testing inner state reusage.") {
+        delta.clear();
+        delta.add(0, 0, 1);
+        delta.add(1, 1, 3);
+        delta.add(1, 2, 3);
+        delta.add(1, 3, 2);
+        delta.add(2, 4, 3);
+
+        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+
+        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 });
+        CHECK(output_nft.num_of_states() == 14);
+
+    }
 }
 
 TEST_CASE("mata::nft::Nft::insert_word()") {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4278,13 +4278,13 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected.delta.add(1, 'b', 3);
             expected.delta.add(3, 'b', 1);
 
-            CHECK(are_equivalent(nft, expected));
+            CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
         SECTION("num_of_levels == 4") {
             nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
-            nft.insert_identity(0, 'a');
-            nft.insert_identity(1, 'b');
+            nft.insert_identity(0, 'a', JumpMode::AppendDontCares);
+            nft.insert_identity(1, 'b', JumpMode::AppendDontCares);
 
             expected = Nft(8, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 1, 2, 2, 3, 3 }, 4);
             expected.delta.add(0, 'a', 2);
@@ -4296,7 +4296,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected.delta.add(5, 'b', 7);
             expected.delta.add(7, 'b', 1);
 
-            CHECK(are_equivalent(nft, expected));
+            CHECK(are_equivalent(nft, expected, JumpMode::AppendDontCares));
         }
     }
 
@@ -4309,12 +4309,12 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
 
             SECTION("symbols cnt == 1") {
                 nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
-                nft.insert_identity(1, 'c');
+                nft.insert_identity(1, 'c', JumpMode::AppendDontCares);
 
                 expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
                 expected.delta.add(1, 'c', 1);
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::AppendDontCares));
             }
 
             SECTION("symbols cnt == 2") {
@@ -4325,7 +4325,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
                 expected.insert_identity(1, 'c');
                 expected.insert_identity(1, 'd');
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
             }
         }
 
@@ -4339,18 +4339,18 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
                 expected.delta.add(1, 'c', 3);
                 expected.delta.add(3, 'c', 1);
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
             }
 
             SECTION("symbols cnt == 2") {
                 nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
-                nft.insert_identity(1, {'c', 'd'});
+                nft.insert_identity(1, {'c', 'd'}, JumpMode::AppendDontCares);
 
                 expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
-                expected.insert_identity(1, 'c');
-                expected.insert_identity(1, 'd');
+                expected.insert_identity(1, 'c', JumpMode::AppendDontCares);
+                expected.insert_identity(1, 'd', JumpMode::AppendDontCares);
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::AppendDontCares));
             }
         }
 
@@ -4366,20 +4366,20 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
                 expected.delta.add(4, 'c', 5);
                 expected.delta.add(5, 'c', 1);
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
             }
 
             SECTION("symbols cnt == 4") {
                 nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
                 nft.insert_identity(1, {'c', 'd', 'e', 'f'});
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1, 2, 3 }, 4);
+                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
                 expected.insert_identity(1, 'c');
                 expected.insert_identity(1, 'd');
                 expected.insert_identity(1, 'e');
                 expected.insert_identity(1, 'f');
 
-                CHECK(are_equivalent(nft, expected));
+                CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
 
             }
         }
@@ -4397,7 +4397,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
             expected.delta.add(2, 'c', 2);
 
-            CHECK(are_equivalent(nft, expected));
+            CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
         SECTION("num_of_levels == 2") {
@@ -4408,7 +4408,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected.delta.add(2, 'c', 3);
             expected.delta.add(3, 'c', 2);
 
-            CHECK(are_equivalent(nft, expected));
+            CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
         SECTION("num_of_levels == 4") {
@@ -4421,7 +4421,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             expected.delta.add(4, 'c', 5);
             expected.delta.add(5, 'c', 2);
 
-            CHECK(are_equivalent(nft, expected));
+            CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
     }
 }


### PR DESCRIPTION
This PR includes:
- Removal of the `default_symbol` parameter from the `mata::nft::insert_levels()` function, as it seems to have no use. This change improves the readability of the code.
- Modifications to the `mata::nft::insert_levels()` function to create only the important inner states when inserting new levels, and to utilize jump transitions.
- Improvements to the `mata::nft::Nft::insert_identity()` method to create an identity utilizing one self-loop transition when using `JumpMode::RepeatSymbol`.
    - **TODO**: Evaluate the performance difference between adding a self-lop transition and inserting a transition for each level.