### PR TITLE
Fix `make_complete()` for NFTs 

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -484,6 +484,13 @@ public:
     bool is_complete(Alphabet const* alphabet = nullptr) const;
 
     /**
+     * @brief Test for automaton completeness with regard to an alphabet.
+     *
+     * An automaton is complete if every reachable state has at least one outgoing transition over every symbol.
+     */
+    bool is_complete(const utils::OrdVector<Symbol>& symbols) const;
+
+    /**
      * @brief Is the automaton graph acyclic? Used for checking language finiteness.
      *
      * @return true <-> Automaton graph is acyclic.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -158,12 +158,38 @@ public:
      * "Minimal next" relates to the next target states ("What is the next minimal level to target in a transition?").
      */
     Level get_minimal_next_level_of(const StateSet& states) const;
+
+    /**
+     * @brief Check whether a transition can be made from a state with level @p source_level to a state with level
+     *  @p target_level.
+     *
+     * A transition can be made if the target level is higher than the source level, or if the target level is 0.
+     *
+     * @param[in] source_level Level of the source state.
+     * @param[in] target_level Level of the target state.
+     * @return @c true if the transition can be made, @c false otherwise.
+     */
+    static bool can_follow(Level source_level, Level target_level);
+
+    /**
+     * @brief Check whether a transition can be made from @p source to @p target.
+     *
+     * A transition can be made if the level of @p target is higher than the level of @p source, or if the level of
+     *  @p target is 0.
+     *
+     * @param[in] source Source state.
+     * @param[in] target Target state.
+     * @return @c true if the transition can be made, @c false otherwise.
+     */
+    bool can_follow_for_states(State source, State target) const;
 };
 
 /**
  * @brief A class representing an NFT.
  */
 class Nft: public nfa::Nfa {
+private:
+    using super = nfa::Nfa;
 public:
     /**
      * @brief Vector of levels giving each state a level in range from 0 to @c num_of_levels - 1.
@@ -174,6 +200,8 @@ public:
     /**
      * @brief Number of levels (tracks) the transducer recognizes. Each transducer transition will comprise
      *  @c num_of_levels of NFA transitions.
+     *
+     * @note The number of levels has to be at least 1.
      */
     size_t num_of_levels{ DEFAULT_NUM_OF_LEVELS };
 
@@ -196,6 +224,11 @@ public:
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
      *
      * @param[in] num_of_states Number of states for which to preallocate Delta.
+     * @param initial_states Initial states of the NFT.
+     * @param final_states Final states of the NFT.
+     * @param levels Levels of the states.
+     * @param num_of_levels Number of levels for the NFT (default: @c DEFAULT_NUM_OF_LEVELS).
+     * @param alphabet Alphabet of the NFT.
      */
     explicit Nft(const size_t num_of_states, utils::SparseSet<State> initial_states = {},
                  utils::SparseSet<State> final_states = {}, Levels levels = {}, const size_t num_of_levels = DEFAULT_NUM_OF_LEVELS,
@@ -773,6 +806,52 @@ public:
         JumpMode jump_mode = JumpMode::RepeatSymbol
     );
 
+
+    /**
+     * @brief Make NFT complete in place.
+     *
+     * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
+     *  transitions from given `state`) to `sink_states[level]` where `level == this->levels[state]`.
+     * If @p sink_states contain states that do not belong to the NFT, they are added to it, but only in the case that
+     *  some transition to those states were added.
+     * If NFT does not contain any states, this function does nothing.
+     *
+     * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
+     *  defined, otherwise use @c this->delta.get_used_symbols().
+     * @param[in] sink_states The level-indexed vector of sink states, one per level into which new transitions are
+     *  added. If @c std::nullopt, add new sink states.
+     * @return @c true if a new transition was added to the NFA, @c false otherwise.
+     */
+    bool make_complete(
+        const Alphabet* alphabet = nullptr,
+        const std::optional<std::vector<State>>& sink_states = std::nullopt
+    );
+
+    /**
+
+     * @brief Make NFT complete in place.
+     *
+     * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
+     *  transitions from given `state`) to `sink_states[level]` where `level == this->levels[state]`.
+     * If @p sink_states contain states that do not belong to the NFT, they are added to it, but only in the case that
+     *  some transition to those states were added.
+     * If NFT does not contain any states, this function does nothing.
+     *
+     * @note This overloaded version is a more efficient version which does not need to compute the set of symbols to
+     *  complete to from the alphabet. Prefer this version when you already have the set of symbols precomputed or plan
+     *  to complete multiple automata over the same set of symbols.
+     *
+     * @param[in] symbols Symbols to compute "missing" symbols from.
+     * @param[in] sink_states The level-indexed vector of sink states, one per level into which new transitions are
+     *  added. If @c std::nullopt, add new sink states.
+     * @return @c true if a new transition was added to the NFA, @c false otherwise.
+     */
+    bool make_complete(
+        const utils::OrdVector<Symbol>& symbols,
+        const std::optional<std::vector<State>>& sink_states = std::nullopt
+    );
+
+    using super::is_complete;
 }; // class Nft.
 
 // Allow variadic number of arguments of the same type.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -79,24 +79,18 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdint>
