### PR TITLE
Fix assertion on trimmed automaton

### DIFF
--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -967,7 +967,7 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
         return Nfa{ dfa_trimmed };
     }
     assert(dfa_trimmed.is_deterministic());
-    assert(dfa_trimmed.get_useful_states().size() == dfa_trimmed.num_of_states());
+    assert(dfa_trimmed.get_useful_states().count() == dfa_trimmed.num_of_states());
 
     // Initialize equivalence classes. The initial partition is {Q}.
     RefinablePartition<State> brp(dfa_trimmed.num_of_states());

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2891,7 +2891,7 @@ TEST_CASE("mata::nfa::algorithms::minimize_hopcroft()") {
     SECTION("line") {
         Nfa aut(3);
         aut.initial.insert(0);
-        aut.final.insert(2);
+        aut.final.insert(3);
         aut.delta.add(0, 'a', 1);
         aut.delta.add(1, 'a', 2);
         aut.delta.add(2, 'a', 3);


### PR DESCRIPTION
The previous assert did not test how many states are useful. This was a cause of the issue #496.