### PR TITLE
nfa python bindings: union_with_product_map, read_word

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -39,10 +39,6 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
     ctypedef umap[string, string] ParameterMap
 
     cdef const Symbol CEPSILON "mata::nfa::EPSILON"
-    cdef const State CMAX_STATE "mata::nfa::Limits::max_state"
-    cdef const State CMIN_STATE "mata::nfa::Limits::min_state"
-    cdef const Symbol CMAX_SYMBOL "mata::nfa::Limits::max_symbol"
-    cdef const Symbol CMIN_SYMBOL "mata::nfa::Limits::min_symbol"
 
     cdef cppclass CStatePost "mata::nfa::StatePost":
         void insert(CSymbolPost&)
@@ -183,7 +179,7 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         bool is_in_lang(CRun&, bool, bool)
         StateSet read_word(CRun&)
         StateSet read_word(CRun&, bool)
-        State read_word_det(CRun&)
+        optional[State] read_word_det(CRun&)
         pair[CRun, bool] get_word_for_path(CRun&)
         void make_complete(CAlphabet*, optional[State]) except +
 

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -39,6 +39,10 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
     ctypedef umap[string, string] ParameterMap
 
     cdef const Symbol CEPSILON "mata::nfa::EPSILON"
+    cdef const State CMAX_STATE "mata::nfa::Limits::max_state"
+    cdef const State CMIN_STATE "mata::nfa::Limits::min_state"
+    cdef const Symbol CMAX_SYMBOL "mata::nfa::Limits::max_symbol"
+    cdef const Symbol CMIN_SYMBOL "mata::nfa::Limits::min_symbol"
 
     cdef cppclass CStatePost "mata::nfa::StatePost":
         void insert(CSymbolPost&)
@@ -177,6 +181,9 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         bool is_in_lang(CRun&)
         bool is_in_lang(CRun&, bool)
         bool is_in_lang(CRun&, bool, bool)
+        StateSet read_word(CRun&)
+        StateSet read_word(CRun&, bool)
+        State read_word_det(CRun&)
         pair[CRun, bool] get_word_for_path(CRun&)
         void make_complete(CAlphabet*, optional[State]) except +
 

--- a/bindings/python/libmata/nfa/nfa.pyi
+++ b/bindings/python/libmata/nfa/nfa.pyi
@@ -501,6 +501,27 @@ class Nfa:
         :return: true if word is in language of the NFA.
         """
         ...
+    def read_word(self, word: list[Symbol], use_epsilon: bool = False) -> set[State]:
+        """Read word and return the set of states the automaton ends up in.
+
+        :param word: word to read.
+        :param use_epsilon: whether the automaton uses epsilon transitions.
+        :return: set of all reachable states after reading the word.
+                 If the word cannot be read, the returned set is empty.
+                 Note: Returns all reachable states, not just final states.
+                 Use is_in_lang() if you need to check language membership.
+
+        """
+        ...
+    def read_word_det(self, word: list[Symbol]) -> State:
+        """Read word and return the state the deterministic automaton ends up in.
+
+        The automaton must be deterministic, otherwise the result is undefined.
+
+        :param word: word to read.
+        :return: The reached state or -1 if the word cannot be read.
+        """
+        ...
     def get_word_for_path(self, path: list[State]) -> tuple[list[Symbol], bool]:
         """For a given path (set of states) returns a corresponding word
 

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -21,7 +21,7 @@ cimport libmata.alphabets as alph
 
 from libmata.nfa.nfa cimport \
     Symbol, State, StateSet, StateRenaming, \
-    CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON
+    CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON, CMAX_STATE
 
 from libmata.alphabets cimport CAlphabet
 from libmata.utils cimport COrdVector, CBinaryRelation, BinaryRelation
@@ -769,6 +769,38 @@ cdef class Nfa:
         run = Run()
         run.thisptr.word = word
         return self.thisptr.get().is_in_lang(dereference(run.thisptr), use_epsilon, match_prefix)
