### PR TITLE
Bug Fix in `from_nfa_with_levels_zero`

### DIFF
--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -101,7 +101,12 @@ Nft parse_from_mata(const std::string& nft_in_mata);
 Nft parse_from_mata(const std::filesystem::path& nft_file);
 
 /**
- * Create NFT from NFA.
+ * Create Nft from @p nfa with specified @p num_of_levels.
+ *
+ * This function takes transition from @p nfa as transitions between zero level and the first level of NFT.
+ * All transition between the remaining levels are created based on the function parameters: @p explicit_transitions
+ * and @p next_levels_symbol.
+ *
  * @param nfa NFA to create NFT from.
  * @param num_of_levels Number of levels of NFT.
  * @param explicit_transitions If true, the transitions between levels are explicit (i.e., no jump transitions,

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -102,13 +102,15 @@ Nft parse_from_mata(const std::filesystem::path& nft_file);
 
 /**
  * Create NFT from NFA.
- * @param nfa_state NFA to create NFT from.
+ * @param nfa NFA to create NFT from.
  * @param num_of_levels Number of levels of NFT.
- * @param next_levels_symbol Symbol to use on non-NFA levels. std::nullopt means using the same symbol on all levels.
- * @param epsilons Which symbols handle as epsilons.
- * @return NFT representing @p nfa_state with @p num_of_levels number of levels.
+ * @param explicit_transitions If true, the transitions between levels are explicit (i.e., no jump transitions,
+ *                             except for the epsilon transitions over all levels).)
+ * @param next_levels_symbol If specified, it is used as a symbol on transitions after the first level.
+ *                           If not specified, the symbol of the transition is reused.
+ * @return NFT representing @p nfa with @p num_of_levels number of levels.
  */
-Nft from_nfa_with_levels_zero(const nfa::Nfa& nfa_state, size_t num_of_levels = DEFAULT_NUM_OF_LEVELS, bool explicit_transitions = true, std::optional<Symbol> next_levels_symbol = {});
+Nft from_nfa_with_levels_zero(const nfa::Nfa& nfa, size_t num_of_levels = DEFAULT_NUM_OF_LEVELS, bool explicit_transitions = true, std::optional<Symbol> next_levels_symbol = {});
 
 /**
  * @brief Creates Nft from @p nfa with specified @p num_of_levels automatically.

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -320,7 +320,7 @@ Nft builder::from_nfa_with_levels_zero(const mata::nfa::Nfa& nfa, const size_t n
         }
     }
 
-    return nft.trim();
+    return nft;
 }
 
 Nft builder::from_nfa_with_levels_advancing(mata::nfa::Nfa nfa, size_t num_of_levels) {


### PR DESCRIPTION
This PR fixes a bug in the `from_nfa_with_levels_zero` function and closes #534. The bug caused `mata::nft::strings::replace_reluctant_regex` to fail because it trimmed the resulting `Nft`. However, the "replace reluctant" algorithm requires these otherwise useless states to function correctly. We should discuss this counterintuitive behavior.
