### PR TITLE
Create Nft with inverted levels (tapes)

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -135,6 +135,11 @@ public:
     ///returns an iterator to the smallest epsilon, or end() if there is no epsilon
     const_iterator first_epsilon_it(Symbol first_epsilon) const;
 
+    /**
+     * @brief Get the set of all target states in the @c StatePost.
+     * @return Set of all target states in the @c StatePost.
+     */
+    StateSet get_successors() const;
 
     /**
      * @brief Iterator over moves represented as @c Move instances.
@@ -166,7 +171,7 @@ public:
         StatePost::const_iterator symbol_post_it_{}; ///< Current symbol post iterator to iterate over.
         /// End symbol post iterator which is no longer iterated over (one after the last symbol post iterated over or
         ///  end()).
-        StatePost::const_iterator symbol_post_end_{}; 
+        StatePost::const_iterator symbol_post_end_{};
     }; // class Moves.
 
     /**
@@ -221,7 +226,7 @@ public:
     /// Const all moves iterator.
     const_iterator(const StatePost& state_post);
     /// Construct iterator from @p symbol_post_it (including) to @p symbol_post_it_end (excluding).
-    const_iterator(const StatePost& state_post, StatePost::const_iterator symbol_post_it, 
+    const_iterator(const StatePost& state_post, StatePost::const_iterator symbol_post_it,
                    StatePost::const_iterator symbol_post_it_end);
     const_iterator(const const_iterator& other) noexcept = default;
     const_iterator(const_iterator&&) = default;
@@ -456,6 +461,23 @@ public:
      * Operation is slow, traverses over all symbol posts.
      */
     std::vector<Transition> get_transitions_to(State state_to) const;
+
+    /**
+     * Get transitions from @p state_from to @p state_to.
+     * @param state_from[in] Source state.
+     * @param state_from[in] Target state.
+     * @return Transitions from @p source to @p state_to.
+     *
+     * Operation is slow, traverses over all symbol posts.
+     */
+    std::vector<Transition> get_transitions_between(State state_from, State state_to) const;
+
+    /**
+     * Get the set of states that are successors of the given @p state.
+     * @param[in] state State from which successors are checked.
+     * @return Set of states that are successors of the given @p state.
+     */
+    StateSet get_successors(State state) const;
 
     /**
      * Iterate over @p epsilon symbol posts under the given @p state.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -67,6 +67,13 @@ public:
      * @param[in] levels_vector Vector of levels to be appended.
      */
     void append(const Levels& levels_vector) { for (const Level& level: levels_vector) { push_back(level); } }
+
+    /**
+     * @brief Count the number of occurrences of a level in @c this.
+     *
+     * @param[in] level Level to be counted.
+     */
+    size_t count(Level level) const { return std::count(begin(), end(), level); }
 };
 
 /**
@@ -166,6 +173,12 @@ public:
      * @return The requested @p state.
      */
     State add_state_with_level(State state, Level level);
+
+    /**
+     * Get the number of states with level @p level.
+     * @return The number of states with level @p level.
+     */
+    size_t num_of_states_with_level(Level level) const;
 
     /**
      * Inserts a @p word into the NFT from a source state @p source to a target state @p target.
@@ -758,6 +771,20 @@ Nft simple_revert(const Nft& aut);
 // It replaces random access addition to SymbolPost by push_back and sorting later, so far seems the slowest of all, except on
 //  dense automata, where it is almost as slow as simple_revert. Candidate for removal.
 Nft somewhat_simple_revert(const Nft& aut);
+
+/**
+ * @brief Inverts the levels of the given transducer @p aut.
+ *
+ * The function inverts the levels of the transducer, i.e., the level 0 becomes the last level, level 1 becomes the
+ * second last level, and so on.
+ *
+ * @param[in] aut The transducer for inverting levels.
+ * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
+ * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
+ * of @c DONT_CARE symbols.
+ * @return A new transducer with inverted levels.
+ */
+Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 // Removing epsilon transitions
 Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -73,7 +73,7 @@ public:
      *
      * @param[in] level Level to be counted.
      */
