### PR TITLE
Change print functions s.t. they print labels stored in the Nfa's alphabet, if existent

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -367,7 +367,7 @@ public:
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
     /**
      * @brief Prints the automaton to the output stream in DOT format
      *
@@ -376,7 +376,7 @@ public:
      * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
     /**
      * @brief Prints the automaton to the file in DOT format
      * @param filename Name of the file to print the automaton to
@@ -385,7 +385,7 @@ public:
      * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -512,7 +512,7 @@ public:
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      * @return automaton in DOT format
      */
-    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    std::string print_to_dot(bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
 
     /**
      * @brief Prints the automaton to the output stream in DOT format
@@ -522,7 +522,7 @@ public:
      * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    void print_to_dot(std::ostream &output, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
 
     /**
      * @brief Prints the automaton to the file in DOT format
@@ -532,7 +532,7 @@ public:
      * @param[in] max_label_length Maximum label length for the output (-1 means no limit, 0 means no labels).
      * If the label is longer than @p max_label_length, it will be truncated, with full label displayed on hover.
      */
-    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1) const;
+    void print_to_dot(const std::string& filename, bool decode_ascii_chars = false, bool use_intervals = false, int max_label_length = -1, const Alphabet* alphabet = nullptr) const;
 
     /**
      * @brief Prints the automaton in mata format

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -456,6 +456,9 @@ void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
         if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
+        if (this->alphabet != nullptr) {
+            return this->alphabet->reverse_translate_symbol(symbol);
+        }
 
         return std::to_string(symbol);
     };

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -456,6 +456,7 @@ void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
         if (decode_ascii_chars) {
             return to_ascii(symbol);
         }
+
         return std::to_string(symbol);
     };
 
@@ -597,7 +598,8 @@ void Nfa::print_to_mata(std::ostream &output, const Alphabet* alphabet) const {
 
     for (const Transition& trans: delta.transitions()) {
         output << "q" << trans.source << " "
-        << ((alphabet != nullptr) ? alphabet->reverse_translate_symbol(trans.symbol) : std::to_string(trans.symbol))
+        << ((alphabet != nullptr) ? alphabet->reverse_translate_symbol(trans.symbol) :
+            ((this->alphabet != nullptr) ? this->alphabet->reverse_translate_symbol(trans.symbol) : std::to_string(trans.symbol)))
         << " q" << trans.target << std::endl;
     }
 }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -429,13 +429,13 @@ bool Nfa::is_flat() const {
     return flat;
 }
 
-std::string Nfa::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+std::string Nfa::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     std::stringstream output;
-    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length, alphabet);
     return output.str();
 }
 
-void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     auto to_ascii = [&](const Symbol symbol) -> std::string {
         // Translate only printable ASCII characters.
         if (symbol < 33 || symbol >= 127) {
@@ -455,12 +455,13 @@ void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
         }
         if (decode_ascii_chars) {
             return to_ascii(symbol);
-        }
-        if (this->alphabet != nullptr) {
+        } else if (alphabet != nullptr) {
+            return alphabet->reverse_translate_symbol(symbol);
+        } else if (this->alphabet != nullptr) {
             return this->alphabet->reverse_translate_symbol(symbol);
+        } else {
+            return std::to_string(symbol);
         }
-
-        return std::to_string(symbol);
     };
 
     auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {
@@ -563,12 +564,12 @@ void Nfa::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
     output << "}" << std::endl;
 }
 
-void Nfa::print_to_dot(const std::string& filename, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+void Nfa::print_to_dot(const std::string& filename, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
     }
-    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
+    print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length, alphabet);
 }
 
 std::string Nfa::print_to_mata(const Alphabet* alphabet) const {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -177,13 +177,13 @@ void Nft::remove_epsilon(Symbol epsilon) {
     *this = mata::nft::remove_epsilon(*this, epsilon);
 }
 
-std::string Nft::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+std::string Nft::print_to_dot(const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     std::stringstream output;
     print_to_dot(output, decode_ascii_chars, use_intervals, max_label_length);
     return output.str();
 }
 
-void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     auto to_ascii = [&](const Symbol symbol) -> std::string {
         // Translate only printable ASCII characters.
         if (symbol < 33 || symbol >= 127) {
@@ -203,8 +203,13 @@ void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
         }
         if (decode_ascii_chars) {
             return to_ascii(symbol);
+        } else if (alphabet != nullptr) {
+            return alphabet->reverse_translate_symbol(symbol);
+        } else if (this->alphabet != nullptr) {
+            return this->alphabet->reverse_translate_symbol(symbol);
+        } else {
+            return std::to_string(symbol);
         }
-        return std::to_string(symbol);
     };
 
     auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {
@@ -314,7 +319,7 @@ void Nft::print_to_dot(std::ostream &output, const bool decode_ascii_chars, cons
     output << "}" << std::endl;
 }
 
-void Nft::print_to_dot(const std::string& filename,  const bool decode_ascii_chars, const bool use_intervals, const int max_label_length) const {
+void Nft::print_to_dot(const std::string& filename,  const bool decode_ascii_chars, const bool use_intervals, const int max_label_length, const Alphabet* alphabet) const {
     std::ofstream output(filename);
     if (!output) {
         throw std::ios_base::failure("Failed to open file: " + filename);
@@ -373,7 +378,10 @@ void Nft::print_to_mata(std::ostream &output) const {
     output << "%LevelsNum " << levels.num_of_levels << std::endl;
 
     for (const Transition& trans: delta.transitions()) {
-        output << "q" << trans.source << " " << trans.symbol << " q" << trans.target << std::endl;
+        output << "q" << trans.source << " "
+        << ((alphabet != nullptr) ? alphabet->reverse_translate_symbol(trans.symbol) :
+            ((this->alphabet != nullptr) ? this->alphabet->reverse_translate_symbol(trans.symbol) : std::to_string(trans.symbol)))
+        << " q" << trans.target << std::endl;
     }
 }
 


### PR DESCRIPTION
This change

- prints labels of the Nfa's alphabet in `print_to_dot`, if they exist
- prints labels of the Nfa's alphabet in `print_to_mata`, if they exist and the parameter `alphabet` of the function is `nullptr`

A few comments:

1. It would be more consistent to add an `alphabet` parameter to `print_to_dot` as well. However, this comes with the following issue: If one uses strings as alphabet elements, some other parameters may not really make sense (`decode_ascii_chars`, `use_intervals`). If one puts the `alphabet` parameter to the end, one would have to explicitly mention these other parameters with their defaults. Otherwise, if the `alphabet` parameter is put to the front, the situation is the same if one wants to call the function without overriding the alphabet.
2. If an Nfa has some `alphabet`, it would also be nice to be able to write something like `aut.delta.add(2, "my_symbol", 3)` instead of `aut.delta.add(2, aut.alphabet->translate_symb("my_symbol"), 3)`. However, this would require `delta` to also store the alphabet. An alternative would be to have a function `aut.delta_add`, but this would make things inconsistent.

The second comment is more of a question if there could exist some solution. The first comment is the reason I'm marking this PR as Draft :)