### PR TITLE
Implement NFT determinization

### DIFF
--- a/doc/src/nfa.rst
+++ b/doc/src/nfa.rst
@@ -1,6 +1,8 @@
 Nondeterministic Finite automata
 ================================
 
+.. doxygenpage:: nfa
+
 Types
 -----
 .. doxygenfile:: nfa/types.hh

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -54,9 +54,9 @@ public:
     StateSet targets{};
 
     SymbolPost() = default;
-    explicit SymbolPost(Symbol symbol) : symbol{ symbol }, targets{} {}
-    SymbolPost(Symbol symbol, State state_to) : symbol{ symbol }, targets{ state_to } {}
-    SymbolPost(Symbol symbol, StateSet states_to) : symbol{ symbol }, targets{ std::move(states_to) } {}
+    explicit SymbolPost(const Symbol symbol) : symbol{ symbol } {}
+    SymbolPost(const Symbol symbol, const State state_to) : symbol{ symbol }, targets{ state_to } {}
+    SymbolPost(const Symbol symbol, StateSet states_to) : symbol{ symbol }, targets{ std::move(states_to) } {}
 
     SymbolPost(SymbolPost&& rhs) noexcept : symbol{ rhs.symbol }, targets{ std::move(rhs.targets) } {}
     SymbolPost(const SymbolPost& rhs) = default;

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -10,6 +10,61 @@
  *  @c mata::nfa::algorithms (concrete implementations of algorithms, such as for complement).
  */
 
+/**
+ * @page nfa Nondeterministic Finite Automata (NFAs)
+ *
+ * @section nfa_design The design of NFAs in Mata
+ *
+ * NFAs in Mata are represented using the @c mata::nfa::Nfa class. The transition relation is represented using
+ *  the @c mata::nfa::Delta class, which provides an efficient way to store and manipulate transitions.
+ * The states of the NFA are represented as integers, starting from 0 up to the number of states minus one.
+ * The initial and final states are represented using the @c mata::utils::SparseSet class, which allows for efficient
+ *  storage and manipulation of sets of states.
+ *
+ * @c mata::nfa::Delta is a key component of the NFA representation. It stores transitions in a three-level data
+ *  structure:
+ *  1. A vector indexed by source states, where each entry @c mata::nfa::StatePost contains a vector of symbol posts
+ *   @c mata::nfa::SymbolPost.
+ *  2. Each mata::nfa::SymbolPost represents a set of transitions labeled with a specific symbol from the source state to
+ *   a set of target states.
+ *  3. Each @c mata::nfa::SymbolPost object contains a set of target states @c std::OrdVector<State> that can be reached
+ *   from the source state via the corresponding symbol.
+ *
+ *  The main idea behind @c mata::nfa::Nfa is that the members (@c mata::nfa::Nfa::delta, @c mata::nfa::Nfa::initial,
+ *   @c mata::nfa::Nfa::alphabet, ...) do not depend on each other.
+ *  This allows for some well-optimized implementations as well as easy replacement of individual members, or extensions
+ *   to the NFA structure (e.g., adding levels for NFT), if needed.
+ *  However, this also poses a risk of inconsistency between the members (e.g., having initial states that do not exist
+ *   in the delta).
+ *  The high-level functions in @c mata::nfa namespace and @c mata::nfa::Nfa class are designed to maintain the
+ *   consistency of the NFA structure, but the individual members can be modified directly by the user, which may lead to
+ *   inconsistencies, yet there are often useful when implementing highly-optimized algorithms.
+ *
+ *  The main operation on NFAs is BFS/DFS through @c mata::nfa::Delta structure, which is used in most algorithms.
+ *  The data structure is designed such that direct access to a specific transition is less efficient, but iterating
+ *   through all transitions from a given source state, for all source states is efficient (e.g.,
+ *   @c mata::utils::SynchronizedIterator).
+ *  When designing algorithms for Mata, be sure utilize iteration through @c mata::nfa::Delta structure as much as
+ *   possible.
+ *
+ *  @section nfa_usage Working with NFAs
+ *
+ *  The library provides various functions to create, manipulate, and analyze NFAs.
+ *  The core operations on NFAs, such as union, intersection, complement, determinization, and minimization, are
+ *   implemented in @c mata::nfa namespace and as methods of the @c mata::nfa::Nfa class.
+ *  More advanced algorithms and utilities are available in the @c mata::nfa::algorithms and @c mata::nfa::plumbing
+ *   namespaces.
+ *  Users can create NFAs manually by adding states and transitions using the methods provided in the @c mata::nfa::Nfa
+ *   and @c mata::nfa::Delta classes, or they can use higher-level functions to construct NFAs from regular expressions,
+ *   words, or other NFAs using the functions in the @c mata::nfa::builder and @c mata::parser namespaces.
+ *
+ *  @note The algorithms provided in Mata for NFAs are designed to perform only the core operations on NFAs, such as
+ *   union, intersection, complement, determinization, minimization, etc., but do not by default optimize the NFAs
+ *   during these operations. Users can apply optimization algorithms separately after performing the core operations,
+ *   such as using the @c mata::nfa::reduce() function to reduce the resulting NFA, @c mata::nfa::minimize() to minimize
+ *   the resulting NFA, or @c mata::nfa::trim() to remove unreachable and non-terminating states.
+ */
+
 #ifndef MATA_NFA_HH_
 #define MATA_NFA_HH_
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -877,6 +877,9 @@ Nft compose(const Nft& lhs, const Nft& rhs, Level lhs_sync_level = 1, Level rhs_
 Nft concatenate(const Nft& lhs, const Nft& rhs, bool use_epsilon = false,
                 StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
+
+#ifdef MATA_NFT_NOT_IMPLEMENTED
+// TODO(nft): Implement for NFTs.
 /**
  * @brief Compute automaton accepting complement of @p aut.
  *
@@ -917,6 +920,7 @@ Nft complement(const Nft& aut, const utils::OrdVector<Symbol>& symbols,
  * @return Minimal deterministic automaton.
  */
 Nft minimize(const Nft &aut, const ParameterMap& params = {{ "algorithm", "brzozowski" }});
+#endif
 
 /**
  * @brief Determinize automaton.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -132,6 +132,32 @@ public:
      * @param[in] level Level to be counted.
      */
     size_t count(Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
+
+    /**
+     * @brief Get levels of states in @p states.
+     */
+    std::vector<Level> get_levels_of(const utils::SparseSet<State>& states) const;
+    /**
+     * @brief Get levels of states in @p states.
+     */
+    std::vector<Level> get_levels_of(const StateSet& states) const;
+
+    /**
+     * @brief Get the minimal level for the states in @p states.
+     *
+     * "Minimal level" is defined as the level with the lowest numerical value, i.e., `0 < 1 < 2 < ... < num_of_levels-1`.
+     * "Minimal" often relates to the current states ("What is the current state with minimal level?")
+     */
+    Level get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering = LevelsOrdering::Minimal) const;
+
+    /**
+     * @brief Get the minimal next level for the states in @p states.
+     *
+     * "Minimal next level" is defined as the minimal level in the next transition (that may follow another level),
+     *  i.e., `1 < 2 < ... < num_of_levels-1 < 0`.
+     * "Minimal next" relates to the next target states ("What is the next minimal level to target in a transition?").
+     */
+    Level get_minimal_next_level_of(const StateSet& states) const;
 };
 
 /**
@@ -659,9 +685,11 @@ public:
      *
      * If you have an automaton with finite language (can be checked using @ref is_acyclic),
      * you can get all words by calling
-     *      get_words(aut.num_of_states())
+     *      aut.get_words(aut.num_of_states())
+     * @param max_length Maximum length of words to be returned. Default: "no limit"; will infinitely loop if the language is infinite.
+     * @return Set of all words in the language of the automaton whose length is <= @p max_length.
      */
-    std::set<Word> get_words(size_t max_length) const;
+    std::set<Word> get_words(size_t max_length = std::numeric_limits<size_t>::max()) const;
 
     /**
      * @brief Apply @p nfa to @c this.
@@ -893,11 +921,11 @@ Nft minimize(const Nft &aut, const ParameterMap& params = {{ "algorithm", "brzoz
 /**
  * @brief Determinize automaton.
  *
- * @param[in] aut Automaton to determinize.
+ * @param[in] nft Automaton to determinize.
  * @param[out] subset_map Map that maps sets of states of input automaton to states of determinized automaton.
  * @return Determinized automaton.
  */
-Nft determinize(const Nft& aut, std::unordered_map<StateSet, State> *subset_map = nullptr);
+Nft determinize(const Nft& nft, std::unordered_map<StateSet, State> *subset_map = nullptr);
 
 /**
  * @brief Reduce the size of the automaton.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -5,6 +5,8 @@
 #ifndef MATA_NFT_TYPES_HH
 #define MATA_NFT_TYPES_HH
 
+#include <utility>
+
 #include "mata/alphabet.hh"
 
 #include "mata/nfa/types.hh"
@@ -14,6 +16,29 @@ namespace mata::nft {
 extern const std::string TYPE_NFT;
 
 using Level = unsigned;
+
+/**
+ * @brief Classes for levels ordering in NFTs.
+ */
+class LevelsOrdering {
+public:
+    using Compare = std::function<bool(Level, Level)>;
+    /**
+     * @brief Ordering for Levels in NFTs where lower levels precede higher levels.
+     *
+     * That is, levels are ordered as follows: 0 < 1 < 2 < ... < num_of_levels-1.
+     */
+    static bool Minimal(const Level lhs, const Level rhs) { return std::less()(lhs, rhs); }
+    /**
+     * @brief Ordering for levels in NFTs where lower levels precede higher levels, except for 0 which is the highest level.
+     *
+     * That is, levels are ordered as follows: 1 < 2 < ... < num_of_levels-1 < 0.
+     * This ordering is used when handling intermediate states (with non-zero levels) in NFTs for determining the next lowest
+     *  level of the next state.
+     */
+    static bool Next(const Level lhs, const Level rhs) { return lhs == 0 ? false : rhs == 0 ? true : lhs < rhs; }
+};
+
 using State = mata::nfa::State;
 using StateSet = mata::nfa::StateSet;
 

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -121,9 +121,10 @@ public:
         return ord_vector;
     }
 