+
+    def read_word(self, vector[Symbol] word, use_epsilon = False):
+        """Read word and return the set of states the automaton ends up in.
+
+        :param word: word to read.
+        :param use_epsilon: whether the automaton uses epsilon transitions.
+        :return: set of all reachable states after reading the word.
+                 If the word cannot be read, the returned set is empty.
+                 Note: Returns all reachable states, not just final states.
+                 Use is_in_lang() if you need to check language membership.
+
+        """
+        run = Run()
+        run.word = word
+        cdef StateSet result = self.thisptr.get().read_word(dereference(run.thisptr), use_epsilon)
+        cdef vector[State] result_vec = result.to_vector()
+        return set(result_vec)
+
+    def read_word_det(self, vector[Symbol] word):
+        """Read word and return the state the deterministic automaton ends up in.
+
+        The automaton must be deterministic, otherwise the result is undefined.
+
+        :param word: word to read.
+        :return: The reached state or -1 if the word cannot be read.
+        """
+        run = Run()
+        run.word = word
+        cdef State result = self.thisptr.get().read_word_det(dereference(run.thisptr))
+        if result == CMAX_STATE:
+            return -1
+        return result
 
     def get_word_for_path(self, path):
         """For a given path (set of states) returns a corresponding word

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -21,7 +21,7 @@ cimport libmata.alphabets as alph
 
 from libmata.nfa.nfa cimport \
     Symbol, State, StateSet, StateRenaming, \
-    CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON, CMAX_STATE
+    CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON
 
 from libmata.alphabets cimport CAlphabet
 from libmata.utils cimport COrdVector, CBinaryRelation, BinaryRelation
@@ -793,14 +793,12 @@ cdef class Nfa:
         The automaton must be deterministic, otherwise the result is undefined.
 
         :param word: word to read.
-        :return: The reached state or -1 if the word cannot be read.
+        :return: The reached state or None if the word cannot be read.
         """
         run = Run()
         run.word = word
