### PR TITLE
No more segfault during regex parsing

### DIFF
--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -252,7 +252,7 @@ namespace {
                     }
                 }
             }
-            RegexParser::renumber_states(output_nfa, explicit_nfa);
+            *output_nfa = Nfa(explicit_nfa).trim();
         }
 
     private: // private methods
@@ -438,16 +438,6 @@ namespace {
                 }
                 nfa.final.insert(target_state);
             }
-        }
-
-        /**
-         * Renumbers the states of the input_nfa to be from <0, numberOfStates>
-         * @param input_nfa Nfa which states should be renumbered
-         * @return Equivalent Nfa as input_nfa but trimmed and with states from interval <0, numberOfStates>
-         */
-        static Nfa renumber_states(Nfa* output_nfa, Nfa &input_nfa) {
-            *output_nfa = Nfa(input_nfa.delta, input_nfa.initial, input_nfa.final).trim();
-            return *output_nfa;
         }
 
         /**


### PR DESCRIPTION
This PR:
- Eliminates a segmentation fault that occurred during regex parsing.
 - The segmentation fault was caused by a state renaming function, which also renamed initial states that were not marked as final and had no outgoing edges, thus lacking a specified new name (default name was `mata::nfa::Limits::max_state`). 
- Fixes the segmentation fault mentioned in #437.