### PR TITLE
Resolve the Naming Confusion between `product` and `union` Methods

### DIFF
--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -52,10 +52,10 @@ may arise during development.
 ## Getting started
 
 The following shows minimal example of relation between C++ library source files and Cython binding
-files. It shows link between (1) Cython binding files (`nfa.pxd`, `nfa.pyx`) and C++ library files 
-(`nfa-plumbing.h`), (2) Cython binding class (`Nfa`) and C++ library class (`mata::nfa::Nfa`; 
-in binding refered as `CNfa`), and (3) Cython binding function (`union` that takes Python 
-classes `Nfa`) and C++ library function (`uni` that takes C++ classes `mata::nfa::Nfa`, 
+files. It shows link between (1) Cython binding files (`nfa.pxd`, `nfa.pyx`) and C++ library files
+(`nfa-plumbing.h`), (2) Cython binding class (`Nfa`) and C++ library class (`mata::nfa::Nfa`;
+in binding refered as `CNfa`), and (3) Cython binding function (`union` that takes Python
+classes `Nfa`) and C++ library function (`uni` that takes C++ classes `mata::nfa::Nfa`,
 in binding refered as `c_uni` and `CNfa` respectively)
 
 ```c++
@@ -63,7 +63,7 @@ in binding refered as `c_uni` and `CNfa` respectively)
 
 // Minimal specification of C++ function, we want to wrap in Binding
 namespace mata::nfa::plumbing {
-    inline void uni(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) { *unionAutomaton = uni(lhs, rhs); }
+    inline void union_nondet(Nfa *unionAutomaton, const Nfa &lhs, const Nfa &rhs) { *unionAutomaton = union_nondet(lhs, rhs); }
 //              ^-- C++ function signature with C++ types
 }
 ```
@@ -82,7 +82,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         CNfa()
 #       ^-- constructor of C++ class using alias `CNfa`
 #           (everything listed here will be visible in binding)
-    
+
 cdef extern from "mata/nfa/plumbing.hh" namespace "mata::nfa::plumbing":
 #                 ^-- source C++ header and namespace, where the function is defined
     cdef void c_uni "mata::nfa::plumbing::uni" (CNfa*, CNfa&, CNfa&)
@@ -93,7 +93,7 @@ cdef extern from "mata/nfa/plumbing.hh" namespace "mata::nfa::plumbing":
 ```cython
 # @file: nfa.pyx
 
-# Minimal example of implementation of Python binding. 
+# Minimal example of implementation of Python binding.
 # These classes and function will be visible and callable in Python.
 
 cdef class Nfa:
@@ -108,12 +108,12 @@ cdef class Nfa:
 #       ^-- creating C++ object, that is wrapped in Python class Nfa
 
 def union(Nfa lhs, Nfa rhs):
-#   ^-- Python function; wrapper for mata::nfa::plumbing::uni()
+#   ^-- Python function; wrapper for mata::nfa::plumbing::union_nondet()
     result = Nfa()
-    mata_nfa.c_uni(
+    mata_nfa.union_nondet(
         result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get())
     )
-#   ^-- call to C++ function `uni()` (it is named as c_uni to avoid collisions with Python)
+#   ^-- call to C++ function `union_nondet()` (it is named as c_uni to avoid collisions with Python)
     return result
 #   ^-- function returns wrapper Python object Nfa, that holds instance of `mata::nfa::Nfa` C++ object
 ```
@@ -122,8 +122,8 @@ def union(Nfa lhs, Nfa rhs):
 
 There are two types of files:
 
-- `*.pxd`: Cython files containing declarations/definitions of the C/C++ API, i.e., symbols one 
-  wants to specifically import and use in the binding (naturally, you do not need to import 
+- `*.pxd`: Cython files containing declarations/definitions of the C/C++ API, i.e., symbols one
+  wants to specifically import and use in the binding (naturally, you do not need to import
   everything).
 - `*.pyx`: Cython files containing the implementation of the Python binding.
 
@@ -150,7 +150,7 @@ The directory structure is as follows:
 ## Adding a new function
 
   1. Declare the function in `.pxd` file:
-    
+
      - For a class function, declare it within the class definition:
 
 ```cython
@@ -169,13 +169,13 @@ cdef extern from "mata/nfa.hh" namespace "mata::nfa":
 cdef extern from "mata/nfa-plumbing.hh" namespace "mata::nfa::plumbing":
 #                ^-- source file                  ^-- namespace
     cdef void get_elements(StateSet*, CBoolVector)
-    #    ^-- function signature using previously defined 
+    #    ^-- function signature using previously defined
     #         Cython types from C/C++ API as parameters
 ```
 
-   - You need to specify: (1) the file where the function is declared (e.g., nfa-plumbing.hh), 
-     (2) the namespace where the function is a member, and (3) the signature of the function. 
-     The signature can be partial; the binding will only use the number of defined parameters. 
+   - You need to specify: (1) the file where the function is declared (e.g., nfa-plumbing.hh),
+     (2) the namespace where the function is a member, and (3) the signature of the function.
+     The signature can be partial; the binding will only use the number of defined parameters.
      The typing can be conservative, e.g., const references do not have to be kept.
 
   2. Implement the function in the `.pyx` file:
@@ -224,10 +224,10 @@ extensions = [
 cdef extern from "mata/alphabet.hh" namespace "mata":
 #                ^-- source file              ^-- namespace
     cdef cppclass COnTheFlyAlphabet "mata::OnTheFlyAlphabet" (CAlphabet):
-        
-        #         ^-- name in bind  ^-- full name           ^-- inheritance (previously defined) 
+
+        #         ^-- name in bind  ^-- full name           ^-- inheritance (previously defined)
         StringToSymbolMap symbol_map
-        # ^-- previously defined type in binding        
+        # ^-- previously defined type in binding
         #                 ^--- property name
         COnTheFlyAlphabet(StringToSymbolMap) except +
         # ^-- constructor                    ^-- can fire exception
@@ -278,7 +278,7 @@ cdef extern from "mata/re2parser.hh" namespace "mata::parser":
     cdef void create_nfa(CNfa*, string) except +
     #         ^-- function signature    ^-- can fire exceptions
 ```
-   
+
   2. Now, you can add new parameter to the function:
 
 ```cython
@@ -304,15 +304,15 @@ cdef extern from "mata/re2parser.hh" namespace "mata::parser":
 
   * **Problem**: You want C/C++ function `func()` to be named the same in Python wrapping
   * **Solution**: You can define the name of the function any way you want, but you need to follow
-    it with its full name in quotes (i.e. you can name the function in the `.pxd` as `c_my_func` 
+    it with its full name in quotes (i.e. you can name the function in the `.pxd` as `c_my_func`
     followed by full name `"Namespace::my_func"`; the function is then called as `c_my_func(..)`
-    in Python). 
+    in Python).
 
 ```cython
 cdef NoodleSequence c_noodlify "mata::strings::seg_nfa::noodlify" (CNfa&, Symbol, bool)
 #                   ^-- name visible in Cython
 #                              ^-- original full C/C++ name
-``` 
+```
 
 ## Declaring function returning complex type
 
@@ -340,7 +340,7 @@ def intersection(Nfa lhs, Nfa rhs, preserve_epsilon: bool = False):
     mata_nfa.intersection(
         result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), preserve_epsilon, NULL
     #   ^-- pointer to mata::nfa::Nfa object
-    #                         ^-- equivalent of *lhs 
+    #                         ^-- equivalent of *lhs
     )
     return result
 ```
@@ -368,7 +368,7 @@ cdef cppclass COnTheFlyAlphabet "mata::OnTheFlyAlphabet" (CAlphabet):
 ```cython
 cdef umap[string, Symbol] c_symbol_map = self.thisptr.get_symbol_map()
 #    ^-- unordered_map    ^-- C/C++ var  ^-- calling wrapper function through C/C++ object in thisptr
-``` 
+```
 
 * **Problem**: You want to declare some method as class function in Python.
 * **Solution**: You implement the method in `pyx` file with `@classmethod` decorator.
@@ -381,7 +381,7 @@ def determinize_with_subset_map(cls, Nfa lhs):
 ```
 
 * The function is then called as `module.Class.method`.
- 
+
 ## Declaring class attributes, getters and  setters
 
 * **Problem**: You want to declare an attribute to be visible in class.
@@ -506,7 +506,7 @@ cdef class SymbolPost:
 
 ## Dereferencing and retyping the object
 
-* **Problem**: You have a pointer (e.g., returned from function) and need to dereference it and 
+* **Problem**: You have a pointer (e.g., returned from function) and need to dereference it and
   retype as well, as Cython cannot infer the type.
 * **Solution**: You `cimport` the `dereference` operator and then explicitly retype using `<CType>` notation.
 
@@ -554,7 +554,7 @@ dereference(it).symbol
 ## Defining C variables in code
 
 * **Problem**: In `pyx` code you need to work with variables of C/C++ types.
-* **Solution**: You define the variable together with its types using `cdef` keyword. 
+* **Solution**: You define the variable together with its types using `cdef` keyword.
   Note: the type needs to be specified so that Cython can infer it. You can also help
   Cython with Python variables and parameters by using the typing notations (i.e., `var : type`)
 
@@ -591,7 +591,7 @@ cdef extern from "<sstream>" namespace "std":
 ```
 
 * Then, you can call function that takes `ofstream` as follows:
- 
+
 ```cython
 cimport libmata.nfa.nfa as mata_nfa
 cdef mata_nfa.ofstream* output
@@ -709,7 +709,7 @@ result.decode('utf-8')
 ## Helping Cython to infer types
 
 * **Problem**: Cython fails to infer types for the variables and cannot compile the binding.
-* **Solution**: You need to help Cython a little: add types to parameters, add types to cdefined 
+* **Solution**: You need to help Cython a little: add types to parameters, add types to cdefined
   variables, or manually retype the variable.
 
 ```cython
@@ -735,7 +735,7 @@ void add(CTrans) except -1
 void add(CTrans) except +
 #                ^-- function may fire exception; C/C++ exceptions will be translated to Python exceptions
 void add(CTrans) except +MemoryError
-#                ^-- function may fire MemoryError (corresponds to bad_alloc) 
+#                ^-- function may fire MemoryError (corresponds to bad_alloc)
 void add(CTrans) noexcept +
 #                ^-- function will not fire exception
 ```
@@ -746,7 +746,7 @@ void add(CTrans) noexcept +
 
 ## Importing C/C++ defined functions and symbols
 
-* **Problem**: You want to import symbols visible from wrapped `libmata` library. 
+* **Problem**: You want to import symbols visible from wrapped `libmata` library.
 * **Solution**: You need to use `cimport`, which tells Cython to import C/C++ typed definitions.
 
 ```cython
@@ -789,7 +789,7 @@ from libcpp.vector cimport vector
 * **Problem**: You imported some other Cython module and want to use non-C/C++ class. The Cython,
   however, says that it does not know the requested member.
 * **Solution**: You have to forward-declare the Python class in `.pxd` file.
- 
+
 * An example of such error is as below:
 
 ```shell
@@ -819,7 +819,7 @@ cdef class Transition:
 
 ## A weird error when Cython cannot retype C/C++ object to Python object
 
-* **Problem**: You want to store some C/C++ type to a C/C++ member of the Python object. Cython, 
+* **Problem**: You want to store some C/C++ type to a C/C++ member of the Python object. Cython,
   however, treats the object as Python object and cannot infer types.
 * **Solution**: You have to explicitly retype the underlying Python object to help Cython with the rest.
 
@@ -860,12 +860,12 @@ for c_noodle in c_noodle_segments:
 ## An error when Cython cannot find cimported function, even if it is defined
 
 * **Problem**: You defined some function `f` you wish to use in binding, you implement the function
-  with same name in the binding, but Cython first says, that 
+  with same name in the binding, but Cython first says, that
   you are redefining the function `f` and then says it cannot `cimport` it.
 * **Solution**: You have to explicitly name the function `f` to, e.g.. `c_f`.
 
 * The following is an example of the error.
- 
+
 ```shell
 warning: libmata/nfa/nfa.pyx:690:0: Overriding cdef method with def method.
 
@@ -893,8 +893,8 @@ libmata/nfa/nfa.pyx:687:12: cimported module has no attribute 'determinize'
 
 # Quick glossary
 
-  - `cdef` = function available in C code; 
-  - `cpdef` = function available in C/C++ and Python, 
+  - `cdef` = function available in C code;
+  - `cpdef` = function available in C/C++ and Python,
   - `def` = function available in Python code.
   - `cimport module` = import C/C++ visible functions; use `module.` prefix to access.
   - `from module cimport func, Class, type` = import selected classes, types or functions; juse no prefix to access.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -564,7 +564,7 @@ Nfa union_nondet(const Nfa &lhs, const Nfa &rhs);
 /**
  * @brief Compute union of two complete deterministic NFAs. Perserves determinism.
  *
- * The union is computed by product construction with or condition on the final states.
+ * The union is computed by product construction with OR condition on the final states.
  * @param lhs First complete deterministic automaton.
  * @param rhs Second complete deterministic automaton.
  */

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -562,15 +562,37 @@ OnTheFlyAlphabet create_alphabet(const std::vector<const Nfa*>& nfas);
 Nfa union_nondet(const Nfa &lhs, const Nfa &rhs);
 
 /**
- * @brief Compute union by product construction.
+ * @brief Compute union of two complete deterministic NFAs. Perserves determinism.
  *
- * Preserves determinism.
- * @param[in] first_epsilon The first symbol to handle as an epsilon.
- * @param[out] prod_map Map mapping product states to the original states.
- * @return Union by product construction of @p lhs and @p rhs.
+ * The union is computed by product construction with or condition on the final states.
+ * @param lhs First complete deterministic automaton.
+ * @param rhs Second complete deterministic automaton.
  */
-Nfa union_product(const Nfa &lhs, const Nfa &rhs, Symbol first_epsilon = EPSILON,
-                  std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
+Nfa union_det_complete_by_product_or(const Nfa &lhs, const Nfa &rhs);
+
+/**
+ * @brief Compute product of two NFAs with OR condition on the final states.
+ *
+ * Automata must share alphabets. //TODO: this is not implemented yet.
+ * @param lhs First NFA.
+ * @param rhs Second NFA.
+ * @param first_epsilon Smallest epsilon symbol. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
+ * @param prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
+ */
+Nfa product_or(const Nfa &lhs, const Nfa &rhs, Symbol first_epsilon = EPSILON,
+               std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
+
+/**
+ * @brief Compute product of two NFAs with AND condition on the final states.
+ *
+ * Automata must share alphabets. //TODO: this is not implemented yet.
+ * @param lhs First NFA.
+ * @param rhs Second NFA.
+ * @param first_epsilon Smallest epsilon symbol. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
+ * @param prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
+ */
+Nfa product_and(const Nfa &lhs, const Nfa &rhs, Symbol first_epsilon = EPSILON,
+               std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
 
 /**
  * @brief Compute a language difference as @p nfa_included \ @p nfa_excluded.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -568,7 +568,7 @@ Nfa union_nondet(const Nfa &lhs, const Nfa &rhs);
  * @param lhs First complete deterministic automaton.
  * @param rhs Second complete deterministic automaton.
  */
-Nfa union_det_complete_by_product_or(const Nfa &lhs, const Nfa &rhs);
+Nfa union_det_complete(const Nfa &lhs, const Nfa &rhs);
 
 /**
  * @brief Compute product of two NFAs with OR condition on the final states.
@@ -576,23 +576,14 @@ Nfa union_det_complete_by_product_or(const Nfa &lhs, const Nfa &rhs);
  * Automata must share alphabets. //TODO: this is not implemented yet.
  * @param lhs First NFA.
  * @param rhs Second NFA.
+ * @param final_condition Condition for a product state to be final.
+ *  - AND: both original states have to be final.
+ *  - OR: at least one of the original states has to be final.
  * @param first_epsilon Smallest epsilon symbol. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
  * @param prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
  */
-Nfa product_or(const Nfa &lhs, const Nfa &rhs, Symbol first_epsilon = EPSILON,
-               std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
-
-/**
- * @brief Compute product of two NFAs with AND condition on the final states.
- *
- * Automata must share alphabets. //TODO: this is not implemented yet.
- * @param lhs First NFA.
- * @param rhs Second NFA.
- * @param first_epsilon Smallest epsilon symbol. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
- * @param prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
- */
-Nfa product_and(const Nfa &lhs, const Nfa &rhs, Symbol first_epsilon = EPSILON,
-               std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
+Nfa product(const Nfa &lhs, const Nfa &rhs, ProductFinalCondition final_condition = ProductFinalCondition::AND,
+            Symbol first_epsilon = EPSILON, std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
 
 /**
  * @brief Compute a language difference as @p nfa_included \ @p nfa_excluded.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -582,7 +582,7 @@ Nfa union_det_complete(const Nfa &lhs, const Nfa &rhs);
  * @param first_epsilon Smallest epsilon symbol. //TODO: this should eventually be taken from the alphabet as anything larger than the largest symbol?
  * @param prod_map Mapping of pairs of the original states (lhs_state, rhs_state) to new product states (not used internally, allocated only when !=nullptr, expensive).
  */
-Nfa product(const Nfa &lhs, const Nfa &rhs, ProductFinalCondition final_condition = ProductFinalCondition::AND,
+Nfa product(const Nfa &lhs, const Nfa &rhs, ProductFinalStateCondition final_condition = ProductFinalStateCondition::AND,
             Symbol first_epsilon = EPSILON, std::unordered_map<std::pair<State,State>,State> *prod_map = nullptr);
 
 /**

--- a/include/mata/nfa/types.hh
+++ b/include/mata/nfa/types.hh
@@ -20,7 +20,7 @@ struct Run {
     std::vector<State> path{}; ///< A finite-length path through automaton.
 };
 
-enum class ProductFinalCondition {
+enum class ProductFinalStateCondition {
     AND, ///< Both original states have to be final.
     OR,  ///< At least one of the original states has to be final.
 };

--- a/include/mata/nfa/types.hh
+++ b/include/mata/nfa/types.hh
@@ -20,6 +20,11 @@ struct Run {
     std::vector<State> path{}; ///< A finite-length path through automaton.
 };
 
+enum class ProductFinalCondition {
+    AND, ///< Both original states have to be final.
+    OR,  ///< At least one of the original states has to be final.
+};
+
 using StateRenaming = std::unordered_map<State, State>;
 
 /**

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -361,7 +361,7 @@ public:
 
     /**
      * Remove simple epsilon transitions from the automaton.
-     * 
+     *
      * @sa mata::nft::remove_epsilon()
      */
     void remove_epsilon(Symbol epsilon = EPSILON);
@@ -374,7 +374,7 @@ public:
     /**
      * @brief In-place union
      */
-    Nft& uni(const Nft &aut);
+    Nft& unite_nondet_with(const Nft &aut);
 
     /**
      * Unify transitions to create a directed graph with at most a single transition between two states.
@@ -594,7 +594,7 @@ template<typename... Ts> using conjunction = std::is_same<bool_pack<true,Ts::val
 /// Check that all types in a sequence of parameters @p Ts are of type @p T.
 template<typename T, typename... Ts> using AreAllOfType = typename conjunction<std::is_same<Ts, T>...>::type;
 
-Nft uni(const Nft &lhs, const Nft &rhs);
+Nft union_nondet(const Nft &lhs, const Nft &rhs);
 
 /**
  * @brief Compute intersection of two NFTs.
@@ -844,7 +844,7 @@ Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
  * @brief Remove simple epsilon transitions.
- * 
+ *
  * Simple epsilon transitions are the transitions of the form
  *      q0 -epsilon-> q1 -epsilon-> q2 -epsilon-> ... -epsilon-> qn
  * where q0 and qn are level 0 states, the states in-between are states
@@ -853,12 +853,12 @@ Nft invert_levels(const Nft& aut, JumpMode jump_mode = JumpMode::RepeatSymbol);
  * and only 1 transition going from qi (the transition qi -epsilon -> qi+1).
  * This means that if there was some state p0 going with epsilon to q1,
  * these to epsilon transitions would not be removed.
- * 
+ *
  * Furthermore, this assumes that the NFT @p aut does not have jump transitions.
- * 
+ *
  * The resulting automaton has the same number of states as @p aut, just the
  * transitions can change. It is recommended to run trim() after this function.
- * 
+ *
  * @param aut NFT without jump transitions
  * @param epsilon symbol representing epsilon
  * @return NFT whose language is same as @p aut but does not contain simple epsilon transitions

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -602,9 +602,9 @@ template<typename T, typename... Ts> using AreAllOfType = typename conjunction<s
  */
 Nft union_nondet(const Nft &lhs, const Nft &rhs);
 
-Nft union_det_complete_by_product_or(const Nft &lhs, const Nft &rhs) = delete;
-Nft product_or(const Nft &lhs, const Nft &rhs, Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
-Nft product_and(const Nft &lhs, const Nft &rhs, Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
+Nft union_det_complete(const Nft &lhs, const Nft &rhs) = delete;
+Nft product(const Nft &lhs, const Nft &rhs, ProductFinalCondition final_condition,
+    Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
 
 /**
  * @brief Compute intersection of two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -594,7 +594,17 @@ template<typename... Ts> using conjunction = std::is_same<bool_pack<true,Ts::val
 /// Check that all types in a sequence of parameters @p Ts are of type @p T.
 template<typename T, typename... Ts> using AreAllOfType = typename conjunction<std::is_same<Ts, T>...>::type;
 
+/**
+ * @brief Compute non-deterministic union.
+ *
+ * Does not add epsilon transitions, just unites initial and final states.
+ * @return Non-deterministic union of @p lhs and @p rhs.
+ */
 Nft union_nondet(const Nft &lhs, const Nft &rhs);
+
+Nft union_det_complete_by_product_or(const Nft &lhs, const Nft &rhs) = delete;
+Nft product_or(const Nft &lhs, const Nft &rhs, Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
+Nft product_and(const Nft &lhs, const Nft &rhs, Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
 
 /**
  * @brief Compute intersection of two NFTs.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -603,7 +603,7 @@ template<typename T, typename... Ts> using AreAllOfType = typename conjunction<s
 Nft union_nondet(const Nft &lhs, const Nft &rhs);
 
 Nft union_det_complete(const Nft &lhs, const Nft &rhs) = delete;
-Nft product(const Nft &lhs, const Nft &rhs, ProductFinalCondition final_condition,
+Nft product(const Nft &lhs, const Nft &rhs, ProductFinalStateCondition final_condition,
     Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) = delete;
 
 /**

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -62,7 +62,7 @@ void construct(Nft* result, const ParsedObject& parsed, Alphabet* alphabet = nul
     *result = builder::construct(parsed, alphabet, state_map);
 }
 
-inline void uni(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAutomaton = uni(lhs, rhs); }
+inline void union_nondet(Nft *unionAutomaton, const Nft &lhs, const Nft &rhs) { *unionAutomaton = union_nondet(lhs, rhs); }
 
 /**
  * @brief Compute intersection of two NFTs.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -45,7 +45,7 @@ enum class JumpMode {
     AppendDontCares ///< Append a sequence of DONT_CAREs to the symbol on the jump.
 };
 
-using ProductFinalCondition = mata::nfa::ProductFinalCondition;
+using ProductFinalStateCondition = mata::nfa::ProductFinalStateCondition;
 
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = mata::nfa::EPSILON;

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -45,6 +45,8 @@ enum class JumpMode {
     AppendDontCares ///< Append a sequence of DONT_CAREs to the symbol on the jump.
 };
 
+using ProductFinalCondition = mata::nfa::ProductFinalCondition;
+
 /// An epsilon symbol which is now defined as the maximal value of data type used for symbols.
 constexpr Symbol EPSILON = mata::nfa::EPSILON;
 constexpr Symbol DONT_CARE = EPSILON - 1;

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1088,39 +1088,41 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     return result;
 }
 
-Nfa mata::nfa::product_or(const Nfa &lhs, const Nfa &rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
-    auto one_final = [&](const State lhs_state,const State rhs_state) {
-        return lhs.final.contains(lhs_state) || rhs.final.contains(rhs_state);
-    };
+Nfa mata::nfa::product(const Nfa &lhs, const Nfa &rhs, const ProductFinalCondition final_condition,
+                       const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
 
-    if (lhs.final.empty() || lhs.initial.empty()) { return rhs; }
-    if (rhs.final.empty() || rhs.initial.empty()) { return lhs; }
-    return algorithms::product(lhs, rhs, one_final, first_epsilon, prod_map);
-}
-
-Nfa mata::nfa::product_and(const Nfa &lhs, const Nfa &rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
-    auto both_final = [&](const State lhs_state,const State rhs_state) {
-        return lhs.final.contains(lhs_state) && rhs.final.contains(rhs_state);
-    };
-
-    if (lhs.final.empty() || lhs.initial.empty() || rhs.final.empty() || rhs.initial.empty()) {
-        return Nfa{};
+    std::function<bool(const State, const State)> is_productstate_final_func;
+    if (final_condition == ProductFinalCondition::OR) {
+        if (lhs.initial.empty() || lhs.final.empty()) { return rhs; }
+        if (rhs.initial.empty() || rhs.final.empty()) { return lhs; }
+        is_productstate_final_func = [&](const State lhs_state, const State rhs_state) {
+            return lhs.final.contains(lhs_state) || rhs.final.contains(rhs_state);
+        };
+    } else if (final_condition == ProductFinalCondition::AND) {
+        if (lhs.initial.empty() || lhs.final.empty()) { return Nfa{}; }
+        if (rhs.initial.empty() || rhs.final.empty()) { return Nfa{}; }
+        is_productstate_final_func = [&](const State lhs_state, const State rhs_state) {
+            return lhs.final.contains(lhs_state)&& rhs.final.contains(rhs_state);
+        };
+    } else {
+        throw std::runtime_error(std::to_string(__func__) + " received an unknown value of the \"final_condition\"");
     }
-    return algorithms::product(lhs, rhs, both_final, first_epsilon, prod_map);
+
+    return algorithms::product(lhs, rhs, std::move(is_productstate_final_func), first_epsilon, prod_map);
 }
 
 Nfa mata::nfa::intersection(const Nfa& lhs, const Nfa& rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State, State>, State>  *prod_map) {
-    return product_and(lhs, rhs, first_epsilon, prod_map);
+    return product(lhs, rhs, ProductFinalCondition::AND, first_epsilon, prod_map);
 }
 
 Nfa mata::nfa::union_nondet(const Nfa &lhs, const Nfa &rhs) { return Nfa{ lhs }.unite_nondet_with(rhs); }
 
-Nfa mata::nfa::union_det_complete_by_product_or(const Nfa &lhs, const Nfa &rhs) {
+Nfa mata::nfa::union_det_complete(const Nfa &lhs, const Nfa &rhs) {
     assert(lhs.is_deterministic());
     assert(rhs.is_deterministic());
     assert(lhs.is_complete());
     assert(rhs.is_complete());
-    return product_or(lhs, rhs, EPSILON);
+    return product(lhs, rhs, ProductFinalCondition::OR, EPSILON);
 }
 
 Simlib::Util::BinaryRelation mata::nfa::algorithms::compute_relation(const Nfa& aut, const ParameterMap& params) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1088,20 +1088,7 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     return result;
 }
 
-
-Nfa mata::nfa::intersection(const Nfa& lhs, const Nfa& rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State, State>, State>  *prod_map) {
-
-    auto both_final = [&](const State lhs_state,const State rhs_state) {
-        return lhs.final.contains(lhs_state) && rhs.final.contains(rhs_state);
-    };
-
-    if (lhs.final.empty() || lhs.initial.empty() || rhs.initial.empty() || rhs.final.empty())
-        return Nfa{};
-
-    return algorithms::product(lhs, rhs, both_final, first_epsilon, prod_map);
-}
-
-Nfa mata::nfa::union_product(const Nfa &lhs, const Nfa &rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
+Nfa mata::nfa::product_or(const Nfa &lhs, const Nfa &rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
     auto one_final = [&](const State lhs_state,const State rhs_state) {
         return lhs.final.contains(lhs_state) || rhs.final.contains(rhs_state);
     };
@@ -1111,7 +1098,30 @@ Nfa mata::nfa::union_product(const Nfa &lhs, const Nfa &rhs, const Symbol first_
     return algorithms::product(lhs, rhs, one_final, first_epsilon, prod_map);
 }
 
+Nfa mata::nfa::product_and(const Nfa &lhs, const Nfa &rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
+    auto both_final = [&](const State lhs_state,const State rhs_state) {
+        return lhs.final.contains(lhs_state) && rhs.final.contains(rhs_state);
+    };
+
+    if (lhs.final.empty() || lhs.initial.empty() || rhs.final.empty() || rhs.initial.empty()) {
+         return Nfa{};
+    }
+    return algorithms::product(lhs, rhs, both_final, first_epsilon, prod_map);
+}
+
+Nfa mata::nfa::intersection(const Nfa& lhs, const Nfa& rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State, State>, State>  *prod_map) {
+    return product_and(lhs, rhs, first_epsilon, prod_map);
+}
+
 Nfa mata::nfa::union_nondet(const Nfa &lhs, const Nfa &rhs) { return Nfa{ lhs }.unite_nondet_with(rhs); }
+
+Nfa mata::nfa::union_det_complete_by_product_or(const Nfa &lhs, const Nfa &rhs) {
+    assert(lhs.is_deterministic());
+    assert(rhs.is_deterministic());
+    assert(lhs.is_complete());
+    assert(rhs.is_complete());
+    return product_or(lhs, rhs, EPSILON);
+}
 
 Simlib::Util::BinaryRelation mata::nfa::algorithms::compute_relation(const Nfa& aut, const ParameterMap& params) {
     if (!haskey(params, "relation")) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1104,7 +1104,7 @@ Nfa mata::nfa::product_and(const Nfa &lhs, const Nfa &rhs, const Symbol first_ep
     };
 
     if (lhs.final.empty() || lhs.initial.empty() || rhs.final.empty() || rhs.initial.empty()) {
-         return Nfa{};
+        return Nfa{};
     }
     return algorithms::product(lhs, rhs, both_final, first_epsilon, prod_map);
 }

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1088,17 +1088,17 @@ Nfa mata::nfa::algorithms::minimize_hopcroft(const Nfa& dfa_trimmed) {
     return result;
 }
 
-Nfa mata::nfa::product(const Nfa &lhs, const Nfa &rhs, const ProductFinalCondition final_condition,
+Nfa mata::nfa::product(const Nfa &lhs, const Nfa &rhs, const ProductFinalStateCondition final_condition,
                        const Symbol first_epsilon, std::unordered_map<std::pair<State,State>,State> *prod_map) {
 
     std::function<bool(const State, const State)> is_productstate_final_func;
-    if (final_condition == ProductFinalCondition::OR) {
+    if (final_condition == ProductFinalStateCondition::OR) {
         if (lhs.initial.empty() || lhs.final.empty()) { return rhs; }
         if (rhs.initial.empty() || rhs.final.empty()) { return lhs; }
         is_productstate_final_func = [&](const State lhs_state, const State rhs_state) {
             return lhs.final.contains(lhs_state) || rhs.final.contains(rhs_state);
         };
-    } else if (final_condition == ProductFinalCondition::AND) {
+    } else if (final_condition == ProductFinalStateCondition::AND) {
         if (lhs.initial.empty() || lhs.final.empty()) { return Nfa{}; }
         if (rhs.initial.empty() || rhs.final.empty()) { return Nfa{}; }
         is_productstate_final_func = [&](const State lhs_state, const State rhs_state) {
@@ -1112,7 +1112,7 @@ Nfa mata::nfa::product(const Nfa &lhs, const Nfa &rhs, const ProductFinalConditi
 }
 
 Nfa mata::nfa::intersection(const Nfa& lhs, const Nfa& rhs, const Symbol first_epsilon, std::unordered_map<std::pair<State, State>, State>  *prod_map) {
-    return product(lhs, rhs, ProductFinalCondition::AND, first_epsilon, prod_map);
+    return product(lhs, rhs, ProductFinalStateCondition::AND, first_epsilon, prod_map);
 }
 
 Nfa mata::nfa::union_nondet(const Nfa &lhs, const Nfa &rhs) { return Nfa{ lhs }.unite_nondet_with(rhs); }
@@ -1122,7 +1122,7 @@ Nfa mata::nfa::union_det_complete(const Nfa &lhs, const Nfa &rhs) {
     assert(rhs.is_deterministic());
     assert(lhs.is_complete());
     assert(rhs.is_complete());
-    return product(lhs, rhs, ProductFinalCondition::OR, EPSILON);
+    return product(lhs, rhs, ProductFinalStateCondition::OR, EPSILON);
 }
 
 Simlib::Util::BinaryRelation mata::nfa::algorithms::compute_relation(const Nfa& aut, const ParameterMap& params) {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -959,12 +959,12 @@ Nft mata::nft::minimize(
     return algo(aut);
 }
 
-Nft mata::nft::uni(const Nft &lhs, const Nft &rhs) {
+Nft mata::nft::union_nondet(const Nft &lhs, const Nft &rhs) {
     Nft union_nft{ lhs };
-    return union_nft.uni(rhs);
+    return union_nft.unite_nondet_with(rhs);
 }
 
-Nft& Nft::uni(const Nft& aut) {
+Nft& Nft::unite_nondet_with(const Nft& aut) {
     size_t n = this->num_of_states();
     auto upd_fnc = [&](State st) {
         return st + n;

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3302,7 +3302,7 @@ TEST_CASE("mata::nfa::union_inplace") {
     }
 }
 
-TEST_CASE("mata::nfa::product_or()") {
+TEST_CASE("mata::nfa::product(OR)") {
     Run one{ { 1 },{} };
     Run zero{{ 0 }, {} };
     Run two{ { 2 },{} };
@@ -3333,7 +3333,7 @@ TEST_CASE("mata::nfa::product_or()") {
     REQUIRE(!rhs.is_in_lang(two_three));
 
     SECTION("Minimal example") {
-        Nfa result = mata::nfa::product_or(lhs, rhs);
+        Nfa result = mata::nfa::product(lhs, rhs, ProductFinalCondition::OR);
         CHECK(!result.is_in_lang(one));
         CHECK(!result.is_in_lang(zero));
         CHECK(result.is_in_lang(two));

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3333,7 +3333,7 @@ TEST_CASE("mata::nfa::product(OR)") {
     REQUIRE(!rhs.is_in_lang(two_three));
 
     SECTION("Minimal example") {
-        Nfa result = mata::nfa::product(lhs, rhs, ProductFinalCondition::OR);
+        Nfa result = mata::nfa::product(lhs, rhs, ProductFinalStateCondition::OR);
         CHECK(!result.is_in_lang(one));
         CHECK(!result.is_in_lang(zero));
         CHECK(result.is_in_lang(two));

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3302,7 +3302,7 @@ TEST_CASE("mata::nfa::union_inplace") {
     }
 }
 
-TEST_CASE("mata::nfa::union_product()") {
+TEST_CASE("mata::nfa::product_or()") {
     Run one{ { 1 },{} };
     Run zero{{ 0 }, {} };
     Run two{ { 2 },{} };
@@ -3333,7 +3333,7 @@ TEST_CASE("mata::nfa::union_product()") {
     REQUIRE(!rhs.is_in_lang(two_three));
 
     SECTION("Minimal example") {
-        Nfa result = mata::nfa::union_product(lhs, rhs);
+        Nfa result = mata::nfa::product_or(lhs, rhs);
         CHECK(!result.is_in_lang(one));
         CHECK(!result.is_in_lang(zero));
         CHECK(result.is_in_lang(two));

--- a/tests/nft/nft-plumbing.cc
+++ b/tests/nft/nft-plumbing.cc
@@ -77,10 +77,10 @@ TEST_CASE("Mata::nft::Plumbing") {
         CHECK(result.is_lang_empty());
     }
 
-    SECTION("Mata::nft::Plumbing::union") {
+    SECTION("Mata::nft::Plumbing::union_nondet") {
         FILL_WITH_AUT_A(lhs);
         FILL_WITH_AUT_B(lhs);
-        mata::nft::plumbing::uni(&result, lhs, rhs);
+        mata::nft::plumbing::union_nondet(&result, lhs, rhs);
         CHECK(!result.is_lang_empty());
     }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2865,7 +2865,7 @@ TEST_CASE("mata::nft::union_norename()") {
     REQUIRE(!rhs.is_in_lang(zero));
 
     SECTION("failing minimal scenario") {
-        Nft result = uni(lhs, rhs);
+        Nft result = union_nondet(lhs, rhs);
         REQUIRE(result.is_in_lang(one));
         REQUIRE(result.is_in_lang(zero));
     }
@@ -2890,14 +2890,14 @@ TEST_CASE("mata::nft::union_inplace") {
     REQUIRE(!rhs.is_in_lang(zero));
 
     SECTION("failing minimal scenario") {
-        Nft result = lhs.uni(rhs);
+        Nft result = lhs.unite_nondet_with(rhs);
         REQUIRE(result.is_in_lang(one));
         REQUIRE(result.is_in_lang(zero));
     }
 
     SECTION("same automata") {
         size_t lhs_states = lhs.num_of_states();
-        Nft result = lhs.uni(lhs);
+        Nft result = lhs.unite_nondet_with(lhs);
         REQUIRE(result.num_of_states() == lhs_states * 2);
     }
 }


### PR DESCRIPTION
This PR resolves the confusion in the naming of `product` and `union` methods by:  

- Creating `Nfa::product`
     - This method computes the product of two automata with an AND or OR condition on final states.  
- Renaming `Nfa::union_product` to `Nfa::union_det_complete`
     - This method utilizes `Nfa::product` with `ProductFinalStateCondition::OR` to compute the union of two deterministic and complete automata while preserving determinism.  
- Modifying `Nfa::include` method to use `Nfa::product` with `ProductFinalStateCondition::AND`. 
- Changing the name of `Nft::uni` and `Nft::nft::uni` to `Nft::unite_nondet_with` and `Nft::nft::union_nondet` to keep with NFA naming.
- Deleting `Nft::product`, `Nft::union_det_complete`
- Updating relevant tests.

Feel free to suggest better names for these methods.  