### PR TITLE
Hopcroft's minimization: Valmari and Lehtinen's variant for a partial transition function

### DIFF
--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -33,6 +33,14 @@ namespace mata::nfa::algorithms {
 Nfa minimize_brzozowski(const Nfa& aut);
 
 /**
+ * Hopcroft minimization of automata. Based on the algorithm from the paper:
+ * "Efficient Minimization of DFAs With Partial Transition Functions" by Antti Valmari and Petri Lehtinen.
+ * @param[in] aut Deterministic automaton without useless states. Perform trimming before calling this function.
+ * @return Minimized deterministic automaton.
+ */
+Nfa minimize_hopcroft(const Nfa& aut);
+
+/**
  * Complement implemented by determization, adding sink state and making automaton complete. Then it adds final states
  *  which were non final in the original automaton.
  * @param[in] aut Automaton to be complemented.

--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -34,11 +34,13 @@ Nfa minimize_brzozowski(const Nfa& aut);
 
 /**
  * Hopcroft minimization of automata. Based on the algorithm from the paper:
- * "Efficient Minimization of DFAs With Partial Transition Functions" by Antti Valmari and Petri Lehtinen.
- * @param[in] aut Deterministic automaton without useless states. Perform trimming before calling this function.
+ *  "Efficient Minimization of DFAs With Partial Transition Functions" by Antti Valmari and Petri Lehtinen.
+ *  The algorithm works in O(a*n*log(n)) time and O(m+n+a) space, where: n is the number of states, a is the size
+ *  of the alphabet, and m is the number of transitions.
+ * @param[in] dfa_trimmed Deterministic automaton without useless states. Perform trimming before calling this function.
  * @return Minimized deterministic automaton.
  */
-Nfa minimize_hopcroft(const Nfa& aut);
+Nfa minimize_hopcroft(const Nfa& dfa_trimmed);
 
 /**
  * Complement implemented by determization, adding sink state and making automaton complete. Then it adds final states

--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -36,7 +36,7 @@ Nfa minimize_brzozowski(const Nfa& aut);
  * Hopcroft minimization of automata. Based on the algorithm from the paper:
  *  "Efficient Minimization of DFAs With Partial Transition Functions" by Antti Valmari and Petri Lehtinen.
  *  The algorithm works in O(a*n*log(n)) time and O(m+n+a) space, where: n is the number of states, a is the size
- *  of the alphabet, and m is the number of transitions.
+ *  of the alphabet, and m is the number of transitions. [https://dl.acm.org/doi/10.1016/j.ipl.2011.12.004]
  * @param[in] dfa_trimmed Deterministic automaton without useless states. Perform trimming before calling this function.
  * @return Minimized deterministic automaton.
  */

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -950,125 +950,129 @@ Nfa mata::nfa::minimize(
     return algo(aut);
 }
 
-// Anonymouse namespace for the Hopcroft minimization algorithm.
+// Anonymous namespace for the Hopcroft minimization algorithm.
 namespace {
 template <typename T>
+/**
+ * A class for partitionable sets of elements. All elements are stored in a contiguous vector.
+ * Elements from the same set are contiguous in the vector. Auxiliary data (indices, positions, etc.) are
+ * stored in separate vectors.
+ */
 class RefinablePartition {
 public:
     static_assert(std::is_unsigned<T>::value, "T must be an unsigned type.");
-    static const T ELEM_NOT_FOUND = std::numeric_limits<T>::max();
+    static const T NO_MORE_ELEMENTS = std::numeric_limits<T>::max();
     static const size_t NO_SPLIT = std::numeric_limits<size_t>::max();
-    size_t sets;                // The name of the last added set.
+    size_t num_of_sets;            // The number of sets in the partition.
+    std::vector<size_t> set_idx;   // For each element, tells the index of the set it belongs to.
 
 private:
-    std::vector<T> elems;       // Contains all elements in such an order that the elements of the same set are contiguous.
-    std::vector<T> loc;         // Contains the location of each element in the elems vector.
-    std::vector<size_t> sidx;   // Contains the set index of each element.
-    std::vector<size_t> first;  // Contains the index of the first element of each set in the elems vector.
-    std::vector<size_t> end;    // Contains the index after the last element of each set in the elems vector.
-    std::vector<size_t> mid;    // Contains the index after the last element of the first half of the set in the elems vector.
+    std::vector<T> elems;       // Contains all elements in an order such that the elements of the same set are contiguous.
+    std::vector<T> location;    // Contains the location of each element in the elements vector.
+    std::vector<size_t> first;  // Contains the index of the first element of each set in the elements vector.
+    std::vector<size_t> end;    // Contains the index after the last element of each set in the elements vector.
+    std::vector<size_t> mid;    // Contains the index after the last element of the first half of the set in the elements vector.
 
 public:
     /**
-     * @brief Construct a new Refinable Partition object
+     * @brief Construct a new Refinable Partition for equivalence classes of states.
      *
-     * @param n The number of elements.
+     * @param n The number of states.
      */
-    RefinablePartition(const size_t n) : sets(1), elems(n), loc(n), sidx(n), first(n), end(n), mid(n) {
+    RefinablePartition(const size_t num_of_states)
+        : num_of_sets(1), elems(num_of_states), location(num_of_states), set_idx(num_of_states),
+          first(num_of_states), end(num_of_states), mid(num_of_states) {
+        // Initially, all states are in the same equivalence class.
         first[0] = mid[0] = 0;
-        end[0] = n;
-        for (T e = 0; e < n; ++e) {
-            elems[e] = loc[e] = e;
-            sidx[e] = 0;
+        end[0] = num_of_states;
+        for (State e = 0; e < num_of_states; ++e) {
+            elems[e] = location[e] = e;
+            set_idx[e] = 0;
         }
     }
 
     /**
-     * @brief Construct a new Refinable Partition object from the transition function.
-     *  The elements are gouped in an ascending order of the labels.
+     * @brief Construct a new Refinable Partition for sets of splitters (transitions incoming to
+     *  equivalence classes under a common symbol). Initially, the partition has n sets, where n is the alphabet size.
      *
      * @param delta The transition function.
      */
     RefinablePartition(const Delta &delta)
-        : sets(0), elems(), loc(), sidx(), first(), end(), mid() {
-        sets = 0;
-        size_t n = 0;
-        std::vector<size_t> sizes;
-        std::unordered_map<Symbol, size_t> idx;
+        : num_of_sets(0), elems(), location(), set_idx(), first(), end(), mid() {
+        size_t num_of_transitions = 0;
+        std::vector<size_t> counts;
+        std::unordered_map<Symbol, size_t> symbol_map;
 
+        // Transitions are grouped by symbols using counting sort in time O(m).
         // Count the number of elements and the number of sets.
-        for (const auto &t : delta.transitions()) {
-            const Symbol a = t.symbol;
-            if (idx.find(a) == idx.end()) {
-                idx[a] = sets++;
-                sizes.push_back(1);
+        for (const auto &trans : delta.transitions()) {
+            const Symbol a = trans.symbol;
+            if (symbol_map.find(a) == symbol_map.end()) {
+                symbol_map[a] = num_of_sets++;
+                counts.push_back(1);
             } else {
-                sizes[idx[a]]++;
+                ++counts[symbol_map[a]];
             }
-            n++;
+            ++num_of_transitions;
         }
 
-        // Initialize the partition.
-        elems.resize(n);
-        loc.resize(n);
-        sidx.resize(n);
-        first.resize(n);
-        end.resize(n);
-        mid.resize(n);
+        // Initialize data structures.
+        elems.resize(num_of_transitions);
+        location.resize(num_of_transitions);
+        set_idx.resize(num_of_transitions);
+        first.resize(num_of_transitions);
+        end.resize(num_of_transitions);
+        mid.resize(num_of_transitions);
 
         // Compute set indices.
+        // Use (mid - 1) as an index for the insertion.
         first[0] = 0;
-        end[0] = sizes[0];
+        end[0] = counts[0];
         mid[0] = end[0];
-        for (size_t i = 1; i < sets; ++i) {
+        for (size_t i = 1; i < num_of_sets; ++i) {
             first[i] = end[i - 1];
-            end[i] = first[i] + sizes[i];
+            end[i] = first[i] + counts[i];
             mid[i] = end[i];
         }
 
         // Fill the sets from the back.
         // Mid, decremented before use, is used as an index for the next element.
-        size_t t_idx = 0;
-        for (const auto &t : delta.transitions()) {
-            const Symbol a = t.symbol;
-            const size_t i = idx[a];
-            const size_t l = mid[i] - 1;
-            mid[i] = l;
-            elems[l] = t_idx;
-            loc[t_idx] = l;
-            sidx[t_idx] = i;
-            t_idx++;
+        size_t trans_idx = 0;   // Index of the transition in the (flattened) delta.
+        for (const auto &trans : delta.transitions()) {
+            const Symbol a = trans.symbol;
+            const size_t a_idx = symbol_map[a];
+            const size_t trans_loc = mid[a_idx] - 1;
+            mid[a_idx] = trans_loc;
+            elems[trans_loc] = trans_idx;
+            location[trans_idx] = trans_loc;
+            set_idx[trans_idx] = a_idx;
+            ++trans_idx;
         }
     }
 
     RefinablePartition(const RefinablePartition &other)
-        : elems(other.elems), loc(other.loc), sidx(other.sidx),
-          first(other.first), end(other.end), mid(other.mid), sets(other.sets) {}
+        : elems(other.elems), location(other.location), set_idx(other.set_idx),
+          first(other.first), end(other.end), mid(other.mid), num_of_sets(other.num_of_sets) {}
 
     RefinablePartition(RefinablePartition &&other) noexcept
-        : elems(std::move(other.elems)), loc(std::move(other.loc)), sidx(std::move(other.sidx)),
-          first(std::move(other.first)), end(std::move(other.end)), mid(std::move(other.mid)), sets(other.sets) {}
+        : elems(std::move(other.elems)), location(std::move(other.location)), set_idx(std::move(other.set_idx)),
+          first(std::move(other.first)), end(std::move(other.end)), mid(std::move(other.mid)), num_of_sets(other.num_of_sets) {}
+
 
     /**
-     * @brief Get the size of the set
+     * @brief Get the number of elements across all sets.
+     *
+     * @return The number of elements.
+     */
+    inline size_t size() const { return elems.size(); }
+
+    /**
+     * @brief Get the size of the set.
      *
      * @param s The set index.
      * @return The size of the set.
      */
-    inline size_t size(size_t s) const { return end[s] - first[s]; }
-
-    inline size_t length() const { return elems.size(); }
-
-
-    inline size_t get_loc(T e) const { return loc[e]; }
-
-    /**
-     * @brief Get the set index of the element.
-     *
-     * @param e The element.
-     * @return The set index of the element.
-     */
-    inline size_t set(T e) const { return sidx[e]; }
+    inline size_t size_of_set(size_t s) const { return end[s] - first[s]; }
 
     /**
      * @brief Get the first element of the set.
@@ -1076,60 +1080,34 @@ public:
      * @param s The set index.
      * @return The first element of the set.
      */
-    inline T get_first(const size_t s) const {
-        // if (first[s] >= end[s]) { return ELEM_NOT_FOUND; }
-        return elems[first[s]];
-     }
+    inline T get_first(const size_t s) const { return elems[first[s]]; }
 
     /**
      * @brief Get the next element of the set.
      *
      * @param e The element.
-     * @return The next element of the set.
+     * @return The next element of the set or NO_MORE_ELEMENTS if there is no next element.
      */
     inline T get_next(const T e) const {
-        if (loc[e] + 1 >= end[sidx[e]]) { return ELEM_NOT_FOUND; }
-        return elems[loc[e] + 1];
+        if (location[e] + 1 >= end[set_idx[e]]) { return NO_MORE_ELEMENTS; }
+        return elems[location[e] + 1];
     }
 
     /**
-     * @brief Mark the element. And move it to the first half of the set.
+     * @brief Mark the element and move it to the first half of the set.
      *
      * @param e The element.
      */
     void mark(const T e) {
-        const size_t s = sidx[e];
-        const size_t l = loc[e];
-        const size_t m = mid[s];
-        if (l >= m) {
-            elems[l] = elems[m];
-            loc[elems[l]] = l;
-            elems[m] = e;
-            loc[e] = m;
-            mid[s] = m + 1;
-        }
-    }
-
-    /**
-     * @brief Split the set into two sets according to the marked elements (the mid).
-     *  The first set name remains the same.
-     *
-     * @param s The set index.
-     * @return The new set index.
-     */
-    size_t split(const size_t s) {
-        if (mid[s] == end[s]) { mid[s] = first[s]; }
-        if (mid[s] == first[s]) {
-            return NO_SPLIT;
-        } else {
-            first[sets] = first[s];
-            mid[sets] = first[s];
-            end[sets] = mid[s];
-            first[s] = mid[s];
-            for (size_t l = first[sets]; l < end[sets]; ++l) {
-                sidx[elems[l]] = sets;
-            }
-            return sets++;
+        const size_t e_set = set_idx[e];
+        const size_t e_loc = location[e];
+        const size_t e_set_mid = mid[e_set];
+        if (e_loc >= e_set_mid) {
+            elems[e_loc] = elems[e_set_mid];
+            location[elems[e_loc]] = e_loc;
+            elems[e_set_mid] = e;
+            location[e] = e_set_mid;
+            mid[e_set] = e_set_mid + 1;
         }
     }
 
@@ -1139,120 +1117,140 @@ public:
      * @param s The set index.
      * @return True if the set has no marked elements, false otherwise.
      */
-    bool no_marks(const size_t s) const { return mid[s] == first[s]; }
+    inline bool no_marks(const size_t s) const { return mid[s] == first[s]; }
 
-    void print_debug() {
-        std::cout << "REFINABLE SETS: " << sets << std::endl;
-
-        std::cout << "REFINABLE ELEMS: ";
-        for (size_t i = 0; i < elems.size(); ++i) {
-            std::cout << i << ":" << elems[i] << " ";
+    /**
+     * @brief Split the set into two sets according to the marked elements (the mid).
+     * The first set name remains the same.
+     *
+     * @param s The set index.
+     * @return The new set index.
+     */
+    size_t split(const size_t s) {
+        if (mid[s] == end[s]) {
+            // If no elements were marked, move the mid to the end (no split needed).
+            mid[s] = first[s];
         }
-        std::cout << std::endl;
-
-        std::cout << "REFINABLE LOCS: ";
-        for (size_t i = 0; i < loc.size(); ++i) {
-            std::cout << i << ":" << loc[i] << " ";
+        if (mid[s] == first[s]) {
+            // If all or no elements were marked, there is no need to split the set.
+            return NO_SPLIT;
+        } else {
+            // Split the set according to the mid.
+            first[num_of_sets] = first[s];
+            mid[num_of_sets] = first[s];
+            end[num_of_sets] = mid[s];
+            first[s] = mid[s];
+            for (size_t l = first[num_of_sets]; l < end[num_of_sets]; ++l) {
+                set_idx[elems[l]] = num_of_sets;
+            }
+            return num_of_sets++;
         }
-        std::cout << std::endl;
-
-        std::cout << "REFINABLE SIDS: ";
-        for (size_t i = 0; i < sidx.size(); ++i) {
-            std::cout << i << ":" << sidx[i] << " ";
-        }
-        std::cout << std::endl;
-
-        std::cout << "REFINABLE FIRST: ";
-        for (size_t i = 0; i < first.size(); ++i) {
-            std::cout << i << ":" << first[i] << " ";
-        }
-        std::cout << std::endl;
-
-        std::cout << "REFINABLE END: ";
-        for (size_t i = 0; i < end.size(); ++i) {
-            std::cout << i << ":" << end[i] << " ";
-        }
-        std::cout << std::endl;
-
-        std::cout << "REFINABLE MID: ";
-        for (size_t i = 0; i < mid.size(); ++i) {
-            std::cout << i << ":" << mid[i] << " ";
-        }
-        std::cout << std::endl;
     }
 };
-}
+} // namespace
 
 
-Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& aut) {
-    if (aut.delta.num_of_transitions() == 0) { return Nfa{ aut }; }
-    assert(aut.is_deterministic());
-    assert(aut.get_useful_states().size() == aut.num_of_states());
+Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
+    if (dfa_trimmed.delta.num_of_transitions() == 0) {
+        // The automaton is trivially minimal.
+        return Nfa{ dfa_trimmed };
+    }
+    assert(dfa_trimmed.is_deterministic());
+    assert(dfa_trimmed.get_useful_states().size() == dfa_trimmed.num_of_states());
 
-    RefinablePartition<State> BRP(aut.num_of_states());
-    RefinablePartition<size_t> TRP(aut.delta);
+    // Initialize equivalence classes. The initial partition is {Q}.
+    RefinablePartition<State> BRP(dfa_trimmed.num_of_states());
+    // Initialize splitters. A splitter is a set of transitions
+    // over a common symbol incoming to an equivalence class. Initially,
+    // the partition has m splitters, where m is the alphabet size.
+    RefinablePartition<size_t> TRP(dfa_trimmed.delta);
 
-    std::vector<State> trans_source_map(TRP.length());
-    std::vector<std::vector<size_t>> incomming_trans_ids(BRP.length(), std::vector<size_t>());
-    size_t trans_id = 0;
-    for (const auto &t : aut.delta.transitions()) {
-        trans_source_map[trans_id] = t.source;
-        incomming_trans_ids[t.target].push_back(trans_id);
-        ++trans_id;
+    // Initialize vector of incoming transitions for each state. Transitions
+    // are represented only by their indices in the (flattened) delta.
+    // Initialize mapping from transition index to its source state.
+    std::vector<State> trans_source_map(TRP.size());
+    std::vector<std::vector<size_t>> incomming_trans_idxs(BRP.size(), std::vector<size_t>());
+    size_t trans_idx = 0;
+    for (const auto &trans : dfa_trimmed.delta.transitions()) {
+        trans_source_map[trans_idx] = trans.source;
+        incomming_trans_idxs[trans.target].push_back(trans_idx);
+        ++trans_idx;
     }
 
-    std::stack<size_t> unready_spls;
-    std::stack<size_t> touched_blocks;
-    std::stack<size_t> touched_spls;
+    // Worklists for the Hopcroft algorithm.
+    std::stack<size_t> unready_spls;    // Splitters that will be used in the backpropagation.
+    std::stack<size_t> touched_blocks;  // Blocks (equivalence classes) touched during backpropagation.
+    std::stack<size_t> touched_spls;    // Splitters touched (in the split_block function) as a result of backpropagation.
 
-    // Split the block.
+    /**
+     * @brief Split the block (equivalence class) according to the marked states.
+     *
+     * @param b The block index.
+     */
     auto split_block = [&](size_t b) {
+        // touched_spls has been moved to a higher scope to avoid multiple constructions/destructions.
         assert(touched_spls.empty());
-        size_t b_prime = BRP.split(b);
+        size_t b_prime = BRP.split(b);  // One block will keep the old name 'b'.
         if (b_prime == RefinablePartition<size_t>::NO_SPLIT) {
+            // All or no states in the block were marked (touched) during the backpropagation.
             return;
         }
-        if (BRP.size(b) < BRP.size(b_prime)) {
+        // According to the Hopcroft's algorithm, it is sufficient to work only with the smaller block.
+        if (BRP.size_of_set(b) < BRP.size_of_set(b_prime)) {
             b_prime = b;
         }
-        for (State q = BRP.get_first(b_prime); q != RefinablePartition<State>::ELEM_NOT_FOUND; q = BRP.get_next(q)) {
-            for (const size_t t : incomming_trans_ids[q]) {
-                const size_t p = TRP.set(t);
-                if (TRP.no_marks(p)) {
-                    touched_spls.push(p);
+        // Split the transitions of the splitters according to the new partitioning.
+        // Transitions in one splitter must have the same symbol and go to the same block.
+        for (State q = BRP.get_first(b_prime); q != RefinablePartition<State>::NO_MORE_ELEMENTS; q = BRP.get_next(q)) {
+            for (const size_t trans_idx : incomming_trans_idxs[q]) {
+                const size_t splitter_idx = TRP.set_idx[trans_idx];
+                if (TRP.no_marks(splitter_idx)) {
+                    touched_spls.push(splitter_idx);
                 }
-                TRP.mark(t);
+                // Mark the transition in the splitter and move it to the first half of the set.
+                TRP.mark(trans_idx);
             }
         }
+        // Refine all splitters where some transitions were marked.
         while (!touched_spls.empty()) {
-            const size_t p = touched_spls.top();
+            const size_t splitter_idx = touched_spls.top();
             touched_spls.pop();
-            const size_t p_prime = TRP.split(p);
-            if (p_prime != RefinablePartition<size_t>::NO_SPLIT) {
-                unready_spls.push(p_prime);
+            const size_t splitter_pime = TRP.split(splitter_idx);
+            if (splitter_pime != RefinablePartition<size_t>::NO_SPLIT) {
+                // Use the new splitter for further refinement of the equivalence classes.
+                unready_spls.push(splitter_pime);
             }
         }
     };
 
-    // Main loop.
-    for (size_t p = 0; p < TRP.sets; ++p) {
-        unready_spls.push(p);
+    // Use all splitters for the initial refinement.
+    for (size_t splitter_idx = 0; splitter_idx < TRP.num_of_sets; ++splitter_idx) {
+        unready_spls.push(splitter_idx);
     }
-    for (const State q : aut.final) {
+
+    // In the first refinement, we split the equivalence classes according to the final states.
+    for (const State q : dfa_trimmed.final) {
         BRP.mark(q);
     }
     split_block(0);
+
+    // Main loop of the Hopcroft's algorithm.
     while (!unready_spls.empty()) {
-        const size_t p = unready_spls.top();
+        const size_t splitter_idx = unready_spls.top();
         unready_spls.pop();
-        for (size_t t = TRP.get_first(p); t != RefinablePartition<size_t>::ELEM_NOT_FOUND; t = TRP.get_next(t)) {
-            const State q = trans_source_map[t];
-            const size_t b_prime = BRP.set(q);
+        // Backpropagation.
+        // Fire back all transitions of the splitter. (Transitions over the same
+        // symbol that go to the same block.) Mark the source states of these transitions.
+        for (size_t trans_idx = TRP.get_first(splitter_idx); trans_idx != RefinablePartition<size_t>::NO_MORE_ELEMENTS; trans_idx = TRP.get_next(trans_idx)) {
+            const State q = trans_source_map[trans_idx];
+            const size_t b_prime = BRP.set_idx[q];
             if (BRP.no_marks(b_prime)) {
                 touched_blocks.push(b_prime);
             }
             BRP.mark(q);
         }
+        // Try to split the blocks touched during the backpropagation.
+        // The block will be split only if some states (not all) were touched (marked).
         while (!touched_blocks.empty()) {
             const size_t b = touched_blocks.top();
             touched_blocks.pop();
@@ -1260,19 +1258,19 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& aut) {
         }
     }
 
-    // Construct the minimized automaton.
-    assert(aut.initial.size() == 1);
-    Nfa result(BRP.sets, StateSet{ BRP.set(*aut.initial.begin()) }, StateSet{});
-    for (size_t p = 0; p < BRP.sets; ++p) {
-        const State q = BRP.get_first(p);
-        if (aut.final.contains(q)) {
-            result.final.insert(p);
+    // Construct the minimized automaton using equivalence classes (BRP).
+    assert(dfa_trimmed.initial.size() == 1);
+    Nfa result(BRP.num_of_sets, StateSet{ BRP.set_idx[*dfa_trimmed.initial.begin()] }, StateSet{});
+    for (size_t block_idx = 0; block_idx < BRP.num_of_sets; ++block_idx) {
+        const State q = BRP.get_first(block_idx);
+        if (dfa_trimmed.final.contains(q)) {
+            result.final.insert(block_idx);
         }
-        StatePost &mut_post = result.delta.mutable_state_post(p);
-        for (const SymbolPost &symbol_post : aut.delta[q]) {
+        StatePost &mut_state_post = result.delta.mutable_state_post(block_idx);
+        for (const SymbolPost &symbol_post : dfa_trimmed.delta[q]) {
             assert(symbol_post.targets.size() == 1);
-            const State target = BRP.set(*symbol_post.targets.begin());
-            mut_post.push_back(SymbolPost{ symbol_post.symbol, StateSet{ target } });
+            const State target = BRP.set_idx[*symbol_post.targets.begin()];
+            mut_state_post.push_back(SymbolPost{ symbol_post.symbol, StateSet{ target } });
         }
     }
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1203,10 +1203,11 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& aut) {
 
     std::stack<size_t> unready_spls;
     std::stack<size_t> touched_blocks;
+    std::stack<size_t> touched_spls;
 
     // Split the block.
     auto split_block = [&](size_t b) {
-        std::stack<size_t> touched_spls;
+        assert(touched_spls.empty());
         size_t b_prime = BRP.split(b);
         if (b_prime == RefinablePartition<size_t>::NO_SPLIT) {
             return;

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -963,15 +963,15 @@ public:
     static_assert(std::is_unsigned<T>::value, "T must be an unsigned type.");
     static const T NO_MORE_ELEMENTS = std::numeric_limits<T>::max();
     static const size_t NO_SPLIT = std::numeric_limits<size_t>::max();
-    size_t num_of_sets;            // The number of sets in the partition.
-    std::vector<size_t> set_idx;   // For each element, tells the index of the set it belongs to.
+    size_t num_of_sets;            ///< The number of sets in the partition.
+    std::vector<size_t> set_idx;   ///< For each element, tells the index of the set it belongs to.
 
 private:
-    std::vector<T> elems;       // Contains all elements in an order such that the elements of the same set are contiguous.
-    std::vector<T> location;    // Contains the location of each element in the elements vector.
-    std::vector<size_t> first;  // Contains the index of the first element of each set in the elements vector.
-    std::vector<size_t> end;    // Contains the index after the last element of each set in the elements vector.
-    std::vector<size_t> mid;    // Contains the index after the last element of the first half of the set in the elements vector.
+    std::vector<T> elems;       ///< Contains all elements in an order such that the elements of the same set are contiguous.
+    std::vector<T> location;    ///< Contains the location of each element in the elements vector.
+    std::vector<size_t> first;  ///< Contains the index of the first element of each set in the elements vector.
+    std::vector<size_t> end;    ///< Contains the index after the last element of each set in the elements vector.
+    std::vector<size_t> mid;    ///< Contains the index after the last element of the first half of the set in the elements vector.
 
 public:
     /**
@@ -1058,6 +1058,31 @@ public:
         : elems(std::move(other.elems)), set_idx(std::move(other.set_idx)), location(std::move(other.location)),
           first(std::move(other.first)), end(std::move(other.end)), mid(std::move(other.mid)), num_of_sets(other.num_of_sets) {}
 
+    RefinablePartition& operator=(const RefinablePartition &other) {
+        if (this != &other) {
+            elems = other.elems;
+            set_idx = other.set_idx;
+            location = other.location;
+            first = other.first;
+            end = other.end;
+            mid = other.mid;
+            num_of_sets = other.num_of_sets;
+        }
+        return *this;
+    }
+
+    RefinablePartition& operator=(RefinablePartition &&other) noexcept {
+        if (this != &other) {
+            elems = std::move(other.elems);
+            set_idx = std::move(other.set_idx);
+            location = std::move(other.location);
+            first = std::move(other.first);
+            end = std::move(other.end);
+            mid = std::move(other.mid);
+            num_of_sets = other.num_of_sets;
+        }
+        return *this;
+    }
 
     /**
      * @brief Get the number of elements across all sets.
@@ -1159,17 +1184,17 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     assert(dfa_trimmed.get_useful_states().size() == dfa_trimmed.num_of_states());
 
     // Initialize equivalence classes. The initial partition is {Q}.
-    RefinablePartition<State> BRP(dfa_trimmed.num_of_states());
+    RefinablePartition<State> brp(dfa_trimmed.num_of_states());
     // Initialize splitters. A splitter is a set of transitions
     // over a common symbol incoming to an equivalence class. Initially,
     // the partition has m splitters, where m is the alphabet size.
-    RefinablePartition<size_t> TRP(dfa_trimmed.delta);
+    RefinablePartition<size_t> trp(dfa_trimmed.delta);
 
     // Initialize vector of incoming transitions for each state. Transitions
     // are represented only by their indices in the (flattened) delta.
     // Initialize mapping from transition index to its source state.
-    std::vector<State> trans_source_map(TRP.size());
-    std::vector<std::vector<size_t>> incomming_trans_idxs(BRP.size(), std::vector<size_t>());
+    std::vector<State> trans_source_map(trp.size());
+    std::vector<std::vector<size_t>> incomming_trans_idxs(brp.size(), std::vector<size_t>());
     size_t trans_idx = 0;
     for (const auto &trans : dfa_trimmed.delta.transitions()) {
         trans_source_map[trans_idx] = trans.source;
@@ -1190,32 +1215,32 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     auto split_block = [&](size_t b) {
         // touched_spls has been moved to a higher scope to avoid multiple constructions/destructions.
         assert(touched_spls.empty());
-        size_t b_prime = BRP.split(b);  // One block will keep the old name 'b'.
+        size_t b_prime = brp.split(b);  // One block will keep the old name 'b'.
         if (b_prime == RefinablePartition<size_t>::NO_SPLIT) {
             // All or no states in the block were marked (touched) during the backpropagation.
             return;
         }
         // According to the Hopcroft's algorithm, it is sufficient to work only with the smaller block.
-        if (BRP.size_of_set(b) < BRP.size_of_set(b_prime)) {
+        if (brp.size_of_set(b) < brp.size_of_set(b_prime)) {
             b_prime = b;
         }
         // Split the transitions of the splitters according to the new partitioning.
         // Transitions in one splitter must have the same symbol and go to the same block.
-        for (State q = BRP.get_first(b_prime); q != RefinablePartition<State>::NO_MORE_ELEMENTS; q = BRP.get_next(q)) {
+        for (State q = brp.get_first(b_prime); q != RefinablePartition<State>::NO_MORE_ELEMENTS; q = brp.get_next(q)) {
             for (const size_t trans_idx : incomming_trans_idxs[q]) {
-                const size_t splitter_idx = TRP.set_idx[trans_idx];
-                if (TRP.no_marks(splitter_idx)) {
+                const size_t splitter_idx = trp.set_idx[trans_idx];
+                if (trp.no_marks(splitter_idx)) {
                     touched_spls.push(splitter_idx);
                 }
                 // Mark the transition in the splitter and move it to the first half of the set.
-                TRP.mark(trans_idx);
+                trp.mark(trans_idx);
             }
         }
         // Refine all splitters where some transitions were marked.
         while (!touched_spls.empty()) {
             const size_t splitter_idx = touched_spls.top();
             touched_spls.pop();
-            const size_t splitter_pime = TRP.split(splitter_idx);
+            const size_t splitter_pime = trp.split(splitter_idx);
             if (splitter_pime != RefinablePartition<size_t>::NO_SPLIT) {
                 // Use the new splitter for further refinement of the equivalence classes.
                 unready_spls.push(splitter_pime);
@@ -1224,13 +1249,13 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     };
 
     // Use all splitters for the initial refinement.
-    for (size_t splitter_idx = 0; splitter_idx < TRP.num_of_sets; ++splitter_idx) {
+    for (size_t splitter_idx = 0; splitter_idx < trp.num_of_sets; ++splitter_idx) {
         unready_spls.push(splitter_idx);
     }
 
     // In the first refinement, we split the equivalence classes according to the final states.
     for (const State q : dfa_trimmed.final) {
-        BRP.mark(q);
+        brp.mark(q);
     }
     split_block(0);
 
@@ -1241,13 +1266,13 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
         // Backpropagation.
         // Fire back all transitions of the splitter. (Transitions over the same
         // symbol that go to the same block.) Mark the source states of these transitions.
-        for (size_t trans_idx = TRP.get_first(splitter_idx); trans_idx != RefinablePartition<size_t>::NO_MORE_ELEMENTS; trans_idx = TRP.get_next(trans_idx)) {
+        for (size_t trans_idx = trp.get_first(splitter_idx); trans_idx != RefinablePartition<size_t>::NO_MORE_ELEMENTS; trans_idx = trp.get_next(trans_idx)) {
             const State q = trans_source_map[trans_idx];
-            const size_t b_prime = BRP.set_idx[q];
-            if (BRP.no_marks(b_prime)) {
+            const size_t b_prime = brp.set_idx[q];
+            if (brp.no_marks(b_prime)) {
                 touched_blocks.push(b_prime);
             }
-            BRP.mark(q);
+            brp.mark(q);
         }
         // Try to split the blocks touched during the backpropagation.
         // The block will be split only if some states (not all) were touched (marked).
@@ -1260,16 +1285,16 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
 
     // Construct the minimized automaton using equivalence classes (BRP).
     assert(dfa_trimmed.initial.size() == 1);
-    Nfa result(BRP.num_of_sets, StateSet{ BRP.set_idx[*dfa_trimmed.initial.begin()] }, StateSet{});
-    for (size_t block_idx = 0; block_idx < BRP.num_of_sets; ++block_idx) {
-        const State q = BRP.get_first(block_idx);
+    Nfa result(brp.num_of_sets, StateSet{ brp.set_idx[*dfa_trimmed.initial.begin()] }, StateSet{});
+    for (size_t block_idx = 0; block_idx < brp.num_of_sets; ++block_idx) {
+        const State q = brp.get_first(block_idx);
         if (dfa_trimmed.final.contains(q)) {
             result.final.insert(block_idx);
         }
         StatePost &mut_state_post = result.delta.mutable_state_post(block_idx);
         for (const SymbolPost &symbol_post : dfa_trimmed.delta[q]) {
             assert(symbol_post.targets.size() == 1);
-            const State target = BRP.set_idx[*symbol_post.targets.begin()];
+            const State target = brp.set_idx[*symbol_post.targets.begin()];
             mut_state_post.push_back(SymbolPost{ symbol_post.symbol, StateSet{ target } });
         }
     }

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1142,7 +1142,7 @@ public:
      * @param s The set index.
      * @return True if the set has no marked elements, false otherwise.
      */
-    inline bool no_marks(const size_t s) const { return mid[s] == first[s]; }
+    inline bool has_no_marks(const size_t s) const { return mid[s] == first[s]; }
 
     /**
      * @brief Split the set into two sets according to the marked elements (the mid).
@@ -1229,7 +1229,7 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
         for (State q = brp.get_first(b_prime); q != RefinablePartition<State>::NO_MORE_ELEMENTS; q = brp.get_next(q)) {
             for (const size_t trans_idx : incomming_trans_idxs[q]) {
                 const size_t splitter_idx = trp.set_idx[trans_idx];
-                if (trp.no_marks(splitter_idx)) {
+                if (trp.has_no_marks(splitter_idx)) {
                     touched_spls.push(splitter_idx);
                 }
                 // Mark the transition in the splitter and move it to the first half of the set.
@@ -1269,7 +1269,7 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
         for (size_t trans_idx = trp.get_first(splitter_idx); trans_idx != RefinablePartition<size_t>::NO_MORE_ELEMENTS; trans_idx = trp.get_next(trans_idx)) {
             const State q = trans_source_map[trans_idx];
             const size_t b_prime = brp.set_idx[q];
-            if (brp.no_marks(b_prime)) {
+            if (brp.has_no_marks(b_prime)) {
                 touched_blocks.push(b_prime);
             }
             brp.mark(q);

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -980,7 +980,7 @@ public:
      * @param n The number of states.
      */
     RefinablePartition(const size_t num_of_states)
-        : num_of_sets(1), elems(num_of_states), location(num_of_states), set_idx(num_of_states),
+        : num_of_sets(1), set_idx(num_of_states), elems(num_of_states), location(num_of_states),
           first(num_of_states), end(num_of_states), mid(num_of_states) {
         // Initially, all states are in the same equivalence class.
         first[0] = mid[0] = 0;
@@ -998,7 +998,7 @@ public:
      * @param delta The transition function.
      */
     RefinablePartition(const Delta &delta)
-        : num_of_sets(0), elems(), location(), set_idx(), first(), end(), mid() {
+        : num_of_sets(0), set_idx(), elems(), location(), first(), end(), mid() {
         size_t num_of_transitions = 0;
         std::vector<size_t> counts;
         std::unordered_map<Symbol, size_t> symbol_map;
@@ -1051,11 +1051,11 @@ public:
     }
 
     RefinablePartition(const RefinablePartition &other)
-        : elems(other.elems), location(other.location), set_idx(other.set_idx),
+        : elems(other.elems), set_idx(other.set_idx), location(other.location),
           first(other.first), end(other.end), mid(other.mid), num_of_sets(other.num_of_sets) {}
 
     RefinablePartition(RefinablePartition &&other) noexcept
-        : elems(std::move(other.elems)), location(std::move(other.location)), set_idx(std::move(other.set_idx)),
+        : elems(std::move(other.elems)), set_idx(std::move(other.set_idx)), location(std::move(other.location)),
           first(std::move(other.first)), end(std::move(other.end)), mid(std::move(other.mid)), num_of_sets(other.num_of_sets) {}
 
 

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2858,6 +2858,97 @@ TEST_CASE("mata::nfa::reduce_size_by_simulation()")
     }
 }
 
+TEST_CASE("mata::nfa::algorithms::minimize_hopcroft()") {
+    SECTION("empty automaton") {
+        Nfa aut;
+        Nfa result = minimize_hopcroft(aut);
+        CHECK(result.is_lang_empty());
+    }
+
+    SECTION("one state") {
+        Nfa aut(1);
+        aut.initial.insert(0);
+        aut.final.insert(0);
+        Nfa result = minimize_hopcroft(aut);
+        CHECK(result.delta.num_of_transitions() == 0);
+        CHECK(result.num_of_states() == 1);
+        CHECK(result.initial.size() == 1);
+        CHECK(result.final.size() == 1);
+        CHECK(result.initial == result.final);
+    }
+
+    SECTION("one trans") {
+        Nfa aut(2);
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.delta.add(0, 'a', 1);
+        Nfa result = minimize_hopcroft(aut);
+        CHECK(result.delta.num_of_transitions() == 1);
+        CHECK(result.num_of_states() == 2);
+        CHECK(result.initial.size() == 1);
+        CHECK(result.final.size() == 1);
+        CHECK(result.initial != result.final);
+        CHECK(are_equivalent(aut, result));
+    }
+
+    SECTION("line") {
+        Nfa aut(3);
+        aut.initial.insert(0);
+        aut.final.insert(2);
+        aut.delta.add(0, 'a', 1);
+        aut.delta.add(1, 'a', 2);
+        aut.delta.add(2, 'a', 3);
+        Nfa result = minimize_hopcroft(aut);
+        CHECK(result.delta.num_of_transitions() == 3);
+        CHECK(result.num_of_states() == 4);
+        CHECK(result.initial.size() == 1);
+        CHECK(result.final.size() == 1);
+        CHECK(result.initial != result.final);
+        CHECK(are_equivalent(aut, result));
+    }
+
+    SECTION("loop") {
+        Nfa aut;
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.delta.add(0, 1, 2);
+        aut.delta.add(1, 0, 1);
+        aut.delta.add(1, 1, 1);
+        aut.delta.add(2, 1, 1);
+
+        Nfa aut_brz = minimize_brzozowski(aut);
+        Nfa aut_hop = minimize_hopcroft(aut);
+        CHECK(are_equivalent(aut_brz, aut_hop));
+        CHECK(aut_brz.num_of_states() == aut_hop.num_of_states());
+        CHECK(aut_brz.delta.num_of_transitions() == aut_hop.delta.num_of_transitions());
+        CHECK(aut_brz.initial.size() == aut_hop.initial.size());
+        CHECK(aut_brz.final.size() == aut_hop.final.size());
+    }
+
+    SECTION("difficult") {
+        Nfa aut;
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.final.insert(6);
+        aut.delta.add(0, 0, 1);
+        aut.delta.add(1, 0, 2);
+        aut.delta.add(2, 0, 4);
+        aut.delta.add(4, 1, 5);
+        aut.delta.add(4, 0, 3);
+        aut.delta.add(5, 0, 6);
+        aut.delta.add(3, 0, 1);
+
+        Nfa aut_brz = minimize_brzozowski(aut);
+        Nfa aut_hop = minimize_hopcroft(aut);
+        CHECK(are_equivalent(aut_brz, aut_hop));
+        CHECK(aut_brz.num_of_states() == aut_hop.num_of_states());
+        CHECK(aut_brz.delta.num_of_transitions() == aut_hop.delta.num_of_transitions());
+        CHECK(aut_brz.initial.size() == aut_hop.initial.size());
+        CHECK(aut_brz.final.size() == aut_hop.final.size());
+    }
+
+}
+
 TEST_CASE("mata::nfa::reduce_size_by_residual()") {
     Nfa aut;
     StateRenaming state_renaming;


### PR DESCRIPTION
This PR introduces the implementation of Valmaria and Lehtinin's variant of Hopcroft's minimization of *deterministic finite automata* with partial transition function.

The performance of this reduction method was tested against Brzozowski's minimization and simulation on **determinized automata** obtained from:
1) Abstract Regular Model Checking,
2) automata generated during the decision process of WS1S logic,
3) automata for regular expressions sourced from RegexLib,
4) automata for regular expressions used in email validation obtained as in [MFPS'17](https://www.cs.princeton.edu/~zkincaid/pub/mfps17.pdf) and in [APLAS'21](https://dl.acm.org/doi/10.1007/978-3-030-89051-3_14),
5) automata for [string constraints derived from Norn and SyGuS-qgen and Others](https://github.com/VeriFIT/nfa-bench/tree/master/benchmarks/bool_comb/ere), and
6) Tabakov-Vardi random automata.

## Timeouts
The timeout was set to 10 seconds.
| Method       | Timeout Count |
| :------------|--------------:|
| Brzozowski   | 2,167          |
| Simulation   | 2,308          |
| Hopcroft     | 481           |

## All Benchmarks
It can be seen that Hopcoroft's algorithm is, on average, **100x faster** than Brzozowski or the simulation.
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/88eef8fc-b7a6-478d-8ff1-67ce831a2eb8)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/e6e9bbe3-7afe-4428-aefb-061e75aee8ca)

## Abstract Regular Model Checking
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/72570358-694e-4260-9ec8-4e45145f9884)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/9d7ed005-86ab-4998-b3ad-7dda3e0773fa)

## WS1S logic
These automate have a binary alphabet.
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/04991248-3bd6-4def-9558-bf4b69cc7c20)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/c86dff68-9cc9-42e0-b5aa-a68636e7e7ab)

## RegexLib
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/a203c3d7-7135-4706-aa34-b37f9c422eab)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/195d46af-c247-46c1-a992-4caa335d3471)

## Email Validation
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/f8685fd8-ab7f-4200-b84a-e0ed17ef2415)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/e0bca1c0-49d9-4d1f-900f-72ef124f0642)

## Norn and SyGuS-qgen and Others
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/ce81a343-6138-4461-839f-58572153c744)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/01d7246e-3b8d-4fe7-b068-041cec0d12e0)

## Tabakov-Vardi
Automata were generated with 10, 50, 100, and 200 states, for alphabets containing 2, 4, 8, and 16 symbols, and with a transitions-to-states ratio per symbol ranging from 0.1 to 1.
### Cactus Plot
![cactus](https://github.com/user-attachments/assets/99497ca5-78d4-4014-bdaf-ae0e5d55c92f)
### Scatter Plot Matrix
![scatter](https://github.com/user-attachments/assets/bb199c4c-1308-4043-85b3-0ffd5511a0ea)


