### PR TITLE
Separate complement using brzozowski minimization from classical complement

### DIFF
--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -41,8 +41,16 @@ Nfa minimize_brzozowski(const Nfa& aut);
  *  minimization.
  * @return Complemented automaton.
  */
-Nfa complement_classical(const Nfa& aut, const mata::utils::OrdVector<Symbol>& symbols,
-                         bool minimize_during_determinization = false);
+Nfa complement_classical(const Nfa& aut, const mata::utils::OrdVector<Symbol>& symbols);
+
+/**
+ * Complement implemented by determization using Brzozowski minimization, adding a sink state and making the automaton
+ *  complete. Then it swaps final and non-final states.
+ * @param[in] aut Automaton to be complemented.
+ * @param[in] symbols Symbols needed to make the automaton complete.
+ * @return Complemented automaton.
+ */
+Nfa complement_brzozowski(const Nfa& aut, const mata::utils::OrdVector<Symbol>& symbols);
 
 /**
  * Inclusion implemented by complementation of bigger automaton, intersecting it with smaller and then it checks

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -396,10 +396,10 @@ public:
     bool make_complete(const Alphabet& alphabet) { return this->make_complete(alphabet, this->num_of_states()); }
 
     /**
-     * Complement deterministic NFA in-place by adding a sink state and swapping final and non-final states.
+     * Complement deterministic automaton in-place by adding a sink state and swapping final and non-final states.
      * @param[in] symbols Symbols needed to make the automaton complete.
      * @param[in] sink_state State to be used as a sink state. Adds a new sink state when not specified.
-     * @return NFA complemented in-place.
+     * @return DFA complemented in-place.
      * @pre @c this is a deterministic automaton.
      */
     Nfa& complement_deterministic(const mata::utils::OrdVector<Symbol>& symbols, std::optional<State> sink_state = std::nullopt);

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -394,6 +394,15 @@ public:
      * @return True if some new transition (and sink state) was added to the automaton.
      */
     bool make_complete(const Alphabet& alphabet) { return this->make_complete(alphabet, this->num_of_states()); }
+
+    /**
+     * Complement deterministic NFA in-place by adding a sink state and swapping final and non-final states.
+     * @param[in] symbols Symbols needed to make the automaton complete.
+     * @param[in] sink_state State to be used as a sink state. Adds a new sink state when not specified.
+     * @return NFA complemented in-place.
+     * @pre @c this is a deterministic automaton.
+     */
+    Nfa& complement_deterministic(const mata::utils::OrdVector<Symbol>& symbols, std::optional<State> sink_state = std::nullopt);
 }; // struct Nfa.
 
 // Allow variadic number of arguments of the same type.
@@ -491,12 +500,14 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
  * @param[in] aut Automaton whose complement to compute.
  * @param[in] alphabet Alphabet used for complementation.
  * @param[in] params Optional parameters to control the complementation algorithm:
- * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
- * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * - "algorithm":
+ *      - "classical": The classical algorithm determinizes the automaton, makes it complete, and swaps final and
+ *                      non-final states.
+ *      - "brzozowski": The Brzozowski algorithm determinizes the automaton using Brzozowski minimization, makes it
+ *                       complete, and swaps final and non-final states.
  * @return Complemented automaton.
  */
-Nfa complement(const Nfa& aut, const Alphabet& alphabet,
-               const ParameterMap& params = {{ "algorithm", "classical" }, { "minimize", "false" }});
+Nfa complement(const Nfa& aut, const Alphabet& alphabet, const ParameterMap& params = { { "algorithm", "classical" } });
 
 /**
  * @brief Compute automaton accepting complement of @p aut.
@@ -509,12 +520,15 @@ Nfa complement(const Nfa& aut, const Alphabet& alphabet,
  * @param[in] aut Automaton whose complement to compute.
  * @param[in] symbols Symbols to complement over.
  * @param[in] params Optional parameters to control the complementation algorithm:
- * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
- * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * - "algorithm":
+ *      - "classical": The classical algorithm determinizes the automaton, makes it complete, and swaps final and
+ *                      non-final states.
+ *      - "brzozowski": The Brzozowski algorithm determinizes the automaton using Brzozowski minimization, makes it
+ *                       complete, and swaps final and non-final states.
  * @return Complemented automaton.
  */
 Nfa complement(const Nfa& aut, const utils::OrdVector<Symbol>& symbols,
-               const ParameterMap& params = {{ "algorithm", "classical" }, { "minimize", "false" }});
+               const ParameterMap& params = { { "algorithm", "classical" } });
 
 /**
  * @brief Compute minimal deterministic automaton.
@@ -524,7 +538,7 @@ Nfa complement(const Nfa& aut, const utils::OrdVector<Symbol>& symbols,
  * - "algorithm": "brzozowski"
  * @return Minimal deterministic automaton.
  */