-        cdef State result = self.thisptr.get().read_word_det(dereference(run.thisptr))
-        if result == CMAX_STATE:
-            return -1
-        return result
+        cdef optional[State] result = self.thisptr.get().read_word_det(dereference(run.thisptr))
+        return result.value() if result.has_value() else None
 
     def get_word_for_path(self, path):
         """For a given path (set of states) returns a corresponding word

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -417,6 +417,65 @@ def test_in_language(
     assert mata_nfa.accepts_epsilon(lhs)
 
 
+def test_read_word():
+    """Test the read_word function."""
+    lhs = mata_nfa.Nfa(3)
+    lhs.make_initial_state(0)
+    lhs.make_final_state(0)
+    lhs.add_transition(0, 0, 0)
+    lhs.add_transition(0, 1, 1)
+    lhs.add_transition(0, 1, 2)
+    lhs.add_transition(2, 0, 0)
+
+    lhs_det, lhs_map = mata_nfa.determinize_with_subset_map(lhs)
+
+    states = lhs.read_word([])
+    state = lhs_det.read_word_det([])
+    assert states == {0}  # Empty word returns initial state 0 (which happens to be final)
+    assert state == lhs_map[(0,)]
+
+    states = lhs.read_word([0])
+    state = lhs_det.read_word_det([0])
+    assert states == {0}  # Should stay in state 0 (which happens to be final)
+    assert state == lhs_map[(0,)]
+
+    states = lhs.read_word([1])
+    state = lhs_det.read_word_det([1])
+    assert states == {1, 2}  # Should end up in state 1 (which is not final)
+    assert state == lhs_map[(1, 2)]
+
+    states = lhs.read_word([1, 1])
+    state = lhs_det.read_word_det([1, 1])
+    assert states == set()  # Empty set, because one cannot get anywhere from {1, 2} via 1
+    assert state == -1
+
+    states = lhs.read_word([1, 0])
+    state = lhs_det.read_word_det([1, 0])
+    assert states == {0}
+    assert state == lhs_map[(0,)]
+
+
+def test_read_word_epsilon():
+    lhs = mata_nfa.Nfa(4)
+    lhs.make_initial_state(0)
+    lhs.make_final_state(0)
+    lhs.add_transition(0, mata_nfa.epsilon(), 1)
+    lhs.add_transition(1, 0, 2)
+    lhs.add_transition(2, mata_nfa.epsilon(), 3)
+
+    states = lhs.read_word([], use_epsilon=True)
+    assert states == {0, 1}
+    states = lhs.read_word([])  # Here, epsilon is considered as a common symbol
+    assert states == {0}
+
+    states = lhs.read_word([0], use_epsilon=True)
+    assert states == {2, 3}
+    states = lhs.read_word([0])
+    assert states == set()
+    states = lhs.read_word([mata_nfa.epsilon(), 0, mata_nfa.epsilon()])
+    assert states == {3}
+
+
 def test_union(
         fa_one_divisible_by_two, fa_one_divisible_by_four, fa_one_divisible_by_eight
 ):

--- a/bindings/python/tests/test_nfa.py
+++ b/bindings/python/tests/test_nfa.py
@@ -447,7 +447,7 @@ def test_read_word():
     states = lhs.read_word([1, 1])
     state = lhs_det.read_word_det([1, 1])
     assert states == set()  # Empty set, because one cannot get anywhere from {1, 2} via 1
-    assert state == -1
+    assert state is None
 
     states = lhs.read_word([1, 0])
     state = lhs_det.read_word_det([1, 0])

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -505,6 +505,54 @@ public:
     bool is_in_lang(const Word& word, const bool use_epsilon = false, const bool match_prefix = false) { return is_in_lang(Run{ word, {} }, use_epsilon, match_prefix); }
 
     /**
+     * @brief Read a word and return the set of states the automaton ends up in.
+     *
+     * @param word The word to read.
+     * @param use_epsilon Whether the automaton uses epsilon transitions.
+     *
+     * @return Set of all reachable states after reading the word. Note: This returns
+     *         all reachable states, not just final states. Use is_in_lang() if you need to check
+     *         language membership, or intersect the result with final states manually if needed.
+     *         Note: The returned set is empty if the word cannot be read.
+     */
+    StateSet read_word(const Run& word, const bool use_epsilon = false) const;
+
+    /**
+     * @brief Read a word and return the set of states the automaton ends up in.
+     *
+     * @param word The word to read.
+     * @param use_epsilon Whether the automaton uses epsilon transitions.
+     *
+     * @return Set of all reachable states after reading the word. Note: This returns
+     *         all reachable states, not just final states. Use is_in_lang() if you need to check
+     *         language membership, or intersect the result with final states manually if needed.
+     *         Note: The returned set is empty if the word cannot be read.
+     */
+    StateSet read_word(const Word& word, const bool use_epsilon = false) const { return read_word(Run{ word, {} }, use_epsilon); }
+
+    /**
+     * @brief Read a word and return the state the deterministic automaton ends up in.
+     *
+     * If the automaton is nondeterministic, the result is undefined.
+     *
+     * @param word The word to read.
+     *
+     * @return The reachable state after reading the word or Limits::max_state if the word cannot be read.
+     */
+    State read_word_det(const Run& word) const;
+
+    /**
+     * @brief Read a word and return the state the deterministic automaton ends up in.
+     *
+     * If the automaton is nondeterministic, the result is undefined.
+     *
+     * @param word The word to read.
+     *
+     * @return The reachable state after reading the word or Limits::max_state if the word cannot be read.
+     */
+    State read_word_det(const Word& word) const { return read_word_det(Run{ word, {} }); }
+
+    /**
      * @brief Check whether a prefix of a run is in the language of an automaton.
      *
      * @param word The run to check.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -537,9 +537,9 @@ public:
      *
      * @param word The word to read.
      *
-     * @return The reachable state after reading the word or Limits::max_state if the word cannot be read.
+     * @return The reachable state after reading the word or std::nullopt if the word cannot be read.
      */
-    State read_word_det(const Run& word) const;
+    std::optional<State> read_word_det(const Run& word) const;
 
     /**
      * @brief Read a word and return the state the deterministic automaton ends up in.
@@ -548,9 +548,9 @@ public:
      *
      * @param word The word to read.
      *
-     * @return The reachable state after reading the word or Limits::max_state if the word cannot be read.
+     * @return The reachable state after reading the word or std::nullopt if the word cannot be read.
      */
-    State read_word_det(const Word& word) const { return read_word_det(Run{ word, {} }); }
+    std::optional<State> read_word_det(const Word& word) const { return read_word_det(Run{ word, {} }); }
 
     /**
      * @brief Check whether a prefix of a run is in the language of an automaton.

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -577,13 +577,13 @@ StateSet mata::nfa::Nfa::read_word(const Run& run, const bool use_epsilon) const
     return current_post;
 }
 
-State mata::nfa::Nfa::read_word_det(const Run& run) const {
-    if (initial.empty()) return Limits::max_state;
+std::optional<State> mata::nfa::Nfa::read_word_det(const Run& run) const {
+    if (initial.empty()) return std::nullopt;
     State current_post = *initial.begin();
 
     for (const Symbol sym : run.word) {
         const StateSet& successors = delta.get_successors(current_post, sym);
-        if (successors.empty()) return Limits::max_state;
+        if (successors.empty()) return std::nullopt;
         current_post = *successors.begin();
     }
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -560,7 +560,7 @@ std::pair<Run, bool> mata::nfa::Nfa::get_word_for_path(const Run& run) const {
 }
 
 //TODO: this is not efficient
-bool mata::nfa::Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bool match_prefix) const {
+StateSet mata::nfa::Nfa::read_word(const Run& run, const bool use_epsilon) const {
     StateSet current_post(this->initial);
 
     if (use_epsilon) {
@@ -570,12 +570,47 @@ bool mata::nfa::Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bo
 
     const EpsilonClosureOpt epsilon_closure_opt = use_epsilon ? EpsilonClosureOpt::AFTER : EpsilonClosureOpt::NONE;
     for (const Symbol sym : run.word) {
-        if (match_prefix && this->final.intersects_with(current_post)) { return true; }
         current_post = this->post(current_post, sym, epsilon_closure_opt);
-        if (current_post.empty()) { return false; }
+        if (current_post.empty()) { return current_post; }
     }
 
-    return this->final.intersects_with(current_post);
+    return current_post;
+}
+
+State mata::nfa::Nfa::read_word_det(const Run& run) const {
+    if (initial.empty()) return Limits::max_state;
+    State current_post = *initial.begin();
+
+    for (const Symbol sym : run.word) {
+        const StateSet& successors = delta.get_successors(current_post, sym);
+        if (successors.empty()) return Limits::max_state;
+        current_post = *successors.begin();
+    }
+
+    return current_post;
+}
+
+//TODO: this is not efficient
+bool mata::nfa::Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bool match_prefix) const {
+    if (match_prefix) {
+        StateSet current_post(this->initial);
+
+        if (use_epsilon) {
+            // Compute epsilon closure from the initial states.
+            current_post = this->post(current_post, EPSILON, EpsilonClosureOpt::BEFORE);
+        }
+
+        const EpsilonClosureOpt epsilon_closure_opt = use_epsilon ? EpsilonClosureOpt::AFTER : EpsilonClosureOpt::NONE;
+        for (const Symbol sym : run.word) {
+            if (this->final.intersects_with(current_post)) { return true; }
+            current_post = this->post(current_post, sym, epsilon_closure_opt);
+            if (current_post.empty()) { return false; }
+        }
+
+        return this->final.intersects_with(current_post);
+    }
+
+    return this->final.intersects_with(read_word(run, use_epsilon));
 }
 
 bool mata::nfa::Nfa::is_lang_empty(Run* cex) const {


### PR DESCRIPTION
provide OR-product and "get nfa configuration after reading a given word", as described in the issue [556](https://github.com/VeriFIT/mata/issues/556)