### PR TITLE
Compose for Nonconsecutive Synchronization Levels

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -628,11 +628,12 @@ Nft intersection(const Nft& lhs, const Nft& rhs,
                  State lhs_first_aux_state = Limits::max_state, State rhs_first_aux_state = Limits::max_state);
 
 /**
- * @brief Composes two NFTs.
+ * @brief Composes two NFTs (lhs || rhs; read as "rhs after lhs").
  *
- * Takes two NFTs and their corresponding synchronization levels as input, and returns a new NFT that represents their
- *  composition as `lhs || rhs` where `a || b` (read as "a pipe b", or "b after a") means apply `a` on input and then apply `b` on
- *  output of `a`.
+ * This function computes the composition of two NFTs, `lhs` and `rhs`, by aligning their synchronization levels.
+ * Transitions between two synchronization levels are ordered as follows: first the transitions of `lhs`, then
+ * the transitions of `rhs` followed by next synchronization level (if exists). By default, synchronization
+ * levels are projected out from the resulting NFT.
  *
  * Vectors of synchronization levels have to be non-empty and of the the same size.
  *
@@ -651,11 +652,12 @@ Nft compose(const Nft& lhs, const Nft& rhs,
             JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 /**
- * @brief Composes two NFTs.
+ * @brief Composes two NFTs (lhs || rhs; read as "rhs after lhs").
  *
- * Takes two NFTs and their corresponding synchronization levels as input, and returns a new NFT that represents their
- *  composition as `lhs || rhs` where `a || b` (read as "a pipe b", or "b after a") means apply `a` on input and then apply `b` on
- *  output of `a`.
+ * This function computes the composition of two NFTs, `lhs` and `rhs`, by aligning their synchronization levels.
+ * Transitions between two synchronization levels are ordered as follows: first the transitions of `lhs`, then
+ * the transitions of `rhs` followed by next synchronization level (if exists). By default, synchronization
+ * levels are projected out from the resulting NFT.
  *
  * @param[in] lhs First transducer to compose.
  * @param[in] rhs Second transducer to compose.

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -35,53 +35,69 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
         }
     };
 
-    // Calculate new_levels_mask, which is used for inserting levels to match the synchronization
-    // transitions in lhs and rhs. It also calculates the vector levels_to_project_out, which contains
-    // levels of synchronized transitions. These levels will be projected out from the Nft after the composition.
+    // Calculate the number of non-synchronization levels in lhs and rhs before/after each/last synchronization level.
     // Example:
-    // lhs_sync_levels: 1 4
-    // rhs_sync_levels: 2 3
-    // lhs_new_levels_mask: 0 1 0 0 0
-    // rhs_new_levels_mask: 0 0 1 1 0
-    // levels_to_project_out: 2 5
-    Level min_level = std::min(*lhs_sync_levels.begin(), *rhs_sync_levels.begin());
-    size_t lhs_suffix_len = lhs.num_of_levels - 1 - *--lhs_sync_levels.end();
-    size_t rhs_suffix_len = rhs.num_of_levels - 1 - *--rhs_sync_levels.end();
-    size_t biggest_suffix_len = std::max(lhs_suffix_len, rhs_suffix_len);
-    BoolVector lhs_new_levels_mask(min_level, false);
-    BoolVector rhs_new_levels_mask(min_level, false);
-    OrdVector<Level> levels_to_project_out;
-    Level lhs_offset{ 0 };
-    Level rhs_offset{ 0 };
-    Level lhs_lvl{ 0 };
-    Level rhs_lvl{ 0 };
-    for (auto lhs_sync_levels_it{ lhs_sync_levels.begin() }, rhs_sync_levels_it{ rhs_sync_levels.begin ()};
-         lhs_sync_levels_it != lhs_sync_levels.end();
-         ++lhs_sync_levels_it, ++rhs_sync_levels_it) {
-        lhs_lvl = *lhs_sync_levels_it + lhs_offset;
-        rhs_lvl = *rhs_sync_levels_it + rhs_offset;
-        if (lhs_lvl < rhs_lvl) {
-            lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), rhs_lvl - lhs_lvl, true);
-            rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), rhs_lvl - lhs_lvl, false);
-            lhs_offset += rhs_lvl - lhs_lvl ;
-        } else if (lhs_lvl > rhs_lvl) {
-            lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), lhs_lvl - rhs_lvl, false);
-            rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), lhs_lvl - rhs_lvl, true);
-            rhs_offset = lhs_lvl - rhs_lvl;
-        } else {
-            lhs_new_levels_mask.resize(lhs_lvl, false);
-            rhs_new_levels_mask.resize(rhs_lvl, false);
-        }
-        lhs_new_levels_mask.push_back(false);
-        rhs_new_levels_mask.push_back(false);
-        levels_to_project_out.push_back(static_cast<Level>(lhs_new_levels_mask.size() - 1));
+    //    Lets suppose we have 2 synchnonization levels.
+    //    The vector lhs_nonsync_levels_cnt = { 2, 0, 1 } indicates that
+    //    - before the first synchronization level (i == 0) there are 2 non-synchronization levels
+    //    - before the second synchronization level (i == 1) there are 0 non-synchronization levels
+    //    - after the last synchronization level (i == |sync| - 1) there is 1 non-synchronization level
+    std::vector<unsigned> lhs_nonsync_levels_cnt;
+    std::vector<unsigned> rhs_nonsync_levels_cnt;
+    const size_t num_of_sync_levels = lhs_sync_levels.size();
+    lhs_nonsync_levels_cnt.reserve(num_of_sync_levels + 1);
+    rhs_nonsync_levels_cnt.reserve(num_of_sync_levels + 1);
+    auto lhs_sync_levels_it = lhs_sync_levels.cbegin();
+    auto rhs_sync_levels_it = rhs_sync_levels.cbegin();
+    // Before the first synchronization level (i == 0)
+    lhs_nonsync_levels_cnt.push_back(*lhs_sync_levels_it++);
+    rhs_nonsync_levels_cnt.push_back(*rhs_sync_levels_it++);
+    // Before each synchronization level (i < |sync| - 1)
+    for (size_t i = 1; i < num_of_sync_levels; ++i) {
+        lhs_nonsync_levels_cnt.push_back(*lhs_sync_levels_it - *(lhs_sync_levels_it - 1) - 1);
+        rhs_nonsync_levels_cnt.push_back(*rhs_sync_levels_it - *(rhs_sync_levels_it - 1) - 1);
+        ++lhs_sync_levels_it;
+        ++rhs_sync_levels_it;
     }
-    // Match the size of vectors and num_of_levels in lhs and rhs after the insertion of new levels.
-    lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), lhs_suffix_len, false);
-    rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), rhs_suffix_len, false);
-    lhs_new_levels_mask.insert(lhs_new_levels_mask.end(), biggest_suffix_len - lhs_suffix_len, true);
-    rhs_new_levels_mask.insert(rhs_new_levels_mask.end(), biggest_suffix_len - rhs_suffix_len, true);
+    // After the last synchronization level (i == |sync| - 1)
+    lhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(lhs.num_of_levels) - *(lhs_sync_levels_it - 1) - 1);
+    rhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(rhs.num_of_levels) - *(rhs_sync_levels_it - 1) - 1);
 
+    // Construct a mask for new levels in lhs and rhs.
+    // For each synchronization block (non-synchronization levels up to a synchronization transition),
+    // first insert the non-synchronization levels from lhs, then from rhs, and finally the synchronization level itself.
+    // For the last block of non-synchronization levels after the last synchronization level,
+    // insert the non-synchronization levels from lhs first, followed by the levels from rhs.
+    auto lhs_nonsync_levels_cnt_it = lhs_nonsync_levels_cnt.cbegin();
+    auto rhs_nonsync_levels_cnt_it = rhs_nonsync_levels_cnt.cbegin();
+    BoolVector lhs_new_levels_mask;
+    BoolVector rhs_new_levels_mask;
+    OrdVector<Level> sync_levels_to_project_out;
+    Level level = 0;
+    const size_t nonsync_levels_cnt_size = lhs_nonsync_levels_cnt.size();
+    for (size_t i = 0; i < nonsync_levels_cnt_size; ++i) {
+        // LHS goes first -> make space (insert new levels) in RHS
+        for (unsigned j = 0; j < *lhs_nonsync_levels_cnt_it; ++j, ++level) {
+            lhs_new_levels_mask.push_back(false);
+            rhs_new_levels_mask.push_back(true);
+        }
+        // RHS goes first -> make space (insert new levels) in LHS
+        for (unsigned j = 0; j < *rhs_nonsync_levels_cnt_it; ++j, ++level) {
+            lhs_new_levels_mask.push_back(true);
+            rhs_new_levels_mask.push_back(false);
+        }
+        // The synchronization level goes last
+        if (i < num_of_sync_levels) {
+            sync_levels_to_project_out.push_back(level);
+            lhs_new_levels_mask.push_back(false);
+            rhs_new_levels_mask.push_back(false);
+            ++level;
+        }
+        ++lhs_nonsync_levels_cnt_it;
+        ++rhs_nonsync_levels_cnt_it;
+    }
+
+    // Insert new levels into lhs and rhs.
     Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, jump_mode);
     Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, jump_mode);
 
@@ -89,12 +105,13 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     const State lhs_first_aux_state = lhs_synced.num_of_states();
     const State rhs_first_aux_state = rhs_synced.num_of_states();
 
+    // Insert self-loops into lhs and rhs to ensure synchronization on epsilon transitions.
     insert_self_loops(lhs_synced, lhs_new_levels_mask);
     insert_self_loops(rhs_synced, rhs_new_levels_mask);
 
     Nft result{ intersection(lhs_synced, rhs_synced, nullptr, jump_mode, lhs_first_aux_state, rhs_first_aux_state) };
     if (project_out_sync_levels) {
-        result = project_out(result, levels_to_project_out, jump_mode);
+        result = project_out(result, sync_levels_to_project_out, jump_mode);
     }
     return result;
 }

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -41,7 +41,7 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     //    The vector lhs_nonsync_levels_cnt = { 2, 0, 1 } indicates that
     //    - before the first synchronization level (i == 0) there are 2 non-synchronization levels
     //    - before the second synchronization level (i == 1) there are 0 non-synchronization levels
-    //    - after the last synchronization level (i == |sync| - 1) there is 1 non-synchronization level
+    //    - after the last synchronization level (i == |sync|) there is 1 non-synchronization level
     std::vector<unsigned> lhs_nonsync_levels_cnt;
     std::vector<unsigned> rhs_nonsync_levels_cnt;
     const size_t num_of_sync_levels = lhs_sync_levels.size();
@@ -52,14 +52,14 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     // Before the first synchronization level (i == 0)
     lhs_nonsync_levels_cnt.push_back(*lhs_sync_levels_it++);
     rhs_nonsync_levels_cnt.push_back(*rhs_sync_levels_it++);
-    // Before each synchronization level (i < |sync| - 1)
+    // Before each synchronization level (i < |sync|)
     for (size_t i = 1; i < num_of_sync_levels; ++i) {
         lhs_nonsync_levels_cnt.push_back(*lhs_sync_levels_it - *(lhs_sync_levels_it - 1) - 1);
         rhs_nonsync_levels_cnt.push_back(*rhs_sync_levels_it - *(rhs_sync_levels_it - 1) - 1);
         ++lhs_sync_levels_it;
         ++rhs_sync_levels_it;
     }
-    // After the last synchronization level (i == |sync| - 1)
+    // After the last synchronization level (i == |sync|)
     lhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(lhs.num_of_levels) - *(lhs_sync_levels_it - 1) - 1);
     rhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(rhs.num_of_levels) - *(rhs_sync_levels_it - 1) - 1);
 

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -68,6 +68,14 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     // first insert the non-synchronization levels from lhs, then from rhs, and finally the synchronization level itself.
     // For the last block of non-synchronization levels after the last synchronization level,
     // insert the non-synchronization levels from lhs first, followed by the levels from rhs.
+    // Example:
+    //                 LHS                         |                    RHS
+    // --------------------------------------------+---------------------------------------------
+    //            num_of_levels = 5                |             num_of_levels = 4
+    //          sync_levels = { 2, 4 }             |            sync_levels = { 1, 2 }
+    // --------------------------------------------|---------------------------------------------
+    //       nonsync_levels_cnt = { 2, 1, 0 }      |       nonsync_levels_cnt = { 1, 0, 1 }
+    //  new_levels_mask = { 0, 0, 1, 0, 0, 0, 1 }  |  new_levels_mask = { 1, 1, 0, 0, 1, 0, 0 }
     auto lhs_nonsync_levels_cnt_it = lhs_nonsync_levels_cnt.cbegin();
     auto rhs_nonsync_levels_cnt_it = rhs_nonsync_levels_cnt.cbegin();
     BoolVector lhs_new_levels_mask;

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -422,52 +422,146 @@ TEST_CASE("Mata::nft::compose()") {
     }
 
     SECTION("level ordering") {
-        lhs = Nft(13, { 0 }, { 12 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
-        lhs.delta.add(0, 'u', 1);
-        lhs.delta.add(1, 'a', 2);
-        lhs.delta.add(2, 'b', 3);
-        lhs.delta.add(3, 'v', 4);
-        lhs.delta.add(4, 'w', 5);
-        lhs.delta.add(5, 'c', 6);
-        lhs.delta.add(6, 'x', 7);
-        lhs.delta.add(7, 'y', 8);
-        lhs.delta.add(8, 'd', 9);
-        lhs.delta.add(9, 'e', 10);
-        lhs.delta.add(10, 'z', 11);
-        lhs.delta.add(11, 'f', 12);
+        SECTION("no jump") {
+            lhs = Nft(13, { 0 }, { 12 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs.delta.add(0, 'u', 1);
+            lhs.delta.add(1, 'a', 2);
+            lhs.delta.add(2, 'b', 3);
+            lhs.delta.add(3, 'v', 4);
+            lhs.delta.add(4, 'w', 5);
+            lhs.delta.add(5, 'c', 6);
+            lhs.delta.add(6, 'x', 7);
+            lhs.delta.add(7, 'y', 8);
+            lhs.delta.add(8, 'd', 9);
+            lhs.delta.add(9, 'e', 10);
+            lhs.delta.add(10, 'z', 11);
+            lhs.delta.add(11, 'f', 12);
 
-        rhs = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
-        rhs.delta.add(0, 'g', 1);
-        rhs.delta.add(1, 'h', 2);
-        rhs.delta.add(2, 'u', 3);
-        rhs.delta.add(3, 'i', 4);
-        rhs.delta.add(4, 'v', 5);
-        rhs.delta.add(5, 'w', 6);
-        rhs.delta.add(6, 'j', 7);
-        rhs.delta.add(7, 'x', 8);
-        rhs.delta.add(8, 'y', 9);
-        rhs.delta.add(9, 'k', 10);
-        rhs.delta.add(10, 'l', 11);
-        rhs.delta.add(11, 'm', 12);
-        rhs.delta.add(12, 'z', 13);
+            rhs = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            rhs.delta.add(0, 'g', 1);
+            rhs.delta.add(1, 'h', 2);
+            rhs.delta.add(2, 'u', 3);
+            rhs.delta.add(3, 'i', 4);
+            rhs.delta.add(4, 'v', 5);
+            rhs.delta.add(5, 'w', 6);
+            rhs.delta.add(6, 'j', 7);
+            rhs.delta.add(7, 'x', 8);
+            rhs.delta.add(8, 'y', 9);
+            rhs.delta.add(9, 'k', 10);
+            rhs.delta.add(10, 'l', 11);
+            rhs.delta.add(11, 'm', 12);
+            rhs.delta.add(12, 'z', 13);
 
-        expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
-        expected.delta.add(0, 'g', 1);
-        expected.delta.add(1, 'h', 2);
-        expected.delta.add(2, 'a', 3);
-        expected.delta.add(3, 'b', 4);
-        expected.delta.add(4, 'i', 5);
-        expected.delta.add(5, 'c', 6);
-        expected.delta.add(6, 'j', 7);
-        expected.delta.add(7, 'd', 8);
-        expected.delta.add(8, 'e', 9);
-        expected.delta.add(9, 'k', 10);
-        expected.delta.add(10, 'l', 11);
-        expected.delta.add(11, 'm', 12);
-        expected.delta.add(12, 'f', 13);
+            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected.delta.add(0, 'g', 1);
+            expected.delta.add(1, 'h', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(3, 'b', 4);
+            expected.delta.add(4, 'i', 5);
+            expected.delta.add(5, 'c', 6);
+            expected.delta.add(6, 'j', 7);
+            expected.delta.add(7, 'd', 8);
+            expected.delta.add(8, 'e', 9);
+            expected.delta.add(9, 'k', 10);
+            expected.delta.add(10, 'l', 11);
+            expected.delta.add(11, 'm', 12);
+            expected.delta.add(12, 'f', 13);
 
-        result = compose(lhs, rhs, { 0, 3, 4, 6, 7, 10 }, { 2, 4, 5, 7, 8, 12 });
+            result = compose(lhs, rhs, { 0, 3, 4, 6, 7, 10 }, { 2, 4, 5, 7, 8, 12 });
 
-        CHECK(are_equivalent(result, expected));
+            CHECK(are_equivalent(result, expected));
+        }
+
+        SECTION("long jump - JumpMode::RepeatSymbol") {
+            lhs = Nft(12, { 0 }, { 11 }, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs.delta.add(0, 'u', 1);
+            lhs.delta.add(1, 'a', 2);
+            lhs.delta.add(2, 'v', 3);
+            lhs.delta.add(3, 'w', 4);
+            lhs.delta.add(4, 'c', 5);
+            lhs.delta.add(5, 'x', 6);
+            lhs.delta.add(6, 'y', 7);
+            lhs.delta.add(7, 'd', 8);
+            lhs.delta.add(8, 'e', 9);
+            lhs.delta.add(9, 'z', 10);
+            lhs.delta.add(10, 'f', 11);
+
+            rhs = Nft(11, { 0 }, { 10 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 }, 13);
+            rhs.delta.add(0, 'g', 1);
+            rhs.delta.add(1, 'h', 2);
+            rhs.delta.add(2, 'u', 3);
+            rhs.delta.add(3, 'i', 4);
+            rhs.delta.add(4, 'v', 5);
+            rhs.delta.add(5, 'w', 6);
+            rhs.delta.add(6, 'j', 7);
+            rhs.delta.add(7, 'x', 8);
+            rhs.delta.add(8, 'y', 9);
+            rhs.delta.add(9, 'z', 10);
+
+            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected.delta.add(0, 'g', 1);
+            expected.delta.add(1, 'h', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(3, 'a', 4);
+            expected.delta.add(4, 'i', 5);
+            expected.delta.add(5, 'c', 6);
+            expected.delta.add(6, 'j', 7);
+            expected.delta.add(7, 'd', 8);
+            expected.delta.add(8, 'e', 9);
+            expected.delta.add(9, 'y', 10);
+            expected.delta.add(10, 'y', 11);
+            expected.delta.add(11, 'y', 12);
+            expected.delta.add(12, 'f', 13);
+
+            result = compose(lhs, rhs, { 0, 3, 4, 6, 7, 10 }, { 2, 4, 5, 7, 8, 12 }, true, JumpMode::RepeatSymbol);
+
+            CHECK(are_equivalent(result, expected, JumpMode::RepeatSymbol));
+        }
+
+        SECTION("long jump - JumpMode::AppendDontCares") {
+            lhs = Nft(12, { 0 }, { 11 }, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs.delta.add(0, 'u', 1);
+            lhs.delta.add(1, 'a', 2);
+            lhs.delta.add(2, 'v', 3);
+            lhs.delta.add(3, 'w', 4);
+            lhs.delta.add(4, 'c', 5);
+            lhs.delta.add(5, 'x', 6);
+            lhs.delta.add(6, 'y', 7);
+            lhs.delta.add(7, 'd', 8);
+            lhs.delta.add(8, 'e', 9);
+            lhs.delta.add(9, 'z', 10);
+            lhs.delta.add(10, 'f', 11);
+
+            rhs = Nft(11, { 0 }, { 10 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 }, 13);
+            rhs.delta.add(0, 'g', 1);
+            rhs.delta.add(1, 'h', 2);
+            rhs.delta.add(2, 'u', 3);
+            rhs.delta.add(3, 'i', 4);
+            rhs.delta.add(4, 'v', 5);
+            rhs.delta.add(5, 'w', 6);
+            rhs.delta.add(6, 'j', 7);
+            rhs.delta.add(7, 'x', 8);
+            rhs.delta.add(8, 'y', 9);
+            rhs.delta.add(9, 'z', 10);
+
+            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected.delta.add(0, 'g', 1);
+            expected.delta.add(1, 'h', 2);
+            expected.delta.add(2, 'a', 3);
+            expected.delta.add(3, DONT_CARE, 4);
+            expected.delta.add(4, 'i', 5);
+            expected.delta.add(5, 'c', 6);
+            expected.delta.add(6, 'j', 7);
+            expected.delta.add(7, 'd', 8);
+            expected.delta.add(8, 'e', 9);
+            expected.delta.add(9, DONT_CARE, 10);
+            expected.delta.add(10, DONT_CARE, 11);
+            expected.delta.add(11, DONT_CARE, 12);
+            expected.delta.add(12, 'f', 13);
+
+            result = compose(lhs, rhs, { 0, 3, 4, 6, 7, 10 }, { 2, 4, 5, 7, 8, 12 }, true, JumpMode::AppendDontCares);
+
+            CHECK(are_equivalent(result, expected, JumpMode::AppendDontCares));
+        }
     }
 }

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -420,4 +420,54 @@ TEST_CASE("Mata::nft::compose()") {
             CHECK(are_equivalent(result, expected));
         }
     }
+
+    SECTION("level ordering") {
+        lhs = Nft(13, { 0 }, { 12 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+        lhs.delta.add(0, 'u', 1);
+        lhs.delta.add(1, 'a', 2);
+        lhs.delta.add(2, 'b', 3);
+        lhs.delta.add(3, 'v', 4);
+        lhs.delta.add(4, 'w', 5);
+        lhs.delta.add(5, 'c', 6);
+        lhs.delta.add(6, 'x', 7);
+        lhs.delta.add(7, 'y', 8);
+        lhs.delta.add(8, 'd', 9);
+        lhs.delta.add(9, 'e', 10);
+        lhs.delta.add(10, 'z', 11);
+        lhs.delta.add(11, 'f', 12);
+
+        rhs = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+        rhs.delta.add(0, 'g', 1);
+        rhs.delta.add(1, 'h', 2);
+        rhs.delta.add(2, 'u', 3);
+        rhs.delta.add(3, 'i', 4);
+        rhs.delta.add(4, 'v', 5);
+        rhs.delta.add(5, 'w', 6);
+        rhs.delta.add(6, 'j', 7);
+        rhs.delta.add(7, 'x', 8);
+        rhs.delta.add(8, 'y', 9);
+        rhs.delta.add(9, 'k', 10);
+        rhs.delta.add(10, 'l', 11);
+        rhs.delta.add(11, 'm', 12);
+        rhs.delta.add(12, 'z', 13);
+
+        expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+        expected.delta.add(0, 'g', 1);
+        expected.delta.add(1, 'h', 2);
+        expected.delta.add(2, 'a', 3);
+        expected.delta.add(3, 'b', 4);
+        expected.delta.add(4, 'i', 5);
+        expected.delta.add(5, 'c', 6);
+        expected.delta.add(6, 'j', 7);
+        expected.delta.add(7, 'd', 8);
+        expected.delta.add(8, 'e', 9);
+        expected.delta.add(9, 'k', 10);
+        expected.delta.add(10, 'l', 11);
+        expected.delta.add(11, 'm', 12);
+        expected.delta.add(12, 'f', 13);
+
+        result = compose(lhs, rhs, { 0, 3, 4, 6, 7, 10 }, { 2, 4, 5, 7, 8, 12 });
+
+        CHECK(are_equivalent(result, expected));
+    }
 }


### PR DESCRIPTION
This PR:
- Extends the implementation of `Nft::compose()` to handle nonconsecutive sequences of synchronization levels, according to the discussion in #490
- Closes #490
- Improves the `compose()` documentation
- Adds necessary tests

The new implementation is based on:
![20250408_182040](https://github.com/user-attachments/assets/d9e56610-c170-44de-bb7e-4fed06d1c53a)
![20250408_182045](https://github.com/user-attachments/assets/05dab566-b9c4-44cb-9fa3-c5ce06db36dd)