-#include <memory>
 #include <limits>
 #include <set>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "mata/alphabet.hh"
-#include "mata/parser/parser.hh"
-#include "mata/utils/utils.hh"
-#include "mata/utils/ord-vector.hh"
-#include "mata/parser/inter-aut.hh"
-#include "mata/utils/synchronized-iterator.hh"
-#include "mata/utils/sparse-set.hh"
-#include "types.hh"
 #include "delta.hh"
+#include "types.hh"
+#include "mata/alphabet.hh"
+#include "mata/utils/ord-vector.hh"
+#include "mata/utils/sparse-set.hh"
+#include "mata/utils/utils.hh"
 
 #include "mata/nfa/nfa.hh"
 
@@ -131,7 +125,7 @@ public:
      *
      * @param[in] level Level to be counted.
      */
-    size_t count(Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
+    size_t count(const Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
 
     /**
      * @brief Get levels of states in @p states.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -822,7 +822,6 @@ public:
     );
 
     /**
-
      * @brief Make NFT complete in place.
      *
      * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -498,16 +498,18 @@ bool mata::nfa::Nfa::is_deterministic() const {
 
     return true;
 }
-bool mata::nfa::Nfa::is_complete(Alphabet const* alphabet) const {
-    utils::OrdVector<Symbol> symbols{ get_symbols_to_work_with(*this, alphabet) };
-    utils::OrdVector<Symbol> symbs_ls{ symbols };
 
+bool Nfa::is_complete(Alphabet const* const alphabet) const {
+    return is_complete(get_symbols_to_work_with(*this, alphabet));
+}
+
+bool mata::nfa::Nfa::is_complete(const OrdVector<Symbol>& symbols) const {
     // TODO: make a general function for traversal over reachable states that can be shared by other functions?
     std::list<State> worklist(initial.begin(), initial.end());
     std::unordered_set<State> processed(initial.begin(), initial.end());
 
     while (!worklist.empty()) {
-        State state = *worklist.begin();
+        const State state = *worklist.begin();
         worklist.pop_front();
 
         size_t n = 0;      // counter of symbols

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -1,20 +1,18 @@
-/* nft.cc -- operations for NFA
+/** @file
+ * @brief Methods for NFTs.
  */
 
 #include <algorithm>
-#include <list>
+#include <cassert>
 #include <optional>
-#include <iterator>
 #include <fstream>
 #include <string>
 #include <utility>
 #include <ranges>
 
-// MATA headers
 #include "mata/utils/sparse-set.hh"
+#include "mata/nfa/builder.hh"
 #include "mata/nft/nft.hh"
-#include "mata/nft/algorithms.hh"
-#include <mata/simlib/explicit_lts.hh>
 
 
 using namespace mata::utils;
@@ -609,8 +607,8 @@ bool Nft::contains_jump_transitions() const {
     if (num_of_levels == 1) { return false; }
 
     for (const Transition& transition : delta.transitions()) {
-        Level src_level = levels[transition.source];
-        Level tgt_level = levels[transition.target];
+        const Level src_level{ levels[transition.source] };
+        Level tgt_level{ levels[transition.target] };
         if (tgt_level == 0) {
             // we want to check if the difference between src and tgt levels is at most 1 modulo num_of_levels
             tgt_level = tgt_level + static_cast<Level>(num_of_levels);
@@ -631,7 +629,7 @@ bool Nft::is_identical(const Nft& aut) const {
     return num_of_levels == aut.num_of_levels && levels == aut.levels && mata::nfa::Nfa::is_identical(aut);
 }
 
-Levels& Levels::set(State state, Level level) {
+Levels& Levels::set(const State state, const Level level) {
     if (size() <= state) { resize(state + 1, DEFAULT_LEVEL); }
     (*this)[state] = level;
     return *this;
@@ -648,10 +646,8 @@ mata::nfa::Nfa Nft::to_nfa_update_move(
     return to_nfa_move();
 }
 
-
 Nft Nft::apply(const nfa::Nfa& nfa, const Level level_to_apply_on, const bool project_out_applied_level, const JumpMode jump_mode) const {
-    Nft nft_from_nfa{ nfa };
-    return compose(nft_from_nfa, *this, 0, level_to_apply_on, project_out_applied_level, jump_mode);
+    return compose(Nft{ nfa }, *this, 0, level_to_apply_on, project_out_applied_level, jump_mode);
 }
 
 Nft Nft::apply(const Word& word, const Level level_to_apply_on, const bool project_out_applied_level, const JumpMode jump_mode) const {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -16,6 +16,7 @@
 #include "mata/nft/algorithms.hh"
 #include <mata/simlib/explicit_lts.hh>
 
+
 using namespace mata::utils;
 using namespace mata::nft;
 using mata::Symbol;
@@ -49,6 +50,14 @@ Level Levels::get_minimal_level_of(const StateSet& states, LevelsOrdering::Compa
 
 Level Levels::get_minimal_next_level_of(const StateSet& states) const {
     return get_minimal_level_of(states, LevelsOrdering::Next);
+}
+
+bool Levels::can_follow(const Level source_level, const Level target_level) {
+    return source_level < target_level || target_level == 0;
+}
+
+bool Levels::can_follow_for_states(const State source, const State target) const {
+    return can_follow((*this)[source], (*this)[target]);
 }
 
 size_t Nft::num_of_states_with_level(const Level level) const {
@@ -637,4 +646,65 @@ mata::nfa::Nfa Nft::to_nfa_update_move(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) {
     unwind_jumps_inplace(dont_care_symbol_replacements, jump_mode);
     return to_nfa_move();
+}
+
+
+Nft Nft::apply(const nfa::Nfa& nfa, const Level level_to_apply_on, const bool project_out_applied_level, const JumpMode jump_mode) const {
+    Nft nft_from_nfa{ nfa };
+    return compose(nft_from_nfa, *this, 0, level_to_apply_on, project_out_applied_level, jump_mode);
+}
+
+Nft Nft::apply(const Word& word, const Level level_to_apply_on, const bool project_out_applied_level, const JumpMode jump_mode) const {
+    return apply(nfa::builder::create_single_word_nfa(word), level_to_apply_on, project_out_applied_level, jump_mode);
+}
+
+bool Nft::make_complete(const Alphabet* const alphabet, const std::optional<std::vector<State>>& sink_states) {
+    return make_complete(get_symbols_to_work_with(*this, alphabet), sink_states);
+}
+
+bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<std::vector<State>>& sink_states) {
+    bool transition_added{ false };
+    const size_t num_of_states{ this->num_of_states() };
+    const std::vector<State> sinks{ [&]{
+        auto sinks_val{ sink_states.value_or(std::vector<State>{}) };
+        if (sinks_val.empty()) {
+            for (Level level{ 0 }; level < num_of_levels; ++level) { sinks_val.push_back(add_state_with_level(level)); }
+        }
+        assert(
+            [&]{
+                for (Level level{ 0 }; level < num_of_levels; ++level) {
+                    const State sink_state{ sinks_val[level] };
+                    if (sink_state >= this->num_of_states() || levels[sink_state] != level) {
+                        return false;
+                    }
+                }
+                return true;
+            }() && "Nft::make_complete: sink_states must have correct levels and exist in the NFT."
+        );
+        return sinks_val;
+    }() };
+
+    auto next_level = [&](const Level level) {
+        return (num_of_levels == 1) ? level : (level + 1) % static_cast<Level>(num_of_levels);
+    };
+
+    OrdVector<Symbol> used_symbols{};
+    for (State state{ 0 }; state < num_of_states; ++state) {
+        used_symbols.clear();
+        for (const SymbolPost& symbol_post : delta[state]) { used_symbols.insert(symbol_post.symbol); }
+        for (const auto unused_symbols{ symbols.difference(used_symbols) }; const Symbol symbol : unused_symbols) {
+            delta.add(state, symbol, sinks[next_level(levels[state])]);
+            transition_added = true;
+        }
+    }
+
+    if (transition_added && num_of_states <= this->num_of_states()) {
+        for (const Symbol symbol : symbols) {
+            for (Level level{ 0 }; level < num_of_levels; ++level) {
+                delta.add(sinks[level], symbol, sinks[next_level(level)]);
+            }
+        }
+    }
+
+    return transition_added;
 }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -419,15 +419,6 @@ Nft mata::nft::project_to(const Nft& nft, Level level_to_project, const JumpMode
     return project_to(nft, OrdVector<Level>{ level_to_project }, jump_mode);
 }
 
-Nft Nft::apply(const nfa::Nfa& nfa, Level level_to_apply_on, bool project_out_applied_level, JumpMode jump_mode) const {
-    Nft nft_from_nfa{ nfa };
-    return compose(nft_from_nfa, *this, 0, level_to_apply_on, project_out_applied_level, jump_mode);
-}
-
-Nft Nft::apply(const Word& word, Level level_to_apply_on, bool project_out_applied_level, JumpMode jump_mode) const {
-    return apply(nfa::builder::create_single_word_nfa(word), level_to_apply_on, project_out_applied_level, jump_mode);
-}
-
 Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const JumpMode jump_mode) {
     assert(0 < nft.num_of_levels);
     assert(nft.num_of_levels <= new_levels_mask.size());

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include "mata/alphabet.hh"
 #include "mata/nft/types.hh"
 #include "utils.hh"
 
@@ -949,105 +950,106 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls")
     }
 } // }}}
 
-TEST_CASE("mata::nft::make_complete()")
-{ // {{{
-    Nft aut(11);
+TEST_CASE("mata::nft::make_complete()") {
+    Nft nft{ Nft::with_levels(3) };
+    Nft result{ Nft::with_levels(3) };
+    EnumAlphabet alphabet{ 'a', 'b', 'c'};
+    nft.alphabet = &alphabet;
+    result.alphabet = &alphabet;
 
-    SECTION("empty automaton, empty alphabet")
-    {
-        OnTheFlyAlphabet alph{};
+     SECTION("empty automaton, empty alphabet") {
+         alphabet.clear();
+         nft.make_complete(&alphabet);
+     }
 
-        aut.make_complete(&alph, 0);
-
-        REQUIRE(aut.initial.empty());
-        REQUIRE(aut.final.empty());
-        REQUIRE(aut.delta.empty());
+    SECTION("make_complete with num_of_levels == 1") {
+        nft.num_of_levels = 1;
+        nft.initial = { 0 };
+        nft.final = { 2 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        result = nft;
+        result.make_complete(&alphabet);
     }
 
-    SECTION("empty automaton")
-    {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-
-        aut.make_complete(&alph, 0);
-
-        REQUIRE(aut.initial.empty());
-        REQUIRE(aut.final.empty());
-        REQUIRE(aut.delta.contains(0, alph["a"], 0));
-        REQUIRE(aut.delta.contains(0, alph["b"], 0));
+    SECTION("make_complete with num_of_levels == 2") {
+        nft.num_of_levels = 2;
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels = { 0, 1, 0, 1, 0 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        result = nft;
+        result.make_complete(&alphabet);
     }
 
-    SECTION("non-empty automaton, empty alphabet")
-    {
-        OnTheFlyAlphabet alphabet{};
-
-        aut.initial = {1};
-
-        aut.make_complete(&alphabet, 0);
-
-        REQUIRE(aut.initial.size() == 1);
-        REQUIRE(*aut.initial.begin() == 1);
-        REQUIRE(aut.final.empty());
-        REQUIRE(aut.delta.empty());
+    SECTION("make_complete with num_of_levels == 3") {
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels = { 0, 1, 2, 0, 1, 0 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
+        result = nft;
+        result.make_complete(&alphabet);
     }
 
-    SECTION("one-state automaton")
-    {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        constexpr State SINK = 10;
+    SECTION("self loops and jumps") {
+         nft.initial = { 0 };
+         nft.final = { 4 };
+         nft.levels = { 0, 1, 2, 0, 1, 0 };
+         nft.delta.add(0, 'a', 1);
+         nft.delta.add(0, 'b', 0);
+         nft.delta.add(0, 'a', 2);
+         nft.delta.add(0, 'b', 3);
+         nft.delta.add(1, 'b', 2);
+         nft.delta.add(2, 'a', 3);
+         nft.delta.add(3, 'b', 4);
+         nft.delta.add(4, 'a', 5);
+         result = nft;
+         result.make_complete(&alphabet);
+     }
 
-        aut.initial = {1};
+    SECTION("with sinks") {
+         nft.initial = { 0 };
+         nft.final = { 4 };
+         nft.levels = { 0, 1, 2, 0, 1, 0, 0, 1, 2 };
+         nft.delta.add(0, 'a', 1);
+         nft.delta.add(0, 'b', 0);
+         nft.delta.add(0, 'a', 2);
+         nft.delta.add(0, 'b', 3);
+         nft.delta.add(1, 'b', 2);
+         nft.delta.add(1, 'c', 8);
+         nft.delta.add(2, 'a', 3);
+         nft.delta.add(3, 'b', 4);
+         nft.delta.add(4, 'a', 5);
+         result = nft;
+         const std::vector<State> sinks{ 6, 7, 8 };
+         result.make_complete(&alphabet, sinks);
+         CHECK(not result.make_complete(&alphabet, std::vector<State>{ sinks }));
+         for (const State sink : sinks) {
+             for (const auto symbol : alphabet.get_alphabet_symbols()) {
+                 CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks.size()) + *sinks.begin()));
+             }
+         }
+     }
 
-        aut.make_complete(&alph, SINK);
-
-        REQUIRE(aut.initial.size() == 1);
-        REQUIRE(*aut.initial.begin() == 1);
-        REQUIRE(aut.final.empty());
-        REQUIRE(aut.delta.contains(1, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(1, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(SINK, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(SINK, alph["b"], SINK));
+    CHECK(are_equivalent(nft, result));
+    for (State source{ 0 }; source < result.num_of_states(); ++source) {
+        for (const auto symbol : alphabet.get_alphabet_symbols()) {
+            const auto& state_post{ result.delta[source] };
+            auto state_post_it{ state_post.find(symbol) };
+            REQUIRE(state_post_it != state_post.end());
+            for (const auto target : state_post_it->targets) {
+                REQUIRE(result.levels.can_follow_for_states(source, target));
+            }
+        }
     }
-
-    SECTION("bigger automaton")
-    {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b", "c" } };
-        constexpr State SINK = 9;
-
-        aut.initial = {1, 2};
-        aut.final = {8};
-        aut.delta.add(1, alph["a"], 2);
-        aut.delta.add(2, alph["a"], 4);
-        aut.delta.add(2, alph["c"], 1);
-        aut.delta.add(2, alph["c"], 3);
-        aut.delta.add(3, alph["b"], 5);
-        aut.delta.add(4, alph["c"], 8);
-
-        aut.make_complete(&alph, SINK);
-
-        REQUIRE(aut.delta.contains(1, alph["a"], 2));
-        REQUIRE(aut.delta.contains(1, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(1, alph["c"], SINK));
-        REQUIRE(aut.delta.contains(2, alph["a"], 4));
-        REQUIRE(aut.delta.contains(2, alph["c"], 1));
-        REQUIRE(aut.delta.contains(2, alph["c"], 3));
-        REQUIRE(aut.delta.contains(2, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(3, alph["b"], 5));
-        REQUIRE(aut.delta.contains(3, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(3, alph["c"], SINK));
-        REQUIRE(aut.delta.contains(4, alph["c"], 8));
-        REQUIRE(aut.delta.contains(4, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(4, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(5, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(5, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(5, alph["c"], SINK));
-        REQUIRE(aut.delta.contains(8, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(8, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(8, alph["c"], SINK));
-        REQUIRE(aut.delta.contains(SINK, alph["a"], SINK));
-        REQUIRE(aut.delta.contains(SINK, alph["b"], SINK));
-        REQUIRE(aut.delta.contains(SINK, alph["c"], SINK));
-    }
-} // }}}
+}
 
 #ifdef MATA_NFT_NOT_IMPLEMENTED
 TEST_CASE("mata::nft::complement()") {
@@ -2567,68 +2569,70 @@ TEST_CASE("mata::nft::Nft::is_deterministic()")
     }
 } // }}}
 
-TEST_CASE("mata::nft::is_complete()")
-{ // {{{
-    Nft aut('q'+1);
+TEST_CASE("mata::nft::is_complete()") {
+    // Nft aut('q' + 1);
+    Nft nft{ Nft::with_levels(3) };
+    EnumAlphabet alphabet{};
 
-    SECTION("empty automaton")
-    {
-        OnTheFlyAlphabet alph{};
 
-        // is complete for the empty alphabet
-        REQUIRE(aut.is_complete(&alph));
 
-        alph.translate_symb("a1");
-        alph.translate_symb("a2");
-
-        // the empty automaton is complete even for a non-empty alphabet
-        REQUIRE(aut.is_complete(&alph));
-
-        // add a non-reachable state (the automaton should still be complete)
-        aut.delta.add('q', alph["a1"], 'q');
-        REQUIRE(aut.is_complete(&alph));
-    }
-
-    SECTION("small automaton")
-    {
-        OnTheFlyAlphabet alph{};
-
-        aut.initial.insert(4);
-        aut.delta.add(4, alph["a"], 8);
-        aut.delta.add(4, alph["c"], 8);
-        aut.delta.add(4, alph["a"], 6);
-        aut.delta.add(4, alph["b"], 6);
-        aut.delta.add(8, alph["b"], 4);
-        aut.delta.add(6, alph["a"], 2);
-        aut.delta.add(2, alph["b"], 2);
-        aut.delta.add(2, alph["a"], 0);
-        aut.delta.add(2, alph["c"], 12);
-        aut.delta.add(0, alph["a"], 2);
-        aut.delta.add(12, alph["a"], 14);
-        aut.delta.add(14, alph["b"], 12);
-        aut.final.insert({2, 12});
-
-        REQUIRE(!aut.is_complete(&alph));
-
-        aut.make_complete(&alph, 100);
-        REQUIRE(aut.is_complete(&alph));
-    }
-
-    SECTION("using a non-alphabet symbol")
-    {
-        OnTheFlyAlphabet alph{};
-
-        aut.initial.insert(4);
-        aut.delta.add(4, alph["a"], 8);
-        aut.delta.add(4, alph["c"], 8);
-        aut.delta.add(4, alph["a"], 6);
-        aut.delta.add(4, alph["b"], 6);
-        aut.delta.add(6, 100, 4);
-
-        CHECK_THROWS_WITH(aut.is_complete(&alph),
-            Catch::Matchers::ContainsSubstring("symbol that is not in the provided alphabet"));
-    }
-} // }}}
+    // SECTION("empty automaton") {
+    //     OnTheFlyAlphabet alph{};
+    //
+    //     // is complete for the empty alphabet
+    //     REQUIRE(aut.is_complete(&alph));
+    //
+    //     alph.translate_symb("a1");
+    //     alph.translate_symb("a2");
+    //
+    //     // the empty automaton is complete even for a non-empty alphabet
+    //     REQUIRE(aut.is_complete(&alph));
+    //
+    //     // add a non-reachable state (the automaton should still be complete)
+    //     aut.delta.add('q', alph["a1"], 'q');
+    //     REQUIRE(aut.is_complete(&alph));
+    // }
+    //
+    // SECTION("small automaton") {
+    //     OnTheFlyAlphabet alph{};
+    //
+    //     aut.initial.insert(4);
+    //     aut.delta.add(4, alph["a"], 8);
+    //     aut.delta.add(4, alph["c"], 8);
+    //     aut.delta.add(4, alph["a"], 6);
+    //     aut.delta.add(4, alph["b"], 6);
+    //     aut.delta.add(8, alph["b"], 4);
+    //     aut.delta.add(6, alph["a"], 2);
+    //     aut.delta.add(2, alph["b"], 2);
+    //     aut.delta.add(2, alph["a"], 0);
+    //     aut.delta.add(2, alph["c"], 12);
+    //     aut.delta.add(0, alph["a"], 2);
+    //     aut.delta.add(12, alph["a"], 14);
+    //     aut.delta.add(14, alph["b"], 12);
+    //     aut.final.insert({ 2, 12 });
+    //
+    //     REQUIRE(!aut.is_complete(&alph));
+    //
+    //     aut.make_complete(&alph, { 100 });
+    //     REQUIRE(aut.is_complete(&alph));
+    // }
+    //
+    // SECTION("using a non-alphabet symbol") {
+    //     OnTheFlyAlphabet alph{};
+    //
+    //     aut.initial.insert(4);
+    //     aut.delta.add(4, alph["a"], 8);
+    //     aut.delta.add(4, alph["c"], 8);
+    //     aut.delta.add(4, alph["a"], 6);
+    //     aut.delta.add(4, alph["b"], 6);
+    //     aut.delta.add(6, 100, 4);
+    //
+    //     CHECK_THROWS_WITH(
+    //             aut.is_complete(&alph),
+    //             Catch::Matchers::ContainsSubstring("symbol that is not in the provided alphabet")
+    //             );
+    // }
+}
 
 TEST_CASE("mata::nft::is_prefix_in_lang()")
 { // {{{
@@ -3566,7 +3570,7 @@ TEST_CASE("mata::nft::make_complement(): A segmentation fault") {
     r.initial = {0};
     r.delta.add(0, 0, 0);
     REQUIRE(not r.is_complete(&alph));
-    r.make_complete(&alph, 1);
+    r.make_complete(&alph);
     REQUIRE(r.is_complete(&alph));
 }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1049,6 +1049,7 @@ TEST_CASE("mata::nft::make_complete()") {
             }
         }
     }
+    CHECK(result.is_complete());
 }
 
 #ifdef MATA_NFT_NOT_IMPLEMENTED
@@ -2568,71 +2569,6 @@ TEST_CASE("mata::nft::Nft::is_deterministic()")
         REQUIRE(!aut.is_deterministic());
     }
 } // }}}
-
-TEST_CASE("mata::nft::is_complete()") {
-    // Nft aut('q' + 1);
-    Nft nft{ Nft::with_levels(3) };
-    EnumAlphabet alphabet{};
-
-
-
-    // SECTION("empty automaton") {
-    //     OnTheFlyAlphabet alph{};
-    //
-    //     // is complete for the empty alphabet
-    //     REQUIRE(aut.is_complete(&alph));
-    //
-    //     alph.translate_symb("a1");
-    //     alph.translate_symb("a2");
-    //
-    //     // the empty automaton is complete even for a non-empty alphabet
-    //     REQUIRE(aut.is_complete(&alph));
-    //
-    //     // add a non-reachable state (the automaton should still be complete)
-    //     aut.delta.add('q', alph["a1"], 'q');
-    //     REQUIRE(aut.is_complete(&alph));
-    // }
-    //
-    // SECTION("small automaton") {
-    //     OnTheFlyAlphabet alph{};
-    //
-    //     aut.initial.insert(4);
-    //     aut.delta.add(4, alph["a"], 8);
-    //     aut.delta.add(4, alph["c"], 8);
-    //     aut.delta.add(4, alph["a"], 6);
-    //     aut.delta.add(4, alph["b"], 6);
-    //     aut.delta.add(8, alph["b"], 4);
-    //     aut.delta.add(6, alph["a"], 2);
-    //     aut.delta.add(2, alph["b"], 2);
-    //     aut.delta.add(2, alph["a"], 0);
-    //     aut.delta.add(2, alph["c"], 12);
-    //     aut.delta.add(0, alph["a"], 2);
-    //     aut.delta.add(12, alph["a"], 14);
-    //     aut.delta.add(14, alph["b"], 12);
-    //     aut.final.insert({ 2, 12 });
-    //
-    //     REQUIRE(!aut.is_complete(&alph));
-    //
-    //     aut.make_complete(&alph, { 100 });
-    //     REQUIRE(aut.is_complete(&alph));
-    // }
-    //
-    // SECTION("using a non-alphabet symbol") {
-    //     OnTheFlyAlphabet alph{};
-    //
-    //     aut.initial.insert(4);
-    //     aut.delta.add(4, alph["a"], 8);
-    //     aut.delta.add(4, alph["c"], 8);
-    //     aut.delta.add(4, alph["a"], 6);
-    //     aut.delta.add(4, alph["b"], 6);
-    //     aut.delta.add(6, 100, 4);
-    //
-    //     CHECK_THROWS_WITH(
-    //             aut.is_complete(&alph),
-    //             Catch::Matchers::ContainsSubstring("symbol that is not in the provided alphabet")
-    //             );
-    // }
-}
 
 TEST_CASE("mata::nft::is_prefix_in_lang()")
 { // {{{


### PR DESCRIPTION
This PR updates the `make_complete()` and `is_complete()` from NFAs for NFTs, and introduces several utility methods and functions.

Furthermore, the PR

* introduced new level-related static method `can_follow`.
* refactored the `OrdVector` container to return insertion status (iterator and bool) for `insert` operations, aligning with standard STL container semantics.