### PR TITLE
Implementation of Features from #489

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -158,7 +158,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         StateSet post(StateSet&, Symbol)
         State add_state()
         State add_state(State)
-        void print_to_dot(ostream)
+        void print_to_dot(ostream, bool, bool, int)
         CNfa& trim(StateRenaming*)
         CNfa& concatenate(CNfa&)
         CNfa& unite_nondet_with(CNfa&)

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -616,7 +616,7 @@ cdef class Nfa:
     def __repr__(self):
         return str(self)
 
-    def to_dot_file(self, output_file='aut.dot', output_format='pdf', decode_ascii_chars=False, use_intervals=False, max_label_lenght=-1):
+    def to_dot_file(self, output_file='aut.dot', output_format='pdf', decode_ascii_chars=False, use_intervals=False, max_label_length=-1):
         """Transforms the automaton to dot format.
 
         By default, the result is saved to `aut.dot`, and further to `aut.dot.pdf`.

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -632,7 +632,7 @@ cdef class Nfa:
         cdef mata_nfa.ofstream* output
         output = new mata_nfa.ofstream(output_file.encode('utf-8'))
         try:
-            self.thisptr.get().print_to_dot(dereference(output), decode_ascii_chars, use_intervals, max_label_lenght)
+            self.thisptr.get().print_to_dot(dereference(output), decode_ascii_chars, use_intervals, max_label_length)
         finally:
             del output
 

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -616,7 +616,7 @@ cdef class Nfa:
     def __repr__(self):
         return str(self)
 
-    def to_dot_file(self, output_file='aut.dot', output_format='pdf'):
+    def to_dot_file(self, output_file='aut.dot', output_format='pdf', decode_ascii_chars=False, use_intervals=False, max_label_lenght=-1):
         """Transforms the automaton to dot format.
 
         By default, the result is saved to `aut.dot`, and further to `aut.dot.pdf`.
@@ -625,11 +625,14 @@ cdef class Nfa:
 
         :param str output_file: name of the output file where the automaton will be stored
         :param str output_format: format of the output file (pdf/png/etc)
+        :param bool decode_ascii_chars: whether to decode ascii codes
+        :param bool use_intervals: whether to use intervals ([1-3] instead of [1,2,3])
+        :param int max_label_lenght: maximum label length (-1 means no limit, 0 means no label)
         """
         cdef mata_nfa.ofstream* output
         output = new mata_nfa.ofstream(output_file.encode('utf-8'))
         try:
-            self.thisptr.get().print_to_dot(dereference(output))
+            self.thisptr.get().print_to_dot(dereference(output), decode_ascii_chars, use_intervals, max_label_lenght)
         finally:
             del output
 
@@ -638,17 +641,20 @@ cdef class Nfa:
         if err:
             print(f"error while dot file: {err}")
 
-    def to_dot_str(self, encoding='utf-8'):
+    def to_dot_str(self, encoding='utf-8', decode_ascii_chars=False, use_intervals=False, max_label_lenght=-1):
         """Transforms the automaton to dot format string
 
         :param str encoding: encoding of the dot string