-    void insert(iterator itr, const Key& x) {
-        assert(itr == this->end() || x <= *itr);
-        vec_.insert(itr,x);
+    std::pair<iterator, bool> insert(iterator itr, const Key& x) {
+        if (empty() || itr == end()) { return { vec_.insert(itr, x), true }; }
+        if (x >= *itr || (itr != begin() && x <= *(itr - 1))) { return { itr, false }; }
+        return { vec_.insert(itr, x), true };
     }
 
     // EMPLACE_BACK WHICH BREAKS SORTEDNESS,
@@ -151,15 +152,18 @@ public:
     virtual inline iterator erase(const_iterator pos) { return vec_.erase(pos); }
     virtual inline iterator erase(const_iterator first, const_iterator last) { return vec_.erase(first, last); }
 
-    virtual void insert(const Key& x) {
+    virtual std::pair<iterator, bool> insert(const Key& x) {
         assert(is_sorted());
 
         reserve_on_insert(vec_);
 
         // Tomas Fiedor: article about better binary search here https://mhdm.dev/posts/sb_lower_bound/.
         auto pos  = std::lower_bound(vec_.begin(), vec_.end(), x);
-        if (pos == vec_.end() || *pos != x)
-            vec_.insert(pos,x);
+        bool inserted{ false };
+        if (pos == vec_.end() || *pos != x) {
+            pos = vec_.insert(pos, x);
+            inserted = true;
+        }
 
         //TODO: measure, if there is not benefit to this custom version, remove
         //size_t first = 0;
@@ -196,16 +200,16 @@ public:
         //vec_[first] = x;
 
         assert(is_sorted());
+        return { pos, inserted };
     }
 
-    virtual void insert(const OrdVector& vec) {
+    virtual bool insert(const OrdVector& vec) {
         static OrdVector tmp{};
         assert(is_sorted());
         assert(vec.is_sorted());
         tmp.clear();
 
-        set_union(*this,vec,tmp);
-
+        const auto inserted{ set_union(*this,vec,tmp) };
         vec_ = tmp.vec_;
         /*
          * Swap, commented below (test do pass) may be better in some cases, such as uniting many vectors into one.
@@ -214,6 +218,7 @@ public:
          */
         //std::swap(tmp.vec_,vec_);
         assert(is_sorted());
+        return inserted;
     }
 
     inline void clear() { vec_.clear(); }
@@ -448,15 +453,22 @@ public:
         return result;
     }
 
-    static void set_union(const OrdVector& lhs, const OrdVector& rhs, OrdVector& result) {
+    static bool set_union(const OrdVector& lhs, const OrdVector& rhs, OrdVector& result) {
         assert(lhs.is_sorted());
         assert(rhs.is_sorted());
 
-        if (lhs.empty()) { result = rhs; return; }
-        if (rhs.empty()) { result = lhs; return; }
+        const bool rhs_empty{ rhs.empty() };
+        if (lhs.empty()) {
+            result = rhs;
+            return !rhs_empty;
+        }
+        if (rhs_empty) {
+            result = lhs;
+            return false;
+        }
 
         result.reserve(lhs.size()+rhs.size());
-        std::set_union(lhs.vec_.begin(),lhs.vec_.end(),rhs.vec_.begin(),rhs.vec_.end(),std::back_inserter(result.vec_));
+        std::ranges::set_union(lhs.vec_, rhs.vec_, std::back_inserter(result.vec_));
 
         //TODO: measure, if there is not benefit to this custom version, remove
         //auto lhs_it = lhs.begin();
@@ -485,6 +497,10 @@ public:
         //}
 
         assert(result.is_sorted());
+        // FIXME: This always returns `.begin()`, even if the first inserted element is further in the vector. Made to
+        //  keep the interface similar to std::set.
+        if (result.size() > lhs.size()) { return true; }
+        return false;
     }
 
     static OrdVector set_union(const OrdVector& lhs, const OrdVector& rhs) {

--- a/include/mata/utils/synchronized-iterator.hh
+++ b/include/mata/utils/synchronized-iterator.hh
@@ -282,7 +282,7 @@ public:
  * takes the iterator and v and extracts the v.begin() and v.end() from v.
  */
 template<class Container>
-void push_back (SynchronizedIterator<typename Container::const_iterator> &i,const Container &container) {
+void push_back (SynchronizedIterator<typename Container::const_iterator> &i,const Container& container) {
     i.push_back(container.begin(),container.end());
 }
 

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -201,7 +201,7 @@ namespace {
 }
 
 std::ostream &std::operator<<(std::ostream &os, const mata::nfa::Transition &trans) { // {{{
-    std::string result = "(" + std::to_string(trans.source) + ", " +
+    const std::string result = "(" + std::to_string(trans.source) + ", " +
                          std::to_string(trans.symbol) + ", " + std::to_string(trans.target) + ")";
     return os << result;
 }
@@ -220,8 +220,8 @@ bool mata::nfa::Nfa::make_complete(const OrdVector<Symbol>& symbols, const std::
         for (const SymbolPost& symbol_post: delta[state]) {
             used_symbols.insert(symbol_post.symbol);
         }
-        const OrdVector<Symbol> unused_symbols{ symbols.difference(used_symbols) };
-        for (const Symbol symbol: unused_symbols) {
+        for (const OrdVector<Symbol> unused_symbols{ symbols.difference(used_symbols) };
+             const Symbol symbol : unused_symbols) {
             delta.add(state, symbol, sink_state_val);
             transition_added = true;
         }

--- a/src/nft/complement.cc
+++ b/src/nft/complement.cc
@@ -1,15 +1,15 @@
-/* nft-complement.cc -- NFT complement
+/** @file
+ * @brief Complement of NFTs.
  */
 
-// MATA headers
-#include "mata/nft/nft.hh"
 #include "mata/nft/algorithms.hh"
+#include "mata/nft/nft.hh"
 
 using namespace mata::nft;
 using namespace mata::utils;
 
 Nft mata::nft::algorithms::complement_classical(const Nft& aut, const OrdVector<Symbol>& symbols,
-                                                bool minimize_during_determinization) {
+                                                const bool minimize_during_determinization) {
     Nft result;
     State sink_state;
     if (minimize_during_determinization) {
@@ -26,8 +26,7 @@ Nft mata::nft::algorithms::complement_classical(const Nft& aut, const OrdVector<
         std::unordered_map<StateSet, State> subset_map;
         result = determinize(aut, &subset_map);
         // check if a sink state was not created during determinization
-        auto sink_state_iter = subset_map.find({});
-        if (sink_state_iter != subset_map.end()) {
+        if (const auto sink_state_iter = subset_map.find({}); sink_state_iter != subset_map.end()) {
             sink_state = sink_state_iter->second;
         } else {
             sink_state = result.num_of_states();
@@ -36,6 +35,7 @@ Nft mata::nft::algorithms::complement_classical(const Nft& aut, const OrdVector<
 
     result.make_complete(symbols, sink_state);
     result.final.complement(result.num_of_states());
+
     return result;
 }
 
@@ -61,7 +61,7 @@ Nft mata::nft::complement(const Nft& aut, const mata::utils::OrdVector<mata::Sym
     }
 
     bool minimize_during_determinization = false;
-    if (params.find("minimize") != params.end()) {
+    if (params.contains("minimize")) {
         const std::string& minimize_arg = params.at("minimize");
         if ("true" == minimize_arg) { minimize_during_determinization = true; }
         else if ("false" == minimize_arg) { minimize_during_determinization = false; }

--- a/src/nft/complement.cc
+++ b/src/nft/complement.cc
@@ -8,6 +8,7 @@
 using namespace mata::nft;
 using namespace mata::utils;
 
+#ifdef MATA_NFT_NOT_IMPLEMENTED
 Nft mata::nft::algorithms::complement_classical(const Nft& aut, const OrdVector<Symbol>& symbols,
                                                 const bool minimize_during_determinization) {
     Nft result;
@@ -73,3 +74,4 @@ Nft mata::nft::complement(const Nft& aut, const mata::utils::OrdVector<mata::Sym
 
     return algo(aut, symbols, minimize_during_determinization);
 }
+#endif

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -7,6 +7,8 @@
 #include <iterator>
 #include <fstream>
 #include <string>
+#include <utility>
+#include <ranges>
 
 // MATA headers
 #include "mata/utils/sparse-set.hh"
@@ -22,8 +24,32 @@ using mata::BoolVector;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 
-const std::string mata::nft::TYPE_NFT = "NFT";
+constexpr std::string mata::nft::TYPE_NFT = "NFT";
 
+std::vector<Level> Levels::get_levels_of(const utils::SparseSet<State>& states) const {
+    std::vector<Level> result;
+    result.reserve(states.size());
+    for (const State state: states) { result.push_back((*this)[state]); }
+    return result;
+}
+std::vector<Level> Levels::get_levels_of(const StateSet& states) const {
+    std::vector<Level> result;
+    result.reserve(states.size());
+    for (const State state: states) { result.push_back((*this)[state]); }
+    return result;
+}
+
+Level Levels::get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering) const {
+    if (states.empty()) {
+        throw std::runtime_error("Levels::get_minimal_level_of: states is empty, no level can be obtained.");
+    }
+    auto levels = states | std::views::transform([&](const State& state) { return (*this)[state]; });
+    return std::ranges::min(levels, std::move(levels_ordering));
+}
+
+Level Levels::get_minimal_next_level_of(const StateSet& states) const {
+    return get_minimal_level_of(states, LevelsOrdering::Next);
+}
 
 size_t Nft::num_of_states_with_level(const Level level) const {
     return levels.count(level);

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -926,6 +926,7 @@ Nft mata::nft::algorithms::minimize_brzozowski(const Nft& aut) {
     return determinize(revert(determinize(revert(aut))));
 }
 
+#ifdef MATA_NFT_NOT_IMPLEMENTED
 Nft mata::nft::minimize(
                 const Nft& aut,
                 const ParameterMap& params)
@@ -948,6 +949,7 @@ Nft mata::nft::minimize(
 
     return algo(aut);
 }
+#endif
 
 Nft mata::nft::union_nondet(const Nft &lhs, const Nft &rhs) {
     Nft union_nft{ lhs };
@@ -1129,7 +1131,7 @@ Nft mata::nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* 
     return result;
 }
 
-std::ostream& std::operator<<(std::ostream& os, const Nft& nft) {
+std::ostream& operator<<(std::ostream& os, const Nft& nft) {
     nft.print_to_mata(os);
     return os;
 }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1,11 +1,12 @@
-/* nft.cc -- operations for NFT
+/** @file
+ * @brief Operations on Nondeterministic Finite Transducers (NFTs).
  */
 
 #include <algorithm>
 #include <list>
 #include <unordered_set>
 #include <iterator>
-#include <algorithm>
+#include <ranges>
 
 // MATA headers
 #include "mata/nft/delta.hh"
@@ -1028,79 +1029,103 @@ Nft mata::nft::reduce(const Nft &aut, StateRenaming *state_renaming, const Param
     return result;
 }
 
-Nft mata::nft::determinize(
-        const Nft&  aut,
-        std::unordered_map<StateSet, State> *subset_map) {
+Nft mata::nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset_map) {
+    Nft result{ Nft::with_levels(nft.num_of_levels) };
+    result.alphabet = nft.alphabet;
+    if (nft.initial.empty()) { return result; }
 
-    Nft result;
-    //assuming all sets targets are non-empty
-    std::vector<std::pair<State, StateSet>> worklist;
+    // Assuming all sets targets are non-empty.
+    std::vector<std::pair<State, StateSet>> worklist{};
     bool deallocate_subset_map = false;
     if (subset_map == nullptr) {
-        subset_map = new std::unordered_map<StateSet,State>();
+        subset_map = new std::unordered_map<StateSet, State>{};
         deallocate_subset_map = true;
     }
 
-    result.clear();
+    const StateSet sources_init{ nft.initial };
+    const State source_init_res{ result.add_state() };
+    result.initial.insert(source_init_res);
 
-    const StateSet S0 =  StateSet(aut.initial);
-    const State S0id = result.add_state();
-    result.initial.insert(S0id);
+    if (nft.final.intersects_with(sources_init)) { result.final.insert(source_init_res); }
+    worklist.emplace_back(source_init_res, sources_init);
 
-    if (aut.final.intersects_with(S0)) {
-        result.final.insert(S0id);
-    }
-    worklist.emplace_back(S0id, S0);
-
-    (*subset_map)[mata::utils::OrdVector<State>(S0)] = S0id;
-
-    if (aut.delta.empty())
+    if (nft.delta.empty()) {
+        if (deallocate_subset_map) { delete subset_map; }
         return result;
+    }
 
-    using Iterator = mata::utils::OrdVector<SymbolPost>::const_iterator;
-    SynchronizedExistentialSymbolPostIterator synchronized_iterator;
+    (*subset_map)[sources_init] = source_init_res;
 
+    using Iterator = OrdVector<SymbolPost>::const_iterator;
+    SynchronizedExistentialSymbolPostIterator synchronized_iterator{};
+    // A map of jumps from a `result` source state to a set of targets in the `nft` that is yet to be added to the
+    //  `result`.
+    std::unordered_map<State, StatePost> wip_jumps{};
     while (!worklist.empty()) {
-        const auto Spair = worklist.back();
+        auto [source_res, sources] = std::move(worklist.back());
         worklist.pop_back();
-        const StateSet S = Spair.second;
-        const State Sid = Spair.first;
-        if (S.empty()) {
-            // This should not happen assuming all sets targets are non-empty.
-            break;
-        }
+        if (sources.empty()) { break; } // This should not happen assuming all sets targets are non-empty.
 
-        // add moves of S to the sync ex iterator
-        // TODO: shouldn't we also reset first?
-        for (State q: S) {
-            mata::utils::push_back(synchronized_iterator, aut.delta[q]);
+        // Add moves of `sources` to the synchronized existential iterator.
+        synchronized_iterator.reset();
+        for (const State source_orig : sources) { push_back(synchronized_iterator, nft.delta[source_orig]); }
+
+        // Add partially processed jumps from `source_res` to the synchronized iterator.
+        StatePost wip_jumps_state_post;
+        if (auto wip_jumps_state_post_it{ wip_jumps.find(source_res) }; wip_jumps_state_post_it != wip_jumps.end()) {
+            wip_jumps_state_post = std::move(wip_jumps_state_post_it->second);
+            wip_jumps.erase(wip_jumps_state_post_it);
+            push_back(synchronized_iterator, wip_jumps_state_post);
         }
 
         while (synchronized_iterator.advance()) {
-
-            // extract post from the sychronized_iterator iterator
             const std::vector<Iterator>& moves = synchronized_iterator.get_current();
-            Symbol currentSymbol = (*moves.begin())->symbol;
-            StateSet T = synchronized_iterator.unify_targets();
+            const Symbol current_symbol{ (*moves.begin())->symbol };
+            StateSet targets{ synchronized_iterator.unify_targets() };
+            const auto existing_targets_it = subset_map->find(targets);
+            const bool target_res_exists{ existing_targets_it != subset_map->end() };
 
-            const auto existingTitr = subset_map->find(T);
-            State Tid;
-            if (existingTitr != subset_map->end()) {
-                Tid = existingTitr->second;
+            State target_res;
+            // Targets that need further processing because they were not reached yet at this step.
+            StateSet targets_partial{};
+            StateSet targets_resolved{};
+            Level next_level;
+            if (target_res_exists) {
+                target_res = existing_targets_it->second;
+                next_level = result.levels[target_res];
             } else {
-                Tid = result.add_state();
-                (*subset_map)[mata::utils::OrdVector<State>(T)] = Tid;
-                if (aut.final.intersects_with(T)) {
-                    result.final.insert(Tid);
-                }
-                worklist.emplace_back(Tid, T);
+                // Create target of the minimal level between all the original targets.
+                next_level = nft.levels.get_minimal_next_level_of(targets);
+                if (next_level != 0) {
+                    for (const State state : targets) {
+                        (nft.levels[state] == next_level ? targets_resolved : targets_partial).push_back(state);
+                    }
+                } else { targets_resolved = std::move(targets); }
             }
-            result.delta.mutable_state_post(Sid).insert(SymbolPost(currentSymbol, Tid));
+
+            // Try to add the transition to the result. If the target state does not exist yet, create it.
+            if (auto [it, inserted]{ result.delta.mutable_state_post(source_res).insert(SymbolPost{ current_symbol }) };
+                inserted) {
+                if (!target_res_exists) {
+                    target_res = result.add_state_with_level(next_level);
+                    (*subset_map)[mata::utils::OrdVector<State>(targets_resolved)] = target_res;
+                    if (!targets_partial.empty()) {
+                        // Some targets were not resolved at this step, so we need to store them for further processing.
+                        wip_jumps.emplace(target_res, StatePost{ { current_symbol, targets_partial } });
+                    }
+                    worklist.emplace_back(target_res, targets_resolved);
+                    if (next_level == 0) {
+                        // `Nft` transition cannot jump beyond level 0, so we stop unwinding the targets_resolved by
+                        //   level here.
+                        if (nft.final.intersects_with(targets_resolved)) { result.final.insert(target_res); }
+                    }
+                }
+                it->push_back(target_res);
+            }
         }
     }
 
     if (deallocate_subset_map) { delete subset_map; }
-
     return result;
 }
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1113,7 +1113,7 @@ Run mata::nft::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return mata::nfa::encode_word(alphabet, input);
 }
 
-std::set<mata::Word> mata::nft::Nft::get_words(size_t max_length) const {
+std::set<mata::Word> mata::nft::Nft::get_words(const size_t max_length) const {
     std::set<mata::Word> result;
 
     // contains a pair: a state s and the word with which we got to the state s
@@ -1139,7 +1139,7 @@ std::set<mata::Word> mata::nft::Nft::get_words(size_t max_length) const {
                 mata::Word new_word = word;
                 new_word.push_back(sp.symbol);
                 for (State s_to : sp.targets) {
-                    new_worklist.push_back({s_to, new_word});
+                    new_worklist.emplace_back(s_to, new_word);
                     if (final.contains(s_to)) {
                         result.insert(new_word);
                     }

--- a/src/nft/universal.cc
+++ b/src/nft/universal.cc
@@ -1,7 +1,7 @@
-/* nft-universal.cc -- NFT universality
+/* @file
+ * @brief NFT universality.
  */
 
-// MATA headers
 #include "mata/nft/nft.hh"
 #include "mata/nft/algorithms.hh"
 #include "mata/utils/sparse-set.hh"
@@ -12,7 +12,7 @@ using namespace mata::utils;
 //TODO: this could be merged with inclusion, or even removed, universality could be implemented using inclusion,
 // it is not something needed in practice, so some little overhead is ok
 
-
+#ifdef MATA_NFT_NOT_IMPLEMENTED
 /// naive universality check (complementation + emptiness)
 bool mata::nft::algorithms::is_universal_naive(
 	const Nft&         aut,
@@ -23,7 +23,7 @@ bool mata::nft::algorithms::is_universal_naive(
 
 	return cmpl.is_lang_empty(cex);
 } // is_universal_naive }}}
-
+#endif
 
 /// universality check using Antichains
 bool mata::nft::algorithms::is_universal_antichains(
@@ -132,23 +132,28 @@ bool mata::nft::algorithms::is_universal_antichains(
 
 // The dispatching method that calls the correct one based on parameters.
 bool mata::nft::Nft::is_universal(const Alphabet& alphabet, Run* cex, const ParameterMap& params) const {
-	// setting the default algorithm
-	decltype(algorithms::is_universal_naive)* algo = algorithms::is_universal_naive;
-	if (!haskey(params, "algorithm")) {
-		throw std::runtime_error(std::to_string(__func__) +
-			" requires setting the \"algorithm\" key in the \"params\" argument; "
-			"received: " + std::to_string(params));
-	}
+    // TODO(nft): Revert back to the naive algorithm when implemented for NFTs?
+    // Setting the default algorithm.
+    decltype(algorithms::is_universal_antichains)* algo = algorithms::is_universal_antichains;
+    if (!haskey(params, "algorithm")) {
+            throw std::runtime_error(std::to_string(__func__) +
+                    " requires setting the \"algorithm\" key in the \"params\" argument; "
+                    "received: " + std::to_string(params));
+    }
 
-	const std::string& str_algo = params.at("algorithm");
-	if ("naive" == str_algo) { /* default */ }
-	else if ("antichains" == str_algo) {
-		algo = algorithms::is_universal_antichains;
-	} else {
-		throw std::runtime_error(std::to_string(__func__) +
-			" received an unknown value of the \"algorithm\" key: " + str_algo);
-	}
-	return algo(*this, alphabet, cex);
+    const std::string& str_algo = params.at("algorithm");
+    if ("naive" == str_algo) {
+        /* default */
+        throw std::runtime_error(std::to_string(__func__) +
+                 " naive algorithm is not implemented for NFTs");
+    }
+    else if ("antichains" == str_algo) {
+            algo = algorithms::is_universal_antichains;
+    } else {
+            throw std::runtime_error(std::to_string(__func__) +
+                    " received an unknown value of the \"algorithm\" key: " + str_algo);
+    }
+    return algo(*this, alphabet, cex);
 } // is_universal()
 
 bool mata::nft::Nft::is_universal(const Alphabet& alphabet, const ParameterMap& params) const {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1,10 +1,12 @@
 // TODO: some header
 
+#include <algorithm>
 #include <unordered_set>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include "mata/nft/types.hh"
 #include "utils.hh"
 
 #include "mata/utils/sparse-set.hh"
@@ -1848,6 +1850,25 @@ TEST_CASE("mata::nft::Levels") {
         CHECK(levels.count(3) == 0);
         CHECK(levels.count(5) == 0);
     }
+
+    SECTION("mata::nft::Levels::get_levels_of()") {
+        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        StateSet states = { 0, 2, 4, 5 };
+        std::vector<Level> expected_levels = { 1, 1, 4, 2 };
+        CHECK(levels.get_levels_of(states) == expected_levels);
+    }
+
+    SECTION("mata::nft::Levels::get_minimal_next_level_of()") {
+        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        StateSet states = { 0, 1, 4, 5 };
+        CHECK(levels.get_minimal_next_level_of(states) == 1);
+        states.erase(0);
+        CHECK(levels.get_minimal_next_level_of(states) == 2);
+        states.erase(5);
+        CHECK(levels.get_minimal_next_level_of(states) == 4);
+        states.erase(4);
+        CHECK(levels.get_minimal_next_level_of(states) == 0);
+    }
 }
 
 TEST_CASE("mata::nft::Nft::invert_levels()") {
@@ -3518,92 +3539,92 @@ TEST_CASE("mata::nft::print_to_mata()") {
 }
 
 TEST_CASE("mata::nft::Nft::trim() bug") {
-	Nft aut(5, {0}, {4});
-	aut.delta.add(0, 122, 1);
-	aut.delta.add(1, 98, 1);
-	aut.delta.add(1, 122, 1);
-	aut.delta.add(1, 97, 2);
-	aut.delta.add(2, 122, 1);
-	aut.delta.add(2, 97, 1);
-	aut.delta.add(1, 97, 4);
-	aut.delta.add(3, 97, 4);
+    Nft aut(5, {0}, {4});
+    aut.delta.add(0, 122, 1);
+    aut.delta.add(1, 98, 1);
+    aut.delta.add(1, 122, 1);
+    aut.delta.add(1, 97, 2);
+    aut.delta.add(2, 122, 1);
+    aut.delta.add(2, 97, 1);
+    aut.delta.add(1, 97, 4);
+    aut.delta.add(3, 97, 4);
 
-	Nft aut_copy {aut};
-	CHECK(are_equivalent(aut_copy.trim(), aut));
+    Nft aut_copy {aut};
+    CHECK(are_equivalent(aut_copy.trim(), aut));
 }
 
 TEST_CASE("mata::nft::get_useful_states_tarjan") {
-	SECTION("Nft 1") {
-		Nft aut(5, {0}, {4});
-		aut.delta.add(0, 122, 1);
-		aut.delta.add(1, 98, 1);
-		aut.delta.add(1, 122, 1);
-		aut.delta.add(1, 97, 2);
-		aut.delta.add(2, 122, 1);
-		aut.delta.add(2, 97, 1);
-		aut.delta.add(1, 97, 4);
-		aut.delta.add(3, 97, 4);
+    SECTION("Nft 1") {
+        Nft aut(5, {0}, {4});
+        aut.delta.add(0, 122, 1);
+        aut.delta.add(1, 98, 1);
+        aut.delta.add(1, 122, 1);
+        aut.delta.add(1, 97, 2);
+        aut.delta.add(2, 122, 1);
+        aut.delta.add(2, 97, 1);
+        aut.delta.add(1, 97, 4);
+        aut.delta.add(3, 97, 4);
 
-		mata::BoolVector bv = aut.get_useful_states();
-		mata::BoolVector ref({ 1, 1, 1, 0, 1});
-		CHECK(bv == ref);
-	}
+        mata::BoolVector bv = aut.get_useful_states();
+        mata::BoolVector ref({ 1, 1, 1, 0, 1});
+        CHECK(bv == ref);
+    }
 
-	SECTION("Empty NFT") {
-		Nft aut;
-		mata::BoolVector bv = aut.get_useful_states();
-		CHECK(bv == mata::BoolVector({}));
-	}
+    SECTION("Empty NFT") {
+        Nft aut;
+        mata::BoolVector bv = aut.get_useful_states();
+        CHECK(bv == mata::BoolVector({}));
+    }
 
-	SECTION("Single-state NFT") {
-		Nft aut(1, {0}, {});
-		mata::BoolVector bv = aut.get_useful_states();
-		CHECK(bv == mata::BoolVector({ 0}));
-	}
+    SECTION("Single-state NFT") {
+        Nft aut(1, {0}, {});
+        mata::BoolVector bv = aut.get_useful_states();
+        CHECK(bv == mata::BoolVector({ 0}));
+    }
 
-	SECTION("Single-state NFT acc") {
-		Nft aut(1, {0}, {0});
-		mata::BoolVector bv = aut.get_useful_states();
-		CHECK(bv == mata::BoolVector({ 1}));
-	}
+    SECTION("Single-state NFT acc") {
+        Nft aut(1, {0}, {0});
+        mata::BoolVector bv = aut.get_useful_states();
+        CHECK(bv == mata::BoolVector({ 1}));
+    }
 
-	SECTION("Nft 2") {
-		Nft aut(5, {0, 1}, {2});
-		aut.delta.add(0, 122, 2);
-		aut.delta.add(2, 98, 3);
-		aut.delta.add(1, 98, 4);
-		aut.delta.add(4, 97, 3);
+    SECTION("Nft 2") {
+        Nft aut(5, {0, 1}, {2});
+        aut.delta.add(0, 122, 2);
+        aut.delta.add(2, 98, 3);
+        aut.delta.add(1, 98, 4);
+        aut.delta.add(4, 97, 3);
 
-		mata::BoolVector bv = aut.get_useful_states();
-		mata::BoolVector ref({ 1, 0, 1, 0, 0});
-		CHECK(bv == ref);
-	}
+        mata::BoolVector bv = aut.get_useful_states();
+        mata::BoolVector ref({ 1, 0, 1, 0, 0});
+        CHECK(bv == ref);
+    }
 
-	SECTION("Nft 3") {
-		Nft aut(2, {0, 1}, {0, 1});
-		aut.delta.add(0, 122, 0);
-		aut.delta.add(1, 98, 1);
+    SECTION("Nft 3") {
+        Nft aut(2, {0, 1}, {0, 1});
+        aut.delta.add(0, 122, 0);
+        aut.delta.add(1, 98, 1);
 
-		mata::BoolVector bv = aut.get_useful_states();
-		mata::BoolVector ref({ 1, 1});
-		CHECK(bv == ref);
-	}
+        mata::BoolVector bv = aut.get_useful_states();
+        mata::BoolVector ref({ 1, 1});
+        CHECK(bv == ref);
+    }
 
-	SECTION("Nft no final") {
-		Nft aut(5, {0}, {});
-		aut.delta.add(0, 122, 1);
-		aut.delta.add(1, 98, 1);
-		aut.delta.add(1, 122, 1);
-		aut.delta.add(1, 97, 2);
-		aut.delta.add(2, 122, 1);
-		aut.delta.add(2, 97, 1);
-		aut.delta.add(1, 97, 4);
-		aut.delta.add(3, 97, 4);
+    SECTION("Nft no final") {
+        Nft aut(5, {0}, {});
+        aut.delta.add(0, 122, 1);
+        aut.delta.add(1, 98, 1);
+        aut.delta.add(1, 122, 1);
+        aut.delta.add(1, 97, 2);
+        aut.delta.add(2, 122, 1);
+        aut.delta.add(2, 97, 1);
+        aut.delta.add(1, 97, 4);
+        aut.delta.add(3, 97, 4);
 
-		mata::BoolVector bv = aut.get_useful_states();
-		mata::BoolVector ref({ 0, 0, 0, 0, 0});
-		CHECK(bv == ref);
-	}
+        mata::BoolVector bv = aut.get_useful_states();
+        mata::BoolVector ref({ 0, 0, 0, 0, 0});
+        CHECK(bv == ref);
+    }
 
     SECTION("more initials") {
         Nft aut(4, {0, 1, 2}, {0, 3});

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -443,63 +443,124 @@ TEST_CASE("mata::nft::is_lang_empty_cex()")
 }
 
 
-TEST_CASE("mata::nft::determinize()")
-{
-    Nft aut(3);
+TEST_CASE("mata::nft::determinize()") {
+    Nft nft{ Nft::with_levels(3) };
     Nft result;
     std::unordered_map<StateSet, State> subset_map;
 
-    SECTION("empty automaton")
-    {
-        result = determinize(aut);
-
-        REQUIRE(result.final.empty());
-        REQUIRE(result.delta.empty());
-        CHECK(result.is_lang_empty());
+    SECTION("empty automaton") {
+        result = determinize(nft, &subset_map);
     }
 
-    SECTION("simple automaton 1")
-    {
-        aut.initial = {1 };
-        aut.final = {1 };
-        result = determinize(aut, &subset_map);
-
-        REQUIRE(result.initial[subset_map[{1}]]);
-        REQUIRE(result.final[subset_map[{1}]]);
-        REQUIRE(result.delta.empty());
+    SECTION("simple automaton 1") {
+        nft.initial = { 0 };
+        nft.final = { 0 };
+        nft.levels = { 0 };
+        result = determinize(nft, &subset_map);
     }
 
-    SECTION("simple automaton 2")
-    {
-        aut.initial = {1 };
-        aut.final = {2 };
-        aut.delta.add(1, 'a', 2);
-        result = determinize(aut, &subset_map);
-
-        REQUIRE(result.initial[subset_map[{1}]]);
-        REQUIRE(result.final[subset_map[{2}]]);
-        REQUIRE(result.delta.contains(subset_map[{1}], 'a', subset_map[{2}]));
+    SECTION("simple automaton 2") {
+        nft.initial = { 0 };
+        nft.final = { 1 };
+        nft.delta.add(0, 'a', 1);
+        nft.levels = { 0, 0 };
+        result = determinize(nft, &subset_map);
     }
 
-    SECTION("This broke Delta when delta[q] could cause re-allocation of post")
-    {
-        Nft x{};
-        x.initial.insert(0);
-        x.final.insert(4);
-        x.delta.add(0, 1, 3);
-        x.delta.add(3, 1, 3);
-        x.delta.add(3, 2, 3);
-        x.delta.add(3, 0, 1);
-        x.delta.add(1, 1, 1);
-        x.delta.add(1, 2, 1);
-        x.delta.add(1, 0, 2);
-        x.delta.add(2, 0, 2);
-        x.delta.add(2, 1, 2);
-        x.delta.add(2, 2, 2);
-        x.delta.add(2, 0, 4);
-        OnTheFlyAlphabet alphabet{};
-        auto complement_result{determinize(x)};
+    SECTION("simple automaton with epsilons") {
+        nft.initial = { 0 };
+        nft.final = { 3, 4, 6 };
+        nft.levels = { 0, 1, 2, 0, 0, 2, 0 };
+        nft.delta.reserve(7);
+        nft.delta.add(0, EPSILON, 3);
+        nft.delta.add(0, EPSILON, 5);
+        nft.delta.add(5, EPSILON, 6);
+        nft.delta.add(0, EPSILON, 1);
+        nft.delta.add(1, EPSILON, 2);
+        nft.delta.add(2, EPSILON, 4);
+        result = determinize(nft, &subset_map);
     }
+
+    SECTION("simple automaton with epsilons") {
+        nft.initial = { 0 };
+        nft.final = { 3, 4, 6 };
+        nft.levels = { 0, 1, 2, 0, 0, 2, 0 };
+        nft.delta.reserve(7);
+        nft.delta.add(0, 'a', 3);
+        nft.delta.add(0, 'a', 5);
+        nft.delta.add(5, 'a', 6);
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'a', 2);
+        nft.delta.add(2, 'a', 4);
+        result = determinize(nft, &subset_map);
+    }
+
+    SECTION("nft with loops") {
+        nft.initial = { 0 };
+        nft.final = { 3, 4 };
+        nft.levels = { 0, 2, 1, 0, 0 };
+        nft.delta.add(0, 'a', 2);
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(0, 'a', 0);
+        nft.delta.add(0, 'a', 4);
+        nft.delta.add(1, 'a', 0);
+        nft.delta.add(2, 'b', 3);
+        nft.delta.add(3, 'c', 3);
+        nft.delta.add(4, 'd', 4);
+        result = determinize(nft, &subset_map);
+    }
+
+
+    SECTION("simple automaton with symbols and epsilons") {
+        nft.initial = { 0 };
+        nft.final = { 3, 4, 6, 9, 10 };
+        nft.levels = { 0, 1, 2, 0, 0, 2, 0, 1, 2, 0, 0, 1 };
+        nft.delta.add(0, EPSILON, 3);
+        nft.delta.add(0, EPSILON, 5);
+        nft.delta.add(5, 'a', 6);
+        nft.delta.add(0, EPSILON, 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'c', 4);
+        nft.delta.add(0, EPSILON, 7);
+        nft.delta.add(7, EPSILON, 8);
+        nft.delta.add(8, 'a', 9);
+        nft.delta.add(9, 'd', 10);
+        nft.delta.add(0, 'e', 6);
+        nft.delta.add(9, 'f', 9);
+        nft.delta.add(9, 'g', 11);
+        nft.delta.add(11, 'g', 9);
+        result = determinize(nft, &subset_map);
+    }
+
+    CHECK(result.initial.size() <= 1);
+    for (const auto& state_post: result.delta) {
+        for (const auto& [symbol, targets]: state_post) {
+            CHECK(targets.size() == 1);
+        }
+    }
+    CHECK(result.num_of_levels == 3);
+    CHECK(are_equivalent(nft, result));
+    CHECK(result.num_of_states() == result.get_reachable_states().size());
+
+    // SECTION("This broke Delta when delta[q] could cause re-allocation of post")
+    // {
+    //     Nft x{};
+    //     x.initial.insert(0);
+    //     x.final.insert(4);
+    //     x.delta.add(0, 1, 3);
+    //     x.delta.add(3, 1, 3);
+    //     x.delta.add(3, 2, 3);
+    //     x.delta.add(3, 0, 1);
+    //     x.delta.add(1, 1, 1);
+    //     x.delta.add(1, 2, 1);
+    //     x.delta.add(1, 0, 2);
+    //     x.delta.add(2, 0, 2);
+    //     x.delta.add(2, 1, 2);
+    //     x.delta.add(2, 2, 2);
+    //     x.delta.add(2, 0, 4);
+    //     OnTheFlyAlphabet alphabet{};
+    //     auto complement_result{determinize(x)};
+    // }
 } // }}}
 
 TEST_CASE("mata::nft::minimize() for profiling", "[.profiling],[minimize]") {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1049,27 +1049,28 @@ TEST_CASE("mata::nft::make_complete()")
     }
 } // }}}
 
-TEST_CASE("mata::nft::complement()")
-{ // {{{
+#ifdef MATA_NFT_NOT_IMPLEMENTED
+TEST_CASE("mata::nft::complement()") {
     Nft aut(3);
     Nft cmpl;
 
-    SECTION("empty automaton, empty alphabet")
-    {
+    SECTION("empty automaton, empty alphabet") {
         OnTheFlyAlphabet alph{};
-
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+            aut, alph, { { "algorithm", "classical" },
+                         { "minimize", "false" } }
+        );
         Nft empty_string_nft{ nft::builder::create_sigma_star_nft(&alph) };
         CHECK(are_equivalent(cmpl, empty_string_nft));
     }
 
-    SECTION("empty automaton")
-    {
+    SECTION("empty automaton") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "false" } }
+                );
 
         REQUIRE(cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
@@ -1081,26 +1082,28 @@ TEST_CASE("mata::nft::complement()")
         CHECK(are_equivalent(cmpl, sigma_star_nft));
     }
 
-    SECTION("empty automaton accepting epsilon, empty alphabet")
-    {
+    SECTION("empty automaton accepting epsilon, empty alphabet") {
         OnTheFlyAlphabet alph{};
-        aut.initial = {1};
-        aut.final = {1};
+        aut.initial = { 1 };
+        aut.final = { 1 };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "false" } }
+                );
 
         CHECK(cmpl.is_lang_empty());
     }
 
-    SECTION("empty automaton accepting epsilon")
-    {
+    SECTION("empty automaton accepting epsilon") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = {1};
-        aut.final = {1};
+        aut.initial = { 1 };
+        aut.final = { 1 };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "false" } }
+                );
 
         REQUIRE(!cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"]}, {}}));
@@ -1112,18 +1115,19 @@ TEST_CASE("mata::nft::complement()")
         REQUIRE(cmpl.delta.num_of_transitions() == 4);
     }
 
-    SECTION("non-empty automaton accepting a*b*")
-    {
+    SECTION("non-empty automaton accepting a*b*") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = {1, 2};
-        aut.final = {1, 2};
+        aut.initial = { 1, 2 };
+        aut.final = { 1, 2 };
 
         aut.delta.add(1, alph["a"], 1);
         aut.delta.add(1, alph["a"], 2);
         aut.delta.add(2, alph["b"], 2);
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "false" } }
+                );
 
         REQUIRE(!cmpl.is_in_lang(Word{}));
         REQUIRE(!cmpl.is_in_lang(Word{ alph["a"] }));
@@ -1138,22 +1142,24 @@ TEST_CASE("mata::nft::complement()")
         REQUIRE(cmpl.delta.num_of_transitions() == 6);
     }
 
-    SECTION("empty automaton, empty alphabet, minimization")
-    {
+    SECTION("empty automaton, empty alphabet, minimization") {
         OnTheFlyAlphabet alph{};
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "true" } }
+                );
         Nft empty_string_nft{ nft::builder::create_sigma_star_nft(&alph) };
         CHECK(are_equivalent(empty_string_nft, cmpl));
     }
 
-    SECTION("empty automaton, minimization")
-    {
+    SECTION("empty automaton, minimization") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "true" } }
+                );
 
         REQUIRE(cmpl.is_in_lang({}));
         REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
@@ -1165,11 +1171,10 @@ TEST_CASE("mata::nft::complement()")
         CHECK(are_equivalent(sigma_star_nft, cmpl));
     }
 
-    SECTION("minimization vs no minimization")
-    {
+    SECTION("minimization vs no minimization") {
         OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = {0, 1};
-        aut.final = {1, 2};
+        aut.initial = { 0, 1 };
+        aut.final = { 1, 2 };
 
         aut.delta.add(1, alph["b"], 1);
         aut.delta.add(1, alph["a"], 2);
@@ -1177,27 +1182,30 @@ TEST_CASE("mata::nft::complement()")
         aut.delta.add(0, alph["a"], 1);
         aut.delta.add(0, alph["a"], 2);
 
-        cmpl = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "false"}});
+        cmpl = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "false" } }
+                );
 
-        Nft cmpl_min = complement(aut, alph, {{"algorithm", "classical"},
-                                    {"minimize", "true"}});
+        Nft cmpl_min = complement(
+                aut, alph, { { "algorithm", "classical" },
+                             { "minimize", "true" } }
+                );
 
         CHECK(are_equivalent(cmpl, cmpl_min, &alph));
         CHECK(cmpl_min.num_of_states() == 4);
         CHECK(cmpl.num_of_states() == 5);
     }
+}
+#endif
 
-} // }}}
-
-TEST_CASE("mata::nft::is_universal()")
-{ // {{{
+TEST_CASE("mata::nft::is_universal()") {
     Nft aut(6);
     Run cex;
     ParameterMap params;
 
-    const std::unordered_set<std::string> ALGORITHMS = {
-        "naive",
+    const std::unordered_set<std::string> algorithms = {
+        // "naive", // FIXME(nft): Uncomment when naive algorithm is implemented for NFTs.
         "antichains",
     };
 
@@ -1205,7 +1213,7 @@ TEST_CASE("mata::nft::is_universal()")
     {
         OnTheFlyAlphabet alph{};
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, params);
 
@@ -1219,7 +1227,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.initial = {1};
         aut.final = {1};
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 
@@ -1234,7 +1242,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.initial = {1};
         aut.final = {1};
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 
@@ -1253,7 +1261,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(1, alph["a"], 2);
         aut.delta.add(2, alph["b"], 2);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, params);
 
@@ -1270,7 +1278,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(1, alph["a"], 1);
         aut.delta.add(2, alph["b"], 2);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, params);
 
@@ -1287,7 +1295,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(1, alph["a"], 1);
         aut.delta.add(1, alph["b"], 1);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, params);
 
@@ -1312,7 +1320,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(3, alph["b"], 5);
         aut.delta.add(5, alph["b"], 5);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 
@@ -1340,7 +1348,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(4, alph["a"], 4);
         aut.delta.add(4, alph["b"], 4);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 
@@ -1364,7 +1372,7 @@ TEST_CASE("mata::nft::is_universal()")
         aut.delta.add(4, alph["b"], 2);
         aut.delta.add(4, alph["b"], 3);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 
@@ -1380,7 +1388,7 @@ TEST_CASE("mata::nft::is_universal()")
 
         aut.delta.add(1, alph["a"], 1);
 
-        for (const auto& algo : ALGORITHMS) {
+        for (const auto& algo : algorithms) {
             params["algorithm"] = algo;
             bool is_univ = aut.is_universal(alph, &cex, params);
 


### PR DESCRIPTION
This PR implements determinization for NFTs with epsilons and jumps, handling epsilons as normal alphabet symbols and handling level transitions by partitioning target states by their levels.

Since this change also breaks the as of now unimplemented NFT functions (not yet updated for NFTs) calling the previous NFA implementations, this PR also disables the existing, yet unimplemented functions such as complement, minimization, etc.


The PR adds helper methods `get_levels_for()` and `get_next_transition_level_for()` to the `Levels` class for level management.

I advise the reviewers to review the PR commit by commit.

Resolves first part of #571.