### PR TITLE
Rename functions to adhere to snake_case naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Further, you can add transitions in form of tripple `(state_from, symbol, target
 You can verify the state of your automaton by generating the automaton in `.dot` format.
 
 ```cpp
-    aut.print_to_DOT(std::cout);
+    aut.print_to_dot(std::cout);
 
     return 0;
 }

--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -599,7 +599,7 @@ output = new mata_nfa.ofstream(output_file.encode('utf-8'))
 #        ^-- creates new ofstream
 #                              ^-- you need to encode the Python string to utf-8
 try:
-    self.thisptr.get().print_to_DOT(dereference(output))
+    self.thisptr.get().print_to_dot(dereference(output))
     #                               ^-- call the function with the ofstream
 finally:
 # ^-- this assures that the `output` will be cleaned

--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -649,7 +649,7 @@ while it != end:
 #     ^-- comparsion of two iterators
     t = SymbolPost(
         dereference(it).symbol,
-        dereference(it).targets.ToVector()
+        dereference(it).targets.to_vector()
         # ^-- to access the value of iterator you need to dereference
     )
     postinc(it)

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -47,7 +47,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         void push_back(CSymbolPost&)
         void remove(CSymbolPost&)
         bool empty()
-        vector[CSymbolPost] ToVector()
+        vector[CSymbolPost] to_vector()
         COrdVector[CSymbolPost].const_iterator cbegin()
         COrdVector[CSymbolPost].const_iterator cend()
 

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -158,7 +158,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         StateSet post(StateSet&, Symbol)
         State add_state()
         State add_state(State)
-        void print_to_DOT(ostream)
+        void print_to_dot(ostream)
         CNfa& trim(StateRenaming*)
         CNfa& concatenate(CNfa&)
         CNfa& unite_nondet_with(CNfa&)

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -627,7 +627,7 @@ cdef class Nfa:
         cdef mata_nfa.ofstream* output
         output = new mata_nfa.ofstream(output_file.encode('utf-8'))
         try:
-            self.thisptr.get().print_to_DOT(dereference(output))
+            self.thisptr.get().print_to_dot(dereference(output))
         finally:
             del output
 
@@ -646,7 +646,7 @@ cdef class Nfa:
         output_stream = new mata_nfa.stringstream("".encode('ascii'))
         cdef string result
         try:
-            self.thisptr.get().print_to_DOT(dereference(output_stream))
+            self.thisptr.get().print_to_dot(dereference(output_stream))
             result = output_stream.str()
         finally:
             del output_stream

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -142,7 +142,7 @@ cdef class SymbolPost:
 
     @property
     def targets(self):
-        cdef vector[State] states_as_vector = self.thisptr.targets.ToVector()
+        cdef vector[State] states_as_vector = self.thisptr.targets.to_vector()
         return [s for s in states_as_vector]
 
     @targets.setter
@@ -425,7 +425,7 @@ cdef class Nfa:
         :return: SymbolPost
         """
         cdef mata_nfa.CStatePost transitions = self.thisptr.get().delta.state_post(state)
-        cdef vector[mata_nfa.CSymbolPost] transitions_list = transitions.ToVector()
+        cdef vector[mata_nfa.CSymbolPost] transitions_list = transitions.to_vector()
 
         cdef vector[mata_nfa.CSymbolPost].iterator it = transitions_list.begin()
         cdef vector[mata_nfa.CSymbolPost].iterator end = transitions_list.end()
@@ -433,7 +433,7 @@ cdef class Nfa:
         while it != end:
             t = SymbolPost(
                 dereference(it).symbol,
-                dereference(it).targets.ToVector()
+                dereference(it).targets.to_vector()
             )
             postinc(it)
             transsymbols.append(t)
@@ -499,7 +499,7 @@ cdef class Nfa:
 
         :return: A set of reachable states.
         """
-        cdef vector[State] return_value = self.thisptr.get().get_reachable_states().ToVector()
+        cdef vector[State] return_value = self.thisptr.get().get_reachable_states().to_vector()
         return {state for state in return_value}
 
     def get_terminating_states(self):