+        :param bool decode_ascii_chars: whether to decode ascii codes
+        :param bool use_intervals: whether to use intervals ([1-3] instead of [1,2,3])
+        :param int max_label_lenght: maximum label length (-1 means no limit, 0 means no label)
         :return: string with dot representation of the automaton
         """
         cdef mata_nfa.stringstream* output_stream
         output_stream = new mata_nfa.stringstream("".encode('ascii'))
         cdef string result
         try:
-            self.thisptr.get().print_to_dot(dereference(output_stream))
+            self.thisptr.get().print_to_dot(dereference(output_stream), decode_ascii_chars, use_intervals, max_label_lenght)
             result = output_stream.str()
         finally:
             del output_stream

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -308,31 +308,31 @@ public:
     /**
      * @brief Prints the automaton in DOT format
      *
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
      *
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -309,21 +309,30 @@ public:
      * @brief Prints the automaton in DOT format
      *
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(const bool ascii = false) const;
+    std::string print_to_dot(bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
      *
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, const bool ascii = false) const;
+    void print_to_dot(std::ostream &output, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, const bool ascii = false) const;
+    void print_to_dot(const std::string& filename, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -424,33 +424,33 @@ public:
     /**
      * @brief Prints the automaton in DOT format
      *
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
 
     /**
      * @brief Prints the automaton to the output stream in DOT format
      *
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
 
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
-     * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] decode_ascii_chars Whether to use ASCII characters for the output.
      * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
-     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
-     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
+     * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
+    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -425,23 +425,32 @@ public:
      * @brief Prints the automaton in DOT format
      *
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(bool ascii = false) const;
+    std::string print_to_dot(bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
 
     /**
      * @brief Prints the automaton to the output stream in DOT format
      *
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, bool ascii = false) const;
+    void print_to_dot(std::ostream &output, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
 
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
      * @param[in] ascii Whether to use ASCII characters for the output.
+     * @param[in] use_intervals Whether to use intervals (e.g. [1-3] instead of 1,2,3) for labels.
+     * @param[in] max_label_len Maximum label length for the output (-1 means no limit, 0 means no labels).
+     * If the label is longer than @p max_label_len, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, const bool ascii = false) const;
+    void print_to_dot(const std::string& filename, bool ascii = false, bool use_intervals = false, int max_label_len = -1) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -111,12 +111,19 @@ extern const std::string g_GIT_SHA1;
  *   5. Other helper functions.
  */
 namespace utils {
-
-inline std::string replace_all(const std::string& input, const std::string& match, const std::string& replace) {
+/**
+ * @brief  Replace all occurrences of a substring in a string
+ *
+ * @param input The input string
+ * @param needle The substring to be replaced
+ * @param replace The replacement string
+ * @return A new string with all occurrences of the substring replaced.
+ */
+inline std::string replace_all(const std::string& input, const std::string& needle, const std::string& replace) {
 	std::string result = input;
 	size_t pos = 0;
-	while ((pos = result.find(match, pos)) != std::string::npos) {
-		result.replace(pos, match.length(), replace);
+	while ((pos = result.find(needle, pos)) != std::string::npos) {
+		result.replace(pos, needle.length(), replace);
 		pos += replace.length();
 	}
 	return result;

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -112,6 +112,16 @@ extern const std::string g_GIT_SHA1;
  */
 namespace utils {
 
+inline std::string replace_all(const std::string& input, const std::string& match, const std::string& replace) {
+	std::string result = input;
+	size_t pos = 0;
+	while ((pos = result.find(match, pos)) != std::string::npos) {
+		result.replace(pos, match.length(), replace);
+		pos += replace.length();
+	}
+	return result;
+}
+
 /** Are two sets disjoint? */
 template <class T>
 bool are_disjoint(const std::set<T>& lhs, const std::set<T>& rhs)

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -429,13 +429,13 @@ bool Nfa::is_flat() const {
     return flat;
 }
 
-std::string Nfa::print_to_dot(const bool ascii, const bool use_intervals, const int max_label_len) const {
+std::string Nfa::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     std::stringstream output;
-    print_to_dot(output, ascii, use_intervals, max_label_len);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
     return output.str();
 }
 
-void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_intervals, const int max_label_len) const {
+void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
         switch (symbol) {
             case EPSILON:      return "<eps>";
@@ -456,7 +456,7 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
     };
 
     auto translate_symbol = [&](const Symbol symbol) {
-        if (ascii) {
+        if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
         return translate_special_symbols(symbol);
@@ -519,7 +519,7 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
             }
         }
         for (const auto& [target, symbols]: tgt_symbols_map) {
-            if (max_label_len == 0) {
+            if (max_label_length == 0) {
                 output << source << " -> " << target << ";" << std::endl;
                 continue;
             }
@@ -527,8 +527,8 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
             std::string label = (use_intervals) ? vec_of_symbols_to_string_with_intervals(symbols) : vec_of_symbols_to_string(symbols);
             std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
             bool is_shortened = false;
-            if (max_label_len > 0 && label.length() > static_cast<size_t>(max_label_len)) {
-                label = label.substr(0, static_cast<size_t>(max_label_len)) + "...";
+            if (max_label_length > 0 && label.length() > static_cast<size_t>(max_label_length)) {
+                label = label.substr(0, static_cast<size_t>(max_label_length)) + "...";
                 is_shortened = true;
             }
 
@@ -548,12 +548,12 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
     output << "}" << std::endl;
 }
 
-void Nfa::print_to_dot(const std::string& filename, const bool ascii, const bool use_intervals, const int max_label_len) const {
+void Nfa::print_to_dot(const std::string& filename, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output, ascii, use_intervals, max_label_len);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
 }
 
 std::string Nfa::print_to_mata(const Alphabet* alphabet) const {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -429,24 +429,78 @@ bool Nfa::is_flat() const {
     return flat;
 }
 
-std::string Nfa::print_to_dot(const bool ascii) const {
+std::string Nfa::print_to_dot(const bool ascii, const bool use_intervals, const int max_label_len) const {
     std::stringstream output;
-    print_to_dot(output, ascii);
+    print_to_dot(output, ascii, use_intervals, max_label_len);
     return output.str();
 }
 
-void Nfa::print_to_dot(std::ostream &output, const bool ascii) const {
+void Nfa::print_to_dot(std::ostream &output, const bool ascii, const bool use_intervals, const int max_label_len) const {
+    auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
+        switch (symbol) {
+            case EPSILON:      return "<eps>";
+            default:           return "<" + std::to_string(symbol) + ">";
+        }
+    };
+
     auto to_ascii = [&](const Symbol symbol) {
         // Translate only printable ASCII characters.
-        if (symbol < 33) {
-            return "<" + std::to_string(symbol) + ">";
+        if (symbol < 33 || symbol >= 127) {
+            return translate_special_symbols(symbol);
         }
         switch (symbol) {
             case '"':     return std::string("\\\"");
             case '\\':    return std::string("\\\\");
-            case EPSILON: return std::string("<eps>");
             default:      return std::string(1, static_cast<char>(symbol));
         }
+    };
+
+    auto translate_symbol = [&](const Symbol symbol) {
+        if (ascii) {
+            return to_ascii(symbol);
+        }
+        return translate_special_symbols(symbol);
+    };
+
+    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {
+        std::string result;
+        for (const Symbol& symbol: symbols) {
+            result += translate_symbol(symbol) + ",";
+        }
+        result.pop_back(); // Remove last comma
+        return result;
+    };
+
+    auto vec_of_symbols_to_string_with_intervals = [&](const OrdVector<Symbol>& symbols) {
+        std::string result;
+
+        std::vector<std::pair<Symbol, Symbol>> intervals;
+        auto symbols_it = symbols.begin();
+        std::pair<Symbol, Symbol> interval{*symbols_it, *symbols_it};
+        ++symbols_it;
+        for (; symbols_it != symbols.end(); ++symbols_it) {
+            if (*symbols_it == interval.second + 1) {
+                interval.second = *symbols_it;
+            } else {
+                intervals.push_back(interval);
+                interval = {*symbols_it, *symbols_it};
+            }
+        }
+        intervals.push_back(interval);
+
+        for (const auto& interval: intervals) {
+            const size_t interval_size = interval.second - interval.first + 1;
+            if (interval_size == 1) {
+                result += translate_symbol(interval.first) + ",";
+            } else if (interval_size == 2) {
+                result += translate_symbol(interval.first) + "," + translate_symbol(interval.second) + ",";
+            } else {
+                result += "[" + translate_symbol(interval.first) + "-" + translate_symbol(interval.second) + "],";
+            }
+        }
+
+        result.pop_back(); // Remove last comma
+        return result;
     };
 
     output << "digraph finiteAutomaton {" << std::endl
@@ -458,15 +512,30 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii) const {
 
     const size_t delta_size = delta.num_of_states();
     for (State source = 0; source != delta_size; ++source) {
+        std::unordered_map<State, OrdVector<Symbol>> tgt_symbols_map;
         for (const SymbolPost &move: delta[source]) {
-            output << source << " -> {";
             for (State target: move.targets) {
-                output << target << " ";
+                tgt_symbols_map[target].insert(move.symbol);
             }
-            if (ascii) {
-                output << "} [label=\"" << to_ascii(move.symbol) << "\"];" << std::endl;
+        }
+        for (const auto& [target, symbols]: tgt_symbols_map) {
+            if (max_label_len == 0) {
+                output << source << " -> " << target << ";" << std::endl;
+                continue;
+            }
+
+            std::string label = (use_intervals) ? vec_of_symbols_to_string_with_intervals(symbols) : vec_of_symbols_to_string(symbols);
+            std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
+            bool is_shortened = false;
+            if (max_label_len > 0 && label.length() > static_cast<size_t>(max_label_len)) {
+                label = label.substr(0, static_cast<size_t>(max_label_len)) + "...";
+                is_shortened = true;
+            }
+
+            if (is_shortened) {
+                output << source << " -> " << target << " [label=\"" << label << "\", tooltip=\"" << on_hover_label << "\"];" << std::endl;
             } else {
-                output << "} [label=\"" << move.symbol << "\"];" << std::endl;
+                output << source << " -> " << target << " [label=\"" << label << "\"];" << std::endl;
             }
         }
     }
@@ -479,12 +548,12 @@ void Nfa::print_to_dot(std::ostream &output, const bool ascii) const {
     output << "}" << std::endl;
 }
 
-void Nfa::print_to_dot(const std::string& filename, const bool ascii) const {
+void Nfa::print_to_dot(const std::string& filename, const bool ascii, const bool use_intervals, const int max_label_len) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output, ascii);
+    print_to_dot(output, ascii, use_intervals, max_label_len);
 }
 
 std::string Nfa::print_to_mata(const Alphabet* alphabet) const {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -436,30 +436,27 @@ std::string Nfa::print_to_dot(const bool decode_ascii_chars, const bool use_inte
 }
 
 void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
-    auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
-        switch (symbol) {
-            case EPSILON:      return "<eps>";
-            default:           return "<" + std::to_string(symbol) + ">";
-        }
-    };
-
-    auto to_ascii = [&](const Symbol symbol) {
+    auto to_ascii = [&](const Symbol symbol) -> std::string {
         // Translate only printable ASCII characters.
         if (symbol < 33 || symbol >= 127) {
-            return translate_special_symbols(symbol);
+            return "<" + std::to_string(symbol) + ">";
         }
         switch (symbol) {
-            case '"':     return std::string("\\\"");
-            case '\\':    return std::string("\\\\");
+            case '"':     return "\\\"";
+            case '\\':    return "\\\\";
             default:      return std::string(1, static_cast<char>(symbol));
         }
     };
 
-    auto translate_symbol = [&](const Symbol symbol) {
+    auto translate_symbol = [&](const Symbol symbol) -> std::string {
+        switch (symbol) {
+            case EPSILON:      return "<eps>";
+            default:           break;
+        }
         if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
-        return translate_special_symbols(symbol);
+        return std::to_string(symbol);
     };
 
     auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -528,7 +528,7 @@ void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
             std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
             bool is_shortened = false;
             if (max_label_length > 0 && label.length() > static_cast<size_t>(max_label_length)) {
-                label = label.substr(0, static_cast<size_t>(max_label_length)) + "...";
+                label.replace(static_cast<size_t>(max_label_length), std::string::npos, "...");
                 is_shortened = true;
             }
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -86,13 +86,13 @@ void Nft::remove_epsilon(Symbol epsilon) {
     *this = mata::nft::remove_epsilon(*this, epsilon);
 }
 
-std::string Nft::print_to_dot(const bool ascii, const bool use_intervals, const int max_label_len) const {
+std::string Nft::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     std::stringstream output;
-    print_to_dot(output, ascii, use_intervals, max_label_len);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
     return output.str();
 }
 
-void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_intervals, const int max_label_len) const {
+void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
         switch (symbol) {
             case EPSILON:      return "<eps>";
@@ -115,7 +115,7 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
     };
 
     auto translate_symbol = [&](const Symbol symbol) {
-        if (ascii) {
+        if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
         return translate_special_symbols(symbol);
@@ -178,7 +178,7 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
             }
         }
         for (const auto& [target, symbols]: tgt_symbols_map) {
-            if (max_label_len == 0) {
+            if (max_label_length == 0) {
                 output << source << " -> " << target << ";" << std::endl;
                 continue;
             }
@@ -186,8 +186,8 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
             std::string label = (use_intervals) ? vec_of_symbols_to_string_with_intervals(symbols) : vec_of_symbols_to_string(symbols);
             std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
             bool is_shortened = false;
-            if (max_label_len > 0 && label.length() > static_cast<size_t>(max_label_len)) {
-                label = label.substr(0, static_cast<size_t>(max_label_len)) + "...";
+            if (max_label_length > 0 && label.length() > static_cast<size_t>(max_label_length)) {
+                label = label.substr(0, static_cast<size_t>(max_label_length)) + "...";
                 is_shortened = true;
             }
 
@@ -211,12 +211,12 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_in
     output << "}" << std::endl;
 }
 
-void Nft::print_to_dot(const std::string& filename,  const bool ascii, const bool use_intervals, const int max_label_len) const {
+void Nft::print_to_dot(const std::string& filename,  const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output, ascii, use_intervals, max_label_len);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
 }
 
 std::string Nft::print_to_mata() const {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -93,31 +93,27 @@ std::string Nft::print_to_dot(const bool decode_ascii_chars, const bool use_inte
 }
 
 void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
-    auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
-        switch (symbol) {
-            case EPSILON:      return "<eps>";
-            case DONT_CARE:    return "<dcare>";
-            default:           return "<" + std::to_string(symbol) + ">";
-        }
-    };
-
-    auto to_ascii = [&](const Symbol symbol) {
+    auto to_ascii = [&](const Symbol symbol) -> std::string {
         // Translate only printable ASCII characters.
         if (symbol < 33 || symbol >= 127) {
-            return translate_special_symbols(symbol);
+            return "<" + std::to_string(symbol) + ">";
         }
         switch (symbol) {
-            case '"':  return std::string("\\\"");
-            case '\\': return std::string("\\\\");
-            default:   return std::string(1, static_cast<char>(symbol));
+            case '"':     return "\\\"";
+            case '\\':    return "\\\\";
+            default:      return std::string(1, static_cast<char>(symbol));
         }
     };
 
-    auto translate_symbol = [&](const Symbol symbol) {
+    auto translate_symbol = [&](const Symbol symbol) -> std::string {
+        switch (symbol) {
+            case EPSILON:      return "<eps>";
+            default:           break;
+        }
         if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
-        return translate_special_symbols(symbol);
+        return std::to_string(symbol);
     };
 
     auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -186,7 +186,7 @@ void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
             std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
             bool is_shortened = false;
             if (max_label_length > 0 && label.length() > static_cast<size_t>(max_label_length)) {
-                label = label.substr(0, static_cast<size_t>(max_label_length)) + "...";
+                label.replace(static_cast<size_t>(max_label_length), std::string::npos, "...");
                 is_shortened = true;
             }
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -86,26 +86,26 @@ void Nft::remove_epsilon(Symbol epsilon) {
     *this = mata::nft::remove_epsilon(*this, epsilon);
 }
 
-std::string Nft::print_to_dot(const bool ascii) const {
+std::string Nft::print_to_dot(const bool ascii, const bool use_intervals, const int max_label_len) const {
     std::stringstream output;
-    print_to_dot(output, ascii);
+    print_to_dot(output, ascii, use_intervals, max_label_len);
     return output.str();
 }
 
-void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
+void Nft::print_to_dot(std::ostream &output, const bool ascii, const bool use_intervals, const int max_label_len) const {
     auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
         switch (symbol) {
             case EPSILON:      return "<eps>";
             case EPSILON - 99: return "<marker>";
             case DONT_CARE:    return "<dcare>";
-            default:           return std::to_string(symbol);
+            default:           return "<" + std::to_string(symbol) + ">";
         }
     };
 
     auto to_ascii = [&](const Symbol symbol) {
         // Translate only printable ASCII characters.
-        if (symbol < 33) {
-            return "<" + std::to_string(symbol) + ">";
+        if (symbol < 33 || symbol >= 127) {
+            return translate_special_symbols(symbol);
         }
         switch (symbol) {
             case '"':  return std::string("\\\"");
@@ -113,6 +113,55 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
             default:   return std::string(1, static_cast<char>(symbol));
         }
     };
+
+    auto translate_symbol = [&](const Symbol symbol) {
+        if (ascii) {
+            return to_ascii(symbol);
+        }
+        return translate_special_symbols(symbol);
+    };
+
+    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {
+        std::string result;
+        for (const Symbol& symbol: symbols) {
+            result += translate_symbol(symbol) + ",";
+        }
+        result.pop_back(); // Remove last comma
+        return result;
+    };
+
+    auto vec_of_symbols_to_string_with_intervals = [&](const OrdVector<Symbol>& symbols) {
+        std::string result;
+
+        std::vector<std::pair<Symbol, Symbol>> intervals;
+        auto symbols_it = symbols.begin();
+        std::pair<Symbol, Symbol> interval{*symbols_it, *symbols_it};
+        ++symbols_it;
+        for (; symbols_it != symbols.end(); ++symbols_it) {
+            if (*symbols_it == interval.second + 1) {
+                interval.second = *symbols_it;
+            } else {
+                intervals.push_back(interval);
+                interval = {*symbols_it, *symbols_it};
+            }
+        }
+        intervals.push_back(interval);
+
+        for (const auto& interval: intervals) {
+            const size_t interval_size = interval.second - interval.first + 1;
+            if (interval_size == 1) {
+                result += translate_symbol(interval.first) + ",";
+            } else if (interval_size == 2) {
+                result += translate_symbol(interval.first) + "," + translate_symbol(interval.second) + ",";
+            } else {
+                result += "[" + translate_symbol(interval.first) + "-" + translate_symbol(interval.second) + "],";
+            }
+        }
+
+        result.pop_back(); // Remove last comma
+        return result;
+    };
+
     output << "digraph finiteAutomaton {" << std::endl
                  << "node [shape=circle];" << std::endl;
 
@@ -122,18 +171,30 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
 
     const size_t delta_size = delta.num_of_states();
     for (State source = 0; source != delta_size; ++source) {
+        std::unordered_map<State, OrdVector<Symbol>> tgt_symbols_map;
         for (const SymbolPost &move: delta[source]) {
-            output << source << " -> {";
             for (State target: move.targets) {
-                output << target << " ";
+                tgt_symbols_map[target].insert(move.symbol);
+            }
+        }
+        for (const auto& [target, symbols]: tgt_symbols_map) {
+            if (max_label_len == 0) {
+                output << source << " -> " << target << ";" << std::endl;
+                continue;
             }
 
-            if (ascii && move.symbol < 128) {
-                output << "} [label=\"" << to_ascii(move.symbol) << "\"];" << std::endl;
-            } else if (ascii && move.symbol >= 128) {
-                output << "} [label=\"" << translate_special_symbols(move.symbol) << "\"];" << std::endl;
+            std::string label = (use_intervals) ? vec_of_symbols_to_string_with_intervals(symbols) : vec_of_symbols_to_string(symbols);
+            std::string on_hover_label = utils::replace_all(utils::replace_all(label, "<", "&lt;"), ">", "&gt;");
+            bool is_shortened = false;
+            if (max_label_len > 0 && label.length() > static_cast<size_t>(max_label_len)) {
+                label = label.substr(0, static_cast<size_t>(max_label_len)) + "...";
+                is_shortened = true;
+            }
+
+            if (is_shortened) {
+                output << source << " -> " << target << " [label=\"" << label << "\", tooltip=\"" << on_hover_label << "\"];" << std::endl;
             } else {
-                output << "} [label=\"" << translate_special_symbols(move.symbol) << "\"];" << std::endl;
+                output << source << " -> " << target << " [label=\"" << label << "\"];" << std::endl;
             }
         }
     }
@@ -150,12 +211,12 @@ void Nft::print_to_dot(std::ostream &output, const bool ascii) const {
     output << "}" << std::endl;
 }
 
-void Nft::print_to_dot(const std::string& filename, const bool ascii) const {
+void Nft::print_to_dot(const std::string& filename,  const bool ascii, const bool use_intervals, const int max_label_len) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output, ascii);
+    print_to_dot(output, ascii, use_intervals, max_label_len);
 }
 
 std::string Nft::print_to_mata() const {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -96,7 +96,6 @@ void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
     auto translate_special_symbols = [&](const Symbol symbol) -> std::string {
         switch (symbol) {
             case EPSILON:      return "<eps>";
-            case EPSILON - 99: return "<marker>";
             case DONT_CARE:    return "<dcare>";
             default:           return "<" + std::to_string(symbol) + ">";
         }


### PR DESCRIPTION
This PR extends the functionality of print_to_dot. And closes #489

It now:
1) Merges multiple edges between two states and places a list of labels on the merged edge.
**Optional:**
2) Collapses contiguous sequences of symbols in labels into intervals.
3) Truncates long labels (the full label can be seen when hovering over the edge).
4) Removes all labels.