### PR TITLE
Fix counterexamples for inclusion

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -226,11 +226,6 @@ public:
     Run get_shortest_accepting_run_from_state(State q, const std::vector<State>& distances_to_final) const;
 
     /**
-     * @brief Returns vector ret where ret[q].second is the shortest path from any initial state to q and ret[q].first is the length of this path
-     */
-    std::vector<std::pair<State, Run>> distances_from_initial_with_runs() const;
-
-    /**
      * Remove epsilon transitions from the automaton.
      */
     void remove_epsilon(Symbol epsilon = EPSILON);

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -212,6 +212,20 @@ public:
     std::vector<State> distances_from_initial() const;
 
     /**
+     * @brief Returns vector ret where ret[q] is the length of the shortest path from q to any final state
+     */
+    std::vector<State> distances_to_final() const;
+
+    /**
+     * @brief Get some shortest accepting run from state @p q
+     * 
+     * Assumes that @p q is a state of this automaton and that there is some accepting run from q
+     * 
+     * @param distances_to_final Vector of the lengths of the shortest runs from states (can be computed using distances_to_final())
+     */
+    Run get_shortest_accepting_run_from_state(State q, const std::vector<State>& distances_to_final) const;
+
+    /**
      * @brief Returns vector ret where ret[q].second is the shortest path from any initial state to q and ret[q].first is the length of this path
      */
     std::vector<std::pair<State, Run>> distances_from_initial_with_runs() const;

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -219,7 +219,7 @@ public:
     /**
      * @brief Get some shortest accepting run from state @p q
      * 
-     * Assumes that @p q is a state of this automaton and that there is some accepting run from q
+     * Assumes that @p q is a state of this automaton and that there is some accepting run from @p q
      * 
      * @param distances_to_final Vector of the lengths of the shortest runs from states (can be computed using distances_to_final())
      */

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -206,7 +206,15 @@ public:
      */
     Nfa& trim(StateRenaming* state_renaming = nullptr);
 
+    /**
+     * @brief Returns vector ret where ret[q] is the length of the shortest path from any initial state to q
+     */
     std::vector<State> distances_from_initial() const;
