### PR TITLE
Fix emplace back implementations

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -68,7 +68,6 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         void reserve(size_t)
         CStatePost& state_post(State)
         CStatePost& operator[](State)
-        void emplace_back()
         void clear()
         bool empty()
         void resize(size_t)

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -27,7 +27,6 @@ struct Transition {
             : source(source), symbol(symbol), target(target) {}
 
     bool operator==(const Transition& rhs) const { return source == rhs.source && symbol == rhs.symbol && target == rhs.target; }
-    bool operator!=(const Transition& rhs) const { return !this->operator==(rhs); }
 };
 
 /**

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -183,11 +183,11 @@ public:
     /**
      * Iterator over epsilon moves in @c StatePost represented as @c Move instances.
      */
-    Moves moves_epsilons(const Symbol first_epsilon = EPSILON) const;
+    Moves moves_epsilons(Symbol first_epsilon = EPSILON) const;
     /**
      * Iterator over alphabet (normal) symbols (not over epsilons) in @c StatePost represented as @c Move instances.
      */
-    Moves moves_symbols(const Symbol last_symbol = EPSILON - 1) const;
+    Moves moves_symbols(Symbol last_symbol = EPSILON - 1) const;
 
     /**
      * Count the number of all moves in @c StatePost.

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -126,8 +126,7 @@ public:
     using super::back;
     using super::filter;
 
-    void erase(const SymbolPost& s) {super::erase(s);}
-    void erase(const_iterator first, const_iterator last) {super::erase(first,last);}
+    using super::erase;
 
     using super::find;
     iterator find(const Symbol symbol) { return super::find({ symbol, {} }); }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -82,6 +82,12 @@ public:
     // but useful for adding states in a random order to sort later (supposedly more efficient than inserting in a random order)
     void inline push_back(const State s) { targets.push_back(s); }
 
+    template <typename... Args>
+    StateSet& emplace_back(Args&&... args) {
+	// Forwardinng the variadic template pack of arguments to the emplace_back() of the underlying container.
+        return targets.emplace_back(std::forward<Args>(args)...);
+    }
+
     void erase(State s) { targets.erase(s); }
 
     std::vector<State>::const_iterator find(State s) const { return targets.find(s); }
@@ -102,14 +108,18 @@ public:
     using super::begin, super::end, super::cbegin, super::cend;
     using super::OrdVector;
     using super::operator=;
+    using super::operator==;
     StatePost(const StatePost&) = default;
     StatePost(StatePost&&) = default;
     StatePost& operator=(const StatePost&) = default;
     StatePost& operator=(StatePost&&) = default;
+    bool operator==(const StatePost&) const = default;
     using super::insert;
     using super::reserve;
     using super::empty, super::size;
     using super::ToVector;
+    // dangerous, breaks the sortedness invariant
+    using super::emplace_back;
     // dangerous, breaks the sortedness invariant
     using super::push_back;
     // is adding non-const version as well ok?
@@ -330,7 +340,11 @@ public:
 
     void defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
 
-    void emplace_back() { state_posts_.emplace_back(); }
+    template <typename... Args>
+    StatePost& emplace_back(Args&&... args) {
+	// Forwarding the variadic template pack of arguments to the emplace_back() of the underlying container.
+        return state_posts_.emplace_back(std::forward<Args>(args)...);
+    }
 
     void clear() { state_posts_.clear(); }
 

--- a/include/mata/parser/parser.hh
+++ b/include/mata/parser/parser.hh
@@ -37,7 +37,6 @@ struct ParsedSection {
 
 	/// Equality operator
 	bool operator==(const ParsedSection& rhs) const;
-	bool operator!=(const ParsedSection& rhs) const { return !(*this == rhs); }
 
 	/// subscript operator for the key-value store
 	const std::vector<std::string>& operator[](const std::string& key) const;

--- a/include/mata/utils/closed-set.hh
+++ b/include/mata/utils/closed-set.hh
@@ -110,23 +110,9 @@ struct ClosedSet {
            insert(antichain);
        }
 
-       // operators
-
-       // Two closed sets are equivalent iff their type, borders
-       // and corresponding antichains are the same
-       bool operator==(const ClosedSet<T>& rhs) const
-        { // {{{
-            return type_ == rhs.type && min_val_ == rhs.min_val &&
-            max_val_ == rhs.max_val && antichain_ == rhs.antichain;
-        } // operator== }}}
-
-       // Two closed sets are not equivalent iff their type,
-       // borders or corresponding antichains differ
-       bool operator!=(const ClosedSet<T>& rhs) const
-        { // {{{
-            return type_ != rhs.type_ || min_val_ != rhs.min_val_ ||
-            max_val_ != rhs.max_val_ || antichain_ != rhs.antichain_;
-        } // operator!= }}}
+       /// Two closed sets are equivalent iff their type, borders and corresponding antichains are the same. They are
+       ///  not equivalent otherwise.
+       bool operator==(const ClosedSet<T>& rhs) const = default;
 
         // A closed set is considered to be smaller than the other one iff
         // it is a subset of the other one
@@ -147,7 +133,7 @@ struct ClosedSet {
         bool operator>=(const ClosedSet<T>& rhs) const
         { // {{{
             assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
-            "Types and borders of given closed sets must be the same to perform their <=-comparison.");
+            "Types and borders of given closed sets must be the same to perform their >=-comparison.");
             return contains(rhs.antichain);
         } // operator<= }}}
 

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -352,7 +352,6 @@ public:
 		assert(rhs.vectorIsSorted());
 		return (vec_ == rhs.vec_);
 	}
-    bool operator!=(const OrdVector& rhs) const { return !(*this == rhs); }
 
     bool operator<(const OrdVector& rhs) const {
         assert(vectorIsSorted());

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -133,7 +133,8 @@ public:
     // but useful in NFA where temporarily breaking the sortedness invariant allows for a faster algorithm (e.g. revert)
     template <typename... Args>
     reference emplace_back(Args&&... args) {
-       return vec_.emplace_back(std::forward<Args>(args)...);
+	// Forwarding the variadic template pack of arguments to the emplace_back() of the underlying container.
+        return vec_.emplace_back(std::forward<Args>(args)...);
     }
 
     // PUSH_BACK WHICH BREAKS SORTEDNESS,
@@ -144,7 +145,6 @@ public:
     // PUSH_BACK WHICH BREAKS SORTEDNESS,
     // dangerous,
     // but useful in NFA where temporarily breaking the sortedness invariant allows for a faster algorithm (e.g. revert)
-    // btw, do we need move here?
     reference push_back(Key&& t) { return emplace_back(std::move(t)); }
 
     virtual inline void reserve(size_t size) { vec_.reserve(size); }

--- a/include/mata/utils/synchronized-iterator.hh
+++ b/include/mata/utils/synchronized-iterator.hh
@@ -63,7 +63,6 @@ public:
         this->ends.emplace_back(end);
     };
 
-
     /** Empties positions and ends.
      * Though they should keep the allocated space.
      * @param size Number of elements to reserve up-front for positions and ends.

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -50,6 +50,13 @@ TEST_CASE("mata::nfa::size()") {
     CHECK(nfa.num_of_states() == 0);
 }
 
+TEST_CASE("StatePost::emplace_back()") {
+    StatePost state_post{};
+    state_post.emplace_back(1, StateSet{2, 3});
+    CHECK(state_post == StatePost{ SymbolPost{ Symbol{ 1 }, StateSet{ 2, 3 } } });
+    CHECK(*state_post.find(1) == SymbolPost{ SymbolPost{ Symbol{ 1 }, StateSet{ 2, 3 } } });
+}
+
 TEST_CASE("mata::nfa::Trans::operator<<") {
     Transition trans(1, 2, 3);
     REQUIRE(std::to_string(trans) == "(1, 2, 3)");


### PR DESCRIPTION
This PR fixes the implementations of `emplace_back()` methods throughout the Mata library to correctly construct the object in-place directly at the end of the containers.

Furthermore, this PR removes the redundant implementations of operators which are automatically generated by the compiler such as `operator!=()` for the existing `operator==()`.

Merging this PR fixes #331.