### PR TITLE
Update Catch2 to version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,13 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG        v2.13.9 # TODO: maybe we should move to v3
+        GIT_TAG        v3.7.1
         )
         FetchContent_MakeAvailable(Catch2)
         list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
-        include(Catch)
-        # Adds Catch2::Catch2
+        include(Catch) # Adds Catch2::Catch2WithMain and Catch2::Catch2
+        get_target_property(catch2_includes Catch2 INTERFACE_INCLUDE_DIRECTORIES)
+        target_include_directories(Catch2 SYSTEM INTERFACE ${catch2_includes})
     endif()
 
 endif()
@@ -101,7 +102,7 @@ endif ()
 if(MATA_ENABLE_COVERAGE)
     if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
         message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
-    endif() 
+    endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g --coverage")
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,6 @@ add_executable(tests
 		ord-vector.cc
 		sparse-set.cc
 		synchronized-iterator.cc
-		main.cc
 		alphabet.cc
 		parser.cc
 		re2parser.cc
@@ -19,7 +18,7 @@ add_executable(tests
 		strings/nfa-string-solving.cc
 )
 
-target_link_libraries(tests PRIVATE libmata Catch2::Catch2)
+target_link_libraries(tests PRIVATE libmata Catch2::Catch2WithMain)
 
 # Add common compile warnings.
 target_compile_options(tests PRIVATE "$<$<CONFIG:DEBUG>:${MATA_COMMON_WARNINGS}>")

--- a/tests/alphabet.cc
+++ b/tests/alphabet.cc
@@ -2,7 +2,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/alphabet.hh"
 #include "mata/nfa/nfa.hh"

--- a/tests/main.cc
+++ b/tests/main.cc
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/tests/mintermization.cc
+++ b/tests/mintermization.cc
@@ -1,7 +1,8 @@
 /* tests-mintermization.cc -- tests of Mintermization
  */
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/parser/inter-aut.hh"
 #include "mata/parser/mintermization.hh"

--- a/tests/nfa/builder.cc
+++ b/tests/nfa/builder.cc
@@ -3,7 +3,8 @@
 #include <unordered_set>
 #include <fstream>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/builder.hh"

--- a/tests/nfa/delta.cc
+++ b/tests/nfa/delta.cc
@@ -7,7 +7,8 @@
 #include "mata/nfa/delta.hh"
 #include "mata/nfa/nfa.hh"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 using namespace mata::nfa;
 

--- a/tests/nfa/nfa-concatenation.cc
+++ b/tests/nfa/nfa-concatenation.cc
@@ -4,7 +4,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/strings.hh"

--- a/tests/nfa/nfa-plumbing.cc
+++ b/tests/nfa/nfa-plumbing.cc
@@ -4,7 +4,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/plumbing.hh"

--- a/tests/nfa/nfa-product.cc
+++ b/tests/nfa/nfa-product.cc
@@ -4,7 +4,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 

--- a/tests/nfa/nfa-profiling.cc
+++ b/tests/nfa/nfa-profiling.cc
@@ -1,6 +1,7 @@
 // TODO: some header
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include "utils.hh"
 
 #include "mata/nfa/nfa.hh"

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2,7 +2,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "utils.hh"
 
@@ -1120,7 +1121,7 @@ TEST_CASE("mata::nfa::construct() invalid calls")
         parsec.type = "FA";
 
         CHECK_THROWS_WITH(builder::construct(parsec),
-                          Catch::Contains("expecting type"));
+                          Catch::Matchers::ContainsSubstring("expecting type"));
     }
 
     SECTION("construct() call with an epsilon transition")
@@ -1129,7 +1130,7 @@ TEST_CASE("mata::nfa::construct() invalid calls")
         parsec.body = { {"q1", "q2"} };
 
         CHECK_THROWS_WITH(builder::construct(parsec),
-                          Catch::Contains("Epsilon transition"));
+                          Catch::Matchers::ContainsSubstring("Epsilon transition"));
     }
 
     SECTION("construct() call with a nonsense transition")
