### PR TITLE
Homomorphic nft in transducer noodlification

### DIFF
--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -57,9 +57,11 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
 /**
  * @brief Check if transducer @p nft T is for sure homomorphic, that is whether for each two words u,v, it holds T(u.v) = T(u).T(v).
  * 
- * The check is only a heuristic, it can return false even if T is homomorphic. We do this by checking whether there is exactly one
- * initial and final state (and they are the same), and each (transducer) transition from the initial state does not contain epsilon,
- * while all other transitions contain epsilon always on the first tape and a some symbol on the second tape.
+ * @warning The check is only a heuristic, it can return false even if T is homomorphic.
+ * 
+ * We check whether there is exactly one initial and final state (and they are the same), and each (transducer) transition from
+ * the initial state does not contain epsilon, while all other transitions contain epsilon always on the first tape and some symbol
+ * on the second tape.
  */
 bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
     if (nft->num_of_levels != 2) {

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -55,6 +55,54 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
     return concatenation;
 }
 
+/**
+ * @brief Check if transducer @p nft T is for sure homomorphic, that is whether for each two words u,v, it holds T(u.v) = T(u).T(v).
+ * 
+ * The check is only a heuristic, it can return false even if T is homomorphic. We do this by checking whether there is exactly one
+ * initial and final state (and they are the same), and each (transducer) transition from the initial state does not contain epsilon,
+ * while all other transitions contain epsilon always on the first tape and a some symbol on the second tape.
+ */
+bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
+    if (nft->num_of_levels != 2) {
+        return false;
+    }
+
+    if (nft->final.size() != 1 || nft->initial.size() != 1) {
+        return false;
+    }
+
+    // the only initial and the only final state must be the same state
+    if (*nft->final.begin() != *nft->initial.begin()) {
+        return false;
+    }
+
+    size_t num_of_states = nft->num_of_states();
+    for (State q = 0; q < num_of_states; ++q) {
+        if (nft->levels[q] == mata::nft::DEFAULT_LEVEL) {
+            for (const SymbolPost& first_tape_transition : nft->delta[q]) {
+                bool first_tape_is_epsilon = (first_tape_transition.symbol == mata::nft::EPSILON);
+                bool is_initial = (q == *nft->initial.begin());
+                if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
+                    return false;
+                }
+                for (State interim_state : first_tape_transition.targets) {
+                    if (nft->levels[interim_state] == mata::nft::DEFAULT_LEVEL) {
+                        // there is some jump transition
+                        return false;
+                    }
+                    for (const SymbolPost& second_tape_transition : nft->delta[interim_state]) {
+                        if (second_tape_transition.symbol == mata::nft::EPSILON) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 } // namespace
 
 std::vector<seg_nfa::Noodle> seg_nfa::noodlify(const SegNfa& aut, const Symbol epsilon, bool include_empty) {

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -8,7 +8,6 @@
 #include "mata/nfa/algorithms.hh"
 #include "mata/nft/algorithms.hh"
 
-using namespace mata::nfa;
 using namespace mata::strings;
 
 namespace {
@@ -337,7 +336,7 @@ std::vector<seg_nfa::Noodle> seg_nfa::noodlify_for_equation(
     Nfa concatenated_lhs{ *lhs_aut_begin };
     for (auto next_lhs_aut_it{ lhs_aut_begin + 1 }; next_lhs_aut_it != lhs_aut_end;
          ++next_lhs_aut_it) {
-        concatenated_lhs = concatenate(concatenated_lhs, *next_lhs_aut_it, EPSILON);
+        concatenated_lhs = concatenate(concatenated_lhs, *next_lhs_aut_it, mata::nfa::EPSILON);
     }
 
     auto product_pres_eps_trans{
@@ -356,7 +355,7 @@ std::vector<seg_nfa::Noodle> seg_nfa::noodlify_for_equation(
             product_pres_eps_trans = revert(product_pres_eps_trans);
         }
     }
-    return noodlify(product_pres_eps_trans, EPSILON, include_empty);
+    return noodlify(product_pres_eps_trans, mata::nfa::EPSILON, include_empty);
 }
 
 std::vector<seg_nfa::Noodle> seg_nfa::noodlify_for_equation(
@@ -386,7 +385,7 @@ std::vector<seg_nfa::Noodle> seg_nfa::noodlify_for_equation(
     Nfa concatenated_lhs{ *(*lhs_aut_begin) };
     for (auto next_lhs_aut_it{ lhs_aut_begin + 1 }; next_lhs_aut_it != lhs_aut_end;
          ++next_lhs_aut_it) {
-        concatenated_lhs = concatenate(concatenated_lhs, *(*next_lhs_aut_it), EPSILON);
+        concatenated_lhs = concatenate(concatenated_lhs, *(*next_lhs_aut_it), mata::nfa::EPSILON);
     }
 
     auto product_pres_eps_trans{
@@ -404,7 +403,7 @@ std::vector<seg_nfa::Noodle> seg_nfa::noodlify_for_equation(
             product_pres_eps_trans = revert(product_pres_eps_trans);
         }
     }
-    return noodlify(product_pres_eps_trans, EPSILON, include_empty);
+    return noodlify(product_pres_eps_trans, mata::nfa::EPSILON, include_empty);
 }
 
 
@@ -418,11 +417,11 @@ std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_for_equation(
     unify_initial_and_final_states(rhs_automata, unified_nfas);
 
     // Automata representing the left/rigth side concatenated over different epsilon transitions.
-    Nfa concatenated_lhs = concatenate_with(lhs_automata, EPSILON);
-    Nfa concatenated_rhs = concatenate_with(rhs_automata, EPSILON-1);
+    Nfa concatenated_lhs = concatenate_with(lhs_automata, mata::nfa::EPSILON);
+    Nfa concatenated_rhs = concatenate_with(rhs_automata, mata::nfa::EPSILON-1);
 
     auto product_pres_eps_trans{
-            intersection(concatenated_lhs, concatenated_rhs, EPSILON-1).trim() };
+            intersection(concatenated_lhs, concatenated_rhs, mata::nfa::EPSILON-1).trim() };
 
     if (product_pres_eps_trans.is_lang_empty()) {
         return {};
@@ -438,7 +437,7 @@ std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_for_equation(
             product_pres_eps_trans = revert(product_pres_eps_trans);
         }
     }
-    return noodlify_mult_eps(product_pres_eps_trans, { EPSILON, EPSILON-1 }, include_empty);
+    return noodlify_mult_eps(product_pres_eps_trans, { mata::nfa::EPSILON, mata::nfa::EPSILON-1 }, include_empty);
 }
 
 seg_nfa::VisitedEpsilonsCounterVector seg_nfa::process_eps_map(const VisitedEpsilonsCounterMap& eps_cnt) {
@@ -457,9 +456,9 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
 ) {
     if (input_automata.empty() || output_automata.empty()) { return {}; }
 
-    // delimiters, we cannot use EPSILON, because that is normal EPSILON which can be used in nft (non-preserving lengths nfts are allowed) and EPSILON-1 is DONT_CARE
-    constexpr Symbol INPUT_DELIMITER = EPSILON-2;
-    constexpr Symbol OUTPUT_DELIMITER = EPSILON-3;
+    // delimiters, we cannot use mata::nfa::EPSILON, because that is normal mata::nfa::EPSILON which can be used in nft (non-preserving lengths nfts are allowed) and mata::nfa::EPSILON-1 is DONT_CARE
+    constexpr Symbol INPUT_DELIMITER = mata::nfa::EPSILON-2;
+    constexpr Symbol OUTPUT_DELIMITER = mata::nfa::EPSILON-3;
 
     // to have less noodles, we try to have one initial and one final state for each input/output automaton
     std::unordered_set<std::shared_ptr<Nfa>> unified_nfas;

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -9,7 +9,6 @@
 
 using namespace mata::nfa;
 using namespace mata::strings;
-using namespace mata::nfa::algorithms;
 
 namespace {
 
@@ -50,7 +49,7 @@ void unify_initial_and_final_states(const std::vector<std::shared_ptr<Nfa>>& nfa
 Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol delimiter) {
     Nfa concatenation{*nfas[0]};
     for (std::vector<std::shared_ptr<Nfa>>::size_type i = 1; i < nfas.size(); ++i) {
-        concatenation = concatenate_eps(concatenation, *nfas[i], delimiter, true);
+        concatenation = mata::nfa::algorithms::concatenate_eps(concatenation, *nfas[i], delimiter, true);
     }
     return concatenation;
 }

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -61,7 +61,7 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
  * initial and final state (and they are the same), and each (transducer) transition from the initial state does not contain epsilon,
  * while all other transitions contain epsilon always on the first tape and a some symbol on the second tape.
  */
-bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
+bool is_nft_homomorphic(const std::shared_ptr<Nft> nft, bool check_inverted = false) {
     if (nft->num_of_levels != 2) {
         return false;
     }
@@ -81,8 +81,14 @@ bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
             for (const SymbolPost& first_tape_transition : nft->delta[q]) {
                 bool first_tape_is_epsilon = (first_tape_transition.symbol == mata::nft::EPSILON);
                 bool is_initial = (q == *nft->initial.begin());
-                if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
-                    return false;
+                if (check_inverted) {
+                    if (first_tape_is_epsilon) {
+                        return false;
+                    }
+                } else {
+                    if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
+                        return false;
+                    }
                 }
                 for (State interim_state : first_tape_transition.targets) {
                     if (nft->levels[interim_state] == mata::nft::DEFAULT_LEVEL) {
@@ -90,8 +96,15 @@ bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
                         return false;
                     }
                     for (const SymbolPost& second_tape_transition : nft->delta[interim_state]) {
-                        if (second_tape_transition.symbol == mata::nft::EPSILON) {
-                            return false;
+                        bool second_tape_is_epsilon = (second_tape_transition.symbol == mata::nft::EPSILON);
+                        if (check_inverted) {
+                            if ((second_tape_is_epsilon && is_initial) || (!second_tape_is_epsilon && !is_initial)) {
+                                return false;
+                            }
+                        } else {
+                            if (second_tape_is_epsilon) {
+                                return false;
+                            }
                         }
                     }
                 }
@@ -494,7 +507,7 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
 
     Nft intersection;
 
-    if (is_nft_homomorphic(nft)) {
+    if (is_nft_homomorphic(nft, false)) {
         // For the case that input nft T is homomorphic, i.e., for each two words u,v, we have T(u.v) = T(u).T(v),
         // we can do the following optimization. Let I1, ..., In be the input automata. Because T is homomorphic,
         // we can take the concatenation T(I1).T(I2)...T(In) connected with INPUT_DELIMITER instead of computing
@@ -505,27 +518,67 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
             concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, INPUT_DELIMITER, true);
         }
         intersection = std::move(concatenation);
+        intersection.trim();
+    
+        if(intersection.final.empty()) {
+            return {};
+        }
+
+        // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
+        // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
+        add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
+        add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
+        intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
+        intersection.trim();
+    
+        if(intersection.final.empty()) {
+            return {};
+        }
+    } else if (is_nft_homomorphic(nft, true)) {
+        // We do the same optimization but backwards (T is homomorphic but for output)
+        mata::nft::Nft concatenation{mata::nft::compose(mata::nft::Nft(*output_automata[0]), *nft, 0, 1, false)};
+        for (std::vector<std::shared_ptr<mata::nfa::Nfa>>::size_type i = 1; i < output_automata.size(); ++i) {
+            mata::nft::Nft composition = mata::nft::compose(mata::nft::Nft(*output_automata[i]), *nft, 0, 1, false);
+            concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, OUTPUT_DELIMITER, true);
+        }
+        intersection = std::move(concatenation);
+        intersection.trim();
+
+        if(intersection.final.empty()) {
+            return {};
+        }
+
+        // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition"
+        // of nft and we also need to OUTPUT_DELIMITER as "epsilon transition" of the input nfa, so that we do not lose it
+        add_self_loop_for_every_default_state(concatenated_input_nft, OUTPUT_DELIMITER);
+        add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
+        intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
+        intersection.trim();
+
+        if(intersection.final.empty()) {
+            return {};
+        }
     } else {
         intersection = *nft;
         // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition" of nft
         add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
         intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
-    }
-    intersection.trim();
+        intersection.trim();
 
-    if(intersection.final.empty()) {
-        return {};
-    }
+        if(intersection.final.empty()) {
+            return {};
+        }
 
-    // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
-    // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
-    add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
-    add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
-    intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
-    intersection.trim();
+        // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
+        // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
+        add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
+        add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
+        intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
+        intersection.trim();
 
-    if(intersection.final.empty()) {
-        return {};
+        if(intersection.final.empty()) {
+            return {};
+        }
     }
 
     // we assume that the operations did not add jump transitions

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -6,6 +6,7 @@
 #include "mata/nft/builder.hh"
 #include "mata/nfa/strings.hh"
 #include "mata/nfa/algorithms.hh"
+#include "mata/nft/algorithms.hh"
 
 using namespace mata::nfa;
 using namespace mata::strings;
@@ -492,11 +493,25 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
     // of the transducer, so that intersection works correctly (i.e. the delimiters behave
     // as epsilon transitions).
 
-    Nft intersection = *nft;
+    Nft intersection;
 
-    // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition" of nft
-    add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
-    intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
+    if (is_nft_homomorphic(nft)) {
+        // For the case that input nft T is homomorphic, i.e., for each two words u,v, we have T(u.v) = T(u).T(v),
+        // we can do the following optimization. Let I1, ..., In be the input automata. Because T is homomorphic,
+        // we can take the concatenation T(I1).T(I2)...T(In) connected with INPUT_DELIMITER instead of computing
+        // the composition with concatenated_input_nft.
+        mata::nft::Nft concatenation{mata::nft::compose(mata::nft::Nft(*input_automata[0]), *nft, 0, 0, false)};
+        for (std::vector<std::shared_ptr<mata::nfa::Nfa>>::size_type i = 1; i < input_automata.size(); ++i) {
+            mata::nft::Nft composition = mata::nft::compose(mata::nft::Nft(*input_automata[i]), *nft, 0, 0, false);
+            concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, INPUT_DELIMITER, true);
+        }
+        intersection = std::move(concatenation);
+    } else {
+        intersection = *nft;
+        // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition" of nft
+        add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
+        intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
+    }
     intersection.trim();
 
     if(intersection.final.empty()) {

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -59,21 +59,17 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
  * 
  * @warning The check is only a heuristic, it can return false even if T is homomorphic.
  * 
- * We check whether there is exactly one initial and final state (and they are the same), and each (transducer) transition from
- * the initial state does not contain epsilon, while all other transitions contain epsilon always on the first tape and some symbol
- * on the second tape.
+ * We check whether there is exactly one initial and final state (and they are the same), and every transition other than those
+ * coming from the initial state have epsilon on the first tape.
  */
 bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
     if (nft->num_of_levels != 2) {
         return false;
     }
 
-    if (nft->final.size() != 1 || nft->initial.size() != 1) {
-        return false;
-    }
-
     // the only initial and the only final state must be the same state
-    if (*nft->final.begin() != *nft->initial.begin()) {
+    if (nft->final.size() != 1 || nft->initial.size() != 1
+            || *nft->final.begin() != *nft->initial.begin()) {
         return false;
     }
 
@@ -83,19 +79,9 @@ bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
             for (const SymbolPost& first_tape_transition : nft->delta[q]) {
                 bool first_tape_is_epsilon = (first_tape_transition.symbol == mata::nft::EPSILON);
                 bool is_initial = (q == *nft->initial.begin());
-                if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
+                // there can be a concrete symbol on the first tape only on the transitions from the initial state
+                if (!first_tape_is_epsilon && !is_initial) {
                     return false;
-                }
-                for (State interim_state : first_tape_transition.targets) {
-                    if (nft->levels[interim_state] == mata::nft::DEFAULT_LEVEL) {
-                        // there is some jump transition
-                        return false;
-                    }
-                    for (const SymbolPost& second_tape_transition : nft->delta[interim_state]) {
-                        if (second_tape_transition.symbol == mata::nft::EPSILON) {
-                            return false;
-                        }
-                    }
                 }
             }
         }

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -48,7 +48,7 @@ void unify_initial_and_final_states(const std::vector<std::shared_ptr<Nfa>>& nfa
 
 Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol delimiter) {
     Nfa concatenation{*nfas[0]};
-    for (std::vector<std::shared_ptr<Nfa>>::size_type i = 1; i < nfas.size(); ++i) {
+    for (size_t i = 1; i < nfas.size(); ++i) {
         concatenation = mata::nfa::algorithms::concatenate_eps(concatenation, *nfas[i], delimiter, true);
     }
     return concatenation;
@@ -502,7 +502,7 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
         // we can take the concatenation T(I1).T(I2)...T(In) connected with INPUT_DELIMITER instead of computing
         // the composition with concatenated_input_nft.
         mata::nft::Nft concatenation{mata::nft::compose(mata::nft::Nft(*input_automata[0]), *nft, 0, 0, false)};
-        for (std::vector<std::shared_ptr<mata::nfa::Nfa>>::size_type i = 1; i < input_automata.size(); ++i) {
+        for (size_t i = 1; i < input_automata.size(); ++i) {
             mata::nft::Nft composition = mata::nft::compose(mata::nft::Nft(*input_automata[i]), *nft, 0, 0, false);
             concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, INPUT_DELIMITER, true);
         }

--- a/src/strings/nfa-noodlification.cc
+++ b/src/strings/nfa-noodlification.cc
@@ -61,7 +61,7 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
  * initial and final state (and they are the same), and each (transducer) transition from the initial state does not contain epsilon,
  * while all other transitions contain epsilon always on the first tape and a some symbol on the second tape.
  */
-bool is_nft_homomorphic(const std::shared_ptr<Nft> nft, bool check_inverted = false) {
+bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
     if (nft->num_of_levels != 2) {
         return false;
     }
@@ -81,14 +81,8 @@ bool is_nft_homomorphic(const std::shared_ptr<Nft> nft, bool check_inverted = fa
             for (const SymbolPost& first_tape_transition : nft->delta[q]) {
                 bool first_tape_is_epsilon = (first_tape_transition.symbol == mata::nft::EPSILON);
                 bool is_initial = (q == *nft->initial.begin());
-                if (check_inverted) {
-                    if (first_tape_is_epsilon) {
-                        return false;
-                    }
-                } else {
-                    if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
-                        return false;
-                    }
+                if ((first_tape_is_epsilon && is_initial) || (!first_tape_is_epsilon && !is_initial)) {
+                    return false;
                 }
                 for (State interim_state : first_tape_transition.targets) {
                     if (nft->levels[interim_state] == mata::nft::DEFAULT_LEVEL) {
@@ -96,15 +90,8 @@ bool is_nft_homomorphic(const std::shared_ptr<Nft> nft, bool check_inverted = fa
                         return false;
                     }
                     for (const SymbolPost& second_tape_transition : nft->delta[interim_state]) {
-                        bool second_tape_is_epsilon = (second_tape_transition.symbol == mata::nft::EPSILON);
-                        if (check_inverted) {
-                            if ((second_tape_is_epsilon && is_initial) || (!second_tape_is_epsilon && !is_initial)) {
-                                return false;
-                            }
-                        } else {
-                            if (second_tape_is_epsilon) {
-                                return false;
-                            }
+                        if (second_tape_transition.symbol == mata::nft::EPSILON) {
+                            return false;
                         }
                     }
                 }
@@ -507,7 +494,7 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
 
     Nft intersection;
 
-    if (is_nft_homomorphic(nft, false)) {
+    if (is_nft_homomorphic(nft)) {
         // For the case that input nft T is homomorphic, i.e., for each two words u,v, we have T(u.v) = T(u).T(v),
         // we can do the following optimization. Let I1, ..., In be the input automata. Because T is homomorphic,
         // we can take the concatenation T(I1).T(I2)...T(In) connected with INPUT_DELIMITER instead of computing
@@ -518,67 +505,27 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
             concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, INPUT_DELIMITER, true);
         }
         intersection = std::move(concatenation);
-        intersection.trim();
-    
-        if(intersection.final.empty()) {
-            return {};
-        }
-
-        // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
-        // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
-        add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
-        add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
-        intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
-        intersection.trim();
-    
-        if(intersection.final.empty()) {
-            return {};
-        }
-    } else if (is_nft_homomorphic(nft, true)) {
-        // We do the same optimization but backwards (T is homomorphic but for output)
-        mata::nft::Nft concatenation{mata::nft::compose(mata::nft::Nft(*output_automata[0]), *nft, 0, 1, false)};
-        for (std::vector<std::shared_ptr<mata::nfa::Nfa>>::size_type i = 1; i < output_automata.size(); ++i) {
-            mata::nft::Nft composition = mata::nft::compose(mata::nft::Nft(*output_automata[i]), *nft, 0, 1, false);
-            concatenation = mata::nft::algorithms::concatenate_eps(concatenation, composition, OUTPUT_DELIMITER, true);
-        }
-        intersection = std::move(concatenation);
-        intersection.trim();
-
-        if(intersection.final.empty()) {
-            return {};
-        }
-
-        // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition"
-        // of nft and we also need to OUTPUT_DELIMITER as "epsilon transition" of the input nfa, so that we do not lose it
-        add_self_loop_for_every_default_state(concatenated_input_nft, OUTPUT_DELIMITER);
-        add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
-        intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
-        intersection.trim();
-
-        if(intersection.final.empty()) {
-            return {};
-        }
     } else {
         intersection = *nft;
         // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition" of nft
         add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
         intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
-        intersection.trim();
+    }
+    intersection.trim();
 
-        if(intersection.final.empty()) {
-            return {};
-        }
+    if(intersection.final.empty()) {
+        return {};
+    }
 
-        // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
-        // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
-        add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
-        add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
-        intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
-        intersection.trim();
+    // we intersect output nfa with nft on the output track but we need to add OUTPUT_DELIMITER as a "epsilon transition" of nft
+    // and, we also need to INPUT_DELIMITER as "epsilon transition" of the output nfa, so that we do not lose it
+    add_self_loop_for_every_default_state(concatenated_output_nft, INPUT_DELIMITER);
+    add_self_loop_for_every_default_state(intersection, OUTPUT_DELIMITER);
+    intersection = mata::nft::compose(concatenated_output_nft, intersection, 0, 1, false);
+    intersection.trim();
 
-        if(intersection.final.empty()) {
-            return {};
-        }
+    if(intersection.final.empty()) {
+        return {};
     }
 
     // we assume that the operations did not add jump transitions


### PR DESCRIPTION
Adds a simple heuristic to check if a 2-tape transducer T is homomorphic, that is for every two words u,v, we have T(u.v) = T(u).T(v). Furthermore, I use this check in transducer noodlification, so that we do simpler splitting on input tape (we split just between input variables).