### PR TITLE
Typo in a performance comparison script.

### DIFF
--- a/tests-integration/scripts/compare_profiles.py
+++ b/tests-integration/scripts/compare_profiles.py
@@ -30,7 +30,7 @@ def load_dataframe(path):
 if __name__ == "__main__":
     profiles = sys.argv[1:]
     if len(profiles) == 0:
-        printf(f"usage: compare_profiles.py [target.csv baseline1.csv ... baselinen.csv]")
+        print(f"usage: compare_profiles.py [target.csv baseline1.csv ... baselinen.csv]")
 
     averages, medians, timeouts = [], [], []
     columns, to_columns = set(), set()


### PR DESCRIPTION
This PR corrects a typo in the performance comparison script `compare_profiles.py`.