### PR TITLE
Add `at`, `min`, and `max` methods for `OrdVector`

### DIFF
--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -265,6 +265,22 @@ public:
     virtual const Key& front() const { return vec_[0]; }
     virtual Key& front() { return vec_[0]; }
 
+    virtual const Key& min() const {
+        if (vec_.empty()) {
+            throw std::out_of_range("Cannot get min from an empty OrdVector");
+        }
+        return vec_.front();
+    }
+    virtual const Key& max() const {
+        if (vec_.empty()) {
+            throw std::out_of_range("Cannot get max from an empty OrdVector");
+        }
+        return vec_.back();
+    }
+
+    virtual const Key& at(const size_t index) const { return vec_.at(index); }
+    virtual Key& at(const size_t index) { return vec_.at(index); }
+
     /**
      * Check whether @p key exists in the ordered vector.
      */

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -271,7 +271,22 @@ public:
         }
         return vec_.front();
     }
+
+    virtual Key& min() {
+        if (vec_.empty()) {
+            throw std::out_of_range("Cannot get min from an empty OrdVector");
+        }
+        return vec_.front();
+    }
+
     virtual const Key& max() const {
+        if (vec_.empty()) {
+            throw std::out_of_range("Cannot get max from an empty OrdVector");
+        }
+        return vec_.back();
+    }
+
+    virtual Key& max() {
         if (vec_.empty()) {
             throw std::out_of_range("Cannot get max from an empty OrdVector");
         }

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -113,3 +113,59 @@ TEST_CASE("mata::utils::OrdVector::difference()") {
         CHECK(set1.difference(set2) == mata::utils::OrdVector<int>{ 1, 2 });
     }
 }
+
+TEST_CASE("mata::utils::OrdVector::min()") {
+    SECTION("Empty vector") {
+        OrdVector<int> vec;
+        CHECK_THROWS_AS(vec.min(), std::out_of_range);
+    }
+
+    SECTION("One element") {
+        OrdVector<int> vec{ 42 };
+        CHECK(vec.min() == 42);
+    }
+
+    SECTION("Multiple elements") {
+        OrdVector<int> vec{ 3, 2, 4, 2, 5, 99 };
+        CHECK(vec.min() == 2);
+    }
+}
+
+TEST_CASE("mata::utils::OrdVector::max()") {
+    SECTION("Empty vector") {
+        OrdVector<int> vec;
+        CHECK_THROWS_AS(vec.max(), std::out_of_range);
+    }
+
+    SECTION("One element") {
+        OrdVector<int> vec{ 42 };
+        CHECK(vec.max() == 42);
+    }
+
+    SECTION("Multiple elements") {
+        OrdVector<int> vec{ 3, 2, 4, 2, 5, 99 };
+        CHECK(vec.max() == 99);
+    }
+}
+
+TEST_CASE("mata::utils::OrdVector::at()") {
+    SECTION("Empty vector") {
+        OrdVector<int> vec;
+        CHECK_THROWS_AS(vec.at(0), std::out_of_range);
+    }
+
+    SECTION("One element") {
+        OrdVector<int> vec{ 42 };
+        CHECK(vec.at(0) == 42);
+    }
+
+    SECTION("Multiple elements") {
+        OrdVector<int> vec{ 3, 2, 4, 2, 5, 99 };
+        CHECK(vec.at(0) == 2);
+        CHECK(vec.at(1) == 3);
+        CHECK(vec.at(2) == 4);
+        CHECK(vec.at(3) == 5);
+        CHECK(vec.at(4) == 99);
+        CHECK_THROWS_AS(vec.at(5), std::out_of_range);
+    }
+}


### PR DESCRIPTION
This PR adds `at`, `min`, and `max` methods for `OrdVector`. 
- `min` and `max` return a read-only reference or throw an exception when called on an empty vector.
- `at` returns read/write reference on a given index or throws an `out_of_bounds` exception.