### PR TITLE
New ASCII decoding for `print_to_dot` and new `print_to_mata` methods.

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -315,8 +315,9 @@ public:
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
+     * @param[in] ascii Whether to use ASCII characters for the output.
      */
-    void print_to_dot(const std::string& filename) const;
+    void print_to_dot(const std::string& filename, const bool ascii = false) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -156,15 +156,15 @@ public:
 
     /**
      * @brief Creates Nft from @p nfa with specified @p num_of_levels automatically.
-     * 
+     *
      * It assumes that @p nfa is a representation of an nft without jump transitions.
      * It assign to each state the level based on the distance from the initial state.
      * For example, if there are 2 levels, the initial states are level 0, the following
      * states are level 1, the states after that level 0, etc.
-     * 
+     *
      * If you only have one level, then it is more efficient to call the constructor that
      * takes Nfa as input.
-     * 
+     *
      * @throws std::runtime_error if some state should be assigned two different levels
      */
     static Nft from_nfa_leveled(mata::nfa::Nfa nfa, size_t num_of_levels);
@@ -428,6 +428,12 @@ public:
      */
     void print_to_dot(std::ostream &output, bool ascii = false) const;
     /**
+     * @brief Prints the automaton to the file in DOT format
+     * @param filename Name of the file to print the automaton to
+     * @param[in] ascii Whether to use ASCII characters for the output.
+     */
+    void print_to_dot(const std::string& filename, const bool ascii = false) const;
+    /**
      * @brief Prints the automaton in mata format
      *
      * If you need to parse the automaton again, use IntAlphabet in construct()
@@ -444,7 +450,15 @@ public:
      * TODO handle alphabet of the automaton, currently we print the exact value of the symbols
      */
     void print_to_mata(std::ostream &output) const;
-
+    /**
+     * @brief Prints the automaton to the file in mata format
+     * @param filename Name of the file to print the automaton to
+     *
+     * If you need to parse the automaton again, use IntAlphabet in construct()
+     *
+     * TODO handle alphabet of the automaton, currently we print the exact value of the symbols
+     */
+    void print_to_mata(const std::string& filename) const;
     /// Is the language of the automaton universal?
     bool is_universal(const Alphabet& alphabet, Run* cex = nullptr,
                       const ParameterMap& params = {{ "algorithm", "antichains" }}) const;

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -439,9 +439,14 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii) const {
     auto to_ascii = [&](const Symbol symbol) {
         // Translate only printable ASCII characters.
         if (symbol < 33) {
-            return std::to_string(symbol);
+            return "<" + std::to_string(symbol) + ">";
         }
-        return "\\'" + std::string(1, static_cast<char>(symbol)) + "\\'";
+        switch (symbol) {
+            case '"':     return std::string("\\\"");
+            case '\\':    return std::string("\\\\");
+            case EPSILON: return std::string("<eps>");
+            default:      return std::string(1, static_cast<char>(symbol));
+        }
     };
 
     output << "digraph finiteAutomaton {" << std::endl
@@ -474,12 +479,12 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii) const {
     output << "}" << std::endl;
 }
 
-void Nfa::print_to_dot(const std::string& filename) const {
+void Nfa::print_to_dot(const std::string& filename, const bool ascii) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output);
+    print_to_dot(output, ascii);
 }
 
 std::string Nfa::print_to_mata(const Alphabet* alphabet) const {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -5,6 +5,8 @@
 #include <list>
 #include <optional>
 #include <iterator>
+#include <fstream>
+#include <string>
 
 // MATA headers
 #include "mata/utils/sparse-set.hh"
@@ -88,24 +90,24 @@ std::string Nft::print_to_dot(const bool ascii) const {
 
 void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
     auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
-        if (symbol == EPSILON) {
-            return "<eps>";
+        switch (symbol) {
+            case EPSILON:      return "<eps>";
+            case EPSILON - 99: return "<marker>";
+            case DONT_CARE:    return "<dcare>";
+            default:           return std::to_string(symbol);
         }
-        if (symbol == EPSILON - 99) {
-            return "<marker>";
-        }
-        if (symbol == DONT_CARE) {
-            return "<dcare>";
-        }
-        return std::to_string(symbol);
     };
 
     auto to_ascii = [&](const Symbol symbol) {
         // Translate only printable ASCII characters.
         if (symbol < 33) {
-            return std::to_string(symbol);
+            return "<" + std::to_string(symbol) + ">";
         }
-        return std::string(1, static_cast<char>(symbol));
+        switch (symbol) {
+            case '"':  return std::string("\\\"");
+            case '\\': return std::string("\\\\");
+            default:   return std::string(1, static_cast<char>(symbol));
+        }
     };
     output << "digraph finiteAutomaton {" << std::endl
                  << "node [shape=circle];" << std::endl;
@@ -142,6 +144,14 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
     }
 
     output << "}" << std::endl;
+}
+
+void Nft::print_to_dot(const std::string& filename, const bool ascii) const {
+    std::ofstream output(filename);
+    if (!output) {
+        throw std::ios_base::failure("Failed to open file: " + filename);
+    }
+    print_to_dot(output, ascii);
 }
 
 std::string Nft::print_to_mata() const {
@@ -197,6 +207,14 @@ void Nft::print_to_mata(std::ostream &output) const {
     for (const Transition& trans: delta.transitions()) {
         output << "q" << trans.source << " " << trans.symbol << " q" << trans.target << std::endl;
     }
+}
+
+void Nft::print_to_mata(const std::string& filename) const {
+    std::ofstream output(filename);
+    if (!output) {
+        throw std::ios_base::failure("Failed to open file: " + filename);
+    }
+    print_to_mata(output);
 }
 
 Nft Nft::get_one_letter_aut(Symbol abstract_symbol) const {
@@ -486,7 +504,7 @@ Nft& Nft::insert_identity(const State state, const Symbol symbol, const JumpMode
 
 bool Nft::contains_jump_transitions() {
     if (num_of_levels == 1) { return false; }
-    
+
     for (const Transition& transition : delta.transitions()) {
         Level src_level = levels[transition.source];
         Level tgt_level = levels[transition.target];


### PR DESCRIPTION
This PR:  
- Escapes `"` and `\` in the `print_to_dot` method and closes #499.  
- Changes the format of ASCII code translation. Instead of translating `97` to `"a"` and `20` to `20`, it now returns `a` and `<20>`.  
- Adds support for `EPSILON` during ASCII code translation inside `print_to_dot`. As a result, `EPSILON` is translated to `<eps>`.  
- Adds the methods `Nft::print_to_mata(const std::string& filename)` and `Nft::print_to_dot(const std::string& filename, const bool ascii = false)`.  
