### PR TITLE
Add option to set seed for Tabakov-Vardi

### DIFF
--- a/include/mata/nfa/builder.hh
+++ b/include/mata/nfa/builder.hh
@@ -56,6 +56,7 @@ Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
  *  A value of num_of_states means that there will be a transition between every pair of states for each symbol.
  * @param final_state_density Density of final states in the automaton. The value must be in range [0, 1]. The state 0 is always final.
  *  If the density is 1, every state will be final.
+ * @param seed Seed for the PRNG used. If no seed is given, the algorithm chooses one uniformly at random.
  */
 Nfa create_random_nfa_tabakov_vardi(const size_t num_of_states, const size_t alphabet_size, const double states_trans_ratio_per_symbol, const double final_state_density, const std::optional<unsigned int>& seed = std::nullopt);
 

--- a/include/mata/nfa/builder.hh
+++ b/include/mata/nfa/builder.hh
@@ -57,7 +57,7 @@ Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
  * @param final_state_density Density of final states in the automaton. The value must be in range [0, 1]. The state 0 is always final.
  *  If the density is 1, every state will be final.
  */
-Nfa create_random_nfa_tabakov_vardi(const size_t num_of_states, const size_t alphabet_size, const double states_trans_ratio_per_symbol, const double final_state_density);
+Nfa create_random_nfa_tabakov_vardi(const size_t num_of_states, const size_t alphabet_size, const double states_trans_ratio_per_symbol, const double final_state_density, const std::optional<unsigned int>& seed = std::nullopt);
 
 /** Loads an automaton from Parsed object */
 // TODO this function should the same thing as the one taking IntermediateAut or be deleted

--- a/src/nfa/builder.cc
+++ b/src/nfa/builder.cc
@@ -222,7 +222,7 @@ Nfa builder::create_sigma_star_nfa(mata::Alphabet* alphabet) {
     return nfa;
 }
 
-Nfa builder::create_random_nfa_tabakov_vardi(const size_t num_of_states, const size_t alphabet_size, const double states_trans_ratio_per_symbol, const double final_state_density) {
+Nfa builder::create_random_nfa_tabakov_vardi(const size_t num_of_states, const size_t alphabet_size, const double states_trans_ratio_per_symbol, const double final_state_density, const std::optional<unsigned int>& seed) {
     if (num_of_states == 0) {
         return Nfa();
     }
@@ -238,8 +238,8 @@ Nfa builder::create_random_nfa_tabakov_vardi(const size_t num_of_states, const s
     Nfa nfa{ num_of_states, { 0 }, { 0 }, new OnTheFlyAlphabet{} };
 
     // Initialize the random number generator
-    std::random_device rd;  // Seed for the random number engine
-    std::mt19937 gen(rd()); // Mersenne Twister engine
+    unsigned int seed_value{ seed.value_or(std::random_device{}()) };  // Seed for the random number engine
+    std::mt19937 gen(seed_value); // Mersenne Twister engine
 
     // Unique final state generator
     std::vector<State> states(num_of_states);

--- a/tests/nfa/builder.cc
+++ b/tests/nfa/builder.cc
@@ -282,4 +282,19 @@ TEST_CASE("Create Tabakov-Vardi NFA") {
 
         CHECK_THROWS_AS(mata::nfa::builder::create_random_nfa_tabakov_vardi(num_of_states, alphabet_size, states_trans_ratio_per_symbol, final_state_density), std::runtime_error);
     }
+
+    SECTION("Same seed results in same NFA.") {
+        num_of_states = 10;
+        alphabet_size = 5;
+        states_trans_ratio_per_symbol = 0.5;
+        final_state_density = 0.5;
+        std::optional<unsigned int> seed1{ 3171643142 };
+        std::optional<unsigned int> seed2{ 4283451011 };
+
+        Nfa nfa1_1 = mata::nfa::builder::create_random_nfa_tabakov_vardi(num_of_states, alphabet_size, states_trans_ratio_per_symbol, final_state_density, seed1);
+        Nfa nfa1_2 = mata::nfa::builder::create_random_nfa_tabakov_vardi(num_of_states, alphabet_size, states_trans_ratio_per_symbol, final_state_density, seed1);
+        Nfa nfa2 = mata::nfa::builder::create_random_nfa_tabakov_vardi(num_of_states, alphabet_size, states_trans_ratio_per_symbol, final_state_density, seed2);
+        CHECK(nfa1_1.is_identical(nfa1_2));
+        CHECK(!nfa1_2.is_identical(nfa2));
+    }
 }


### PR DESCRIPTION
This may be beneficial, e.g. when Tabakov-Vardi generated a counterexample for something, and one wants to debug / reproduce the counterexample.