@@ -507,7 +507,7 @@ cdef class Nfa:
 
         :return: A set of terminating states.
         """
-        cdef vector[State] return_value = self.thisptr.get().get_terminating_states().ToVector()
+        cdef vector[State] return_value = self.thisptr.get().get_terminating_states().to_vector()
         return {state for state in return_value}
 
     def trim(self):
@@ -705,7 +705,7 @@ cdef class Nfa:
         """
         cdef vector[State] return_value
         cdef StateSet input_states = StateSet(states)
-        return_value = self.thisptr.get().post(input_states, symbol).ToVector()
+        return_value = self.thisptr.get().post(input_states, symbol).to_vector()
         return {v for v in return_value}
 
     def remove_epsilon_inplace(self, Symbol epsilon = CEPSILON):
@@ -731,7 +731,7 @@ cdef class Nfa:
             return None
 
         cdef CSymbolPost epsilon_transitions = dereference(c_epsilon_symbol_posts_iter)
-        return SymbolPost(epsilon_transitions.symbol, epsilon_transitions.targets.ToVector())
+        return SymbolPost(epsilon_transitions.symbol, epsilon_transitions.targets.to_vector())
 
     def is_universal(self, alph.Alphabet alphabet, params = None):
         """Tests if NFA is universal with regard to the given alphabet.
@@ -1160,7 +1160,7 @@ cdef subset_map_to_dictionary(umap[StateSet, State] subset_map):
     result = {}
     cdef umap[StateSet, State].iterator it = subset_map.begin()
     while it != subset_map.end():
-        key = dereference(it).first.ToVector()
+        key = dereference(it).first.to_vector()
         value = dereference(it).second
         result[tuple(sorted(key))] = value
         postinc(it)

--- a/bindings/python/libmata/utils.pxd
+++ b/bindings/python/libmata/utils.pxd
@@ -44,7 +44,7 @@ cdef extern from "mata/utils/ord-vector.hh" namespace "mata::utils":
     cdef cppclass COrdVector "mata::utils::OrdVector" [T]:
         COrdVector() except+
         COrdVector(vector[T]) except+
-        vector[T] ToVector()
+        vector[T] to_vector()
         size_t size()
 
         cppclass const_iterator:

--- a/examples/example01-simple.cc
+++ b/examples/example01-simple.cc
@@ -14,5 +14,5 @@ int main() {
     aut.delta.add(0, 0, 2);
     aut.delta.add(1, 1, 3);
 
-    aut.print_to_DOT(std::cout);
+    aut.print_to_dot(std::cout);
 }

--- a/examples/example02-determinize.cc
+++ b/examples/example02-determinize.cc
@@ -27,5 +27,5 @@ int main() {
     aut.delta.add(4, 'c', 8);
 
     Nfa determ{ determinize(aut) };
-    determ.print_to_DOT(std::cout);
+    determ.print_to_dot(std::cout);
 }

--- a/examples/example05-parsing.cc
+++ b/examples/example05-parsing.cc
@@ -42,6 +42,6 @@ int main(int argc, char *argv[]) {
     }
 
 
-    aut.print_to_DOT(std::cout);
+    aut.print_to_dot(std::cout);
     return EXIT_SUCCESS;
 }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -116,7 +116,7 @@ public:
     using super::insert;
     using super::reserve;
     using super::empty, super::size;
-    using super::ToVector;
+    using super::to_vector;
     // dangerous, breaks the sortedness invariant
     using super::emplace_back;
     // dangerous, breaks the sortedness invariant

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -256,11 +256,11 @@ public:
      *
      * @return automaton in DOT format
      */
-    std::string print_to_DOT() const;
+    std::string print_to_dot() const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
      */
-    void print_to_DOT(std::ostream &output) const;
+    void print_to_dot(std::ostream &output) const;
     /**
      * @brief Prints the automaton in mata format
      *

--- a/include/mata/utils/closed-set.hh
+++ b/include/mata/utils/closed-set.hh
@@ -164,7 +164,7 @@ struct ClosedSet {
         void insert(const Node& node);
         void insert(const Nodes& nodes) {for (const auto& node: nodes) insert(node); }
 
-        ClosedSet Union (const ClosedSet& rhs) const;
+        ClosedSet set_union (const ClosedSet& rhs) const;
         ClosedSet intersection (const ClosedSet& rhs) const;
         ClosedSet complement () const;
 }; // class ClosedSet.
@@ -197,14 +197,14 @@ template <typename T>
 bool ClosedSet<T>::contains(const Node& node) const {
     if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element : antichain_) {
-            if(element.IsSubsetOf(node)) {
+            if(element.is_subset_of(node)) {
                 return true;
             }
         }
     }
     else if(type_ == ClosedSetType::downward_closed_set) {
         for(auto element : antichain_) {
-            if(node.IsSubsetOf(element)) {
+            if(node.is_subset_of(element)) {
                 return true;
             }
         }
@@ -276,7 +276,7 @@ void ClosedSet<T>::insert(const Node& node) {
     // <=-comparable elements and the result should be upward-closed.
     if(type_ == ClosedSetType::upward_closed_set) {
         for(auto element : antichain_) {
-            if(node.IsSubsetOf(element)) {
+            if(node.is_subset_of(element)) {
                 to_erase.insert(element);
             }
         }
@@ -290,7 +290,7 @@ void ClosedSet<T>::insert(const Node& node) {
     // <=-comparable elements and the result should be downward-closed.
     else if(type_ == ClosedSetType::downward_closed_set) {
         for(auto element : antichain_) {
-            if(element.IsSubsetOf(node)) {
+            if(element.is_subset_of(node)) {
                 to_erase.insert(element);
             }
         }
@@ -310,7 +310,7 @@ void ClosedSet<T>::insert(const Node& node) {
 * @return an union of the given closed sets
 */
 template <typename T>
-ClosedSet<T> ClosedSet<T>::Union(const ClosedSet<T>& rhs) const {
+ClosedSet<T> ClosedSet<T>::set_union(const ClosedSet<T>& rhs) const {
     assert(type_ == rhs.type_ && min_val_ == rhs.min_val_ && max_val_ == rhs.max_val_ &&
     "Types and borders of given closed sets must be the same to compute their union.");
     ClosedSet<T> result(type_, min_val_, max_val_, antichain_);

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -22,7 +22,7 @@ namespace {
  * @returns  The string representation of the object
  */
 template <typename T>
-std::string ToString(const T& n) {
+std::string to_str(const T& n) {
     // the output stream for the string
     std::ostringstream oss;
     // insert the object into the stream
@@ -85,7 +85,7 @@ private:  // Private data members
     VectorType vec_;
 
 private:  // Private methods
-    bool vectorIsSorted() const { return(mata::utils::is_sorted(vec_)); }
+    bool is_sorted() const { return mata::utils::is_sorted(vec_); }
 
 public:
     OrdVector() : vec_() {}
@@ -96,7 +96,7 @@ public:
     OrdVector(std::initializer_list<Key> list) : vec_(list) { utils::sort_and_rmdupl(vec_); }
     OrdVector(const OrdVector& rhs) = default;
     OrdVector(OrdVector&& other) noexcept : vec_{ std::move(other.vec_) } {}
-    explicit OrdVector(const Key& key) : vec_(1, key) { assert(vectorIsSorted()); }
+    explicit OrdVector(const Key& key) : vec_(1, key) { assert(is_sorted()); }
     template <class InputIterator>
     explicit OrdVector(InputIterator first, InputIterator last) : vec_(first, last) { utils::sort_and_rmdupl(vec_); }
 
@@ -153,7 +153,7 @@ public:
     virtual inline void erase(const_iterator first, const_iterator last) { vec_.erase(first, last); }
 
     virtual void insert(const Key& x) {
-        assert(vectorIsSorted());
+        assert(is_sorted());
 
         reserve_on_insert(vec_);
 
@@ -196,13 +196,13 @@ public:
         //// insert the new element
         //vec_[first] = x;
 
-        assert(vectorIsSorted());
+        assert(is_sorted());
     }
 
     virtual void insert(const OrdVector& vec) {
         static OrdVector tmp{};
-        assert(vectorIsSorted());
-        assert(vec.vectorIsSorted());
+        assert(is_sorted());
+        assert(vec.is_sorted());
         tmp.clear();
 
         set_union(*this,vec,tmp);
@@ -214,7 +214,7 @@ public:
          * It would be good to try it with removing epsilon transitions or determinization.
          */
         //std::swap(tmp.vec_,vec_);
-        assert(vectorIsSorted());
+        assert(is_sorted());
     }
 
     inline void clear() { vec_.clear(); }
@@ -222,7 +222,7 @@ public:
     virtual inline size_t size() const { return vec_.size(); }
 
     inline size_t count(const Key& key) const {
-        assert(vectorIsSorted());
+        assert(is_sorted());
         for (auto v : this->vec_) {
             if (v == key)
                 return 1;
@@ -241,10 +241,8 @@ public:
 
     OrdVector intersection(const OrdVector& rhs) const { return intersection(*this, rhs); }
 
-    //TODO: this code of find was duplicated, not nice.
-    // Replacing the original code by std function, but keeping the original here commented, it was nice, might be even better.
     virtual const_iterator find(const Key& key) const {
-        assert(vectorIsSorted());
+        assert(is_sorted());
 
         auto it = std::lower_bound(vec_.begin(), vec_.end(),key);
         if (it == vec_.end() || *it != key)
@@ -253,9 +251,8 @@ public:
             return it;
     }
 
-    //TODO: the original code was duplicated, see comments above.
     virtual iterator find(const Key& key) {
-        assert(vectorIsSorted());
+        assert(is_sorted());
 
         auto it = std::lower_bound(vec_.begin(), vec_.end(),key);
         if (it == vec_.end() || *it != key)
@@ -278,12 +275,12 @@ public:
      * This function expects the vector to be sorted.
      */
     inline void erase(const Key& k) {
-        assert(vectorIsSorted());
+        assert(is_sorted());
         auto found_value_it = std::lower_bound(vec_.begin(), vec_.end(), k);
         if (found_value_it != vec_.end()) {
             if (*found_value_it == k) {
                 vec_.erase(found_value_it);
-                assert(vectorIsSorted());
+                assert(is_sorted());
                 return;
             }
         }
@@ -330,7 +327,7 @@ public:
 	 *
 	 * Overloaded << operator for output stream.
 	 *
-	 * @see  to_string()
+	 * @see  to_str()
 	 *
 	 * @param[in]  os    The output stream
 	 * @param[in]  vec   Assignment to the variables
@@ -341,33 +338,33 @@ public:
 		std::string result = "{";
 
 		for (auto it = vec.cbegin(); it != vec.cend(); ++it) {
-			result += ((it != vec.begin())? ", " : " ") + ToString(*it);
+			result += ((it != vec.begin())? ", " : " ") + to_str(*it);
 		}
 
 		return os << (result + "}");
 	}
 
 	bool operator==(const OrdVector& rhs) const {
-		assert(vectorIsSorted());
-		assert(rhs.vectorIsSorted());
+		assert(is_sorted());
+		assert(rhs.is_sorted());
 		return (vec_ == rhs.vec_);
 	}
 
     bool operator<(const OrdVector& rhs) const {
-        assert(vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+        assert(is_sorted());
+        assert(rhs.is_sorted());
         return std::lexicographical_compare(vec_.begin(), vec_.end(), rhs.vec_.begin(), rhs.vec_.end());
     }
 
-    const std::vector<Key>& ToVector() const { return vec_; }
+    const std::vector<Key>& to_vector() const { return vec_; }
 
-    bool IsSubsetOf(const OrdVector& bigger) const {
+    bool is_subset_of(const OrdVector& bigger) const {
         return std::includes(bigger.cbegin(), bigger.cend(), this->cbegin(), this->cend());
     }
 
-    bool HaveEmptyIntersection(const OrdVector& rhs) const {
-        assert(vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+    bool is_intersection_empty_with(const OrdVector& rhs) const {
+        assert(is_sorted());
+        assert(rhs.is_sorted());
 
         const_iterator itLhs = begin();
         const_iterator itRhs = rhs.begin();
@@ -395,8 +392,8 @@ public:
     void rename(const std::vector<Key> & renaming) { utils::rename(vec_, renaming); }
 
     static OrdVector difference(const OrdVector& lhs, const OrdVector& rhs) {
-        assert(lhs.vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+        assert(lhs.is_sorted());
+        assert(rhs.is_sorted());
 
         OrdVector result{};
         auto lhs_it{ lhs.begin() };
@@ -417,13 +414,13 @@ public:
             }
         }
 
-        assert(result.vectorIsSorted());
+        assert(result.is_sorted());
         return result;
     }
 
     static void set_union(const OrdVector& lhs, const OrdVector& rhs, OrdVector& result) {
-        assert(lhs.vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+        assert(lhs.is_sorted());
+        assert(rhs.is_sorted());
 
         if (lhs.empty()) { result = rhs; return; }
         if (rhs.empty()) { result = lhs; return; }
@@ -457,7 +454,7 @@ public:
         //    }
         //}
 
-        assert(result.vectorIsSorted());
+        assert(result.is_sorted());
     }
 
     static OrdVector set_union(const OrdVector& lhs, const OrdVector& rhs) {
@@ -467,8 +464,8 @@ public:
     }
 
     static OrdVector intersection(const OrdVector& lhs, const OrdVector& rhs) {
-        assert(lhs.vectorIsSorted());
-        assert(rhs.vectorIsSorted());
+        assert(lhs.is_sorted());
+        assert(rhs.is_sorted());
 
         OrdVector result{};
 
@@ -487,7 +484,7 @@ public:
             }
         }
 
-        assert(result.vectorIsSorted());
+        assert(result.is_sorted());
         return result;
     }
 }; // Class OrdVector.
@@ -498,7 +495,7 @@ namespace std {
     template <class Key>
     struct hash<mata::utils::OrdVector<Key>> {
         std::size_t operator()(const mata::utils::OrdVector<Key>& vec) const {
-            return std::hash<std::vector<Key>>{}(vec.ToVector());
+            return std::hash<std::vector<Key>>{}(vec.to_vector());
         }
     };
 }

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -55,7 +55,7 @@ bool mata::nfa::algorithms::is_included_antichains(
 
         //TODO: Can this be done faster using more heuristics? E.g., compare the last elements first ...
         //TODO: Try BDDs! What about some abstractions?
-        return lhs_bigger.IsSubsetOf(rhs_bigger);
+        return lhs_bigger.is_subset_of(rhs_bigger);
     };
 
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -379,13 +379,13 @@ bool Nfa::is_acyclic() const {
     return acyclic;
 }
 
-std::string Nfa::print_to_DOT() const {
+std::string Nfa::print_to_dot() const {
     std::stringstream output;
-    print_to_DOT(output);
+    print_to_dot(output);
     return output.str();
 }
 
-void Nfa::print_to_DOT(std::ostream &output) const {
+void Nfa::print_to_dot(std::ostream &output) const {
     output << "digraph finiteAutomaton {" << std::endl
                  << "node [shape=circle];" << std::endl;
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -158,14 +158,14 @@ namespace {
         covering_indexes.emplace_back();
 
         while (it != subset_map.end()) {               // goes through all found states
-            if (it->first.IsSubsetOf(T)) {
+            if (it->first.is_subset_of(T)) {
                 // check if T is covered
                 // if so add covering state to its covering StateSet
 
                 covering_states[Tid].insert(it->first);
                 covering_indexes[Tid].insert(it->second);
             }
-            else if (T.IsSubsetOf(it->first)) {
+            else if (T.is_subset_of(it->first)) {
                 // check if state in map is covered
                 // if so add covering state to its covering StateSet
 
@@ -321,7 +321,7 @@ namespace {
             if (covered[*i])           // was aready processed
                 continue;
 
-            if (macrostate_vec[*i].IsSubsetOf(check_state)) {
+            if (macrostate_vec[*i].is_subset_of(check_state)) {
                 covering_set.insert(macrostate_vec[*i]);                // is never covered
                 sub_covering_indexes.push_back(*i);
             }
@@ -393,7 +393,7 @@ namespace {
                 if (covered[j])     // if covered there are smaller macrostates, skip
                     continue;
 
-                if (macrostate_vec[j].IsSubsetOf(macrostate_vec[i])) {           // found covering state
+                if (macrostate_vec[j].is_subset_of(macrostate_vec[i])) {           // found covering state
                     covering_set.insert(macrostate_vec[j]);               // is not covered
                     covering_indexes.push_back(j);
                 }


### PR DESCRIPTION
This PR renames some functions from VATA which used the UpperCamelCase to properly adhere to snake_case used elsewhere in Mata.

This PR renames:
1. operations in `ord-vector.hh`, 
2. `Union()` in `ClosedSet`, and
3. `print_to_DOT()` to `print_to_dot()`, for easier typing and consistency, especially with `print_to_mata()`.

The PR fixes #284.