### PR TITLE
Python Binding Fix

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -64,7 +64,6 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
 
     cdef cppclass CDelta "mata::nfa::Delta":
         vector[CStatePost] state_posts
-        CTransitions transitions
 
         void reserve(size_t)
         CStatePost& state_post(State)


### PR DESCRIPTION
This PR (hopefully) fixes the bug in the Python binding for NFA and closes #528.

The bug was caused by the existence of both `transitions` and `transitions()` in `CDelta`. 