### PR TITLE
Expand alphabets

### DIFF
--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -150,7 +150,8 @@ public:
     virtual inline void reserve(size_t size) { vec_.reserve(size); }
     virtual inline void resize(size_t size) { vec_.resize(size); }
 
-    virtual inline void erase(const_iterator first, const_iterator last) { vec_.erase(first, last); }
+    virtual inline iterator erase(const_iterator pos) { return vec_.erase(pos); }
+    virtual inline iterator erase(const_iterator first, const_iterator last) { return vec_.erase(first, last); }
 
     virtual void insert(const Key& x) {
         assert(is_sorted());
@@ -274,18 +275,18 @@ public:
      *
      * This function expects the vector to be sorted.
      */
-    inline void erase(const Key& k) {
+    inline size_t erase(const Key& k) {
         assert(is_sorted());
         auto found_value_it = std::lower_bound(vec_.begin(), vec_.end(), k);
         if (found_value_it != vec_.end()) {
             if (*found_value_it == k) {
                 vec_.erase(found_value_it);
                 assert(is_sorted());
-                return;
+                return 1;
             }
         }
 
-        throw std::runtime_error("Key is not in OrdVector.");
+        return 0;
     }
 
     virtual inline bool empty() const { return vec_.empty(); }

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -160,13 +160,47 @@ void mata::EnumAlphabet::add_new_symbol(const std::string& symbol) {
     add_new_symbol(converted_symbol);
 }
 
-void mata::EnumAlphabet::add_new_symbol(Symbol symbol) {
+void mata::EnumAlphabet::add_new_symbol(const Symbol symbol) {
     symbols_.insert(symbol);
     update_next_symbol_value(symbol);
 }
 
-void mata::EnumAlphabet::update_next_symbol_value(Symbol value) {
+void mata::EnumAlphabet::update_next_symbol_value(const Symbol value) {
     if (next_symbol_value_ <= value) {
         next_symbol_value_ = value + 1;
     }
+}
+
+size_t mata::EnumAlphabet::erase(const Symbol symbol) {
+    size_t num_of_erased{ symbols_.erase(symbol) };
+    if (symbol == next_symbol_value_ - 1) {
+        --next_symbol_value_;
+    }
+    return num_of_erased;
+}
+
+size_t mata::OnTheFlyAlphabet::erase(const Symbol symbol) {
+    const auto symbol_map_end = symbol_map_.end();
+    for (auto it = symbol_map_.begin(); it != symbol_map_end; ++it) {
+        if (it->second == symbol) {
+            if (symbol == next_symbol_value_ - 1) {
+                --next_symbol_value_;
+            }
+            symbol_map_.erase(it);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
+    auto found_it{ symbol_map_.find(symbol_name) };
+    if (found_it != symbol_map_.end()) {
+        if (found_it->second == next_symbol_value_ - 1) {
+            --next_symbol_value_;
+        }
+        symbol_map_.erase(found_it);
+        return 1;
+    }
+    return 0;
 }

--- a/tests/alphabet.cc
+++ b/tests/alphabet.cc
@@ -46,7 +46,7 @@ TEST_CASE("mata::OnTheFlyAlphabet::add_symbols_from()") {
     CHECK(alphabet.get_symbol_map() == OnTheFlyAlphabet::StringToSymbolMap{ { "a", 4 }, { "b", 2 }, { "c", 10 } });
 
     alphabet.add_new_symbol("e", 7);
-    CHECK_THROWS_AS(alphabet.add_new_symbol("a", 0), std::runtime_error);
+    CHECK_THROWS(alphabet.add_new_symbol("a", 0));
 
     symbols = alphabet.get_alphabet_symbols();
     expected = mata::utils::OrdVector<Symbol>{ 7, 4, 2, 10 };
@@ -55,6 +55,34 @@ TEST_CASE("mata::OnTheFlyAlphabet::add_symbols_from()") {
     CHECK(alphabet.get_symbol_map() == OnTheFlyAlphabet::StringToSymbolMap {
         { "a", 4 }, { "b", 2 }, { "c", 10 }, { "e", 7 }
     });
+
+    OnTheFlyAlphabet alphabet2{ alphabet };
+    alphabet2.add_new_symbol("f", 42);
+    CHECK(alphabet.get_alphabet_symbols() != alphabet2.get_alphabet_symbols());
+    CHECK(alphabet.translate_symb("f") != 42);
+    CHECK(alphabet2.translate_symb("f") == 42);
+    size_t num_of_symbols{ alphabet.get_alphabet_symbols().size() };
+    alphabet.erase("e");
+    alphabet.erase("f");
+    CHECK(alphabet.get_alphabet_symbols().size() + 2 == num_of_symbols);
+
+    alphabet2 = alphabet;
+    alphabet2.add_new_symbol("f", 42);
+    CHECK(alphabet.get_alphabet_symbols() != alphabet2.get_alphabet_symbols());
+    CHECK(alphabet.translate_symb("f") != 42);
+    alphabet.erase("f");
+    CHECK(alphabet2.translate_symb("f") == 42);
+
+    OnTheFlyAlphabet alphabet_copy{ alphabet };
+    alphabet2 = OnTheFlyAlphabet{ std::move(alphabet) };
+    CHECK(alphabet2.get_alphabet_symbols() == alphabet_copy.get_alphabet_symbols());
+    alphabet = alphabet2;
+    alphabet2 = std::move(alphabet);
+    CHECK(alphabet2.get_alphabet_symbols() == alphabet_copy.get_alphabet_symbols());
+    alphabet = alphabet2;
+
+    alphabet.clear();
+    CHECK(alphabet.get_number_of_symbols() == 0);
 }
 
 TEST_CASE("mata::EnumAlphabet") {
@@ -91,4 +119,29 @@ TEST_CASE("mata::EnumAlphabet") {
     CHECK(alphabet.translate_symb("1") == 1);
     CHECK_THROWS(alphabet.translate_symb("3414not a number"));
     CHECK_THROWS(alphabet.translate_symb("not a number"));
+
+    EnumAlphabet alphabet3{ alphabet };
+    alphabet3.add_new_symbol(42);
+    CHECK(alphabet.get_alphabet_symbols() != alphabet3.get_alphabet_symbols());
+    CHECK(alphabet3.get_number_of_symbols() == alphabet.get_number_of_symbols() + 1);
+    CHECK_THROWS(alphabet.translate_symb("42"));
+    CHECK(alphabet3.translate_symb("42") == 42);
+
+    alphabet3 = alphabet;
+    alphabet3.add_new_symbol(42);
+    CHECK(alphabet.get_alphabet_symbols() != alphabet3.get_alphabet_symbols());
+    CHECK(alphabet3.get_number_of_symbols() == alphabet.get_number_of_symbols() + 1);
+    CHECK_THROWS(alphabet.translate_symb("42"));
+    CHECK(alphabet3.translate_symb("42") == 42);
+
+    EnumAlphabet alphabet_copy{ alphabet };
+    alphabet3 = EnumAlphabet{ std::move(alphabet) };
+    CHECK(alphabet3.get_alphabet_symbols() == alphabet_copy.get_alphabet_symbols());
+    alphabet = alphabet3;
+    alphabet3 = std::move(alphabet);
+    CHECK(alphabet3.get_alphabet_symbols() == alphabet_copy.get_alphabet_symbols());
+    alphabet = std::move(alphabet3);
+
+    alphabet.clear();
+    CHECK(alphabet.get_number_of_symbols() == 0);
 }

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -15,7 +15,7 @@ TEST_CASE("mata::utils::OrdVector::erase()") {
     CHECK(set == OrdVectorT{ 1, 2, 4, 6 });
     set.erase(4);
     CHECK(set == OrdVectorT{ 1, 2, 6 });
-    CHECK_THROWS(set.erase(5));
+    CHECK(set.erase(5) == 0);
     set.erase(2);
     CHECK(set == OrdVectorT{ 1, 6 });
     set.erase(1);
@@ -25,11 +25,11 @@ TEST_CASE("mata::utils::OrdVector::erase()") {
     CHECK(set == OrdVectorT{ 3 });
     set.erase(3);
     CHECK(set.empty());
-    CHECK_THROWS(set.erase(0));
+    CHECK(set.erase(0) == 0);
     set.emplace_back(3);
     set.emplace_back(4);
     CHECK(set == OrdVectorT{ 3, 4 });
-    CHECK_THROWS(set.erase(0));
+    CHECK(set.erase(0) == 0);
 }
 
 TEST_CASE("mata::utils::OrdVector::front())") {


### PR DESCRIPTION
This PR implements additional methods for alphabets to allow their copying, erasing symbols and clearing the alphabets, as requested by #426:
- `clear()` method to clear the alphabet (for alphabets where it makes sense),
- `erase()` method to erase a specific symbol from the alphabet (for alphabets where it makes sense),
- copy constructors and copy assignments which allow for copying of the whole alphabets.

To allow erasing, the PR also modifies the return type of `erase()` operations for `OrdVector` and alphabets to follow the implementation of erase operations in standard library containers, returning the number of erased elements.

Fixes #426.