### PR TITLE
Renaming of `make/get_one_level_aut` method.

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -419,7 +419,7 @@ public:
     void unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
-     * @brief Creates a transduce with unwinded jump transitions from the current one.
+     * @brief Creates a transducer with unwinded jump transitions from the current one.
      *
      * @param[in] dont_care_symbol_replacements Vector of symbols to replace @c DONT_CARE symbols with.
      * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -416,7 +416,7 @@ public:
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    void unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol);
+    void unwind_jumps_inplace(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
      * @brief Creates a transducer with unwinded jump transitions from the current one.
@@ -426,7 +426,7 @@ public:
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    Nft unwind_jump(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
+    Nft unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
 
     /**
      * @brief Unwinds jump transitions in the given transducer.
@@ -437,7 +437,7 @@ public:
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    void unwind_jump(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
+    void unwind_jumps(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
 
     /**
      * @brief Prints the automaton in DOT format

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -409,27 +409,27 @@ public:
     void get_one_letter_aut(Nft& result) const;
 
     /**
-     * @brief Modifies transducer to have only one level.
+     * @brief Unwinds jump transitions in the transducer.
      *
      * @param[in] dont_care_symbol_replacements Vector of symbols to replace @c DONT_CARE symbols with.
      * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    void make_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol);
+    void unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
     /**
-     * @brief Creates transducer from the current one with only one level.
+     * @brief Creates a transduce with unwinded jump transitions from the current one.
      *
      * @param[in] dont_care_symbol_replacements Vector of symbols to replace @c DONT_CARE symbols with.
      * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    Nft get_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
+    Nft unwind_jump(const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
 
     /**
-     * @brief Modifies transducer to have only one level.
+     * @brief Unwinds jump transitions in the given transducer.
      *
      * @param[out] result A transducer with only one level.
      * @param[in] dont_care_symbol_replacements Vector of symbols to replace @c DONT_CARE symbols with.
@@ -437,7 +437,7 @@ public:
      * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
      * of @c DONT_CARE symbols.
      */
-    void get_one_level_aut(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
+    void unwind_jump(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements = { DONT_CARE }, JumpMode jump_mode = JumpMode::RepeatSymbol) const;
 
     /**
      * @brief Prints the automaton in DOT format

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -50,8 +50,8 @@ bool mata::nft::algorithms::is_included_antichains(
         symbols = alphabet->get_alphabet_symbols();
     }
 
-    return nfa::algorithms::is_included_antichains(smaller.get_one_level_aut(symbols, jump_mode),
-                                                   bigger.get_one_level_aut(symbols, jump_mode),
+    return nfa::algorithms::is_included_antichains(smaller.unwind_jump(symbols, jump_mode),
+                                                   bigger.unwind_jump(symbols, jump_mode),
                                                    alphabet,
                                                    cex);
 } // }}}
@@ -108,8 +108,8 @@ bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *a
         symbols = alphabet->get_alphabet_symbols();
     }
 
-    return nfa::are_equivalent(lhs.get_one_level_aut(symbols, jump_mode),
-                               rhs.get_one_level_aut(symbols, jump_mode),
+    return nfa::are_equivalent(lhs.unwind_jump(symbols, jump_mode),
+                               rhs.unwind_jump(symbols, jump_mode),
                                alphabet,
                                params);
 }

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -50,8 +50,8 @@ bool mata::nft::algorithms::is_included_antichains(
         symbols = alphabet->get_alphabet_symbols();
     }
 
-    return nfa::algorithms::is_included_antichains(smaller.unwind_jump(symbols, jump_mode),
-                                                   bigger.unwind_jump(symbols, jump_mode),
+    return nfa::algorithms::is_included_antichains(smaller.unwind_jumps(symbols, jump_mode),
+                                                   bigger.unwind_jumps(symbols, jump_mode),
                                                    alphabet,
                                                    cex);
 } // }}}
@@ -108,8 +108,8 @@ bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *a
         symbols = alphabet->get_alphabet_symbols();
     }
 
-    return nfa::are_equivalent(lhs.unwind_jump(symbols, jump_mode),
-                               rhs.unwind_jump(symbols, jump_mode),
+    return nfa::are_equivalent(lhs.unwind_jumps(symbols, jump_mode),
+                               rhs.unwind_jumps(symbols, jump_mode),
                                alphabet,
                                params);
 }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -326,7 +326,7 @@ StateSet Nft::post(const StateSet& states, const Symbol& symbol, const EpsilonCl
     return nfa::Nfa::post(states, symbol, epsilon_closure_opt);
 }
 
-void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) {
+void Nft::unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) {
     const bool dcare_for_dcare = dont_care_symbol_replacements == utils::OrdVector<Symbol>({ DONT_CARE });
     std::vector<Transition> transitions_to_del;
     std::vector<Transition> transitions_to_add;
@@ -389,18 +389,18 @@ void Nft::make_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_re
     }
 }
 
-Nft Nft::get_one_level_aut(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
+Nft Nft::unwind_jump(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
     Nft result{ *this };
     // HACK. Works only for automata without levels.
     if (result.levels.size() != result.num_of_states()) {
         return result;
     }
-    result.make_one_level_aut(dont_care_symbol_replacements, jump_mode);
+    result.unwind_jumps(dont_care_symbol_replacements, jump_mode);
     return result;
 }
 
-void Nft::get_one_level_aut(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
-    result = get_one_level_aut(dont_care_symbol_replacements, jump_mode);
+void Nft::unwind_jump(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
+    result = unwind_jump(dont_care_symbol_replacements, jump_mode);
 }
 
 Nft& Nft::operator=(Nft&& other) noexcept {
@@ -604,11 +604,11 @@ Levels& Levels::set(State state, Level level) {
 
 mata::nfa::Nfa Nft::to_nfa_update_copy(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) const {
-    return get_one_level_aut(dont_care_symbol_replacements, jump_mode).to_nfa_copy();
+    return unwind_jump(dont_care_symbol_replacements, jump_mode).to_nfa_copy();
 }
 
 mata::nfa::Nfa Nft::to_nfa_update_move(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) {
-    make_one_level_aut(dont_care_symbol_replacements, jump_mode);
+    unwind_jumps(dont_care_symbol_replacements, jump_mode);
     return to_nfa_move();
 }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -326,7 +326,7 @@ StateSet Nft::post(const StateSet& states, const Symbol& symbol, const EpsilonCl
     return nfa::Nfa::post(states, symbol, epsilon_closure_opt);
 }
 
-void Nft::unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) {
+void Nft::unwind_jumps_inplace(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) {
     const bool dcare_for_dcare = dont_care_symbol_replacements == utils::OrdVector<Symbol>({ DONT_CARE });
     std::vector<Transition> transitions_to_del;
     std::vector<Transition> transitions_to_add;
@@ -389,18 +389,18 @@ void Nft::unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacem
     }
 }
 
-Nft Nft::unwind_jump(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
+Nft Nft::unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
     Nft result{ *this };
     // HACK. Works only for automata without levels.
     if (result.levels.size() != result.num_of_states()) {
         return result;
     }
-    result.unwind_jumps(dont_care_symbol_replacements, jump_mode);
+    result.unwind_jumps_inplace(dont_care_symbol_replacements, jump_mode);
     return result;
 }
 
-void Nft::unwind_jump(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
-    result = unwind_jump(dont_care_symbol_replacements, jump_mode);
+void Nft::unwind_jumps(Nft& result, const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
+    result = unwind_jumps(dont_care_symbol_replacements, jump_mode);
 }
 
 Nft& Nft::operator=(Nft&& other) noexcept {
@@ -604,11 +604,11 @@ Levels& Levels::set(State state, Level level) {
 
 mata::nfa::Nfa Nft::to_nfa_update_copy(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) const {
-    return unwind_jump(dont_care_symbol_replacements, jump_mode).to_nfa_copy();
+    return unwind_jumps(dont_care_symbol_replacements, jump_mode).to_nfa_copy();
 }
 
 mata::nfa::Nfa Nft::to_nfa_update_move(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) {
-    unwind_jumps(dont_care_symbol_replacements, jump_mode);
+    unwind_jumps_inplace(dont_care_symbol_replacements, jump_mode);
     return to_nfa_move();
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3705,8 +3705,8 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         expected.delta.add(4, 1, 2);
         REPLACE_DONT_CARE(expected.delta, 4, 4);
 
-        CHECK(nfa::are_equivalent(aut.unwind_jump({0, 1}, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({0, 1}, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jumps({ 0, 1 }, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
     }
 
@@ -3739,8 +3739,8 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         SPLIT_TRANSITION(expected.delta, 6, DONT_CARE, 14, 6);
         SPLIT_TRANSITION(expected.delta, 6, 1, 11, 4);
 
-        CHECK(nfa::are_equivalent(aut.unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({0, 1}, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jumps({0, 1}, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
 
     }
@@ -3792,8 +3792,8 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         SPLIT_TRANSITION(expected.delta, 13, 0, 23, 15);
         SPLIT_TRANSITION(expected.delta, 14, DONT_CARE, 28, 16);
 
-        CHECK(nfa::are_equivalent(aut.unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jumps({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jumps({ 0, 1 }, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
     }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3671,7 +3671,7 @@ TEST_CASE("mata::nft::Nft::get_words") {
     }
 }
 
-TEST_CASE("mata::nft::Nft::get_one_level_aut") {
+TEST_CASE("mata::nft::Nft::unwind_jump") {
     #define REPLACE_DONT_CARE(delta, src, trg)\
                 delta.add(src, 0, trg);\
                 delta.add(src, 1, trg);\
@@ -3705,8 +3705,8 @@ TEST_CASE("mata::nft::Nft::get_one_level_aut") {
         expected.delta.add(4, 1, 2);
         REPLACE_DONT_CARE(expected.delta, 4, 4);
 
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({0, 1}, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({ DONT_CARE }, JumpMode::AppendDontCares).get_one_level_aut({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({0, 1}, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
     }
 
@@ -3739,8 +3739,8 @@ TEST_CASE("mata::nft::Nft::get_one_level_aut") {
         SPLIT_TRANSITION(expected.delta, 6, DONT_CARE, 14, 6);
         SPLIT_TRANSITION(expected.delta, 6, 1, 11, 4);
 
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({ 0, 1 }, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({ DONT_CARE }, JumpMode::AppendDontCares).get_one_level_aut({0, 1}, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({0, 1}, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
 
     }
@@ -3792,8 +3792,8 @@ TEST_CASE("mata::nft::Nft::get_one_level_aut") {
         SPLIT_TRANSITION(expected.delta, 13, 0, 23, 15);
         SPLIT_TRANSITION(expected.delta, 14, DONT_CARE, 28, 16);
 
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({ 0, 1 }, JumpMode::AppendDontCares), expected));
-        CHECK(nfa::are_equivalent(aut.get_one_level_aut({ DONT_CARE }, JumpMode::AppendDontCares).get_one_level_aut({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
+        CHECK(nfa::are_equivalent(aut.unwind_jump({ DONT_CARE }, JumpMode::AppendDontCares).unwind_jump({ 0, 1 }, JumpMode::AppendDontCares), expected));
         CHECK(nft::are_equivalent(aut, expected, JumpMode::AppendDontCares));
     }
 


### PR DESCRIPTION
This PR fixes the naming and description of the `make/get_one_level_aut` method. This closes #495.