-Nfa minimize(const Nfa &aut, const ParameterMap& params = {{ "algorithm", "brzozowski" }});
+Nfa minimize(const Nfa &aut, const ParameterMap& params = { { "algorithm", "brzozowski" } });
 
 /**
  * @brief Determinize automaton.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -122,6 +122,11 @@ public:
      */
     void unify_final();
 
+    /**
+     * Swap final and non-final states in-place.
+     */
+    Nfa& swap_final_nonfinal() { final.complement(num_of_states()); return *this; }
+
     bool is_state(const State &state_to_check) const { return state_to_check < num_of_states(); }
 
     /**

--- a/include/mata/utils/sparse-set.hh
+++ b/include/mata/utils/sparse-set.hh
@@ -35,7 +35,6 @@ concept Iterable = requires(T t) {
 /**
  * @brief  Implementation of a set of non-negative numbers using sparse-set.
  *
- *
  * This class implements the interface of a set (similar to std::set) using sparse-set date structure,
  * that is, a pair of vectors dense and sparse (... google it).
  * Importantly
@@ -115,13 +114,18 @@ concept Iterable = requires(T t) {
             assert(consistent());
         }
 
-        void erase(const Number val) {
-            if (contains(val)) {
-                dense[sparse[val]] = dense[size_ - 1];
-                sparse[dense[size_ - 1]] = sparse[val];
-                --size_;
-            }
+        /**
+         * Erase @p number from the set without checking for its existence.
+         * @param number Number to be erased.
+         * @pre @p number exists in the set.
+         */
+        void erase_nocheck(const Number number) {
+            dense[sparse[number]] = dense[size_ - 1];
+            sparse[dense[size_ - 1]] = sparse[number];
+            --size_;
         }
+
+        void erase(const Number val) { if (contains(val)) { erase_nocheck(val); } }
 
 //////////////////////////////////////////////////////////////////////////////////
 ///     New Mata code
@@ -236,13 +240,9 @@ concept Iterable = requires(T t) {
         }
 
         template<Iterable T>
-        void erase(const T & set) {
-            erase(set.begin(),set.end());
-        }
+        void erase(const T & set) { erase(set.begin(),set.end()); }
 
-        void erase(const std::initializer_list<Number> & list) {
-            erase(list.begin(),list.end());
-        }
+        void erase(const std::initializer_list<Number> & list) { erase(list.begin(),list.end()); }
 
         //call this (instead of the friend are_disjoint) if you want the other container to be iterated (e.g. if it does not have constant membership)
         template<class T>
