### PR TITLE
Allow creating subfolders for integration tests sources

### DIFF
--- a/tests-integration/CMakeLists.txt
+++ b/tests-integration/CMakeLists.txt
@@ -18,14 +18,20 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/inputs/double-automata.input.in" "${
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/utils/config.hh.in" "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/config.hh" @ONLY)
 
-file(GLOB SOURCES "src/*.cc")
+file(
+    GLOB_RECURSE SOURCES
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
+)
+list(FILTER SOURCES EXCLUDE REGEX ".*/tests-integration/src/utils/.*")
 foreach(SOURCE ${SOURCES})
     get_filename_component(TARGET ${SOURCE} NAME_WE)
 
-    add_executable(${TARGET}
-        ${SOURCE}
-        src/utils/utils.cc
-    )
+    get_filename_component(TARGET_PATH ${SOURCE} DIRECTORY)
+    file(RELATIVE_PATH TARGET_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/" "${TARGET_PATH}")
+
+    add_executable(${TARGET} ${SOURCE} src/utils/utils.cc)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_PATH})
     target_link_libraries(${TARGET} libmata)
 
     # Add common compile warnings.

--- a/tests-integration/src/templates/template-with-cli-args.cc
+++ b/tests-integration/src/templates/template-with-cli-args.cc
@@ -1,9 +1,12 @@
 /**
- * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
+ * TODO: Input automata, that are of type `NFA-bits` are mintermized!
  *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
-#include "utils/utils.hh"
+// TODO: Modify when copying to target `/mata/tests-integration/src/utils/`.
+#include "../utils/utils.hh"
+#include "../utils/config.hh"
+
 #include "mata/nfa/nfa.hh"
 
 #include <iostream>
@@ -36,7 +39,7 @@ int main(int argc, char *argv[])
     TIME_BEGIN(tmp);
 
     /**************************************************
-     *  HERE COMES YOUR CODE THAT YOU WANT TO PROFILE *
+     * TODO: HERE COMES YOUR CODE YOU WANT TO PROFILE *
      *   - Use alphabet alph as source alphabet       *
      *   - Use Nfa aut as source automaton            *
      *   - e.g. complement(aut, alph);                *

--- a/tests-integration/src/templates/template-with-list-of-automata.cc
+++ b/tests-integration/src/templates/template-with-list-of-automata.cc
@@ -1,10 +1,11 @@
 /**
- * NOTE: Input automata, that are of type `NFA-bits` are mintermized!
+ * TODO: Input automata, that are of type `NFA-bits` are mintermized!
  *  - If you want to skip mintermization, set the variable `MINTERMIZE_AUTOMATA` below to `false`
  */
 
-#include "utils/utils.hh"
-#include "utils/config.hh"
+// TODO: Modify when copying to target `/mata/tests-integration/src/utils/`.
+#include "../utils/utils.hh"
+#include "../utils/config.hh"
 
 #include "mata/nfa/nfa.hh"
 
@@ -24,7 +25,7 @@ int main(int argc, char *argv[])
     std::cout << std::fixed << std::setprecision(4);
 
     /**
-     * NOTE: Comment out automata, that you do not want to process or add your own automata.
+     * TODO: Comment out automata that you do not want to process or add your own automata.
      */
     std::vector<std::string> automata = {
             mata::PerformanceTesting::AUTOMATA_DIR + "/b-armc-incl-easiest/aut1.mata",
@@ -129,7 +130,7 @@ int main(int argc, char *argv[])
         TIME_BEGIN(tmp);
 
         /**************************************************
-         *  HERE COMES YOUR CODE THAT YOU WANT TO PROFILE *
+         * TODO: HERE COMES YOUR CODE YOU WANT TO PROFILE *
          *   - Use alphabet alph as source alphabet       *
          *   - Use Nfa aut as source automaton            *
          *   - e.g. complement(aut, alph);                *

--- a/tests-integration/src/templates/template.cc
+++ b/tests-integration/src/templates/template.cc
@@ -1,5 +1,9 @@
-#include "utils/utils.hh"
+// TODO: Modify when copying to target `/mata/tests-integration/src/utils/`.
+#include "../utils/utils.hh"
+#include "../utils/config.hh"
+
 #include "mata/nfa/nfa.hh"
+
 #include <iostream>
 #include <iomanip>
 #include <chrono>
@@ -14,7 +18,7 @@ int main() {
     TIME_BEGIN(tmp);
 
     /**************************************************
-     *  HERE COMES YOUR CODE THAT YOU WANT TO PROFILE *
+     * TODO: HERE COMES YOUR CODE YOU WANT TO PROFILE *
      **************************************************/
 
     TIME_END(tmp);


### PR DESCRIPTION
This pull request includes a change to the `tests-integration/CMakeLists.txt` file to improve the flexibility of how source files are included in the build process.

Build process improvement:

* [`tests-integration/CMakeLists.txt`](diffhunk://#diff-929556b7422539ebb9c747cb6abeeae5f2552d88ee7c6d720ef249fcb53c34b3L21-R21): Modified the `file(GLOB SOURCES "src/*.cc")` command to `file(GLOB SOURCES "src/**/*.cc")` to include source files in subdirectories.