### PR TITLE
Fix `reduce` and `remove_epsilon` for NFTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 # the build directory
 build/
 Testing/
+build-wasm/
 
 # documentation
 doc/api/
@@ -63,6 +64,7 @@ bindings/python/libmata.cpp
 bindings/python/**/*.dot
 bindings/python/**/*.pdf
 bindings/python/MANIFEST
+bindings/python/virtenv
 
 # Performance and profiling tests
 tests-integration/pycobench.tasks

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -833,14 +833,14 @@ Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
  * 
  * Simple epsilon transitions are the transitions of the form
  *      q0 -epsilon-> q1 -epsilon-> q2 -epsilon-> ... -epsilon-> qn
- * where q0 and qn are level 0 states, the states inbetween are states
+ * where q0 and qn are level 0 states, the states in-between are states
  * with level 1, 2, ..., num_of_levels and for each qi, for 0 < i < n,
  * there is only 1 transition going to qi (the transition qi-1 -epsilon-> qi)
  * and only 1 transition going from qi (the transition qi -epsilon -> qi+1).
  * This means that if there was some state p0 going with epsilon to q1,
  * these to epsilon transitions would not be removed.
  * 
- * Furthermore. assumes that the NFT @p aut does not have jump transitions.
+ * Furthermore, this assumes that the NFT @p aut does not have jump transitions.
  * 
  * The resulting automaton has the same number of states as @p aut, just the
  * transitions can change. It is recommended to run trim() after this function.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -829,7 +829,7 @@ Nft somewhat_simple_revert(const Nft& aut);
 Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
- * @brief Remove simple epsilon transitions while 
+ * @brief Remove simple epsilon transitions.
  * 
  * Simple epsilon transitions are the transitions of the form
  *      q0 -epsilon-> q1 -epsilon-> q2 -epsilon-> ... -epsilon-> qn

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -829,7 +829,7 @@ Nft somewhat_simple_revert(const Nft& aut);
 Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
- * @brief Remove simple epsilon transitions.
+ * @brief Remove simple epsilon transitions while 
  * 
  * Simple epsilon transitions are the transitions of the form
  *      q0 -epsilon-> q1 -epsilon-> q2 -epsilon-> ... -epsilon-> qn
@@ -837,8 +837,13 @@ Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
  * with level 1, 2, ..., num_of_levels and for each qi, for 0 < i < n,
  * there is only 1 transition going to qi (the transition qi-1 -epsilon-> qi)
  * and only 1 transition going from qi (the transition qi -epsilon -> qi+1).
- *  
+ * This means that if there was some state p0 going with epsilon to q1,
+ * these to epsilon transitions would not be removed.
+ * 
  * Furthermore. assumes that the NFT @p aut does not have jump transitions.