@@ -1138,7 +1139,7 @@ TEST_CASE("mata::nfa::construct() invalid calls")
         parsec.body = { {"q1", "a", "q2", "q3"} };
 
         CHECK_THROWS_WITH(plumbing::construct(&aut, parsec),
-                          Catch::Contains("Invalid transition"));
+                          Catch::Matchers::ContainsSubstring("Invalid transition"));
     }
 } // }}}
 
@@ -1873,7 +1874,7 @@ TEST_CASE("mata::nfa::is_universal()")
         OnTheFlyAlphabet alph{};
 
         CHECK_THROWS_WITH(aut.is_universal(alph, params),
-            Catch::Contains("requires setting the \"algo\" key"));
+            Catch::Matchers::ContainsSubstring("requires setting the \"algo\" key"));
     }
 
     SECTION("wrong parameters 2")
@@ -1882,7 +1883,7 @@ TEST_CASE("mata::nfa::is_universal()")
         params["algorithm"] = "foo";
 
         CHECK_THROWS_WITH(aut.is_universal(alph, params),
-            Catch::Contains("received an unknown value"));
+            Catch::Matchers::ContainsSubstring("received an unknown value"));
     }
 } // }}}
 
@@ -2184,7 +2185,7 @@ q9 196608 q9
 q10 67 q5
 )"
             ))[0]);
-        
+
         for (const auto& algo : ALGORITHMS) {
             SECTION(algo)
             {
@@ -2208,7 +2209,7 @@ q10 67 q5
         OnTheFlyAlphabet alph{};
 
         CHECK_THROWS_WITH(is_included(smaller, bigger, &alph, params),
-            Catch::Contains("requires setting the \"algo\" key"));
+            Catch::Matchers::ContainsSubstring("requires setting the \"algo\" key"));
         CHECK_NOTHROW(is_included(smaller, bigger, &alph));
     }
 
@@ -2218,7 +2219,7 @@ q10 67 q5
         params["algorithm"] = "foo";
 
         CHECK_THROWS_WITH(is_included(smaller, bigger, &alph, params),
-            Catch::Contains("received an unknown value"));
+            Catch::Matchers::ContainsSubstring("received an unknown value"));
         CHECK_NOTHROW(is_included(smaller, bigger, &alph));
     }
 } // }}}
@@ -2370,9 +2371,9 @@ TEST_CASE("mata::nfa::are_equivalent")
         OnTheFlyAlphabet alph{};
 
         CHECK_THROWS_WITH(are_equivalent(smaller, bigger, &alph, params),
-                          Catch::Contains("requires setting the \"algo\" key"));
+                          Catch::Matchers::ContainsSubstring("requires setting the \"algo\" key"));
         CHECK_THROWS_WITH(are_equivalent(smaller, bigger, params),
-                          Catch::Contains("requires setting the \"algo\" key"));
+                          Catch::Matchers::ContainsSubstring("requires setting the \"algo\" key"));
         CHECK_NOTHROW(are_equivalent(smaller, bigger));
     }
 
@@ -2382,9 +2383,9 @@ TEST_CASE("mata::nfa::are_equivalent")
         params["algorithm"] = "foo";
 
         CHECK_THROWS_WITH(are_equivalent(smaller, bigger, &alph, params),
-                          Catch::Contains("received an unknown value"));
+                          Catch::Matchers::ContainsSubstring("received an unknown value"));
         CHECK_THROWS_WITH(are_equivalent(smaller, bigger, params),
-                          Catch::Contains("received an unknown value"));
+                          Catch::Matchers::ContainsSubstring("received an unknown value"));
         CHECK_NOTHROW(are_equivalent(smaller, bigger));
     }
 }
@@ -2626,7 +2627,7 @@ TEST_CASE("mata::nfa::is_complete()")
         aut.delta.add(6, 100, 4);
 
         CHECK_THROWS_WITH(aut.is_complete(&alph),
-            Catch::Contains("symbol that is not in the provided alphabet"));
+            Catch::Matchers::ContainsSubstring("symbol that is not in the provided alphabet"));
     }
 } // }}}
 