+
+    /**
+     * @brief Returns vector ret where ret[q].second is the shortest path from any initial state to q and ret[q].first is the length of this path
+     */
+    std::vector<std::pair<State, Run>> distances_from_initial_with_runs() const;
 
     /**
      * Remove epsilon transitions from the automaton.

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -178,12 +178,12 @@ bool mata::nfa::algorithms::is_included_antichains(
                     if (cex != nullptr) {
                         cex->word.push_back(smaller_symbol);
                         cex->path.push_back(smaller_state);
-                        ProdStateType trav = prod_state;
-                        while (paths.at(trav).first != trav)
+                        auto next_on_path = paths.find(prod_state);
+                        while (next_on_path->second.first != next_on_path->first)
                         { // go back until initial state
-                            cex->word.push_back(paths.at(trav).second);
-                            cex->path.push_back(std::get<0>(paths.at(trav).first));
-                            trav = paths.at(trav).first;
+                            cex->word.push_back(next_on_path->second.second);
+                            cex->path.push_back(std::get<0>(next_on_path->second.first));
+                            next_on_path = paths.find(next_on_path->second.first);
                         }
 
                         std::reverse(cex->word.begin(), cex->word.end());

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -21,9 +21,21 @@ bool mata::nfa::algorithms::is_included_naive(
     } else {
         bigger_cmpl = complement(bigger, *alphabet);
     }
-    Nfa nfa_isect = intersection(smaller, bigger_cmpl);
 
-    return nfa_isect.is_lang_empty(cex);
+    std::unordered_map<std::pair<State,State>,State> prod_map;
+    Nfa nfa_isect = intersection(smaller, bigger_cmpl, Limits::max_symbol, &prod_map);
+
+    bool result = nfa_isect.is_lang_empty(cex);
+    if (cex != nullptr && !result) {
+        std::unordered_map<State,State> nfa_isect_state_to_smaller_state;
+        for (const auto& prod_map_item : prod_map) {
+            nfa_isect_state_to_smaller_state[prod_map_item.second] = prod_map_item.first.first;
+        }
+        for (State& path_state : cex->path) {
+            path_state = nfa_isect_state_to_smaller_state[path_state];
+        }
+    }
+    return result;
 } // is_included_naive }}}
 
 

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -167,10 +167,10 @@ bool mata::nfa::algorithms::is_included_antichains(
                         cex->word.clear();
                         cex->word.push_back(smaller_symbol);
                         ProdStateType trav = prod_state;
-                        while (paths[trav].first != trav)
+                        while (paths.at(trav).first != trav)
                         { // go back until initial state
-                            cex->word.push_back(paths[trav].second);
-                            trav = paths[trav].first;
+                            cex->word.push_back(paths.at(trav).second);
+                            trav = paths.at(trav).first;
                         }
 
                         std::reverse(cex->word.begin(), cex->word.end());

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -117,37 +117,6 @@ std::vector<State> Nfa::distances_from_initial() const {
     return distances;
 }
 
-std::vector<std::pair<State, Run>> Nfa::distances_from_initial_with_runs() const {
-    std::vector<std::pair<State, Run>> distances(num_of_states()+1, std::make_pair(Limits::max_state, Run()));
-    BoolVector visited(num_of_states()+1, false);
-    std::deque<State> que;
-
-    for (State qi: initial) {
-        visited[qi] = true;
-        distances[qi] = std::make_pair(0, Run{{},{qi}});
-        que.push_back(qi);
-    }
-
-    while (!que.empty()) {
-        State src = que.front();
-        que.pop_front();
-        for (Move move : delta[src].moves()) {
-            if (!visited[move.target]) {
-                visited[move.target] = true;
-                Word shortest_word = distances[src].second.word;
-                shortest_word.push_back(move.symbol);
-                std::vector<State> shortest_path = distances[src].second.path;
-                shortest_path.push_back(move.target);
-                distances[move.target] = std::make_pair(distances[src].first + 1, Run{shortest_word,shortest_path});
-                que.push_back(move.target);
-            }
-        }
-    }
-
-    return distances;
-}
-
-
 std::vector<State> Nfa::distances_to_final() const {
     return revert(*this).distances_from_initial();
 }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -147,6 +147,26 @@ std::vector<std::pair<State, Run>> Nfa::distances_from_initial_with_runs() const
     return distances;
 }
 
+
+std::vector<State> Nfa::distances_to_final() const {
+    return revert(*this).distances_from_initial();
+}
+
+Run Nfa::get_shortest_accepting_run_from_state(State q, const std::vector<State>& distances_to_final) const {
+    Run result{{}, {q}};
+    while (!final[q]) {
+        for (Move move : delta[q].moves()) {
+            if (distances_to_final[move.target] < distances_to_final[q]) {
+                result.word.push_back(move.symbol);
+                result.path.push_back(move.target);
+                q = move.target;
+                break;
+            }
+        }
+    }
+    return result;
+}
+
 Nfa& Nfa::trim(StateRenaming* state_renaming) {
 #ifdef _STATIC_STRUCTURES_
     BoolVector useful_states{ useful_states() };

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -117,6 +117,36 @@ std::vector<State> Nfa::distances_from_initial() const {
     return distances;
 }
 
+std::vector<std::pair<State, Run>> Nfa::distances_from_initial_with_runs() const {
+    std::vector<std::pair<State, Run>> distances(num_of_states()+1, std::make_pair(Limits::max_state, Run()));
+    BoolVector visited(num_of_states()+1, false);
+    std::deque<State> que;
+
+    for (State qi: initial) {
+        visited[qi] = true;
+        distances[qi] = std::make_pair(0, Run{{},{qi}});
+        que.push_back(qi);
+    }
+
+    while (!que.empty()) {
+        State src = que.front();
+        que.pop_front();
+        for (Move move : delta[src].moves()) {
+            if (!visited[move.target]) {
+                visited[move.target] = true;
+                Word shortest_word = distances[src].second.word;
+                shortest_word.push_back(move.symbol);
+                std::vector<State> shortest_path = distances[src].second.path;
+                shortest_path.push_back(move.target);
+                distances[move.target] = std::make_pair(distances[src].first + 1, Run{shortest_word,shortest_path});
+                que.push_back(move.target);
+            }
+        }
+    }
+
+    return distances;
+}
+
 Nfa& Nfa::trim(StateRenaming* state_renaming) {
 #ifdef _STATIC_STRUCTURES_
     BoolVector useful_states{ useful_states() };

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -1919,12 +1919,18 @@ TEST_CASE("mata::nfa::is_included()")
         bigger.final = {1};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
-            bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
-            CHECK(is_incl);
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
+                CHECK(is_incl);
 
-            is_incl = is_included(bigger, smaller, &cex, &alph, params);
-            CHECK(!is_incl);
+                is_incl = is_included(bigger, smaller, &cex, &alph, params);
+                CHECK(!is_incl);
+                CHECK(cex.word.empty());
+                REQUIRE(cex.path.size() == 1);
+                CHECK(cex.path[0] == 1);
+            }
         }
     }
 
@@ -1937,12 +1943,15 @@ TEST_CASE("mata::nfa::is_included()")
         bigger.final = {11};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
-            bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
-            CHECK(is_incl);
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
+                CHECK(is_incl);
 
-            is_incl = is_included(bigger, smaller, &cex, &alph, params);
-            CHECK(is_incl);
+                is_incl = is_included(bigger, smaller, &cex, &alph, params);
+                CHECK(is_incl);
+            }
         }
     }
 
@@ -1953,15 +1962,20 @@ TEST_CASE("mata::nfa::is_included()")
         smaller.final = {1};
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
-            bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
 
-            REQUIRE(!is_incl);
-            REQUIRE(cex.word.empty());
+                REQUIRE(!is_incl);
+                REQUIRE(cex.word.empty());
+                REQUIRE(cex.path.size() == 1);
+                CHECK(cex.path[0] == 1);
 
-            is_incl = is_included(bigger, smaller, &cex, &alph, params);
-            REQUIRE(cex.word.empty());
-            REQUIRE(is_incl);
+                is_incl = is_included(bigger, smaller, &cex, &alph, params);
+                REQUIRE(cex.word.empty());
+                REQUIRE(is_incl);
+            }
         }
     }
 
@@ -1979,12 +1993,15 @@ TEST_CASE("mata::nfa::is_included()")
         bigger.delta.add(11, alph["b"], 11);
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
-            bool is_incl = is_included(smaller, bigger, &alph, params);
-            REQUIRE(is_incl);
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &alph, params);
+                REQUIRE(is_incl);
 
-            is_incl = is_included(bigger, smaller, &alph, params);
-            REQUIRE(!is_incl);
+                is_incl = is_included(bigger, smaller, &alph, params);
+                REQUIRE(!is_incl);
+            }
         }
     }
 
@@ -2002,20 +2019,25 @@ TEST_CASE("mata::nfa::is_included()")
         bigger.delta.add(12, alph["b"], 12);
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
 
-            bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
+                bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
 
-            REQUIRE(!is_incl);
-            REQUIRE((
-                cex.word == Word{alph["a"], alph["b"]} ||
-                cex.word == Word{alph["b"], alph["a"]}));
+                REQUIRE(!is_incl);
+                REQUIRE((
+                    cex.word == Word{alph["a"], alph["b"]} ||
+                    cex.word == Word{alph["b"], alph["a"]}));
+                REQUIRE(cex.path == std::vector<State>{1,1,1});
 
-            is_incl = is_included(bigger, smaller, &cex, &alph, params);
-            REQUIRE(is_incl);
-            REQUIRE((
-                cex.word == Word{alph["a"], alph["b"]} ||
-                cex.word == Word{alph["b"], alph["a"]}));
+                is_incl = is_included(bigger, smaller, &cex, &alph, params);
+                REQUIRE(is_incl);
+                REQUIRE((
+                    cex.word == Word{alph["a"], alph["b"]} ||
+                    cex.word == Word{alph["b"], alph["a"]}));
+                REQUIRE(cex.path == std::vector<State>{1,1,1});
+            }
         }
     }
 
@@ -2042,26 +2064,31 @@ TEST_CASE("mata::nfa::is_included()")
         bigger.delta.add(15, alph["b"], 15);
 
         for (const auto& algo : ALGORITHMS) {
-            params["algorithm"] = algo;
-            bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
-            REQUIRE(!is_incl);
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &cex, &alph, params);
+                REQUIRE(!is_incl);
 
-            REQUIRE(cex.word.size() == 4);
-            REQUIRE((cex.word[0] == alph["a"] || cex.word[0] == alph["b"]));
-            REQUIRE((cex.word[1] == alph["a"] || cex.word[1] == alph["b"]));
-            REQUIRE((cex.word[2] == alph["a"] || cex.word[2] == alph["b"]));
-            REQUIRE((cex.word[3] == alph["a"] || cex.word[3] == alph["b"]));
-            REQUIRE(cex.word[2] != cex.word[3]);
+                REQUIRE(cex.word.size() == 4);
+                REQUIRE((cex.word[0] == alph["a"] || cex.word[0] == alph["b"]));
+                REQUIRE((cex.word[1] == alph["a"] || cex.word[1] == alph["b"]));
+                REQUIRE((cex.word[2] == alph["a"] || cex.word[2] == alph["b"]));
+                REQUIRE((cex.word[3] == alph["a"] || cex.word[3] == alph["b"]));
+                REQUIRE(cex.word[2] != cex.word[3]);
+                REQUIRE(cex.path == std::vector<State>{1,1,1,1,1});
 
-            is_incl = is_included(bigger, smaller, &cex, &alph, params);
-            REQUIRE(is_incl);
+                is_incl = is_included(bigger, smaller, &cex, &alph, params);
+                REQUIRE(is_incl);
 
-            REQUIRE(cex.word.size() == 4);
-            REQUIRE((cex.word[0] == alph["a"] || cex.word[0] == alph["b"]));
-            REQUIRE((cex.word[1] == alph["a"] || cex.word[1] == alph["b"]));
-            REQUIRE((cex.word[2] == alph["a"] || cex.word[2] == alph["b"]));
-            REQUIRE((cex.word[3] == alph["a"] || cex.word[3] == alph["b"]));
-            REQUIRE(cex.word[2] != cex.word[3]);
+                REQUIRE(cex.word.size() == 4);
+                REQUIRE((cex.word[0] == alph["a"] || cex.word[0] == alph["b"]));
+                REQUIRE((cex.word[1] == alph["a"] || cex.word[1] == alph["b"]));
+                REQUIRE((cex.word[2] == alph["a"] || cex.word[2] == alph["b"]));
+                REQUIRE((cex.word[3] == alph["a"] || cex.word[3] == alph["b"]));
+                REQUIRE(cex.word[2] != cex.word[3]);
+                REQUIRE(cex.path == std::vector<State>{1,1,1,1,1});
+            }
         }
     }
 
@@ -2161,6 +2188,12 @@ q10 67 q5
         REQUIRE(!is_incl);
         REQUIRE(smaller.is_in_lang(cex.word));
         REQUIRE(!bigger.is_in_lang(cex.word));
+        REQUIRE(cex.path.size() == cex.word.size() + 1);
+        for (size_t i = 0; i < cex.word.size(); ++i) {
+            const auto& s = smaller.delta[cex.path[i]].find(cex.word[i]);
+            REQUIRE(s != smaller.delta[cex.path[i]].end());
+            REQUIRE(s->targets.contains(cex.path[i+1]));
+        }
     }
 
     SECTION("wrong parameters 1")

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2184,15 +2184,22 @@ q9 196608 q9
 q10 67 q5
 )"
             ))[0]);
-        bool is_incl = mata::nfa::algorithms::is_included_antichains(smaller, bigger, nullptr, &cex);
-        REQUIRE(!is_incl);
-        REQUIRE(smaller.is_in_lang(cex.word));
-        REQUIRE(!bigger.is_in_lang(cex.word));
-        REQUIRE(cex.path.size() == cex.word.size() + 1);
-        for (size_t i = 0; i < cex.word.size(); ++i) {
-            const auto& s = smaller.delta[cex.path[i]].find(cex.word[i]);
-            REQUIRE(s != smaller.delta[cex.path[i]].end());
-            REQUIRE(s->targets.contains(cex.path[i+1]));
+        
+        for (const auto& algo : ALGORITHMS) {
+            SECTION(algo)
+            {
+                params["algorithm"] = algo;
+                bool is_incl = is_included(smaller, bigger, &cex, nullptr, params);
+                REQUIRE(!is_incl);
+                REQUIRE(smaller.is_in_lang(cex.word));
+                REQUIRE(!bigger.is_in_lang(cex.word));
+                REQUIRE(cex.path.size() == cex.word.size() + 1);
+                for (size_t i = 0; i < cex.word.size(); ++i) {
+                    const auto& s = smaller.delta[cex.path[i]].find(cex.word[i]);
+                    REQUIRE(s != smaller.delta[cex.path[i]].end());
+                    CHECK(s->targets.contains(cex.path[i+1]));
+                }
+            }
         }
     }
 

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2065,6 +2065,104 @@ TEST_CASE("mata::nfa::is_included()")
         }
     }
 
+    SECTION("large example")
+    {
+        plumbing::construct(&smaller, mata::IntermediateAut::parse_from_mf(parse_mf(
+R"(@NFA-explicit
+%Alphabet-auto
+%Initial q0
+%Final q10
+q0 65 q1
+q0 66 q1
+q0 67 q1
+q0 196608 q1
+q1 65 q2
+q1 66 q2
+q1 67 q2
+q1 196608 q2
+q2 65 q2
+q2 65 q3
+q2 66 q2
+q2 66 q4
+q2 67 q2
+q2 196608 q2
+q4 66 q5
+q5 66 q6
+q6 65 q6
+q6 65 q7
+q6 66 q6
+q6 67 q6
+q6 196608 q6
+q7 67 q8
+q8 67 q9
+q9 67 q10
+q10 65 q10
+q10 66 q10
+q10 67 q10
+q10 196608 q10
+q3 67 q11
+q11 67 q12
+q12 67 q13
+q13 65 q13
+q13 66 q13
+q13 66 q14
+q13 67 q13
+q13 196608 q13
+q14 66 q15
+q15 66 q16
+q16 65 q10
+q16 66 q10
+q16 67 q10
+q16 196608 q10
+)"
+            ))[0]);
+        plumbing::construct(&bigger, mata::IntermediateAut::parse_from_mf(parse_mf(
+R"(@NFA-explicit
+%Alphabet-auto
+%Initial q0 q7
+%Final q6
+q0 65 q1
+q0 66 q1
+q0 67 q1
+q0 196608 q1
+q1 65 q2
+q1 66 q2
+q1 67 q2
+q1 196608 q2
+q2 65 q2
+q2 66 q2
+q2 66 q3
+q2 67 q2
+q2 196608 q2
+q3 66 q4
+q4 66 q5
+q5 66 q6
+q6 65 q6
+q6 66 q6
+q6 67 q6
+q6 196608 q6
+q7 65 q8
+q7 66 q8
+q7 67 q8
+q7 196608 q8
+q8 65 q8
+q8 66 q9
+q8 67 q8
+q8 196608 q8
+q9 65 q9
+q9 65 q10
+q9 66 q9
+q9 67 q9
+q9 196608 q9
+q10 67 q5
+)"
+            ))[0]);
+        bool is_incl = mata::nfa::algorithms::is_included_antichains(smaller, bigger, nullptr, &cex);
+        REQUIRE(!is_incl);
+        REQUIRE(smaller.is_in_lang(cex.word));
+        REQUIRE(!bigger.is_in_lang(cex.word));
+    }
+
     SECTION("wrong parameters 1")
     {
         OnTheFlyAlphabet alph{};


### PR DESCRIPTION
This PR fixes counterexamples for antichain inclusion algorithm (both the word and path were incorrect) and for naive algorithm it fixes the path in the counterexamples.