### PR TITLE
Add option to keep epsilon in `get_word()`

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -527,7 +527,7 @@ public:
      *
      * The automaton is searched using DFS, returning a word for the first reached final state.
      */
-    std::optional<Word> get_word(Symbol first_epsilon = EPSILON) const;
+    std::optional<Word> get_word(const bool keep_epsilon = false, Symbol first_epsilon = EPSILON) const;
 
     /**
      * @brief Get any arbitrary accepted word in the language of the complement of the automaton.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -526,8 +526,11 @@ public:
      * @brief Get any arbitrary accepted word in the language of the automaton.
      *
      * The automaton is searched using DFS, returning a word for the first reached final state.
+     * 
+     * @param first_epsilon If defined, all symbols >=first_epsilon are assumed to be epsilon and therefore are not in the returned word.
+     * @return std::optional<Word> Some word from the language. If the language is empty, returns std::nullopt.
      */
-    std::optional<Word> get_word(const bool keep_epsilon = false, Symbol first_epsilon = EPSILON) const;
+    std::optional<Word> get_word(const std::optional<Symbol> first_epsilon = EPSILON) const;
 
     /**
      * @brief Get any arbitrary accepted word in the language of the complement of the automaton.

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1279,7 +1279,7 @@ OrdVector<Symbol> mata::nfa::get_symbols_to_work_with(const Nfa& nfa, const mata
     else { return nfa.delta.get_used_symbols(); }
 }
 
-std::optional<mata::Word> Nfa::get_word(const Symbol first_epsilon) const {
+std::optional<mata::Word> Nfa::get_word(const bool keep_epsilon, const Symbol first_epsilon) const {
     if (initial.empty() || final.empty()) { return std::nullopt; }
     if (initial.intersects_with(final)) { return Word{}; }
 
@@ -1343,7 +1343,7 @@ std::optional<mata::Word> Nfa::get_word(const Symbol first_epsilon) const {
     Word word;
     word.reserve(worklist.size());
     for (const auto& [symbol_post_it, symbol_post_end, _targets_it]: worklist) {
-        if (symbol_post_it->symbol < first_epsilon) { word.push_back(symbol_post_it->symbol); }
+        if (keep_epsilon || symbol_post_it->symbol < first_epsilon) { word.push_back(symbol_post_it->symbol); }
     }
     return word;
 }

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1279,7 +1279,7 @@ OrdVector<Symbol> mata::nfa::get_symbols_to_work_with(const Nfa& nfa, const mata
     else { return nfa.delta.get_used_symbols(); }
 }
 
-std::optional<mata::Word> Nfa::get_word(const bool keep_epsilon, const Symbol first_epsilon) const {
+std::optional<mata::Word> Nfa::get_word(const std::optional<Symbol> first_epsilon) const {
     if (initial.empty() || final.empty()) { return std::nullopt; }
     if (initial.intersects_with(final)) { return Word{}; }
 
@@ -1343,7 +1343,7 @@ std::optional<mata::Word> Nfa::get_word(const bool keep_epsilon, const Symbol fi
     Word word;
     word.reserve(worklist.size());
     for (const auto& [symbol_post_it, symbol_post_end, _targets_it]: worklist) {
-        if (keep_epsilon || symbol_post_it->symbol < first_epsilon) { word.push_back(symbol_post_it->symbol); }
+        if (!first_epsilon.has_value() || symbol_post_it->symbol < first_epsilon) { word.push_back(symbol_post_it->symbol); }
     }
     return word;
 }


### PR DESCRIPTION
Needed for Noodler. It should probably be some enum argument, maybe we should have some general argument that says whether epsilon should be handled as normal symbol for all functions that work with epsilons.