### PR TITLE
Allow moving Delta

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -270,9 +270,11 @@ public:
 
     Delta(): state_posts_{} {}
     Delta(const Delta& other) = default;
+    Delta(Delta&& other) = default;
     explicit Delta(size_t n): state_posts_{ n } {}
 
     Delta& operator=(const Delta& other) = default;
+    Delta& operator=(Delta&& other) = default;
 
     bool operator==(const Delta& other) const;
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -313,11 +313,11 @@ public:
     bool is_acyclic() const;
 
     /**
-     * Fill @p alphabet with symbols from @p nfa.
-     * @param[in] nfa NFA with symbols to fill @p alphabet with.
-     * @param[out] alphabet Alphabet to be filled with symbols from @p nfa.
+     * Fill @p alphabet_to_fill with symbols from @p nfa.
+     * @param[in] nfa NFA with symbols to fill @p alphabet_to_fill with.
+     * @param[out] alphabet_to_fill Alphabet to be filled with symbols from @p nfa.
      */
-    void fill_alphabet(mata::OnTheFlyAlphabet& alphabet) const;
+    void fill_alphabet(mata::OnTheFlyAlphabet& alphabet_to_fill) const;
 
     /// Is the language of the automaton universal?
     bool is_universal(const Alphabet& alphabet, Run* cex = nullptr,

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -743,11 +743,11 @@ std::ostream& std::operator<<(std::ostream& os, const Nfa& nfa) {
     return os;
 }
 
-void mata::nfa::Nfa::fill_alphabet(OnTheFlyAlphabet& alphabet) const {
+void mata::nfa::Nfa::fill_alphabet(OnTheFlyAlphabet& alphabet_to_fill) const {
     for (const StatePost& state_post: this->delta) {
         for (const SymbolPost& symbol_post: state_post) {
-            alphabet.update_next_symbol_value(symbol_post.symbol);
-            alphabet.try_add_new_symbol(std::to_string(symbol_post.symbol), symbol_post.symbol);
+            alphabet_to_fill.update_next_symbol_value(symbol_post.symbol);
+            alphabet_to_fill.try_add_new_symbol(std::to_string(symbol_post.symbol), symbol_post.symbol);
         }
     }
 }


### PR DESCRIPTION
This PR allows for move operations on `Delta` in move constructor and move assignment for `Delta`.