### PR TITLE
Add missing Python dependencies for Python binding

### DIFF
--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -7,3 +7,7 @@ ipython>=7.9.0
 pandas>=1.3.5
 networkx>=2.6.3
 graphviz>=0.20.0
+setuptools
+papermill
+ipykernel
+seaborn


### PR DESCRIPTION
This PR adds a few missing dependencies for Python binding. This allows to compile the binding, run the Jupyter notebooks, and run the notebooks directly from the command line using the tool `papermill`.