-    size_t count(Level level) const { return std::count(begin(), end(), level); }
+    size_t count(Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
 };
 
 /**

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -61,6 +61,18 @@ StatePost::const_iterator Delta::epsilon_symbol_posts(const StatePost& state_pos
     return state_post.end();
 }
 
+StateSet StatePost::get_successors() const {
+    StateSet successors;
+    for (const SymbolPost& symbol_post: *this) {
+        successors.insert(symbol_post.targets);
+    }
+    return successors;
+}
+
+StateSet Delta::get_successors(const State state) const {
+    return state_post(state).get_successors();
+}
+
 std::vector<Transition> Delta::get_transitions_to(const State state_to) const {
     std::vector<Transition> transitions_to_state{};
     const size_t num_of_states{ this->num_of_states() };
@@ -73,6 +85,17 @@ std::vector<Transition> Delta::get_transitions_to(const State state_to) const {
         }
     }
     return transitions_to_state;
+}
+
+std::vector<Transition> Delta::get_transitions_between(const State state_from, const State state_to) const {
+    std::vector<Transition> transitions_between{};
+    for (const SymbolPost& symbol_post: state_post(state_from)) {
+        const StateSet::const_iterator state_to_find_it = symbol_post.targets.find(state_to);
+        if (state_to_find_it != symbol_post.targets.end()) {
+            transitions_between.push_back({ state_from, symbol_post.symbol, state_to });
+        }
+    }
+    return transitions_between;
 }
 
 void Delta::add(const State source, Symbol symbol, const State target) {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -23,6 +23,10 @@ using StateBoolArray = std::vector<bool>; ///< Bool array for states in the auto
 const std::string mata::nft::TYPE_NFT = "NFT";
 
 
+size_t Nft::num_of_states_with_level(const Level level) const {
+    return levels.count(level);
+}
+
 Nft& Nft::trim(StateRenaming* state_renaming) {
 
 #ifdef _STATIC_STRUCTURES_

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -754,7 +754,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
                 // It is a transition from a nonzero-state (inner state) to a zero-state (tail).
                 // Map it as transition from the zero-state (head) to that nonzero-state (inner state).
                 if (jump_mode == JumpMode::AppendDontCares && (aut.num_of_levels - aut.levels[src]) > 1) {
-                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - 1));
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut_inv.levels[renaming[src]] - 1));
                     aut_inv.delta.add(renaming[head], DONT_CARE, aux_state);
                     aut_inv.delta.add(aux_state, symbol, renaming[src]);
                 } else {
@@ -764,7 +764,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
                 // It is a transition between two nonzero-states (inner states).
                 // Just swap the source and target.
                 if (jump_mode == JumpMode::AppendDontCares && (aut.levels[trg] - aut.levels[src]) > 1) {
-                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.levels[trg] - 1));
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut_inv.levels[renaming[src]] - 1));
                     aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
                     aut_inv.delta.add(aux_state, symbol, renaming[src]);
                 } else {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -677,6 +677,120 @@ Nft mata::nft::revert(const Nft& aut) {
     //return somewhat_simple_revert(aut);
 }
 
+Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode = JumpMode::RepeatSymbol) {
+    const size_t num_of_states = aut.num_of_states();
+
+    // Find states with level zero and rename them.
+    std::vector<State> renaming(num_of_states, Limits::max_state);
+    size_t num_of_zerostates = 0;
+    for (State s = 0; s < num_of_states; ++s) {
+        if (aut.levels[s] == 0) {
+            renaming[s] = num_of_zerostates++;
+        }
+    }
+
+    // Rename initial states
+    SparseSet<State> new_initial;
+    for (const State s: aut.initial) {
+        new_initial.insert(renaming[s]);
+    }
+    // Rename final states
+    SparseSet<State> new_final;
+    for (const State s: aut.final) {
+        new_final.insert(renaming[s]);
+    }
+    // Create new automaton
+    Nft aut_inv = Nft(num_of_zerostates, std::move(new_initial), std::move(new_final), Levels(num_of_zerostates, 0), aut.num_of_levels, aut.alphabet);
+
+    // Main part of the algorithm.
+    // Invert each TREE between one root (zero-state) and all its leaves (zeor-states)
+    std::vector<SparseSet<State>> tree_leaves(num_of_zerostates);   // Indexed by tree root (zero-state).
+    std::queue<State> worklist;
+    for (State tree_root = 0; tree_root < num_of_states; ++tree_root) {
+        // Test if the state is a root of some tree.
+        if (aut.levels[tree_root] != 0) {
+            continue;   // Not a root.
+        }
+        // First, visit all states of the tree and create their inverted versions (with inverted levels) in aut_inv.
+        worklist.push(tree_root);
+        while (!worklist.empty()) {
+            State src = worklist.front();
+            worklist.pop();
+            for (const SymbolPost& move: aut.delta[src]) {
+                for (const State trg: move.targets) {
+                    if (aut.levels[trg] == 0) {
+                        // A leaf has been reached.
+                        tree_leaves[tree_root].insert(trg);
+                        continue;
+                    }
+                    // Create new state wiht inverted level.
+                    State tgt_inv = aut_inv.add_state_with_level(aut.num_of_levels - aut.levels[trg]);
+                    renaming[trg] = tgt_inv;
+                    worklist.push(trg);
+                }
+            }
+        }
+
+        // Second, iterate over the tree again and map its transitions to aut_inv.
+        worklist.push(tree_root);
+        while (!worklist.empty()) {
+            State src = worklist.front();
+            worklist.pop();
+            for (const SymbolPost& move: aut.delta[src]) {
+                for (const State trg: move.targets) {
+                    const bool is_src_root = src == tree_root;
+                    const bool is_trg_leaf = aut.levels[trg] == 0;
+                    if (is_src_root && is_trg_leaf) {
+                        // It is a direct transition between two zero-states (the root and a leaf).
+                        // Just copy it.
+                        if (jump_mode == JumpMode::AppendDontCares && aut.num_of_levels > 1) {
+                            const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
+                            aut_inv.delta.add(renaming[src], DONT_CARE, aux_state);
+                            aut_inv.delta.add(aux_state, move.symbol, renaming[trg]);
+                        } else {
+                            aut_inv.delta.add(renaming[src], move.symbol, renaming[trg]);
+                        }
+                    } else if (is_src_root) {
+                        // It is a transition from a zero-state (root) to a nonzero-state (inner node).
+                        // Map it as transitions from that nonzero-state (inner node) to all tree leaves (zero-states).
+                        for (const State tree_trg: tree_leaves[tree_root]) {
+                            if (jump_mode == JumpMode::AppendDontCares && aut.levels[trg] > 1) {
+                                const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
+                                aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
+                                aut_inv.delta.add(aux_state, move.symbol, renaming[tree_trg]);
+                            } else {
+                                aut_inv.delta.add(renaming[trg], move.symbol, renaming[tree_trg]);
+                            }
+                        }
+                    } else if (is_trg_leaf) {
+                        // It is a transition from a nonzero-state (inner node) to a zero-state (leaf).
+                        // Map it as transitions from a zero-state (root) to that nonzero-state (inner node).
+                        if (jump_mode == JumpMode::AppendDontCares && (aut.num_of_levels - aut.levels[src]) > 1) {
+                            const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
+                            aut_inv.delta.add(renaming[tree_root], DONT_CARE, aux_state);
+                            aut_inv.delta.add(aux_state, move.symbol, renaming[src]);
+                        } else {
+                            aut_inv.delta.add(renaming[tree_root], move.symbol, renaming[src]);
+                        }
+                    } else {
+                        // It is a transition between two nonzero-states (inner nodes).
+                        // Just swap the source and target.
+                        if (jump_mode == JumpMode::AppendDontCares && (aut.levels[trg] - aut.levels[src]) > 1) {
+                            const State aux_state = aut_inv.add_state_with_level(aut.levels[trg] - 1);
+                            aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
+                            aut_inv.delta.add(aux_state, move.symbol, renaming[src]);
+                        } else {
+                            aut_inv.delta.add(renaming[trg], move.symbol, renaming[src]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return aut_inv;
+}
+
 std::pair<Run, bool> mata::nft::Nft::get_word_for_path(const Run& run) const {
     if (run.path.empty()) { return {{}, true}; }
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -677,7 +677,7 @@ Nft mata::nft::revert(const Nft& aut) {
     //return somewhat_simple_revert(aut);
 }
 
-Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode = JumpMode::RepeatSymbol) {
+Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
     const size_t num_of_states = aut.num_of_states();
 
     // Find states with level zero and rename them.
@@ -702,88 +702,104 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode = JumpMode
     // Create new automaton
     Nft aut_inv = Nft(num_of_zerostates, std::move(new_initial), std::move(new_final), Levels(num_of_zerostates, 0), aut.num_of_levels, aut.alphabet);
 
-    // Main part of the algorithm.
-    // Invert each TREE between one root (zero-state) and all its leaves (zeor-states)
-    std::vector<SparseSet<State>> tree_leaves(num_of_zerostates);   // Indexed by tree root (zero-state).
-    std::queue<State> worklist;
-    for (State tree_root = 0; tree_root < num_of_states; ++tree_root) {
-        // Test if the state is a root of some tree.
-        if (aut.levels[tree_root] != 0) {
-            continue;   // Not a root.
+    // Creates new states with inverted levels for each inner state in the path.
+    auto create_states_with_inverted_levels = [&](const std::vector<State>& path_states) {
+        for (const State s: path_states) {
+            if (aut.levels[s] == 0) { continue; }
+            renaming[s] = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - aut.levels[s]));
         }
-        // First, visit all states of the tree and create their inverted versions (with inverted levels) in aut_inv.
-        worklist.push(tree_root);
-        while (!worklist.empty()) {
-            State src = worklist.front();
-            worklist.pop();
-            for (const SymbolPost& move: aut.delta[src]) {
-                for (const State trg: move.targets) {
-                    if (aut.levels[trg] == 0) {
-                        // A leaf has been reached.
-                        tree_leaves[tree_root].insert(trg);
-                        continue;
-                    }
-                    // Create new state wiht inverted level.
-                    State tgt_inv = aut_inv.add_state_with_level(aut.num_of_levels - aut.levels[trg]);
-                    renaming[trg] = tgt_inv;
-                    worklist.push(trg);
+    };
+
+    // Returns transitions of the path.
+    auto get_path_transitions = [&](const std::vector<State>& path_states) {
+        std::vector<Transition> path_transitions;
+        for (size_t i = 0; i < path_states.size() - 1; ++i) {
+            const State src = path_states[i];
+            const State trg = path_states[i + 1];
+            std::vector<Transition> transitions_between = aut.delta.get_transitions_between(src, trg);
+            path_transitions.insert(path_transitions.end(), transitions_between.begin(), transitions_between.end());
+        }
+
+        return path_transitions;
+    };
+
+    // Creates inverted transitions for each transition in the path.
+    // Can work with different jump modes.
+    auto map_inverted_transitions = [&](const std::vector<Transition>& path, const State head, const State tail) {
+        for (const auto &[src, symbol, trg]: path) {
+            const bool is_src_head = src == head;
+            const bool is_trg_tail = trg == tail;
+            if (is_src_head && is_trg_tail) {
+                // It is a direct transition between two zero-states (the head and the tail).
+                // Just copy it.
+                if (jump_mode == JumpMode::AppendDontCares && aut.num_of_levels > 1) {
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - 1));
+                    aut_inv.delta.add(renaming[src], DONT_CARE, aux_state);
+                    aut_inv.delta.add(aux_state, symbol, renaming[trg]);
+                } else {
+                    aut_inv.delta.add(renaming[src], symbol, renaming[trg]);
+                }
+            } else if (is_src_head) {
+                // It is a transition from a zero-state (head) to a nonzero-state (inner state).
+                // Map it as transition from that nonzero-state (inner state) to the tail (zero-states).
+                if (jump_mode == JumpMode::AppendDontCares && aut.levels[trg] > 1) {
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - 1));
+                    aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
+                    aut_inv.delta.add(aux_state, symbol, renaming[tail]);
+                } else {
+                    aut_inv.delta.add(renaming[trg], symbol, renaming[tail]);
+                }
+
+            } else if (is_trg_tail) {
+                // It is a transition from a nonzero-state (inner state) to a zero-state (tail).
+                // Map it as transition from the zero-state (head) to that nonzero-state (inner state).
+                if (jump_mode == JumpMode::AppendDontCares && (aut.num_of_levels - aut.levels[src]) > 1) {
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - 1));
+                    aut_inv.delta.add(renaming[head], DONT_CARE, aux_state);
+                    aut_inv.delta.add(aux_state, symbol, renaming[src]);
+                } else {
+                    aut_inv.delta.add(renaming[head], symbol, renaming[src]);
+                }
+            } else {
+                // It is a transition between two nonzero-states (inner states).
+                // Just swap the source and target.
+                if (jump_mode == JumpMode::AppendDontCares && (aut.levels[trg] - aut.levels[src]) > 1) {
+                    const State aux_state = aut_inv.add_state_with_level(static_cast<Level>(aut.levels[trg] - 1));
+                    aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
+                    aut_inv.delta.add(aux_state, symbol, renaming[src]);
+                } else {
+                    aut_inv.delta.add(renaming[trg], symbol, renaming[src]);
                 }
             }
         }
+    };
 
-        // Second, iterate over the tree again and map its transitions to aut_inv.
-        worklist.push(tree_root);
-        while (!worklist.empty()) {
-            State src = worklist.front();
-            worklist.pop();
-            for (const SymbolPost& move: aut.delta[src]) {
-                for (const State trg: move.targets) {
-                    const bool is_src_root = src == tree_root;
-                    const bool is_trg_leaf = aut.levels[trg] == 0;
-                    if (is_src_root && is_trg_leaf) {
-                        // It is a direct transition between two zero-states (the root and a leaf).
-                        // Just copy it.
-                        if (jump_mode == JumpMode::AppendDontCares && aut.num_of_levels > 1) {
-                            const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
-                            aut_inv.delta.add(renaming[src], DONT_CARE, aux_state);
-                            aut_inv.delta.add(aux_state, move.symbol, renaming[trg]);
-                        } else {
-                            aut_inv.delta.add(renaming[src], move.symbol, renaming[trg]);
-                        }
-                    } else if (is_src_root) {
-                        // It is a transition from a zero-state (root) to a nonzero-state (inner node).
-                        // Map it as transitions from that nonzero-state (inner node) to all tree leaves (zero-states).
-                        for (const State tree_trg: tree_leaves[tree_root]) {
-                            if (jump_mode == JumpMode::AppendDontCares && aut.levels[trg] > 1) {
-                                const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
-                                aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
-                                aut_inv.delta.add(aux_state, move.symbol, renaming[tree_trg]);
-                            } else {
-                                aut_inv.delta.add(renaming[trg], move.symbol, renaming[tree_trg]);
-                            }
-                        }
-                    } else if (is_trg_leaf) {
-                        // It is a transition from a nonzero-state (inner node) to a zero-state (leaf).
-                        // Map it as transitions from a zero-state (root) to that nonzero-state (inner node).
-                        if (jump_mode == JumpMode::AppendDontCares && (aut.num_of_levels - aut.levels[src]) > 1) {
-                            const State aux_state = aut_inv.add_state_with_level(aut.num_of_levels - 1);
-                            aut_inv.delta.add(renaming[tree_root], DONT_CARE, aux_state);
-                            aut_inv.delta.add(aux_state, move.symbol, renaming[src]);
-                        } else {
-                            aut_inv.delta.add(renaming[tree_root], move.symbol, renaming[src]);
-                        }
-                    } else {
-                        // It is a transition between two nonzero-states (inner nodes).
-                        // Just swap the source and target.
-                        if (jump_mode == JumpMode::AppendDontCares && (aut.levels[trg] - aut.levels[src]) > 1) {
-                            const State aux_state = aut_inv.add_state_with_level(aut.levels[trg] - 1);
-                            aut_inv.delta.add(renaming[trg], DONT_CARE, aux_state);
-                            aut_inv.delta.add(aux_state, move.symbol, renaming[src]);
-                        } else {
-                            aut_inv.delta.add(renaming[trg], move.symbol, renaming[src]);
-                        }
-                    }
-                }
+    // Main loop of the algorithm.
+    for (State path_head = 0; path_head < num_of_states; ++path_head) {
+        // Test if the state is a head of some path.
+        if (aut.levels[path_head] != 0) {
+            continue;   // Not a head.
+        }
+        // Process all paths using dfs.
+        std::stack<std::pair<State, std::vector<State>>> stack;
+        stack.push({ path_head, { path_head } });
+        while (!stack.empty()) {
+            auto &[src, path] = stack.top();
+            stack.pop();
+
+            if (aut.levels[src] == 0 && path.size() > 1) {
+                // A tail of the path (src) has been reached.
+                create_states_with_inverted_levels(path);
+                const std::vector<Transition> path_transitions = get_path_transitions(path);
+                map_inverted_transitions(path_transitions, path.front(), path.back());
+                continue;
+            }
+
+            for (const State trg: aut.delta[src].get_successors()) {
+                // Extend the path.
+                std::vector<State> new_path = path;
+                new_path.push_back(trg);
+                stack.push({ trg, new_path });
             }
         }
     }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -784,7 +784,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
         std::stack<std::pair<State, std::vector<State>>> stack;
         stack.push({ path_head, { path_head } });
         while (!stack.empty()) {
-            auto &[src, path] = stack.top();
+            auto [src, path] = stack.top();
             stack.pop();
 
             if (aut.levels[src] == 0 && path.size() > 1) {
@@ -799,7 +799,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
                 // Extend the path.
                 std::vector<State> new_path = path;
                 new_path.push_back(trg);
-                stack.push({ trg, new_path });
+                stack.push({ trg, std::move(new_path) });
             }
         }
     }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2271,8 +2271,6 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.delta.add(5, 'j', 4);
             Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
 
-            aut_new.print_to_dot(std::cerr);
-
             Nft expected = Nft(18);
             expected.initial.insert(0);
             expected.final.insert(10);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1893,8 +1893,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, 'a', 2);
 
-            CHECK(aut_new.num_of_states() == 3);
-            CHECK(aut_new.delta.num_of_transitions() == 2);
+            CHECK(aut_new.num_of_states() <= 3);
+            CHECK(aut_new.delta.num_of_transitions() <= 2);
             CHECK(are_equivalent(aut_new, expected));
             CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
@@ -1921,8 +1921,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.delta.add(2, 'd', 3);
             expected.delta.add(3, 'c', 4);
 
-            CHECK(aut_new.num_of_states() == 5);
-            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(aut_new.num_of_states() <= 5);
+            CHECK(aut_new.delta.num_of_transitions() <= 4);
             CHECK(are_equivalent(aut_new, expected));
             CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
@@ -1949,8 +1949,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'a', 3);
 
-            CHECK(aut_new.num_of_states() == 4);
-            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(aut_new.num_of_states() <= 4);
+            CHECK(aut_new.delta.num_of_transitions() <= 4);
             CHECK(are_equivalent(aut_new, expected));
             CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
@@ -1967,21 +1967,112 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.delta.add(0, 'd', 2);
             Nft aut_new = invert_levels(aut);
 
-            Nft expected = Nft(4);
+            Nft expected = Nft(5);
             expected.initial.insert(0);
-            expected.final.insert(3);
+            expected.final.insert(4);
             expected.num_of_levels = 4;
-            expected.levels = {0, 1, 3, 0};
+            expected.levels = {0, 1, 3, 1, 0};
             expected.delta.add(0, 'c', 1);
             expected.delta.add(1, 'b', 2);
-            expected.delta.add(2, 'a', 3);
-            expected.delta.add(1, 'd', 3);
+            expected.delta.add(2, 'a', 4);
+            expected.delta.add(0, 'c', 3);
+            expected.delta.add(3, 'd', 4);
 
-            CHECK(aut_new.num_of_states() == 4);
-            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(aut_new.num_of_states() == 5);
+            CHECK(aut_new.delta.num_of_transitions() == 5);
             CHECK(are_equivalent(aut_new, expected));
             CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
 
+        SECTION("Complex - 2 levels") {
+            Nft aut(5);
+            aut.initial.insert(0);
+            aut.final.insert(2);
+            aut.final.insert(4);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(1, 'd', 4);
+            aut.delta.add(2, 'c', 1);
+            aut.delta.add(2, 'e', 3);
+            aut.delta.add(3, 'g', 4);
+            aut.delta.add(4, 'f', 3);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(9);
+            expected.initial.insert(0);
+            expected.final.insert(2);
+            expected.final.insert(6);
+            expected.num_of_levels = 2;
+            expected.levels = { 0, 1, 0, 1, 1, 1, 0, 1, 1 };
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(0, 'd', 8);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(2, 'g', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'c', 2);
+            expected.delta.add(4, 'e', 6);
+            expected.delta.add(5, 'c', 6);
+            expected.delta.add(6, 'g', 7);
+            expected.delta.add(7, 'f', 6);
+            expected.delta.add(8, 'a', 6);
+
+            CHECK(aut_new.num_of_states() <= 9);
+            CHECK(aut_new.delta.num_of_transitions() <= 12);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("Complex 2 - 3 levels") {
+            Nft aut(6);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.final.insert(4);
+            aut.num_of_levels = 3;
+            aut.levels = { 0, 1, 2, 0, 0, 2 };
+            aut.delta.add(0, 'a', 3);
+            aut.delta.add(0, 'b', 2);
+            aut.delta.add(0, 'c', 1);
+            aut.delta.add(1, 'd', 2);
+            aut.delta.add(1, 'f', 3);
+            aut.delta.add(1, 'h', 4);
+            aut.delta.add(1, 'i', 5);
+            aut.delta.add(2, 'e', 3);
+            aut.delta.add(2, 'g', 4);
+            aut.delta.add(5, 'j', 4);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(13);
+            expected.initial.insert(0);
+            expected.final.insert(10);
+            expected.final.insert(11);
+            expected.num_of_levels = 3;
+            expected.levels = { 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1 };
+            expected.delta.add(0, 'a', 10);
+            expected.delta.add(0, 'e', 1);
+            expected.delta.add(0, 'e', 2);
+            expected.delta.add(0, 'f', 4);
+            expected.delta.add(0, 'h', 5);
+            expected.delta.add(0, 'g', 6);
+            expected.delta.add(0, 'j', 8);
+            expected.delta.add(0, 'g', 12);
+            expected.delta.add(1, 'b', 10);
+            expected.delta.add(2, 'd', 3);
+            expected.delta.add(3, 'c', 10);
+            expected.delta.add(4, 'c', 10);
+            expected.delta.add(5, 'c', 11);
+            expected.delta.add(6, 'd', 7);
+            expected.delta.add(7, 'c', 11);
+            expected.delta.add(8, 'i', 9);
+            expected.delta.add(9, 'c', 11);
+            expected.delta.add(12, 'b', 11);
+
+            CHECK(aut_new.num_of_states() <= 13);
+            CHECK(aut_new.delta.num_of_transitions() <= 18);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
 
     }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1978,8 +1978,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.delta.add(0, 'c', 3);
             expected.delta.add(3, 'd', 4);
 
-            CHECK(aut_new.num_of_states() == 5);
-            CHECK(aut_new.delta.num_of_transitions() == 5);
+            CHECK(aut_new.num_of_states() <= 5);
+            CHECK(aut_new.delta.num_of_transitions() <= 5);
             CHECK(are_equivalent(aut_new, expected));
             CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
@@ -2075,6 +2075,239 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             CHECK(are_equivalent(invert_levels(aut_new), aut));
         }
 
+    }
+
+    SECTION("jump mode == AppendDontCares") {
+        SECTION("empty automaton") {
+            Nft aut;
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+            CHECK(aut_new.num_of_states() == 0);
+            CHECK(are_equivalent(aut, aut_new, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("no transition only states") {
+            Nft aut(3);
+            aut.initial.insert(1);
+            aut.final.insert(2);
+            aut.num_of_levels = 1;
+            aut.levels = { 1, 0, 0 };
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+            CHECK(aut_new.is_lang_empty());
+            CHECK(aut_new.delta.num_of_transitions() == 0);
+            CHECK(are_equivalent(aut, aut_new, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Linear - 2 levels") {
+            Nft aut(3);
+            aut.initial.insert(0);
+            aut.final.insert(2);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            Nft expected = Nft(3);
+            expected.initial.insert(0);
+            expected.final.insert(2);
+            expected.num_of_levels = 2;
+            expected.levels = { 0, 1, 0 };
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(1, 'a', 2);
+
+            CHECK(aut_new.num_of_states() <= 3);
+            CHECK(aut_new.delta.num_of_transitions() <= 2);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Linear 2 - 2 levels") {
+            Nft aut(5);
+            aut.initial.insert(0);
+            aut.final.insert(4);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(3, 'd', 4);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            Nft expected = Nft(5);
+            expected.initial.insert(0);
+            expected.final.insert(4);
+            expected.num_of_levels = 2;
+            expected.levels = {0, 1, 0, 1, 0};
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'd', 3);
+            expected.delta.add(3, 'c', 4);
+
+            CHECK(aut_new.num_of_states() <= 5);
+            CHECK(aut_new.delta.num_of_transitions() <= 4);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Linear + long jump - 3 levels") {
+            Nft aut(4);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.num_of_levels = 3;
+            aut.levels = { 0, 1, 2, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(0, 'd', 3);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            Nft expected = Nft(5);
+            expected.initial.insert(0);
+            expected.final.insert(3);
+            expected.num_of_levels = 3;
+            expected.levels = {0, 1, 2, 0, 2};
+            expected.delta.add(0, 'c', 1);
+            expected.delta.add(0, DONT_CARE, 4);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(4, 'd', 3);
+
+            CHECK(aut_new.num_of_states() <= 5);
+            CHECK(aut_new.delta.num_of_transitions() <= 5);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Linear + long jump 2 - 4 levels") {
+            Nft aut(4);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.num_of_levels = 4;
+            aut.levels = { 0, 1, 3, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(0, 'd', 2);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            Nft expected = Nft(7);
+            expected.initial.insert(0);
+            expected.final.insert(4);
+            expected.num_of_levels = 4;
+            expected.levels = { 0, 1, 2, 3, 0, 1, 3 };
+            expected.delta.add(0, 'c', 1);
+            expected.delta.add(0, 'c', 5);
+            expected.delta.add(1, DONT_CARE, 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(3, 'a', 4);
+            expected.delta.add(5, DONT_CARE, 6);
+            expected.delta.add(6, 'd', 4);
+
+            CHECK(aut_new.num_of_states() <= 7);
+            CHECK(aut_new.delta.num_of_transitions() <= 7);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Complex - 2 levels") {
+            Nft aut(5);
+            aut.initial.insert(0);
+            aut.final.insert(2);
+            aut.final.insert(4);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(1, 'd', 4);
+            aut.delta.add(2, 'c', 1);
+            aut.delta.add(2, 'e', 3);
+            aut.delta.add(3, 'g', 4);
+            aut.delta.add(4, 'f', 3);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            Nft expected = Nft(9);
+            expected.initial.insert(0);
+            expected.final.insert(2);
+            expected.final.insert(6);
+            expected.num_of_levels = 2;
+            expected.levels = { 0, 1, 0, 1, 1, 1, 0, 1, 1 };
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(0, 'd', 8);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'b', 3);
+            expected.delta.add(2, 'g', 4);
+            expected.delta.add(2, 'd', 5);
+            expected.delta.add(3, 'c', 2);
+            expected.delta.add(4, 'e', 6);
+            expected.delta.add(5, 'c', 6);
+            expected.delta.add(6, 'g', 7);
+            expected.delta.add(7, 'f', 6);
+            expected.delta.add(8, 'a', 6);
+
+            CHECK(aut_new.num_of_states() <= 9);
+            CHECK(aut_new.delta.num_of_transitions() <= 12);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
+
+        SECTION("Complex 2 - 3 levels") {
+            Nft aut(6);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.final.insert(4);
+            aut.num_of_levels = 3;
+            aut.levels = { 0, 1, 2, 0, 0, 2 };
+            aut.delta.add(0, 'a', 3);
+            aut.delta.add(0, 'b', 2);
+            aut.delta.add(0, 'c', 1);
+            aut.delta.add(1, 'd', 2);
+            aut.delta.add(1, 'f', 3);
+            aut.delta.add(1, 'h', 4);
+            aut.delta.add(1, 'i', 5);
+            aut.delta.add(2, 'e', 3);
+            aut.delta.add(2, 'g', 4);
+            aut.delta.add(5, 'j', 4);
+            Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
+
+            aut_new.print_to_dot(std::cerr);
+
+            Nft expected = Nft(18);
+            expected.initial.insert(0);
+            expected.final.insert(10);
+            expected.final.insert(11);
+            expected.num_of_levels = 3;
+            expected.levels = { 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1, 2, 2, 1, 1, 2 };
+            expected.delta.add(0, 'e', 1);
+            expected.delta.add(0, 'e', 2);
+            expected.delta.add(0, 'g', 6);
+            expected.delta.add(0, 'j', 8);
+            expected.delta.add(0, 'g', 12);
+            expected.delta.add(0, DONT_CARE, 13);
+            expected.delta.add(0, DONT_CARE, 15);
+            expected.delta.add(0, DONT_CARE, 16);
+            expected.delta.add(1, DONT_CARE, 14);
+            expected.delta.add(2, 'd', 3);
+            expected.delta.add(3, 'c', 10);
+            expected.delta.add(4, 'c', 10);
+            expected.delta.add(5, 'c', 11);
+            expected.delta.add(6, 'd', 7);
+            expected.delta.add(7, 'c', 11);
+            expected.delta.add(8, 'i', 9);
+            expected.delta.add(9, 'c', 11);
+            expected.delta.add(12, DONT_CARE, 17);
+            expected.delta.add(13, 'a', 10);
+            expected.delta.add(14, 'b', 10);
+            expected.delta.add(15, 'f', 4);
+            expected.delta.add(16, 'h', 5);
+            expected.delta.add(17, 'b', 11);
+
+            CHECK(aut_new.num_of_states() <= 18);
+            CHECK(aut_new.delta.num_of_transitions() <= 23);
+            CHECK(are_equivalent(aut_new, expected, JumpMode::AppendDontCares));
+            CHECK(are_equivalent(invert_levels(aut_new, JumpMode::AppendDontCares), aut, JumpMode::AppendDontCares));
+        }
     }
 }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1831,6 +1831,162 @@ TEST_CASE("mata::nft::revert()")
     }
 } // }}}
 
+TEST_CASE("mata::nft::Levels") {
+    SECTION("empty") {
+        Levels levels;
+        CHECK(levels.count(3) == 0);
+    }
+
+    SECTION("existing") {
+        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        CHECK(levels.count(0) == 3);
+        CHECK(levels.count(1) == 2);
+        CHECK(levels.count(2) == 1);
+        CHECK(levels.count(4) == 1);
+    }
+
+    SECTION("non-existing") {
+        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        CHECK(levels.count(3) == 0);
+        CHECK(levels.count(5) == 0);
+    }
+}
+
+TEST_CASE("mata::nft::Nft::invert_levels()") {
+    SECTION("jump_mpde == RepeatSymbol") {
+        SECTION("empty automaton") {
+            Nft aut;
+            Nft aut_new = invert_levels(aut);
+            CHECK(aut_new.num_of_states() == 0);
+            CHECK(are_equivalent(aut, aut_new));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("no transition only states") {
+            Nft aut(3);
+            aut.initial.insert(1);
+            aut.final.insert(2);
+            aut.num_of_levels = 1;
+            aut.levels = { 1, 0, 0 };
+            Nft aut_new = invert_levels(aut);
+            CHECK(aut_new.is_lang_empty());
+            CHECK(aut_new.delta.num_of_transitions() == 0);
+            CHECK(are_equivalent(aut, aut_new));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("Linear - 2 levels") {
+            Nft aut(3);
+            aut.initial.insert(0);
+            aut.final.insert(2);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(3);
+            expected.initial.insert(0);
+            expected.final.insert(2);
+            expected.num_of_levels = 2;
+            expected.levels = { 0, 1, 0 };
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(1, 'a', 2);
+
+            CHECK(aut_new.num_of_states() == 3);
+            CHECK(aut_new.delta.num_of_transitions() == 2);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("Linear 2 - 2 levels") {
+            Nft aut(5);
+            aut.initial.insert(0);
+            aut.final.insert(4);
+            aut.num_of_levels = 2;
+            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(3, 'd', 4);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(5);
+            expected.initial.insert(0);
+            expected.final.insert(4);
+            expected.num_of_levels = 2;
+            expected.levels = {0, 1, 0, 1, 0};
+            expected.delta.add(0, 'b', 1);
+            expected.delta.add(1, 'a', 2);
+            expected.delta.add(2, 'd', 3);
+            expected.delta.add(3, 'c', 4);
+
+            CHECK(aut_new.num_of_states() == 5);
+            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("Linear + long jump - 3 levels") {
+            Nft aut(4);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.num_of_levels = 3;
+            aut.levels = { 0, 1, 2, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(0, 'd', 3);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(4);
+            expected.initial.insert(0);
+            expected.final.insert(3);
+            expected.num_of_levels = 3;
+            expected.levels = {0, 1, 2, 0};
+            expected.delta.add(0, 'd', 3);
+            expected.delta.add(0, 'c', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'a', 3);
+
+            CHECK(aut_new.num_of_states() == 4);
+            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+        }
+
+        SECTION("Linear + long jump 2 - 4 levels") {
+            Nft aut(4);
+            aut.initial.insert(0);
+            aut.final.insert(3);
+            aut.num_of_levels = 4;
+            aut.levels = { 0, 1, 3, 0 };
+            aut.delta.add(0, 'a', 1);
+            aut.delta.add(1, 'b', 2);
+            aut.delta.add(2, 'c', 3);
+            aut.delta.add(0, 'd', 2);
+            Nft aut_new = invert_levels(aut);
+
+            Nft expected = Nft(4);
+            expected.initial.insert(0);
+            expected.final.insert(3);
+            expected.num_of_levels = 4;
+            expected.levels = {0, 1, 3, 0};
+            expected.delta.add(0, 'c', 1);
+            expected.delta.add(1, 'b', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(1, 'd', 3);
+
+            CHECK(aut_new.num_of_states() == 4);
+            CHECK(aut_new.delta.num_of_transitions() == 4);
+            CHECK(are_equivalent(aut_new, expected));
+            CHECK(are_equivalent(invert_levels(aut_new), aut));
+
+        }
+
+    }
+}
+
 
 TEST_CASE("mata::nft::Nft::is_deterministic()")
 { // {{{


### PR DESCRIPTION
This PR introduces:
- Method `Nft::invert_levels` with tests:
   - `Nft::invert_levels` creates an Nft where the 1st tape becomes the n-th, the 2nd becomes the (n-1)-th, and so on.
   - `(a,b)----a---->(c,d)----b---->(e,f)` will become `(b,a)----a---->(d,c)----b---->(f,e)`
- Method `StatePost::get_successors` and `Delta::get_successors`
    -  TODO: Remove `Delta::post` in the future.
- Method `Delta::get_transitions_between`:
   - Returns a vector of transitions that lead from `state_from` to `state_to`
- Method `Levels::count`:
   - Based on `std::count`
- Method `Nft::num_of_states_with_level`:
   - Based on the previous method `count`