+ * 
+ * The resulting automaton has the same number of states as @p aut, just the
+ * transitions can change. It is recommended to run trim() after this function.
  * 
  * @param aut NFT without jump transitions
  * @param epsilon symbol representing epsilon

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -327,7 +327,7 @@ public:
     Nft& insert_identity(State state, Symbol symbol, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
-     * @brief Checks if the transition contains any jump transition
+     * @brief Checks if the transducer contains any jump transition
      */
     bool contains_jump_transitions();
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -360,6 +360,13 @@ public:
     Nft& trim(StateRenaming* state_renaming = nullptr);
 
     /**
+     * Remove simple epsilon transitions from the automaton.
+     * 
+     * @sa mata::nft::remove_epsilon()
+     */
+    void remove_epsilon(Symbol epsilon = EPSILON);
+
+    /**
      * @brief In-place concatenation.
      */
     Nft& concatenate(const Nft& aut);
@@ -821,7 +828,22 @@ Nft somewhat_simple_revert(const Nft& aut);
  */
 Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
-// Removing epsilon transitions
+/**
+ * @brief Remove simple epsilon transitions.
+ * 
+ * Simple epsilon transitions are the transitions of the form
+ *      q0 -epsilon-> q1 -epsilon-> q2 -epsilon-> ... -epsilon-> qn
+ * where q0 and qn are level 0 states, the states inbetween are states
+ * with level 1, 2, ..., num_of_levels and for each qi, for 0 < i < n,
+ * there is only 1 transition going to qi (the transition qi-1 -epsilon-> qi)
+ * and only 1 transition going from qi (the transition qi -epsilon -> qi+1).
+ *  
+ * Furthermore. assumes that the NFT @p aut does not have jump transitions.
+ * 
+ * @param aut NFT without jump transitions
+ * @param epsilon symbol representing epsilon
+ * @return NFT whose language is same as @p aut but does not contain simple epsilon transitions
+ */
 Nft remove_epsilon(const Nft& aut, Symbol epsilon = EPSILON);
 
 /**

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -80,6 +80,10 @@ Nft& Nft::trim(StateRenaming* state_renaming) {
     return *this;
 }
 
+void Nft::remove_epsilon(Symbol epsilon = EPSILON) {
+    *this = mata::nft::remove_epsilon(*this, epsilon);
+}
+
 std::string Nft::print_to_dot(const bool ascii) const {
     std::stringstream output;
     print_to_dot(output, ascii);

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -80,7 +80,7 @@ Nft& Nft::trim(StateRenaming* state_renaming) {
     return *this;
 }
 
-void Nft::remove_epsilon(Symbol epsilon = EPSILON) {
+void Nft::remove_epsilon(Symbol epsilon) {
     *this = mata::nft::remove_epsilon(*this, epsilon);
 }
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -149,14 +149,15 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
                             continue;
                         }
                         for (State target : eps_move_it_s->targets) {
-                            assert(aut.levels[target] == cur_level + 1);
                             if (cur_level == aut.num_of_levels-1) {
+                                assert(aut.levels[target] == DEFAULT_LEVEL);
                                 std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
                                 new_safe_epsilon_run.push_back(target);
                                 safe_epsilon_runs.push_back(new_safe_epsilon_run);
                                 eps_delta[state].insert(target);
                                 eps_delta_inverse[target].insert(state);
                             } else if (reversed_nfa.delta[target].size() == 1) {
+                                assert(aut.levels[target] == cur_level + 1);
                                 std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
                                 new_safe_epsilon_run.push_back(target);
                                 new_state_safe_epsilon_runs.push_back(new_safe_epsilon_run);

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -139,7 +139,7 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
             std::vector<std::vector<State>> state_safe_epsilon_runs{ {state} };
             for (Level cur_level = 0; cur_level < aut.num_of_levels; ++cur_level) {
                 std::vector<std::vector<State>> new_state_safe_epsilon_runs;
-                for (std::vector<State> safe_epsilon_run : state_safe_epsilon_runs) {
+                for (const std::vector<State>& safe_epsilon_run : state_safe_epsilon_runs) {
                     State state_s = safe_epsilon_run.back();
                     const StatePost& post_s{ aut.delta[state_s] };
                     const auto eps_move_it_s { post_s.find(epsilon) };
@@ -151,13 +151,15 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
                         for (State target : eps_move_it_s->targets) {
                             assert(aut.levels[target] == cur_level + 1);
                             if (cur_level == aut.num_of_levels-1) {
-                                safe_epsilon_run.push_back(target);
-                                safe_epsilon_runs.push_back(safe_epsilon_run);
+                                std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
+                                new_safe_epsilon_run.push_back(target);
+                                safe_epsilon_runs.push_back(new_safe_epsilon_run);
                                 eps_delta[state].insert(target);
                                 eps_delta_inverse[target].insert(state);
                             } else if (reversed_nfa.delta[target].size() == 1) {
-                                safe_epsilon_run.push_back(target);
-                                new_state_safe_epsilon_runs.push_back(safe_epsilon_run);
+                                std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
+                                new_safe_epsilon_run.push_back(target);
+                                new_state_safe_epsilon_runs.push_back(new_safe_epsilon_run);
                             }
                         }
                     }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -52,6 +52,7 @@ namespace {
 
     Nft reduce_size_by_simulation(const Nft& aut, StateRenaming &state_renaming) {
         Nft result;
+        result.num_of_levels = aut.num_of_levels;
         const auto sim_relation = algorithms::compute_relation(
                 aut, ParameterMap{{ "relation", "simulation"}, { "direction", "forward"}});
 
@@ -68,7 +69,8 @@ namespace {
         for (State q = 0; q < num_of_states; ++q) {
             const State qReprState = quot_proj[q];
             if (state_renaming.count(qReprState) == 0) { // we need to map q's class to a new state in reducedAut
-                const State qClass = result.add_state();
+                assert(aut.levels[q] == aut.levels[qReprState]);
+                const State qClass = result.add_state_with_level(aut.levels[qReprState]);
                 state_renaming[qReprState] = qClass;
                 state_renaming[q] = qClass;
             } else {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -129,10 +129,17 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
     const size_t num_of_states{aut.num_of_states() };
     mata::nfa::Nfa reversed_nfa{ mata::nfa::revert(aut) };
 
+    // this vector will collect epsilon run from level 0 state to level 0 state
+    // that contains only epsilon transitions, and all states inbetween (i.e.
+    // not-level-0 states) will have only one epsilon transition going to it
+    // and one epsilon transition going from it
     std::vector<std::vector<State>> safe_epsilon_runs;
 
-    std::vector<StateSet> eps_delta(num_of_states);
-    std::vector<StateSet> eps_delta_inverse(num_of_states);
+    // for each level 0 state q, eps_delta[q] represents all states to which
+    // we can get to by some safe epsilon run
+    std::map<State,StateSet> eps_delta;
+    // its inverse
+    std::map<State,StateSet> eps_delta_inverse;
 
     for (State state = 0; state != num_of_states; ++state) {
         if (aut.levels[state] == DEFAULT_LEVEL) {
@@ -150,16 +157,20 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
                         }
                         for (State target : eps_move_it_s->targets) {
                             if (cur_level == aut.num_of_levels-1) {
+                                // we are at the last level, next level will be 0
                                 assert(aut.levels[target] == DEFAULT_LEVEL);
                                 std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
                                 new_safe_epsilon_run.push_back(target);
+                                // we finish with generating this safe epsilon run and push it to safe_epsilon_runs directly
                                 safe_epsilon_runs.push_back(new_safe_epsilon_run);
                                 eps_delta[state].insert(target);
                                 eps_delta_inverse[target].insert(state);
                             } else if (reversed_nfa.delta[target].size() == 1) {
+                                // we are not at the last level, next state must be level incremented by one (assuming no jumps)
                                 assert(aut.levels[target] == cur_level + 1);
                                 std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
                                 new_safe_epsilon_run.push_back(target);
+                                // this safe epsilon run is not finished yet, we save new_state_safe_epsilon_runs to return to it
                                 new_state_safe_epsilon_runs.push_back(new_safe_epsilon_run);
                             }
                         }
@@ -202,11 +213,12 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
         }
     }
 
-    // At this point eps_delta represents epsilon closure, but it might not be reflexive
+    // At this point eps_delta represents epsilon closure of level 0 states, but it might not be reflexive
 
     // Construct the automaton without epsilon transitions.
     Nft result{ aut };
 
+    // we first remove all epsilon transitions
     std::set<Transition> safe_epsilon_runs_transitions;
     for (const auto& safe_epsilon_run : safe_epsilon_runs) {
         for (size_t i = 0; i < safe_epsilon_run.size()-1; ++i) {
@@ -218,11 +230,12 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
         }
     }
 
+    // we add new transitions using epsilon closure
     for (State state{ 0 }; state < num_of_states; ++state) {
         for (State eps_cl_state : eps_delta[state]) { // For every state in its epsilon closure.
             if (aut.final[eps_cl_state]) result.final.insert(state);
+            // we only need to add the first transition to level 1 state
             for (const SymbolPost& move : aut.delta[eps_cl_state]) {
-                // TODO: this could be done more efficiently if we had a better add method
                 for (State tgt_state : move.targets) {
                     result.delta.add(state, move.symbol, tgt_state);
                 }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -41,6 +41,11 @@ namespace {
             LTSforSimulation.add_transition(finalState, maxSymbol + 1, finalState);
         }
 
+        // similarly, states on different levels cannot be simulate, we add self loops over the same fresh symbol for each state of the same level
+        for (State state = 0; state < state_num; ++state) {
+            LTSforSimulation.add_transition(state, maxSymbol + 2 + aut.levels[state], state);
+        }
+
         LTSforSimulation.init();
         return LTSforSimulation.compute_simulation();
     }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -125,61 +125,103 @@ namespace {
     }
 }
 
-//TODO: based on the comments inside, this function needs to be rewritten in a more optimal way.
 Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
-    // cannot use multimap, because it can contain multiple occurrences of (a -> a), (a -> a)
-    std::unordered_map<State, StateSet> eps_closure;
-
-    // TODO: grossly inefficient
-    // first we compute the epsilon closure
     const size_t num_of_states{aut.num_of_states() };
-    for (size_t i{ 0 }; i < num_of_states; ++i)
-    {
-        for (const auto& trans: aut.delta[i])
-        { // initialize
-            const auto it_ins_pair = eps_closure.insert({i, {i}});
-            if (trans.symbol == epsilon)
-            {
-                StateSet& closure = it_ins_pair.first->second;
-                // TODO: Fix possibly insert to OrdVector. Create list already ordered, then merge (do not need to resize each time);
-                closure.insert(trans.targets);
-            }
-        }
-    }
+    mata::nfa::Nfa reversed_nfa{ mata::nfa::revert(aut) };
 
-    bool changed = true;
-    while (changed) { // Compute the fixpoint.
-        changed = false;
-        for (size_t i = 0; i < num_of_states; ++i) {
-            const StatePost& post{ aut.delta[i] };
-            const auto eps_move_it { post.find(epsilon) };//TODO: make faster if default epsilon
-            if (eps_move_it != post.end()) {
-                StateSet& src_eps_cl = eps_closure[i];
-                for (const State tgt: eps_move_it->targets) {
-                    const StateSet& tgt_eps_cl = eps_closure[tgt];
-                    for (const State st: tgt_eps_cl) {
-                        if (src_eps_cl.count(st) == 0) {
-                            changed = true;
-                            break;
+    std::vector<std::vector<State>> safe_epsilon_runs;
+
+    std::vector<StateSet> eps_delta(num_of_states);
+    std::vector<StateSet> eps_delta_inverse(num_of_states);
+
+    for (State state = 0; state != num_of_states; ++state) {
+        if (aut.levels[state] == DEFAULT_LEVEL) {
+            std::vector<std::vector<State>> state_safe_epsilon_runs{ {state} };
+            for (Level cur_level = 0; cur_level < aut.num_of_levels; ++cur_level) {
+                std::vector<std::vector<State>> new_state_safe_epsilon_runs;
+                for (std::vector<State> safe_epsilon_run : state_safe_epsilon_runs) {
+                    State state_s = safe_epsilon_run.back();
+                    const StatePost& post_s{ aut.delta[state_s] };
+                    const auto eps_move_it_s { post_s.find(epsilon) };
+                    if (eps_move_it_s != post_s.end()) {
+                        if (cur_level != DEFAULT_LEVEL && aut.delta[state_s].size() != 1) {
+                            // for levels > DEFAULT_LEVEL we do not want to have transitions that are not with empty symbol
+                            continue;
+                        }
+                        for (State target : eps_move_it_s->targets) {
+                            assert(aut.levels[target] == cur_level + 1);
+                            if (cur_level == aut.num_of_levels-1) {
+                                safe_epsilon_run.push_back(target);
+                                safe_epsilon_runs.push_back(safe_epsilon_run);
+                                eps_delta[state].insert(target);
+                                eps_delta_inverse[target].insert(state);
+                            } else if (reversed_nfa.delta[target].size() == 1) {
+                                safe_epsilon_run.push_back(target);
+                                new_state_safe_epsilon_runs.push_back(safe_epsilon_run);
+                            }
                         }
                     }
-                    src_eps_cl.insert(tgt_eps_cl);
+                }
+                if (new_state_safe_epsilon_runs.empty()) {
+                    break;
+                } else {
+                    state_safe_epsilon_runs = new_state_safe_epsilon_runs;
                 }
             }
         }
     }
 
+    // compute the transition closure of the epsilon delta
+    // by using simplified Floyd-Warshall algorithm, see
+    // https://stackoverflow.com/a/76173280
+    for (State state{ 0 }; state < num_of_states; ++state) {
+        // for every pair of transitions
+        //       before_state -epsilon-> state -epsilon-> after_state
+        // we add transition
+        //       before_state -epsilon-> after_state
+        const StateSet& after_states = eps_delta[state];
+        const StateSet& before_states = eps_delta_inverse[state];
+
+        if (after_states.empty() || before_states.empty()) {
+            // there is no such pair of transitions
+            continue;
+        }
+
+        for (State before_state : before_states) {
+            if (before_state != state) {
+                eps_delta[before_state].insert(after_states);
+            }
+        }
+        for (State after_state : after_states) {
+            if (after_state != state) {
+                eps_delta_inverse[after_state].insert(before_states);
+            }
+        }
+    }
+
+    // At this point eps_delta represents epsilon closure, but it might not be reflexive
+
     // Construct the automaton without epsilon transitions.
-    Nft result{ Delta{}, aut.initial, aut.final, aut.levels, aut.num_of_levels, aut.alphabet };
-    for (const auto& state_closure_pair : eps_closure) { // For every state.
-        State src_state = state_closure_pair.first;
-        for (State eps_cl_state : state_closure_pair.second) { // For every state in its epsilon closure.
-            if (aut.final[eps_cl_state]) result.final.insert(src_state);
+    Nft result{ aut };
+
+    std::set<Transition> safe_epsilon_runs_transitions;
+    for (const auto& safe_epsilon_run : safe_epsilon_runs) {
+        for (size_t i = 0; i < safe_epsilon_run.size()-1; ++i) {
+            Transition safe_epsilon_run_transition{ safe_epsilon_run[i], epsilon, safe_epsilon_run[i+1] };
+            if (!safe_epsilon_runs_transitions.contains(safe_epsilon_run_transition)) {
+                result.delta.remove(safe_epsilon_run_transition);
+                safe_epsilon_runs_transitions.insert(safe_epsilon_run_transition);
+            }
+        }
+    }
+
+    for (State state{ 0 }; state < num_of_states; ++state) {
+        for (State eps_cl_state : eps_delta[state]) { // For every state in its epsilon closure.
+            if (aut.final[eps_cl_state]) result.final.insert(state);
             for (const SymbolPost& move : aut.delta[eps_cl_state]) {
-                if (move.symbol == epsilon) continue;
                 // TODO: this could be done more efficiently if we had a better add method
                 for (State tgt_state : move.targets) {
-                    result.delta.add(src_state, move.symbol, tgt_state);
+                    result.delta.add(state, move.symbol, tgt_state);
                 }
             }
         }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -41,7 +41,7 @@ namespace {
             LTSforSimulation.add_transition(finalState, maxSymbol + 1, finalState);
         }
 
-        // similarly, states on different levels cannot be simulate, we add self loops over the same fresh symbol for each state of the same level
+        // similarly, states on different levels cannot be simulated by each other, we add self loops over the same fresh symbol for each state of the same level
         for (State state = 0; state < state_num; ++state) {
             LTSforSimulation.add_transition(state, maxSymbol + 2 + aut.levels[state], state);
         }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -137,9 +137,9 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
 
     // for each level 0 state q, eps_delta[q] represents all states to which
     // we can get to by some safe epsilon run
-    std::map<State,StateSet> eps_delta;
+    std::vector<StateSet> eps_delta(num_of_states);
     // its inverse
-    std::map<State,StateSet> eps_delta_inverse;
+    std::vector<StateSet> eps_delta_inverse(num_of_states);
 
     for (State state = 0; state != num_of_states; ++state) {
         if (aut.levels[state] == DEFAULT_LEVEL) {
@@ -217,6 +217,7 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
 
     // Construct the automaton without epsilon transitions.
     Nft result{ aut };
+    result.delta.allocate(num_of_states); // just to be safe
 
     // we first remove all epsilon transitions
     std::set<Transition> safe_epsilon_runs_transitions;
@@ -233,11 +234,11 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
     // we add new transitions using epsilon closure
     for (State state{ 0 }; state < num_of_states; ++state) {
         for (State eps_cl_state : eps_delta[state]) { // For every state in its epsilon closure.
-            if (aut.final[eps_cl_state]) result.final.insert(state);
-            // we only need to add the first transition to level 1 state
-            for (const SymbolPost& move : aut.delta[eps_cl_state]) {
-                for (State tgt_state : move.targets) {
-                    result.delta.add(state, move.symbol, tgt_state);
+            if (eps_cl_state != state) { // transitions from state are already in result
+                if (aut.final[eps_cl_state]) { result.final.insert(state); }
+                // we only need to add the first transition to level 1 state
+                for (const SymbolPost& move : result.delta[eps_cl_state]) {
+                    result.delta.add(state, move.symbol, move.targets);
                 }
             }
         }

--- a/tests/nft/nft-concatenation.cc
+++ b/tests/nft/nft-concatenation.cc
@@ -62,7 +62,9 @@ using Symbol = mata::Symbol;
 
 TEST_CASE("mata::nft::concatenate()") {
     Nft lhs{};
+    lhs.num_of_levels = 1;
     Nft rhs{};
+    rhs.num_of_levels = 1;
     Nft result{};
 
     SECTION("Empty automaton without states") {

--- a/tests/nft/nft-plumbing.cc
+++ b/tests/nft/nft-plumbing.cc
@@ -34,6 +34,7 @@ using OnTheFlyAlphabet = mata::OnTheFlyAlphabet;
     x.delta.add(7, 'a', 5); \
     x.delta.add(5, 'a', 5); \
     x.delta.add(5, 'c', 9); \
+	x.levels.set(10); \
 
 
 // Automaton B
@@ -52,6 +53,7 @@ using OnTheFlyAlphabet = mata::OnTheFlyAlphabet;
     x.delta.add(2, 'c', 12); \
     x.delta.add(12, 'a', 14); \
     x.delta.add(14, 'b', 12); \
+	x.levels.set(14); \
 
 // }}}
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -14,6 +14,7 @@
 #include "mata/nft/builder.hh"
 #include "mata/nft/plumbing.hh"
 #include "mata/nft/algorithms.hh"
+#include "mata/nfa/algorithms.hh"
 #include "mata/nfa/nfa.hh"
 
 using namespace mata;
@@ -2673,6 +2674,60 @@ TEST_CASE("mata::nft::fw-direct-simulation()")
         REQUIRE(result.get(8,1));
         REQUIRE(result.get(8,2));
         REQUIRE(result.get(8,5));
+    }
+
+    SECTION("more than one level")
+    {
+        Nft aut;
+        aut.add_state_with_level(0, 0);
+        aut.add_state_with_level(1, 0);
+        aut.add_state_with_level(2, 1);
+        aut.add_state_with_level(3, 1);
+
+        aut.initial.insert(0);
+        aut.final.insert(3);
+
+        aut.delta.add(0, 'a', 1);
+        aut.delta.add(1, 'a', 3);
+        aut.delta.add(0, 'a', 2);
+        aut.delta.add(2, 'a', 3);
+
+        Simlib::Util::BinaryRelation sim_for_nfa = mata::nfa::algorithms::compute_relation(aut);
+        Simlib::Util::BinaryRelation sim_for_nft = compute_relation(aut);
+
+        CHECK(sim_for_nfa.get(0,0));
+        CHECK(!sim_for_nfa.get(0,1));
+        CHECK(!sim_for_nfa.get(0,2));
+        CHECK(!sim_for_nfa.get(0,3));
+        CHECK(!sim_for_nfa.get(1,0));
+        CHECK(sim_for_nfa.get(1,1));
+        CHECK(sim_for_nfa.get(1,2));
+        CHECK(!sim_for_nfa.get(1,3));
+        CHECK(!sim_for_nfa.get(2,0));
+        CHECK(sim_for_nfa.get(2,1));
+        CHECK(sim_for_nfa.get(2,2));
+        CHECK(!sim_for_nfa.get(2,3));
+        CHECK(!sim_for_nfa.get(3,0));
+        CHECK(!sim_for_nfa.get(3,1));
+        CHECK(!sim_for_nfa.get(3,2));
+        CHECK(sim_for_nfa.get(3,3));
+
+        CHECK(sim_for_nft.get(0,0));
+        CHECK(!sim_for_nft.get(0,1));
+        CHECK(!sim_for_nft.get(0,2));
+        CHECK(!sim_for_nft.get(0,3));
+        CHECK(!sim_for_nft.get(1,0));
+        CHECK(sim_for_nft.get(1,1));
+        CHECK(!sim_for_nft.get(1,2));
+        CHECK(!sim_for_nft.get(1,3));
+        CHECK(!sim_for_nft.get(2,0));
+        CHECK(!sim_for_nft.get(2,1));
+        CHECK(sim_for_nft.get(2,2));
+        CHECK(!sim_for_nft.get(2,3));
+        CHECK(!sim_for_nft.get(3,0));
+        CHECK(!sim_for_nft.get(3,1));
+        CHECK(!sim_for_nft.get(3,2));
+        CHECK(sim_for_nft.get(3,3));
     }
 } // }}
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3011,7 +3011,7 @@ TEST_CASE("mata::nft::remove_epsilon()") {
         aut.add_transition(0, {'b', 'a', 'a'}, 3);
         aut.add_transition(3, {'a', 'a', 'a'}, 2);
         aut.add_transition(1, {'a', 'a', 'a'}, 2);
-        aut.add_transition(2,  {'c', 'b', 'd'});
+        aut.add_transition(2,  {'c', 'b', 'd'}, 2);
         aut.remove_epsilon('a');
         REQUIRE(aut.delta[0].size() == 2);
         CHECK(aut.delta[0].to_vector()[0].symbol == 'b');

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2682,7 +2682,7 @@ TEST_CASE("mata::nft::fw-direct-simulation()")
         aut.add_state_with_level(0, 0);
         aut.add_state_with_level(1, 0);
         aut.add_state_with_level(2, 1);
-        aut.add_state_with_level(3, 1);
+        aut.add_state_with_level(3, 0);
 
         aut.initial.insert(0);
         aut.final.insert(3);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2819,6 +2819,31 @@ TEST_CASE("mata::nft::reduce_size_by_simulation()")
         Nft result = reduce(aut.trim(), &state_renaming);
         CHECK(are_equivalent(result, aut));
     }
+
+    SECTION("multiple tapes")
+    {
+        aut.add_state_with_level(0, 0);
+        aut.add_state_with_level(1, 0);
+        aut.initial = { 0 };
+        aut.final = { 1 };
+        aut.add_transition(0, {'a', 'a'}, 1);
+        aut.add_transition(0, {'a', 'a'}, 1);
+        aut.add_transition(0, {'a', 'a'}, 1);
+        REQUIRE(aut.num_of_states() == 5);
+        Nft result = reduce(aut, &state_renaming);
+        CHECK(are_equivalent(result, aut));
+        REQUIRE(result.num_of_states() == 3);
+        REQUIRE(state_renaming.size() == 5);
+        State middle_state = state_renaming.at(2);
+        CHECK(middle_state == state_renaming.at(3));
+        CHECK(middle_state == state_renaming.at(4));
+        CHECK(result.delta.contains(state_renaming.at(0), 'a', middle_state));
+        CHECK(result.delta.contains(middle_state, 'a', state_renaming.at(1)));
+        REQUIRE(result.num_of_levels == 2);
+        CHECK(result.levels[state_renaming.at(0)] == 0);
+        CHECK(result.levels[state_renaming.at(1)] == 0);
+        CHECK(result.levels[middle_state] == 1);
+    }
 }
 
 TEST_CASE("mata::nft::union_norename()") {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2986,22 +2986,45 @@ TEST_CASE("mata::nft::get_trans_as_sequence(}") {
     REQUIRE(std::vector<Transition>{ transitions.begin(), transitions.end() } == expected);
 }
 
-TEST_CASE("mata::nft::remove_epsilon()")
-{
-    Nft aut{20};
-    FILL_WITH_AUT_A(aut);
-    aut.remove_epsilon('c');
-    REQUIRE(aut.delta.contains(10, 'a', 7));
-    REQUIRE(aut.delta.contains(10, 'b', 7));
-    REQUIRE(!aut.delta.contains(10, 'c', 7));
-    REQUIRE(aut.delta.contains(7, 'a', 5));
-    REQUIRE(aut.delta.contains(7, 'a', 3));
-    REQUIRE(!aut.delta.contains(7, 'c', 3));
-    REQUIRE(aut.delta.contains(7, 'b', 9));
-    REQUIRE(aut.delta.contains(7, 'a', 7));
-    REQUIRE(aut.delta.contains(5, 'a', 5));
-    REQUIRE(!aut.delta.contains(5, 'c', 9));
-    REQUIRE(aut.delta.contains(5, 'a', 9));
+TEST_CASE("mata::nft::remove_epsilon()") {
+    SECTION("1 tape") {
+        Nft aut{20};
+        FILL_WITH_AUT_A(aut);
+        aut.remove_epsilon('c');
+        REQUIRE(aut.delta.contains(10, 'a', 7));
+        REQUIRE(aut.delta.contains(10, 'b', 7));
+        REQUIRE(!aut.delta.contains(10, 'c', 7));
+        REQUIRE(aut.delta.contains(7, 'a', 5));
+        REQUIRE(aut.delta.contains(7, 'a', 3));
+        REQUIRE(!aut.delta.contains(7, 'c', 3));
+        REQUIRE(aut.delta.contains(7, 'b', 9));
+        REQUIRE(aut.delta.contains(7, 'a', 7));
+        REQUIRE(aut.delta.contains(5, 'a', 5));
+        REQUIRE(!aut.delta.contains(5, 'c', 9));
+        REQUIRE(aut.delta.contains(5, 'a', 9));
+    }
+
+    SECTION("3 tapes") {
+        Nft aut{4, {0}, {2}};
+        aut.num_of_levels = 3;
+        aut.add_transition(0, {'a', 'a', 'a'}, 1);
+        aut.add_transition(0, {'b', 'a', 'a'}, 3);
+        aut.add_transition(3, {'a', 'a', 'a'}, 2);
+        aut.add_transition(1, {'a', 'a', 'a'}, 2);
+        aut.add_transition(2,  {'c', 'b', 'd'});
+        aut.remove_epsilon('a');
+        REQUIRE(aut.delta[0].size() == 2);
+        CHECK(aut.delta[0].to_vector()[0].symbol == 'b');
+        CHECK(aut.delta[0].to_vector()[1].symbol == 'c');
+        REQUIRE(aut.delta[2].size() == 1);
+        CHECK(aut.delta[0].to_vector()[1].targets == aut.delta[2].to_vector()[0].targets);
+        REQUIRE(aut.delta[1].size() == 1);
+        CHECK(aut.delta[1].to_vector()[0].symbol == 'c');
+        CHECK(aut.delta[1].to_vector()[0].targets == aut.delta[2].to_vector()[0].targets);
+        REQUIRE(aut.delta[3].size() == 1);
+        CHECK(aut.delta[3].to_vector()[0].symbol == 'c');
+        CHECK(aut.delta[3].to_vector()[0].targets == aut.delta[2].to_vector()[0].targets);
+    }
 }
 
 TEST_CASE("Profile mata::nft::remove_epsilon()", "[.profiling]")

--- a/tests/nft/utils.hh
+++ b/tests/nft/utils.hh
@@ -20,9 +20,11 @@
 	x.delta.add(7, 'a', 5); \
 	x.delta.add(5, 'a', 5); \
 	x.delta.add(5, 'c', 9); \
+	x.levels.set(10); \
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
+	x.add_state(14); \
 	x.initial = {4}; \
 	x.final = {2, 12}; \
 	x.delta.add(4, 'c', 8); \
@@ -37,6 +39,7 @@
 	x.delta.add(2, 'c', 12); \
 	x.delta.add(12, 'a', 14); \
 	x.delta.add(14, 'b', 12); \
+	x.levels.set(14); \
 
 // Automaton C
 // the same as B, but with small symbols
@@ -55,6 +58,7 @@
 	x.delta.add(2, 3, 12); \
 	x.delta.add(12, 1, 14); \
 	x.delta.add(14, 2, 12);   \
+	x.levels.set(14); \
 
 // Automaton D // shomewhat larger
 #define FILL_WITH_AUT_D(x) \
@@ -90,9 +94,11 @@
     x.delta.add(3, 110, 3);\
     x.delta.add(3, 111, 2);\
     x.delta.add(3, 114, 3);\
+	x.levels.set(3); \
 
 // Automaton E
 #define FILL_WITH_AUT_E(x) \
+	x.add_state(4); \
 	x.initial = {1, 3}; \
 	x.final = {4}; \
 	x.delta.add(1, 'b', 2); \

--- a/tests/nft/utils.hh
+++ b/tests/nft/utils.hh
@@ -3,6 +3,7 @@
 
 // Automaton A
 #define FILL_WITH_AUT_A(x) \
+	x.num_of_levels = 1; \
     x.initial = {1, 3}; \
 	x.final = {5}; \
 	x.delta.add(1, 'a', 3); \
@@ -24,6 +25,7 @@
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
+	x.num_of_levels = 1; \
 	x.add_state(14); \
 	x.initial = {4}; \
 	x.final = {2, 12}; \
@@ -44,6 +46,7 @@
 // Automaton C
 // the same as B, but with small symbols
 #define FILL_WITH_AUT_C(x) \
+	x.num_of_levels = 1; \
 	x.initial = {4}; \
 	x.final = {2, 12}; \
 	x.delta.add(4, 3, 8); \
@@ -62,6 +65,7 @@
 
 // Automaton D // shomewhat larger
 #define FILL_WITH_AUT_D(x) \
+	x.num_of_levels = 1; \
     x.initial = {0}; \
     x.final = {3}; \
     x.delta.add(0, 46, 0); \
@@ -98,6 +102,7 @@
 
 // Automaton E
 #define FILL_WITH_AUT_E(x) \
+	x.num_of_levels = 1; \
 	x.add_state(4); \
 	x.initial = {1, 3}; \
 	x.final = {4}; \


### PR DESCRIPTION
This function fixes simulation computation and reduction so that it works for NFTs (also with jumps). It also add (a limited) support for removing epsilon transition of NFTs (only without jumps).