### PR TITLE
Fix NFT construction for replace operations in strings

### DIFF
--- a/include/mata/applications/strings.hh
+++ b/include/mata/applications/strings.hh
@@ -494,17 +494,17 @@ Nft replace_reluctant_regex(const std::string& regex, const Word& replacement, A
                             ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
 
 /**
- * @brief Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+ * @brief Create NFT modelling a reluctant leftmost replace of regex represented by deterministic automaton @p aut to @p replacement.
  *
  * The most general replace operation, handling any regex as the part to be replaced.
- * @param regex NFA representing regex to be replaced.
+ * @param aut deterministic automaton representing regex to be replaced.
  * @param replacement Literal to replace with.
  * @param alphabet Alphabet over which to create the NFT.
  * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
  * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
  * @return The reluctant leftmost replace NFT.
  */
-Nft replace_reluctant_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+Nft replace_reluctant_regex(nfa::Nfa aut, const Word& replacement, Alphabet* alphabet,
                             ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
 
 /**
@@ -547,17 +547,17 @@ Nft replace_reluctant_single_symbol(Symbol from_symbol, const Word& replacement,
 class ReluctantReplace {
 public:
     /**
-     * @brief Create NFT modelling a reluctant leftmost replace of regex @p regex to @p replacement.
+     * @brief Create NFT modelling a reluctant leftmost replace of regex represented by deterministic automaton @p aut to @p replacement.
      *
      * The most general replace operation, handling any regex as the part to be replaced.
-     * @param regex NFA representing regex to be replaced.
+     * @param aut Deterministic automaton representing regex to be replaced.
      * @param replacement Literal to replace with.
      * @param alphabet Alphabet over which to create the NFT.
      * @param replace_mode Whether to replace all or just the single (the leftmost) occurrence of @p regex.
      * @param begin_marker Symbol to be used internally as a begin marker of replaced @p regex.
      * @return The reluctant leftmost replace NFT.
      */
-    static Nft replace_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+    static Nft replace_regex(nfa::Nfa aut, const Word& replacement, Alphabet* alphabet,
                              ReplaceMode replace_mode = ReplaceMode::All, Symbol begin_marker = BEGIN_MARKER);
     /**
      * Create NFT modelling a reluctant leftmost replace of literal @p literal to @p replacement.

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -255,13 +255,13 @@ Nft mata::applications::strings::replace::replace_reluctant_regex(
 }
 
 Nft mata::applications::strings::replace::replace_reluctant_regex(
-    nfa::Nfa regex,
+    nfa::Nfa aut,
     const Word& replacement,
     Alphabet* alphabet,
     ReplaceMode replace_mode,
     Symbol begin_marker
 ) {
-    return ReluctantReplace::replace_regex(std::move(regex), replacement, alphabet, replace_mode, begin_marker);
+    return ReluctantReplace::replace_regex(std::move(aut), replacement, alphabet, replace_mode, begin_marker);
 }
 
 nfa::Nfa ReluctantReplace::end_marker_dfa(nfa::Nfa regex) {
@@ -493,7 +493,7 @@ Nft applications::strings::replace::replace_reluctant_single_symbol(Symbol from_
     return ReluctantReplace::replace_symbol(from_symbol, replacement, alphabet, replace_mode);
 }
 
-Nft ReluctantReplace::replace_regex(nfa::Nfa regex, const Word& replacement, Alphabet* alphabet,
+Nft ReluctantReplace::replace_regex(nfa::Nfa aut, const Word& replacement, Alphabet* alphabet,
                                               ReplaceMode replace_mode, Symbol begin_marker) {
     // SMT-LIB theory Strings (Unicode Strings): Semantics for matching empty words in replace regex functions:
     // ; (str.replace_re s r t) is the string obtained by replacing the
@@ -506,15 +506,15 @@ Nft ReluctantReplace::replace_regex(nfa::Nfa regex, const Word& replacement, Alp
     // ; left-to right, each shortest *non-empty* match of r in s by t.
     // (str.replace_re_all String RegLan String String)
     if (replace_mode == ReplaceMode::All) {
-        // Removing the empty string from the regex.
-        regex.unify_initial(true).final.erase(*regex.initial.begin());
+        // Removing the empty string from aut.
+        aut.unify_initial(true).final.erase(*regex.initial.begin());
     }
 
     ReluctantReplace reluctant_replace{};
     // TODO(nft): Add optional bool parameter to revert whether to swap initial and final states.
-    Nft dft_begin_marker{ reluctant_replace.begin_marker_nft(reluctant_replace.begin_marker_nfa(regex, alphabet), begin_marker) };
+    Nft dft_begin_marker{ reluctant_replace.begin_marker_nft(reluctant_replace.begin_marker_nfa(aut, alphabet), begin_marker) };
     Nft nft_reluctant_replace{
-        reluctant_replace.reluctant_leftmost_nft(std::move(regex), alphabet, begin_marker, replacement, replace_mode) };
+        reluctant_replace.reluctant_leftmost_nft(std::move(aut), alphabet, begin_marker, replacement, replace_mode) };
     return compose(dft_begin_marker, nft_reluctant_replace);
 }
 

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -251,7 +251,7 @@ Nft mata::applications::strings::replace::replace_reluctant_regex(
     ReplaceMode replace_mode,
     Symbol begin_marker
 ) {
-    return replace_reluctant_regex(nfa::builder::create_from_regex(regex), replacement, alphabet, replace_mode, begin_marker);
+    return replace_reluctant_regex(nfa::determinize(nfa::builder::create_from_regex(regex)), replacement, alphabet, replace_mode, begin_marker);
 }
 
 Nft mata::applications::strings::replace::replace_reluctant_regex(
@@ -300,7 +300,7 @@ Nft ReluctantReplace::marker_nft(const nfa::Nfa& marker_dfa, Symbol marker) {
 }
 
 nfa::Nfa ReluctantReplace::generic_marker_dfa(const std::string& regex, Alphabet* alphabet) {
-    return generic_marker_dfa(nfa::builder::create_from_regex(regex), alphabet);
+    return generic_marker_dfa(nfa::determinize(nfa::builder::create_from_regex(regex)), alphabet);
 }
 
 nfa::Nfa ReluctantReplace::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet) {
@@ -336,7 +336,7 @@ nfa::Nfa ReluctantReplace::generic_marker_dfa(nfa::Nfa regex, Alphabet* alphabet
 }
 
 nfa::Nfa ReluctantReplace::begin_marker_nfa(const std::string& regex, Alphabet* alphabet) {
-    return begin_marker_nfa(nfa::builder::create_from_regex(regex), alphabet);
+    return begin_marker_nfa(nfa::determinize(nfa::builder::create_from_regex(regex)), alphabet);
 }
 
 nfa::Nfa ReluctantReplace::begin_marker_nfa(nfa::Nfa regex, Alphabet* alphabet) {
@@ -392,7 +392,7 @@ nfa::Nfa ReluctantReplace::reluctant_nfa_with_marker(nfa::Nfa nfa, const Symbol 
 
 Nft ReluctantReplace::reluctant_leftmost_nft(const std::string& regex, Alphabet* alphabet, Symbol begin_marker,
                                          const Word& replacement, ReplaceMode replace_mode) {
-    return reluctant_leftmost_nft(nfa::builder::create_from_regex(regex), alphabet, begin_marker, replacement, replace_mode);
+    return reluctant_leftmost_nft(nfa::determinize(nfa::builder::create_from_regex(regex)), alphabet, begin_marker, replacement, replace_mode);
 }
 
 Nft ReluctantReplace::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet* alphabet, Symbol begin_marker,

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -495,6 +495,11 @@ Nft applications::strings::replace::replace_reluctant_single_symbol(Symbol from_
 
 Nft ReluctantReplace::replace_regex(nfa::Nfa aut, const Word& replacement, Alphabet* alphabet,
                                               ReplaceMode replace_mode, Symbol begin_marker) {
+    // if aut is empty, the operation does nothing -> we return identity
+    if (aut.is_lang_empty()) {
+        return create_identity(alphabet);
+    }
+
     // SMT-LIB theory Strings (Unicode Strings): Semantics for matching empty words in replace regex functions:
     // ; (str.replace_re s r t) is the string obtained by replacing the
     // ; shortest leftmost match of r in s, if any, by t.

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -507,7 +507,7 @@ Nft ReluctantReplace::replace_regex(nfa::Nfa aut, const Word& replacement, Alpha
     // (str.replace_re_all String RegLan String String)
     if (replace_mode == ReplaceMode::All) {
         // Removing the empty string from aut.
-        aut.unify_initial(true).final.erase(*regex.initial.begin());
+        aut.unify_initial(true).final.erase(*aut.initial.begin());
     }
 
     ReluctantReplace reluctant_replace{};

--- a/src/applications/strings/strings.cc
+++ b/src/applications/strings/strings.cc
@@ -217,7 +217,6 @@ std::optional<std::vector<mata::Word>> mata::applications::strings::get_words_of
     if (nft.initial.empty() || nft.final.empty()) { return std::nullopt; }
     if (nft.initial.intersects_with(nft.final) && std::ranges::all_of(lengths, [](int x) { return x == 0; })) { return std::vector<mata::Word>(nft.num_of_levels, mata::Word()); }
 
-    std::vector<mata::Word> result(lengths.size());
     for (const State initial_state: nft.initial) {
         /// Current state, its state post iterator, its end iterator, and iterator in the current symbol post to target states.
         std::vector<std::tuple<State, StatePost::const_iterator, StatePost::const_iterator, StateSet::const_iterator>> worklist{};


### PR DESCRIPTION
Fixes comments in `mata::applications::strings::replace` operations + fix empty language NFA for these operations.