@@ -3138,19 +3139,19 @@ TEST_CASE("mata::nfa::reduce_size_by_residual()") {
     SECTION("error checking")
     {
         CHECK_THROWS_WITH(reduce(aut, &state_renaming, params_after),
-                          Catch::Contains("requires setting the \"type\" key in the \"params\" argument;"));
+                          Catch::Matchers::ContainsSubstring("requires setting the \"type\" key in the \"params\" argument;"));
 
         params_after["type"] = "bad_type";
         CHECK_THROWS_WITH(reduce(aut, &state_renaming, params_after),
-                          Catch::Contains("requires setting the \"direction\" key in the \"params\" argument;"));
+                          Catch::Matchers::ContainsSubstring("requires setting the \"direction\" key in the \"params\" argument;"));
 
         params_after["direction"] = "unknown_direction";
         CHECK_THROWS_WITH(reduce(aut, &state_renaming, params_after),
-                          Catch::Contains("received an unknown value of the \"direction\" key"));
+                          Catch::Matchers::ContainsSubstring("received an unknown value of the \"direction\" key"));
 
         params_after["direction"] = "forward";
         CHECK_THROWS_WITH(reduce(aut, &state_renaming, params_after),
-                          Catch::Contains("received an unknown value of the \"type\" key"));
+                          Catch::Matchers::ContainsSubstring("received an unknown value of the \"type\" key"));
 
         params_after["type"] = "after";
         CHECK_NOTHROW(reduce(aut, &state_renaming, params_after));

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -1,7 +1,8 @@
 /* tests-ord-vector.cc -- tests of OrdVector
  */
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/utils/utils.hh"
 #include "mata/utils/ord-vector.hh"

--- a/tests/parser.cc
+++ b/tests/parser.cc
@@ -7,7 +7,8 @@
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/builder.hh"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 using namespace mata::parser;
 using namespace mata::utils;
@@ -440,7 +441,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key2\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("expecting automaton type"));
+                          Catch::Matchers::ContainsSubstring("expecting automaton type"));
 	}
 
 	SECTION("trailing characters behind @TYPE")
@@ -449,7 +450,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"@Type another\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("invalid trailing characters"));
+                          Catch::Matchers::ContainsSubstring("invalid trailing characters"));
 	}
 
 	SECTION("missing type")
@@ -459,7 +460,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key2\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("expecting automaton type"));
+                          Catch::Matchers::ContainsSubstring("expecting automaton type"));
 	}
 
 	SECTION("unterminated quote")
@@ -469,7 +470,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 \"value\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("missing ending quotes"));
+                          Catch::Matchers::ContainsSubstring("missing ending quotes"));
 	}
 
 	SECTION("unterminated quote 2")
@@ -479,7 +480,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 \"\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("missing ending quotes"));
+                          Catch::Matchers::ContainsSubstring("missing ending quotes"));
 	}
 
 	SECTION("newlines within names")
@@ -496,7 +497,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"3\"";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("missing ending quotes"));
+                          Catch::Matchers::ContainsSubstring("missing ending quotes"));
 	}
 
 	SECTION("quoted strings starting in the middle of strings")
@@ -506,7 +507,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 val\"ue\"\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("misplaced quotes"));
+                          Catch::Matchers::ContainsSubstring("misplaced quotes"));
 	}
 
 	SECTION("quoted strings ending in the middle of strings")
@@ -516,7 +517,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 \"val\"ue\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("misplaced quotes"));
+                          Catch::Matchers::ContainsSubstring("misplaced quotes"));
 	}
 
 	SECTION("incorrect position of special characters")
@@ -526,8 +527,8 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 @here";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of @TYPE") &&
-			Catch::Contains("@here"));
+			Catch::Matchers::ContainsSubstring("invalid position of @TYPE") &&
+			Catch::Matchers::ContainsSubstring("@here"));
 	}
 
 	SECTION("incorrect position of special characters 2")
