### PR TITLE
Parsing Regexes with `^` and `$` - Fix

### DIFF
--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -142,7 +142,7 @@ namespace {
                 bool increment_current_state{true};
                 re2::Prog::Inst *inst = prog->inst(static_cast<int>(re2_state));
                 // Every type of state can be final (due to epsilon transition), so we check it regardless of its type
-                 if (this->state_cache.is_final_state[re2_state]) {
+                 if (this->state_cache.is_final_state[re2_state] && inst->opcode() == re2::kInstMatch) {
                     this->make_state_final(re2_state, explicit_nfa);
                 }
                 switch (inst->opcode()) {
@@ -184,7 +184,8 @@ namespace {
                         if (empty_flag & re2::kEmptyEndText) {
                             // TODO How to handle?
                             // symbols.push_back(302);
-                            increment_current_state = false;
+                            this->create_explicit_nfa_transitions(current_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
+                            // increment_current_state = false;
                         }
                         // \b - word boundary
                         if (empty_flag & re2::kEmptyWordBoundary) {

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -136,8 +136,7 @@ namespace {
             this->outgoingEdges = std::vector<std::vector<std::pair<mata::Symbol, mata::nfa::State>>> (prog_size);
 
             // We traverse all the states and create corresponding states and edges in Nfa
-            for (State current_state = start_state, re2_state = start_state; re2_state < prog_size; ++re2_state, ++current_state) {
-                /// Whether to increment the current state @c current_state when the @c re2_state increments.
+            for (State re2_state = start_state; re2_state < prog_size; ++re2_state) {
                 re2::Prog::Inst *inst = prog->inst(static_cast<int>(re2_state));
                 // Every type of state can be final (due to epsilon transition), so we check it regardless of its type
                  if (this->state_cache.is_final_state[re2_state] && inst->opcode() == re2::kInstMatch) {
@@ -157,13 +156,13 @@ namespace {
                     case re2::kInstCapture:
                         if (use_epsilon) {
                             symbols.push_back(epsilon_value);
-                            this->create_explicit_nfa_transitions(current_state, inst, symbols, explicit_nfa, use_epsilon, epsilon_value);
+                            this->create_explicit_nfa_transitions(re2_state, inst, symbols, explicit_nfa, use_epsilon, epsilon_value);
                             symbols.clear();
                         }
                         break;
                     case re2::kInstEmptyWidth:
                         if (use_epsilon) {
-                            this->create_explicit_nfa_transitions(current_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
+                            this->create_explicit_nfa_transitions(re2_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
                         }
                         break;
                     // kInstByteRange represents states with a "byte range" on the outgoing transition(s)
@@ -180,7 +179,7 @@ namespace {
                                 }
                             }
                         }
-                        this->create_explicit_nfa_transitions(current_state, inst, symbols, explicit_nfa, use_epsilon, epsilon_value);
+                        this->create_explicit_nfa_transitions(re2_state, inst, symbols, explicit_nfa, use_epsilon, epsilon_value);
 
                         if (!use_epsilon) {
                             // There is an epsilon transition to the currentState+1 we will need to copy transitions of

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -78,7 +78,6 @@ namespace {
             const auto prog_size = static_cast<size_t>(prog->size());
             // The same symbol in lowercase and uppercase is 32 symbols from each other in ASCII
             const int ascii_shift_value = 32;
-            int empty_flag;
             std::vector<mata::Symbol> symbols;
             Nfa explicit_nfa(prog_size);
 
@@ -137,9 +136,8 @@ namespace {
             this->outgoingEdges = std::vector<std::vector<std::pair<mata::Symbol, mata::nfa::State>>> (prog_size);
 
             // We traverse all the states and create corresponding states and edges in Nfa
-            for (State current_state = start_state, re2_state = start_state; re2_state < prog_size; ++re2_state) {
+            for (State current_state = start_state, re2_state = start_state; re2_state < prog_size; ++re2_state, ++current_state) {
                 /// Whether to increment the current state @c current_state when the @c re2_state increments.
-                bool increment_current_state{true};
                 re2::Prog::Inst *inst = prog->inst(static_cast<int>(re2_state));
                 // Every type of state can be final (due to epsilon transition), so we check it regardless of its type
                  if (this->state_cache.is_final_state[re2_state] && inst->opcode() == re2::kInstMatch) {
@@ -164,40 +162,8 @@ namespace {
                         }
                         break;
                     case re2::kInstEmptyWidth:
-                        empty_flag = static_cast<int>(inst->empty());
-                        // ^ - beginning of line
-                        if (empty_flag & re2::kEmptyBeginLine) {
-                            increment_current_state = false;
-                        }
-                        // $ - end of line
-                        if (empty_flag & re2::kEmptyEndLine) {
-                            // TODO How to handle?
-                            // symbols.push_back(301);
-                            increment_current_state = false;
-                        }
-                        // \A - beginning of text
-                        if (empty_flag & re2::kEmptyBeginText) {
-                            // increment_current_state = false;
+                        if (use_epsilon) {
                             this->create_explicit_nfa_transitions(current_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
-                        }
-                        // \z - end of text
-                        if (empty_flag & re2::kEmptyEndText) {
-                            // TODO How to handle?
-                            // symbols.push_back(302);
-                            this->create_explicit_nfa_transitions(current_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
-                            // increment_current_state = false;
-                        }
-                        // \b - word boundary
-                        if (empty_flag & re2::kEmptyWordBoundary) {
-                            // TODO How to handle?
-                            // symbols.push_back(303);
-                            increment_current_state = false;
-                        }
-                        // \B - not \b
-                        if (empty_flag & re2::kEmptyNonWordBoundary) {
-                            // TODO How to handle?
-                            // symbols.push_back(304);
-                            increment_current_state = false;
                         }
                         break;
                     // kInstByteRange represents states with a "byte range" on the outgoing transition(s)
@@ -228,8 +194,6 @@ namespace {
                         symbols.clear();
                         break;
                 }
-
-                if (increment_current_state) { ++current_state; }
             }
             if (!use_epsilon) {
                 // We will traverse the vector in reversed order. Like that, we will also handle chains of epsilon transitions

--- a/src/re2parser.cc
+++ b/src/re2parser.cc
@@ -137,13 +137,12 @@ namespace {
             this->outgoingEdges = std::vector<std::vector<std::pair<mata::Symbol, mata::nfa::State>>> (prog_size);
 
             // We traverse all the states and create corresponding states and edges in Nfa
-            for (State current_state = start_state, re2_state = start_state; re2_state < prog_size; ++
-                 re2_state) {
+            for (State current_state = start_state, re2_state = start_state; re2_state < prog_size; ++re2_state) {
                 /// Whether to increment the current state @c current_state when the @c re2_state increments.
                 bool increment_current_state{true};
                 re2::Prog::Inst *inst = prog->inst(static_cast<int>(re2_state));
                 // Every type of state can be final (due to epsilon transition), so we check it regardless of its type
-                if (this->state_cache.is_final_state[re2_state]) {
+                 if (this->state_cache.is_final_state[re2_state]) {
                     this->make_state_final(re2_state, explicit_nfa);
                 }
                 switch (inst->opcode()) {
@@ -178,7 +177,8 @@ namespace {
                         }
                         // \A - beginning of text
                         if (empty_flag & re2::kEmptyBeginText) {
-                            increment_current_state = false;
+                            // increment_current_state = false;
+                            this->create_explicit_nfa_transitions(current_state, inst, {epsilon_value}, explicit_nfa, use_epsilon, epsilon_value);
                         }
                         // \z - end of text
                         if (empty_flag & re2::kEmptyEndText) {

--- a/tests/re2parser.cc
+++ b/tests/re2parser.cc
@@ -1287,43 +1287,55 @@ TEST_CASE("mata::Parser error")
         CHECK(are_equivalent(x, y));
     }
 
-    // TODO uncomment these two after the issues are fixed
+    SECTION("Regex from issue #457") {
+        Nfa x{2, {0}, {1}};
+        x.delta.add(0,'a',1);
+        x.delta.add(0,'b',1);
+        Nfa y = mata::parser::create_nfa("(a|b)");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("(a$|b)");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("a|b");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("a$|b");
+        CHECK(are_equivalent(x, y));
+    }
 
-    // SECTION("Regex from issue #457") {
-    //     Nfa x{2, {0}, {1}};
-    //     x.delta.add(0,'a',1);
-    //     x.delta.add(0,'b',1);
-    //     Nfa y = mata::parser::create_nfa("(a|b)");
-    //     CHECK(are_equivalent(x, y));
-    //     y = mata::parser::create_nfa("(a$|b)");
-    //     CHECK(are_equivalent(x, y));
-    //     y = mata::parser::create_nfa("a|b");
-    //     CHECK(are_equivalent(x, y));
-    //     y = mata::parser::create_nfa("a$|b");
-    //     CHECK(are_equivalent(x, y));
-    // }
+    SECTION("Variation of issue #457") {
+        Nfa x{2, {0}, {1}};
+        x.delta.add(0,'a',1);
+        x.delta.add(0,'b',1);
+        Nfa y = mata::parser::create_nfa("(a|b)");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("(^a|b)");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("^a|b");
+        CHECK(are_equivalent(x, y));
+        y = mata::parser::create_nfa("a|^b");
+        CHECK(are_equivalent(x, y));
+    }
 
-    // SECTION("Regexes from issue #437") {
-    //     std::vector<std::string> regexes = {
-    //         "^.*[sS][yY][sS][tT][eE][mM][pP][aA][tT][hH]\\=([hH][tT]{2}[pP][sS]?)|([fF][tT][pP])",
-    //         R"REGEX(^[^\f\n\r\t\v]{65}|[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]{65}|[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]{65})REGEX",
-    //         R"REGEX(^get (X.downloadX[ -~]*|X.supernode[ -~]|X.status[ -~]|X.network[ -~]*|X.files|X.hash\=[0-9a-f]*X[ -~]*) httpX1.1|user-agent: kazaa|x-kazaa(-username|-network|-ip|-supernodeip|-xferid|-xferuid|tag)|^give [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]?[0-9]?[0-9]?)REGEX",
-    //         R"REGEX(^(\*[\x01\x02].*\x03\x0b|\*\x01.?.?.?.?\x01)|flapon|toc_signon.*0x)REGEX",
-    //         R"REGEX(^(\x11\x20\x01...?\x11|\xfe\xfd.?.?.?.?.?.?(\x14\x01\x06|\xff\xff\xff))|[\]\x01].?battlefield2)REGEX",
-    //         R"REGEX(^(\x13bittorrent protocol|azver\x01$|get Xscrape\?info_hash\=get Xannounce\?info_hash\=|get XclientXbitcometX|GET Xdata\?fid\=)|d1:ad2:id20:|\x08'7P\)[RP])REGEX",
-    //         R"REGEX(^[a-z][a-z0-9\-_]+|login: [\x09-\x0d -~]* name: [\x09-\x0d -~]* Directory:)REGEX",
-    //         R"REGEX(^get X.*icy-metadata:1|icy [1-5][0-9][0-9] [\x09-\x0d -~]*(content-type:audio|icy-))REGEX",
-    //         R"REGEX(^([()]|get)(...?.?.?(reg|get|query)|.+User-Agent: (MozillaX4\.0 \(compatible; (MSIE 6\.0; Windows NT 5\.1;? ?\)|MSIE 5\.00; Windows 98\))))|Keep-Alive\x0d\x0a\x0d\x0a[26])REGEX",
-    //         R"REGEX(^[\f\n\r\t\v]*Accept-Language[\f\n\r\t\v]*|3a|[\f\n\r\t\v]*([^\r\n]*?\x2c){20})REGEX"
-    //     };
+    SECTION("Regexes from issue #437") {
+        std::vector<std::string> regexes = {
+            "^.*[sS][yY][sS][tT][eE][mM][pP][aA][tT][hH]\\=([hH][tT]{2}[pP][sS]?)|([fF][tT][pP])",
+            R"REGEX(^[^\f\n\r\t\v]{65}|[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]{65}|[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]+[\f\n\r\t\v]+[^\f\n\r\t\v]{65})REGEX",
+            R"REGEX(^get (X.downloadX[ -~]*|X.supernode[ -~]|X.status[ -~]|X.network[ -~]*|X.files|X.hash\=[0-9a-f]*X[ -~]*) httpX1.1|user-agent: kazaa|x-kazaa(-username|-network|-ip|-supernodeip|-xferid|-xferuid|tag)|^give [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]?[0-9]?[0-9]?)REGEX",
+            R"REGEX(^(\*[\x01\x02].*\x03\x0b|\*\x01.?.?.?.?\x01)|flapon|toc_signon.*0x)REGEX",
+            R"REGEX(^(\x11\x20\x01...?\x11|\xfe\xfd.?.?.?.?.?.?(\x14\x01\x06|\xff\xff\xff))|[\]\x01].?battlefield2)REGEX",
+            R"REGEX(^(\x13bittorrent protocol|azver\x01$|get Xscrape\?info_hash\=get Xannounce\?info_hash\=|get XclientXbitcometX|GET Xdata\?fid\=)|d1:ad2:id20:|\x08'7P\)[RP])REGEX",
+            R"REGEX(^[a-z][a-z0-9\-_]+|login: [\x09-\x0d -~]* name: [\x09-\x0d -~]* Directory:)REGEX",
+            R"REGEX(^get X.*icy-metadata:1|icy [1-5][0-9][0-9] [\x09-\x0d -~]*(content-type:audio|icy-))REGEX",
+            R"REGEX(^([()]|get)(...?.?.?(reg|get|query)|.+User-Agent: (MozillaX4\.0 \(compatible; (MSIE 6\.0; Windows NT 5\.1;? ?\)|MSIE 5\.00; Windows 98\))))|Keep-Alive\x0d\x0a\x0d\x0a[26])REGEX",
+            R"REGEX(^[\f\n\r\t\v]*Accept-Language[\f\n\r\t\v]*|3a|[\f\n\r\t\v]*([^\r\n]*?\x2c){20})REGEX"
+        };
 
-    //     for (std::string regex : regexes) {
-    //         Nfa x = mata::parser::create_nfa(regex);
-    //         Nfa y = mata::parser::create_nfa(regex.substr(1));
-    //         CHECK(!x.is_lang_empty());
-    //         CHECK(are_equivalent(x, y));
-    //     }
-    // }
+        for (std::string regex : regexes) {
+            Nfa x = mata::parser::create_nfa(regex);
+            Nfa y = mata::parser::create_nfa(regex.substr(1));
+            CHECK(!x.is_lang_empty());
+            CHECK(are_equivalent(x, y));
+        }
+    }
 
     SECTION("Another failing regex") {
         Nfa x = mata::parser::create_nfa("(cd(abcde)+)|(a(aaa)+|ccc+)");


### PR DESCRIPTION
This PR fixes a bug in the regex parser that, for regular expressions combining ^, $, and capture groups, sometimes produced incorrect results. This closes #457 and #437, where the bug and example or regular expressions were reported.

The bug was caused by not incrementing `current_state`, which caused it to fall behind `re2_state`. This led to the discontinuation of transitions in the resulting automaton. We must always keep up with the `re2_state`.

The following images demonstrate how the automata were constructed. Don’t try to understand them — they serve more as a reminder for my future self in case another bug arises in the regex parser.

![20250430_173207](https://github.com/user-attachments/assets/3ebb067a-1ba6-4051-a47b-7351f8f72e57)
![20250501_110540](https://github.com/user-attachments/assets/490be7e0-e569-47be-be32-dcd2f20dc6fd)
![20250501_115025](https://github.com/user-attachments/assets/bf22f915-6b62-4b8a-9e97-abe713816557)
![20250501_125012](https://github.com/user-attachments/assets/08b2d355-e441-453e-b5c9-8782bca60f67)
