### PR TITLE
perf(delta): Optimize find() to not create empty SymbolPosts on each call

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -129,8 +129,16 @@ public:
     using super::erase;
 
     using super::find;
-    iterator find(const Symbol symbol) { return super::find({ symbol, {} }); }
-    const_iterator find(const Symbol symbol) const { return super::find({ symbol, {} }); }
+    iterator find(const Symbol symbol) {
+        static SymbolPost symbol_post{};
+        symbol_post.symbol = symbol;
+        return super::find(symbol_post);
+    }
+    const_iterator find(const Symbol symbol) const {
+        static SymbolPost symbol_post{};
+        symbol_post.symbol = symbol;
+        return super::find(symbol_post);
+    }
 
     ///returns an iterator to the smallest epsilon, or end() if there is no epsilon
     const_iterator first_epsilon_it(Symbol first_epsilon) const;


### PR DESCRIPTION
This PR optimises the `find()` method to create the empty `SymbolPosts` used only for the `looked_for_symbol_post.symbol == delta_state_post_element.symbol` comparison statically, so as not to allocate an empty `SymbolPost` on heap on each `find()` invocation. This proved to be an issue in numerous uses of Mata.

Further improvements will include empirical linear search in small-enough vectors and more.