@@ -261,7 +261,7 @@ concept Iterable = requires(T t) {
             Number old_domain_size = domain_size_;
             for (Number i = 0; i < new_domain_size; ++i) {
                 if (contains(i))
-                    erase(i);
+                    erase_nocheck(i);
                 else
                     insert(i);
             }
@@ -274,8 +274,8 @@ concept Iterable = requires(T t) {
 
         template<typename F>
         void filter(F && is_staying) {
-            for (Number i = 0; i < size_; i++) {
-                while (i<size_ && !is_staying(dense[i])) {
+            for (Number i{ 0 }; i < size_; ++i) {
+                while (i < size_ && !is_staying(dense[i])) {
                     erase(dense[i]);
                 }
             }

--- a/src/nfa/complement.cc
+++ b/src/nfa/complement.cc
@@ -8,35 +8,21 @@
 using namespace mata::nfa;
 using namespace mata::utils;
 
-Nfa mata::nfa::algorithms::complement_classical(const Nfa& aut, const OrdVector<Symbol>& symbols,
-                                                bool minimize_during_determinization) {
-    Nfa result;
-    State sink_state;
-    if (minimize_during_determinization) {
-        result = minimize_brzozowski(aut); // brzozowski minimization makes it deterministic
-        if (result.final.empty() && !result.initial.empty()) {
-            assert(result.initial.size() == 1);
-            // if automaton does not accept anything, then there is only one (initial) state
-            // which can be the sink state (so we do not create unnecessary one)
-            sink_state = *result.initial.begin();
-        } else {
-            sink_state = result.num_of_states();
-        }
-    } else {
-        std::unordered_map<StateSet, State> subset_map;
-        result = determinize(aut, &subset_map);
-        // check if a sink state was not created during determinization
-        auto sink_state_iter = subset_map.find({});
-        if (sink_state_iter != subset_map.end()) {
-            sink_state = sink_state_iter->second;
-        } else {
-            sink_state = result.num_of_states();
-        }
-    }
+Nfa mata::nfa::algorithms::complement_classical(const Nfa& aut, const OrdVector<Symbol>& symbols) {
+    return determinize(aut)
+        .trim()
+        .complement_deterministic(symbols);
+}
 
-    result.make_complete(symbols, sink_state);
-    result.swap_final();
-    return result;
+Nfa algorithms::complement_brzozowski(const Nfa& aut, const OrdVector<Symbol>& symbols) {
+    Nfa result{ minimize_brzozowski(aut) }; // Brzozowski minimization makes it deterministic.
+    if (result.final.empty() && !result.initial.empty()) {
+        assert(result.initial.size() == 1);
+        // If the DFA does not accept anything, then there is only one (initial) state which can be the sink state (so
+        //  we do not create an unnecessary new sink state).
+        return result.complement_deterministic(symbols, *result.initial.begin());
+    }
+    return result.complement_deterministic(symbols);
 }
 
 Nfa mata::nfa::complement(const Nfa& aut, const Alphabet& alphabet, const ParameterMap& params) {
@@ -44,7 +30,6 @@ Nfa mata::nfa::complement(const Nfa& aut, const Alphabet& alphabet, const Parame
 }
 
 Nfa mata::nfa::complement(const Nfa& aut, const mata::utils::OrdVector<mata::Symbol>& symbols, const ParameterMap& params) {
-    Nfa result;
     // Setting the requested algorithm.
     decltype(algorithms::complement_classical)* algo = algorithms::complement_classical;
     if (!haskey(params, "algorithm")) {
@@ -55,21 +40,11 @@ Nfa mata::nfa::complement(const Nfa& aut, const mata::utils::OrdVector<mata::Sym
 
     const std::string& str_algo = params.at("algorithm");
     if ("classical" == str_algo) {  /* default */ }
+    else if ("brzozowski" == str_algo) {  algo = algorithms::complement_brzozowski; }
     else {
         throw std::runtime_error(std::to_string(__func__) +
                                  " received an unknown value of the \"algo\" key: " + str_algo);
     }
 
-    bool minimize_during_determinization = false;
-    if (params.find("minimize") != params.end()) {
-        const std::string& minimize_arg = params.at("minimize");
-        if ("true" == minimize_arg) { minimize_during_determinization = true; }
-        else if ("false" == minimize_arg) { minimize_during_determinization = false; }
-        else {
-            throw std::runtime_error(std::to_string(__func__) +
-                                     " received an unknown value of the \"minimize\" key: " + str_algo);
-        }
-    }
-
-    return algo(aut, symbols, minimize_during_determinization);
+    return algo(aut, symbols);
 }

--- a/src/nfa/complement.cc
+++ b/src/nfa/complement.cc
@@ -35,7 +35,7 @@ Nfa mata::nfa::algorithms::complement_classical(const Nfa& aut, const OrdVector<
     }
 
     result.make_complete(symbols, sink_state);
-    result.final.complement(result.num_of_states());
+    result.swap_final();
     return result;
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -555,3 +555,14 @@ bool Nfa::is_identical(const Nfa& aut) const {
     }
     return delta == aut.delta;
 }
+
+Nfa& Nfa::complement_deterministic(const OrdVector<Symbol>& symbols, std::optional<State> sink_state) {
+    const State sink{ sink_state.value_or(num_of_states()) };
+    if (initial.empty()) { // The automaton has no reachable states (accepting an empty language).
+        // Insert a single initial sink state.
+        initial.insert(sink);
+    }
+    make_complete(symbols, sink);
+    swap_final_nonfinal();
+    return *this;
+}

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -489,7 +489,7 @@ bool mata::nfa::Nfa::make_complete(const Alphabet& alphabet, State sink_state) {
 bool mata::nfa::Nfa::make_complete(const mata::utils::OrdVector<Symbol>& symbols, State sink_state) {
     bool was_something_added{ false };
 
-    size_t num_of_states{ this->num_of_states() };
+    const size_t num_of_states{ this->num_of_states() };
     for (State state = 0; state < num_of_states; ++state) {
         OrdVector<Symbol> used_symbols{};
         for (auto const &move : this->delta[state]) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -151,11 +151,11 @@ namespace {
                                     const State Tid, const StateSet& T,                      // current state to check
                                     Nfa& result) {
 
-        std::unordered_map<StateSet, State>::iterator it = subset_map.begin();
+        auto it = subset_map.begin();
 
         // initiate with empty StateSets
-        covering_states.emplace_back(mata::utils::OrdVector<State>());
-        covering_indexes.emplace_back(mata::utils::OrdVector<State>());
+        covering_states.emplace_back();
+        covering_indexes.emplace_back();
 
         while (it != subset_map.end()) {               // goes through all found states
             if (it->first.IsSubsetOf(T)) {
@@ -194,7 +194,7 @@ namespace {
                     // remove covered state from the automaton, replace with covering set
                     remove_covered_state(covering_indexes[erase_state], erase_state, result);
 
-                    std::unordered_map<StateSet, State>::iterator temp = it++;
+                    auto temp = it++;
                     // move state from subset_map to covered
                     auto transfer = subset_map.extract(temp);
                     covered.insert(std::move(transfer));
@@ -228,8 +228,8 @@ namespace {
         worklist.emplace_back(S0id, S0);
 
         (subset_map)[mata::utils::OrdVector<State>(S0)] = S0id;
-        covering_states.emplace_back(mata::utils::OrdVector<State>());
-        covering_indexes.emplace_back(mata::utils::OrdVector<State>());
+        covering_states.emplace_back();
+        covering_indexes.emplace_back();
 
         if (aut.delta.empty()){
             return result;
@@ -361,19 +361,19 @@ namespace {
     }
 
     Nfa residual_after(const Nfa&  aut) {
-        std::unordered_map<StateSet, State> *subset_map = new std::unordered_map<StateSet,State>();
+        std::unordered_map<StateSet, State> subset_map{};
         Nfa result;
-        result = determinize(aut, subset_map);
+        result = determinize(aut, &subset_map);
 
         std::vector <StateSet> macrostate_vec;              // ordered vector of macrostates
-        macrostate_vec.reserve(subset_map->size());
-        for (const auto& pair: *subset_map) {                   // order by size from largest to smallest
+        macrostate_vec.reserve(subset_map.size());
+        for (const auto& pair: subset_map) {                   // order by size from largest to smallest
             macrostate_vec.insert(std::upper_bound(macrostate_vec.begin(), macrostate_vec.end(), pair.first,
                                 [](const StateSet & a, const StateSet & b){ return a.size() > b.size(); }), pair.first);
         }
 
-        std::vector <bool> covered(subset_map->size(), false);          // flag of covered states, removed from nfa
-        std::vector <bool> visited(subset_map->size(), false);          // flag of processed state
+        std::vector <bool> covered(subset_map.size(), false);          // flag of covered states, removed from nfa
+        std::vector <bool> visited(subset_map.size(), false);          // flag of processed state
 
         StateSet covering_set;                // doesn't contain duplicates
         std::vector<State> covering_indexes;        // indexes of covering states
@@ -410,26 +410,25 @@ namespace {
 
                     visited[covering_indexes[k]] = true;
 
-                    residual_recurse_coverable(macrostate_vec, covering_indexes, covered, visited, k, subset_map, result);
+                    residual_recurse_coverable(macrostate_vec, covering_indexes, covered, visited, k, &subset_map, result);
                 }
 
                 covering_set.clear();                 // clear variable to store only needed macrostates
                 for (auto index : covering_indexes) {
                     if (covered[index] == 0) {
-                        auto macrostate_ptr = subset_map->find(macrostate_vec[index]);
-                        if (macrostate_ptr == subset_map->end())        // should never happen
+                        auto macrostate_ptr = subset_map.find(macrostate_vec[index]);
+                        if (macrostate_ptr == subset_map.end())        // should never happen
                              throw std::runtime_error(std::to_string(__func__) + " couldn't find expected element in a map.");
 
                         covering_set.insert(macrostate_ptr->second);
                     }
                 }
 
-                remove_covered_state(covering_set, subset_map->find(macrostate_vec[i])->second, result);
+                remove_covered_state(covering_set, subset_map.find(macrostate_vec[i])->second, result);
                 covered[i] = true;
             }
         }
 
-        delete subset_map;  // clean up
         return result;
     }
 
@@ -1195,7 +1194,7 @@ std::set<mata::Word> mata::nfa::Nfa::get_words(unsigned max_length) {
                 mata::Word new_word = word;
                 new_word.push_back(sp.symbol);
                 for (State s_to : sp.targets) {
-                    new_worklist.push_back({s_to, new_word});
+                    new_worklist.emplace_back(s_to, new_word);
                     if (final.contains(s_to)) {
                         result.insert(new_word);
                     }

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2410,8 +2410,6 @@ TEST_CASE("mata::nfa::reduce_size_by_residual()") {
         Nfa result_after = reduce(aut, &state_renaming, params_after);
         Nfa result_with = reduce(aut, &state_renaming, params_with);
 
-        result_after.print_to_DOT(std::cout);
-
         REQUIRE(result_after.num_of_states() == 6);
         REQUIRE(result_after.initial[0]);
         REQUIRE(result_after.initial[1]);

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -982,8 +982,7 @@ TEST_CASE("mata::nfa::complement()")
     {
         OnTheFlyAlphabet alph{};
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
         Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
         CHECK(are_equivalent(cmpl, empty_string_nfa));
     }
@@ -992,8 +991,7 @@ TEST_CASE("mata::nfa::complement()")
     {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
 
         REQUIRE(cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
@@ -1011,8 +1009,7 @@ TEST_CASE("mata::nfa::complement()")
         aut.initial = {1};
         aut.final = {1};
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
 
         CHECK(cmpl.is_lang_empty());
     }
@@ -1023,8 +1020,7 @@ TEST_CASE("mata::nfa::complement()")
         aut.initial = {1};
         aut.final = {1};
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
 
         REQUIRE(!cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"]}, {}}));
@@ -1046,8 +1042,7 @@ TEST_CASE("mata::nfa::complement()")
         aut.delta.add(1, alph["a"], 2);
         aut.delta.add(2, alph["b"], 2);
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(aut, alph, {{"algorithm", "classical"} });
 
         REQUIRE(!cmpl.is_in_lang(Word{}));
         REQUIRE(!cmpl.is_in_lang(Word{ alph["a"] }));
@@ -1066,8 +1061,7 @@ TEST_CASE("mata::nfa::complement()")
     {
         OnTheFlyAlphabet alph{};
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
         Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
         CHECK(are_equivalent(empty_string_nfa, cmpl));
     }
@@ -1076,8 +1070,7 @@ TEST_CASE("mata::nfa::complement()")
     {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
 
         REQUIRE(cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
@@ -1089,8 +1082,7 @@ TEST_CASE("mata::nfa::complement()")
         CHECK(are_equivalent(sigma_star_nfa, cmpl));
     }
 
-    SECTION("minimization vs no minimization")
-    {
+    SECTION("minimization vs no minimization") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
         aut.initial = {0, 1};
         aut.final = {1, 2};
@@ -1101,12 +1093,8 @@ TEST_CASE("mata::nfa::complement()")
         aut.delta.add(0, alph["a"], 1);
         aut.delta.add(0, alph["a"], 2);
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
-
-        Nfa cmpl_min = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
-
+        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
+        Nfa cmpl_min = complement(aut, alph, { { "algorithm", "brzozowski"} });
         CHECK(are_equivalent(cmpl, cmpl_min, &alph));
         CHECK(cmpl_min.num_of_states() == 4);
         CHECK(cmpl.num_of_states() == 5);


### PR DESCRIPTION
This PR:
- optimizes removal of elements from sparse set by not checking for element existence multiple times.
- adds a method to swap final and non-final states in the automaton, as requested by #342.
- adds a convenience function to compute a complement of a DFA in-place, as requested by #342.
- extracts complement using Brzozowski minimization into a separate function, as requested by #342.
- removes an unnecessary use of dynamic memory from #406.

This PR resolves #342.