### PR TITLE
Get word from complement lazy determinization

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -350,7 +350,7 @@ public:
      * you can get all words by calling
      *      get_words(aut.num_of_states())
      */
-    std::set<Word> get_words(unsigned max_length);
+    std::set<Word> get_words(unsigned max_length) const;
 
     /**
      * @brief Get any arbitrary accepted word in the language of the automaton.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -576,9 +576,15 @@ Nfa minimize(const Nfa &aut, const ParameterMap& params = { { "algorithm", "brzo
  *
  * @param[in] aut Automaton to determinize.
  * @param[out] subset_map Map that maps sets of states of input automaton to states of determinized automaton.
+ * @param[in] macrostate_discover Callback event handler for discovering a new macrostate for the first time. The
+ *  parameters are the determinized NFA constructed so far, the current macrostate, and the set of the original states
+ *  corresponding to the macrostate. Return @c true if the determinization should continue, and @c false if the
+ *  determinization should stop and return only the determinized NFA constructed so far.
  * @return Determinized automaton.
  */
-Nfa determinize(const Nfa& aut, std::unordered_map<StateSet, State> *subset_map = nullptr);
+Nfa determinize(
+    const Nfa& aut, std::unordered_map<StateSet, State> *subset_map = nullptr,
+    std::optional<std::function<bool(const Nfa&, const State, const StateSet&)>> macrostate_discover = std::nullopt);
 
 /**
  * @brief Reduce the size of the automaton.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -360,6 +360,23 @@ public:
     std::optional<Word> get_word(Symbol first_epsilon = EPSILON) const;
 
     /**
+     * @brief Get any arbitrary accepted word in the language of the complement of the automaton.
+     *
+     * The automaton is lazily determinized and made complete. The algorithm returns an arbitrary word from the
+     *  complemented NFA constructed until the first macrostate without any final states in the original automaton is
+     *  encountered.
+     *
+     * @param[in] alphabet Alphabet to use for computing the complement. If @c nullptr, uses @c this->alphabet when
+     *  defined, otherwise uses @c this->delta.get_used_symbols().
+     *
+     * @pre The automaton does not contain any epsilon transitions.
+     * TODO: Support lazy epsilon closure?
+     * @return An arbitrary word from the complemented automaton, or @c std::nullopt if the automaton is universal on
+     *  the chosen set of symbols for the complement.
+     */
+    std::optional<Word> get_word_from_complement(const Alphabet* alphabet = nullptr) const;
+
+    /**
      * @brief Make NFA complete in place.
      *
      * For each state 0,...,this->num_of_states()-1, add transitions with "missing" symbols from @p alphabet

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1153,7 +1153,7 @@ Run mata::nfa::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return { .word = alphabet->translate_word(input) };
 }
 
-std::set<mata::Word> mata::nfa::Nfa::get_words(unsigned max_length) {
+std::set<mata::Word> mata::nfa::Nfa::get_words(unsigned max_length) const {
     std::set<mata::Word> result;
 
     // contains a pair: a state s and the word with which we got to the state s

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -249,7 +249,7 @@ namespace {
             }
 
             // add moves of S to the sync ex iterator
-            // TODO: shouldn't we also reset first?
+            synchronized_iterator.reset();
             for (State q: S) {
                 mata::utils::push_back(synchronized_iterator, aut.delta[q]);
             }
@@ -1064,7 +1064,7 @@ Nfa mata::nfa::determinize(
         }
 
         // add moves of S to the sync ex iterator
-        // TODO: shouldn't we also reset first?
+        synchronized_iterator.reset();
         for (State q: S) {
             mata::utils::push_back(synchronized_iterator, aut.delta[q]);
         }
@@ -1246,7 +1246,7 @@ std::optional<mata::Word> Nfa::get_word_from_complement(const Alphabet* alphabet
         const auto[macrostate, orig_states] = std::move(worklist.back());
         worklist.pop_back();
 
-        // TODO: shouldn't we also reset first?
+        synchronized_iterator.reset();
         for (const State orig_state: orig_states) { mata::utils::push_back(synchronized_iterator, delta[orig_state]); }
         bool sync_it_advanced{ synchronized_iterator.advance() };
         for (const Symbol symbol: get_symbols_to_work_with(*this, alphabet)) {

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -567,6 +567,34 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
         result = aut.get_word_from_complement();
         CHECK(!result.has_value());
     }
+
+    SECTION("smaller alphabet symbol") {
+        aut.initial = { 1 };
+        aut.final = { 1 };
+        aut.delta.add(1, 'b', 1);
+        result = aut.get_word_from_complement(&alphabet);
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'a' });
+    }
+
+    SECTION("smaller transition symbol") {
+        aut.initial = { 1 };
+        aut.final = { 1 };
+        aut.delta.add(1, 'a', 1);
+        aut.delta.add(1, 0, 2);
+        result = aut.get_word_from_complement(&alphabet);
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 0 });
+    }
+
+    SECTION("smaller transition symbol 2") {
+        aut.initial = { 1 };
+        aut.final = { 1 };
+        aut.delta.add(1, 0, 2);
+        result = aut.get_word_from_complement(&alphabet);
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 0 });
+    }
 }
 
 TEST_CASE("mata::nfa::minimize() for profiling", "[.profiling],[minimize]") {

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -425,7 +425,6 @@ TEST_CASE("mata::nfa::is_lang_empty_cex()")
     }
 }
 
-
 TEST_CASE("mata::nfa::determinize()")
 {
     Nfa aut(3);
@@ -484,6 +483,91 @@ TEST_CASE("mata::nfa::determinize()")
         auto complement_result{determinize(x)};
     }
 } // }}}
+
+TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
+    Nfa aut{};
+    std::optional<mata::Word> result;
+    std::unordered_map<StateSet, State> subset_map;
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+
+    SECTION("empty automaton") {
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{});
+    }
+
+    SECTION("simple automaton 1") {
+        aut.initial = { 0 };
+        aut.final = { 0 };
+        result = aut.get_word_from_complement(&alphabet);
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'a' });
+    }
+
+    SECTION("simple automaton 2") {
+        aut.initial = { 0 };
+        aut.final = { 1 };
+        aut.delta.add(0, 'a', 1);
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{});
+    }
+
+    SECTION("simple automaton 2 with epsilon") {
+        aut.alphabet = &alphabet;
+        aut.initial = { 0 };
+        aut.final = { 0, 1 };
+        aut.delta.add(0, 'a', 1);
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'b' });
+    }
+
+    SECTION("nfa accepting \\eps+a+b+c") {
+        aut.alphabet = &alphabet;
+        aut.initial = { 0 };
+        aut.final = { 0, 1 };
+        aut.delta.add(0, 'a', 1);
+        aut.delta.add(0, 'b', 1);
+        aut.delta.add(0, 'c', 1);
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'a', 'a' });
+    }
+
+    SECTION("nfa accepting \\eps+a+b+c+aa") {
+        aut.initial = { 0 };
+        aut.final = { 0, 1 };
+        aut.delta.add(0, 'a', 1);
+        aut.delta.add(0, 'b', 1);
+        aut.delta.add(0, 'c', 1);
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'a', 'a' });
+    }
+
+    SECTION("simple automaton 3") {
+        aut.initial = { 1 };
+        aut.final = { 1, 2, 3, 4, 5 };
+        aut.delta.add(1, 'a', 2);
+        aut.delta.add(2, 'a', 3);
+        aut.delta.add(2, 'a', 6);
+        aut.delta.add(6, 'a', 6);
+        aut.delta.add(3, 'a', 4);
+        aut.delta.add(4, 'a', 5);
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{ 'a', 'a','a', 'a', 'a' });
+    }
+
+    SECTION("universal language") {
+        aut.initial = { 1 };
+        aut.final = { 1 };
+        aut.delta.add(1, 'a', 1);
+        result = aut.get_word_from_complement();
+        CHECK(!result.has_value());
+    }
+}
 
 TEST_CASE("mata::nfa::minimize() for profiling", "[.profiling],[minimize]") {
     Nfa aut(4);

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -496,6 +496,21 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
         CHECK(*result == Word{});
     }
 
+    SECTION("empty automaton 2") {
+        aut.initial = { 0 };
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{});
+    }
+
+    SECTION("empty automaton 3") {
+        aut.initial = { 0 };
+        aut.final = { 1 };
+        result = aut.get_word_from_complement();
+        REQUIRE(result.has_value());
+        CHECK(*result == Word{});
+    }
+
     SECTION("simple automaton 1") {
         aut.initial = { 0 };
         aut.final = { 0 };


### PR DESCRIPTION
This PR implements a method to get an arbitrary word from a complement of a language lazily, as requested by #415. That is, we start computing the complement by determinizing the existing NFA while making it complete. We immediately stop when we encounter a macrostate which is not final. Then we can return the access word for this macrostate as an arbitrary word from the complement.

The PR utilizes the overall algorithm of determinization, but does not run nfa::determinize() directly, as there are too many changes to extract any common operations without significantly overengineering the function.
The PR implements the callback function for nfa::determinize() discussed in #415, but since the proper handling of all edge cases proved to be more complex, the callback function is not being used in `Nfa::get_word_from_complement()` in the end. The callback might yet come in handy for lazily getting an arbitrary word from the language difference, which will be implemented in a future PR.

This PR implements the first requested operation from #415.