@@ -537,8 +538,8 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"q1 @here q2";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of @TYPE") &&
-			Catch::Contains("@here"));
+			Catch::Matchers::ContainsSubstring("invalid position of @TYPE") &&
+			Catch::Matchers::ContainsSubstring("@here"));
 	}
 
 	SECTION("incorrect position of special characters 3")
@@ -548,8 +549,8 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"q1 %here q2";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of %KEY") &&
-			Catch::Contains("%here"));
+			Catch::Matchers::ContainsSubstring("invalid position of %KEY") &&
+			Catch::Matchers::ContainsSubstring("%here"));
 	}
 
 	SECTION("incorrect position of special characters 4")
@@ -559,8 +560,8 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1 %here";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-			Catch::Contains("invalid position of %KEY") &&
-			Catch::Contains("%here"));
+			Catch::Matchers::ContainsSubstring("invalid position of %KEY") &&
+			Catch::Matchers::ContainsSubstring("%here"));
 	}
 
 	SECTION("no key name")
@@ -571,7 +572,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key2\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("%KEY name missing"));
+                          Catch::Matchers::ContainsSubstring("%KEY name missing"));
 	}
 
 	SECTION("special characters inside strings 1")
@@ -581,7 +582,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1     value@1\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("misplaced character \'@\'"));
+                          Catch::Matchers::ContainsSubstring("misplaced character \'@\'"));
 	}
 
 	SECTION("special characters inside strings 2")
@@ -591,7 +592,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key2     value%1\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("misplaced character \'%\'"));
+                          Catch::Matchers::ContainsSubstring("misplaced character \'%\'"));
 	}
 
 	SECTION("special characters inside strings 3")
@@ -601,7 +602,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key1     @value\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("invalid position of @TYPE"));
+                          Catch::Matchers::ContainsSubstring("invalid position of @TYPE"));
 	}
 
 	SECTION("special characters inside strings 4")
@@ -611,7 +612,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"%key2     %value\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("invalid position of %KEY"));
+                          Catch::Matchers::ContainsSubstring("invalid position of %KEY"));
 	}
 
 	SECTION("invalid use of quotes")
@@ -620,7 +621,7 @@ TEST_CASE("incorrect use of mata::Parser::parse_mf_section()")
 			"\"@Type\"\n";
 
 		CHECK_THROWS_WITH(parse_mf_section(file),
-                          Catch::Contains("expecting automaton type"));
+                          Catch::Matchers::ContainsSubstring("expecting automaton type"));
 	}
 } // parse_mf_section incorrect }}}
 

--- a/tests/re2parser.cc
+++ b/tests/re2parser.cc
@@ -1,4 +1,5 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/parser/re2parser.hh"

--- a/tests/sparse-set.cc
+++ b/tests/sparse-set.cc
@@ -1,4 +1,5 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 

--- a/tests/strings/nfa-noodlification.cc
+++ b/tests/strings/nfa-noodlification.cc
@@ -2,7 +2,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/strings.hh"

--- a/tests/strings/nfa-segmentation.cc
+++ b/tests/strings/nfa-segmentation.cc
@@ -4,7 +4,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/strings.hh"

--- a/tests/strings/nfa-string-solving.cc
+++ b/tests/strings/nfa-string-solving.cc
@@ -3,7 +3,8 @@
 
 #include <unordered_set>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/nfa/nfa.hh"
 #include "mata/nfa/strings.hh"

--- a/tests/synchronized-iterator.cc
+++ b/tests/synchronized-iterator.cc
@@ -1,4 +1,5 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "mata/utils/utils.hh"
 #include "mata/utils/synchronized-iterator.hh"


### PR DESCRIPTION
This PR finally updates Catch2 to version 3 which gives us better debugging options, better visualization and compatibility, performance, mini-benchmarking infrastructure which might actually improve the overall Mata perftesting abilities, and much more.