### PR TITLE
Move `num_of_levels` into `Nft::levels` class

### DIFF
--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -96,88 +96,6 @@
 
 namespace mata::nft {
 
-class Levels: public std::vector<Level> {
-    using super = std::vector<Level>;
-public:
-    Levels& set(State state, Level level = DEFAULT_LEVEL);
-    using super::vector;
-    using super::operator=;
-    Levels(const std::vector<Level>& levels): super{ levels } {}
-    Levels(std::vector<Level>&& levels): super{ std::move(levels) } {}
-    Levels& operator=(const std::vector<Level>& levels) {
-        if (this != &levels) { super::operator=(levels); }
-        return *this;
-    }
-    Levels& operator=(std::vector<Level>&& levels) {
-        if (this != &levels) { super::operator=(std::move(levels)); }
-        return *this;
-    }
-
-    /**
-     * @brief Append @p levels_vector to the end of @c this.
-     *
-     * @param[in] levels_vector Vector of levels to be appended.
-     */
-    void append(const Levels& levels_vector) { for (const Level& level: levels_vector) { push_back(level); } }
-
-    /**
-     * @brief Count the number of occurrences of a level in @c this.
-     *
-     * @param[in] level Level to be counted.
-     */
-    size_t count(const Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
-
-    /**
-     * @brief Get levels of states in @p states.
-     */
-    std::vector<Level> get_levels_of(const utils::SparseSet<State>& states) const;
-    /**
-     * @brief Get levels of states in @p states.
-     */
-    std::vector<Level> get_levels_of(const StateSet& states) const;
-
-    /**
-     * @brief Get the minimal level for the states in @p states.
-     *
-     * "Minimal level" is defined as the level with the lowest numerical value, i.e., `0 < 1 < 2 < ... < num_of_levels-1`.
-     * "Minimal" often relates to the current states ("What is the current state with minimal level?")
-     */
-    Level get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering = LevelsOrdering::Minimal) const;
-
-    /**
-     * @brief Get the minimal next level for the states in @p states.
-     *
-     * "Minimal next level" is defined as the minimal level in the next transition (that may follow another level),
-     *  i.e., `1 < 2 < ... < num_of_levels-1 < 0`.
-     * "Minimal next" relates to the next target states ("What is the next minimal level to target in a transition?").
-     */
-    Level get_minimal_next_level_of(const StateSet& states) const;
-
-    /**
-     * @brief Check whether a transition can be made from a state with level @p source_level to a state with level
-     *  @p target_level.
-     *
-     * A transition can be made if the target level is higher than the source level, or if the target level is 0.
-     *
-     * @param[in] source_level Level of the source state.
-     * @param[in] target_level Level of the target state.
-     * @return @c true if the transition can be made, @c false otherwise.
-     */
-    static bool can_follow(Level source_level, Level target_level);
-
-    /**
-     * @brief Check whether a transition can be made from @p source to @p target.
-     *
-     * A transition can be made if the level of @p target is higher than the level of @p source, or if the level of
-     *  @p target is 0.
-     *
-     * @param[in] source Source state.
-     * @param[in] target Target state.
-     * @return @c true if the transition can be made, @c false otherwise.
-     */
-    bool can_follow_for_states(State source, State target) const;
-};
-
 /**
  * @brief A class representing an NFT.
  */
@@ -186,18 +104,13 @@ private:
     using super = nfa::Nfa;
 public:
     /**
-     * @brief Vector of levels giving each state a level in range from 0 to @c num_of_levels - 1.
+     * @brief Vector of levels giving each state a level in range from 0 to @c levels.num_of_levels - 1.
      *
      * For state `q`, `levels[q]` gives the state `q` a level.
+     *
+     * Also holds the number of levels in the NFT in @c levels.num_of_levels.
      */
     Levels levels{};
-    /**
-     * @brief Number of levels (tracks) the transducer recognizes. Each transducer transition will comprise
-     *  @c num_of_levels of NFA transitions.
-     *
-     * @note The number of levels has to be at least 1.
-     */
-    size_t num_of_levels{ DEFAULT_NUM_OF_LEVELS };
 
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
@@ -208,12 +121,13 @@ public:
     //  dictionary in the attributes.
 
 public:
-    explicit Nft(Delta delta = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Levels levels = {}, const size_t num_of_levels = DEFAULT_NUM_OF_LEVELS,
-                 Alphabet* alphabet = nullptr)
-        : Nfa(std::move(delta), std::move(initial_states), std::move(final_states), alphabet), num_of_levels(num_of_levels) {
-        this->levels = levels.empty() ? Levels(num_of_states(), DEFAULT_LEVEL) : std::move(levels);
-    }
+    explicit Nft(
+            Delta delta = {}, utils::SparseSet<State> initial_states = {},
+            utils::SparseSet<State> final_states = {}, Levels levels = {},
+            Alphabet* alphabet = nullptr)
+        : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), alphabet },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) } {}
+
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
      *
@@ -221,24 +135,36 @@ public:
      * @param initial_states Initial states of the NFT.
      * @param final_states Final states of the NFT.
      * @param levels Levels of the states.
-     * @param num_of_levels Number of levels for the NFT (default: @c DEFAULT_NUM_OF_LEVELS).
      * @param alphabet Alphabet of the NFT.
      */
     explicit Nft(const size_t num_of_states, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Levels levels = {}, const size_t num_of_levels = DEFAULT_NUM_OF_LEVELS,
+                 utils::SparseSet<State> final_states = {}, Levels levels = {},
                  Alphabet* alphabet = nullptr)
-        : Nfa(num_of_states, std::move(initial_states), std::move(final_states), alphabet),
-          num_of_levels(num_of_levels) {
-        this->levels = levels.empty() ? Levels(num_of_states, DEFAULT_LEVEL) : std::move(levels);
+        : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), alphabet },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) } {}
+
+    static Nft with_levels(
+            Levels levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
+            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
     }
 
-    static Nft with_levels(const size_t num_of_levels, const size_t num_of_states = 0, Levels levels = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), num_of_levels, alphabet };
+    static Nft with_levels(
+            Levels levels, Delta delta, utils::SparseSet<State> initial_states = {},
+            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
     }
-    static Nft with_levels(const size_t num_of_levels, Delta delta, Levels levels = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), num_of_levels, alphabet };
+
+    static Nft with_levels(
+            const size_t num_of_levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
+            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
+    }
+
+    static Nft with_levels(
+            const size_t num_of_levels, Delta delta, utils::SparseSet<State> initial_states = {},
+            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
     }
 
     /**
@@ -247,13 +173,13 @@ public:
     Nft(const Nft& other) = default;
 
     Nft(Nft&& other) noexcept
-        : levels{ std::move(other.levels) }, num_of_levels{ other.num_of_levels } {
-            delta = std::move(other.delta);
-            initial = std::move(other.initial);
-            final = std::move(other.final);
-            attributes = std::move(other.attributes);
-            alphabet = other.alphabet;
-            other.alphabet = nullptr;
+        : levels{ std::move(other.levels) } {
+          delta = std::move(other.delta);
+          initial = std::move(other.initial);
+          final = std::move(other.final);
+          attributes = std::move(other.attributes);
+          alphabet = other.alphabet;
+          other.alphabet = nullptr;
     }
 
     Nft& operator=(const Nft& other) = default;
@@ -270,7 +196,8 @@ public:
      * @param num_of_levels Number of levels for the NFT. (default: 1)
      * @param default_level Default level for the states. (default: 0)
      */
-    explicit Nft(const mata::nfa::Nfa& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL): mata::nfa::Nfa(other), levels(num_of_states(), default_level), num_of_levels(num_of_levels) {}
+    explicit Nft(const mata::nfa::Nfa& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
+        : mata::nfa::Nfa(other), levels{ num_of_levels, num_of_states(), default_level } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -283,9 +210,35 @@ public:
      * @param num_of_levels Number of levels for the NFT. (default: 1)
      * @param default_level Default level for the states. (default: 0)
      */
-    explicit Nft(mata::nfa::Nfa&& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL): mata::nfa::Nfa(std::move(other)), levels(num_of_states(), default_level), num_of_levels(num_of_levels) {}
-    Nft& operator=(const mata::nfa::Nfa& other) noexcept;
-    Nft& operator=(mata::nfa::Nfa&& other) noexcept;
+    explicit Nft(Nfa&& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
+        : Nfa(std::move(other)), levels{ num_of_levels, num_of_states(), default_level } {}
+
+    /**
+     * @brief Construct a new NFT with @p num_of_levels levels from NFA.
+     * All states levels are set to the @p default_level. The transition function
+     * remains the same as in the NFA.
+     *
+     * Note: Constructor functions with more options are available in mata::nft::builder.
+     *
+     * @param other NFA to be converted to NFT.
+     * @param levels Levels for the states of the NFA @c other.
+     */
+    explicit Nft(const Nfa& other, Levels levels): Nfa(other), levels{ std::move(levels) } {}
+
+    /**
+     * @brief Construct a new NFT with @p num_of_levels levels from NFA.
+     * All states levels are set to the @p default_level. The transition function
+     * remains the same as in the NFA.
+     *
+     * Note: Constructor functions with more options are available in mata::nft::builder.
+     *
+     * @param other NFA to be converted to NFT.
+     * @param levels Levels for the states of the NFA @c other.
+     */
+    explicit Nft(Nfa&& other, Levels levels): Nfa{ std::move(other) }, levels{ std::move(levels) } {}
+
+    Nft& operator=(const Nfa& other) noexcept;
+    Nft& operator=(Nfa&& other) noexcept;
 
     /**
      * Add a new (fresh) state to the automaton.
@@ -805,15 +758,13 @@ public:
      * @brief Make NFT complete in place.
      *
      * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
-     *  transitions from given `state`) to `sink_states[level]` where `level == this->levels[state]`.
-     * If @p sink_states contain states that do not belong to the NFT, they are added to it, but only in the case that
-     *  some transition to those states were added.
+     *  transitions from given `state`) to `sink_states[next_level(level)]` where `level == this->levels[state]`.
      * If NFT does not contain any states, this function does nothing.
      *
      * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
      *  defined, otherwise use @c this->delta.get_used_symbols().
-     * @param[in] sink_states The level-indexed vector of sink states, one per level into which new transitions are
-     *  added. If @c std::nullopt, add new sink states.
+     * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
+     *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
@@ -825,9 +776,7 @@ public:
      * @brief Make NFT complete in place.
      *
      * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
-     *  transitions from given `state`) to `sink_states[level]` where `level == this->levels[state]`.
-     * If @p sink_states contain states that do not belong to the NFT, they are added to it, but only in the case that
-     *  some transition to those states were added.
+     *  transitions from given `state`) to `sink_states[next_level(level)]` where `level == this->levels[state]`.
      * If NFT does not contain any states, this function does nothing.
      *
      * @note This overloaded version is a more efficient version which does not need to compute the set of symbols to
@@ -835,8 +784,8 @@ public:
      *  to complete multiple automata over the same set of symbols.
      *
      * @param[in] symbols Symbols to compute "missing" symbols from.
-     * @param[in] sink_states The level-indexed vector of sink states, one per level into which new transitions are
-     *  added. If @c std::nullopt, add new sink states.
+     * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
+     *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
@@ -845,6 +794,7 @@ public:
     );
 
     using super::is_complete;
+    using super::is_deterministic;
 }; // class Nft.
 
 // Allow variadic number of arguments of the same type.
@@ -899,7 +849,7 @@ Nft intersection(const Nft& lhs, const Nft& rhs,
  * the transitions of `rhs` followed by next synchronization level (if exists). By default, synchronization
  * levels are projected out from the resulting NFT.
  *
- * Vectors of synchronization levels have to be non-empty and of the the same size.
+ * Vectors of synchronization levels have to be non-empty and of the same size.
  *
  * @param[in] lhs First transducer to compose.
  * @param[in] rhs Second transducer to compose.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -763,12 +763,15 @@ public:
      *
      * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
      *  defined, otherwise use @c this->delta.get_used_symbols().
+     * @param epsilons Epsilon symbols to include when computing "missing" symbols. Epsilon symbols are handled as normal
+     *  alphabet symbols.
      * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
      *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
         const Alphabet* alphabet = nullptr,
+        const utils::OrdVector<Symbol>& epsilons = {},
         const std::optional<std::vector<State>>& sink_states = std::nullopt
     );
 
@@ -784,12 +787,15 @@ public:
      *  to complete multiple automata over the same set of symbols.
      *
      * @param[in] symbols Symbols to compute "missing" symbols from.
+     * @param epsilons Epsilon symbols to include when computing "missing" symbols. Epsilon symbols are handled as normal
+     *  alphabet symbols.
      * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
      *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
         const utils::OrdVector<Symbol>& symbols,
+        const utils::OrdVector<Symbol>& epsilons = {},
         const std::optional<std::vector<State>>& sink_states = std::nullopt
     );
 

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -5,11 +5,12 @@
 #ifndef MATA_NFT_TYPES_HH
 #define MATA_NFT_TYPES_HH
 
+#include <optional>
 #include <utility>
 
 #include "mata/alphabet.hh"
-
 #include "mata/nfa/types.hh"
+#include "mata/utils/sparse-set.hh"
 
 namespace mata::nft {
 
@@ -77,6 +78,177 @@ constexpr Symbol DONT_CARE = EPSILON - 1;
 
 constexpr Level DEFAULT_LEVEL{ 0 };
 constexpr Level DEFAULT_NUM_OF_LEVELS{ 2 };
+
+class Levels: std::vector<Level> {
+    using super = std::vector<Level>;
+public:
+    /**
+     * @brief Number of levels (tracks) the transducer recognizes. Each transducer transition will comprise
+     *  @c num_of_levels of NFA transitions.
+     *
+     * @note The number of levels has to be at least 1.
+     */
+    size_t num_of_levels{ DEFAULT_NUM_OF_LEVELS };
+
+    // explicit Levels(const std::vector<Level>& levels): super{ levels }, num_of_levels{ num_of_levels_of(levels).value_or(DEFAULT_NUM_OF_LEVELS) } {}
+    // explicit Levels(std::vector<Level>&& levels): super{ std::move(levels) } { num_of_levels = num_of_levels_of(*this).value_or(DEFAULT_NUM_OF_LEVELS); }
+    explicit Levels(const size_t num_of_levels, std::vector<Level> levels = {}): super{ std::move(levels) }, num_of_levels{ num_of_levels } {}
+    Levels() = default;
+    Levels(size_t num_of_levels, size_t count, Level value = DEFAULT_LEVEL);
+    Levels(size_t num_of_levels, std::initializer_list<Level> levels);
+    Levels(size_t num_of_levels, iterator first, iterator last);
+
+    Levels(const Levels& other) = default;
+    Levels(Levels&& other) = default;
+    Levels& operator=(const Levels& other) = default;
+    Levels& operator=(Levels&& other) = default;
+    Levels& operator=(std::initializer_list<value_type> other);
+    Levels& operator=(const std::vector<Level>& levels);
+    Levels& operator=(std::vector<Level>&& levels);
+
+    using
+        // Member types.
+        super::value_type,
+        super::allocator_type,
+        super::size_type,
+        super::difference_type,
+        super::reference,
+        super::const_reference,
+        super::pointer,
+        super::const_pointer,
+        super::iterator,
+        super::const_iterator,
+        super::reverse_iterator,
+        super::const_reverse_iterator,
+        // Member functions.
+        super::assign,
+        // super::assign_range // TODO(C++23): Enable when switching to C++23.
+        super::get_allocator,
+        // - Element access.
+        super::at,
+        super::operator[],
+        super::front,
+        super::back,
+        super::data,
+        super::begin,
+        super::cbegin,
+        super::end,
+        super::cend,
+        super::rbegin,
+        super::crbegin,
+        super::rend,
+        super::crend,
+        // - Capacity.
+        super::empty,
+        super::size,
+        super::max_size,
+        super::reserve,
+        super::capacity,
+        super::shrink_to_fit,
+        // - Modifiers.
+        super::clear,
+        super::insert,
+        // super::insert_range, // TODO(C++23): Enable when switching to C++23.
+        super::emplace,
+        super::erase,
+        super::push_back,
+        super::emplace_back,
+        // super::append_range, // TODO(C++23): Enable when switching to C++23.
+        super::pop_back,
+        super::resize,
+        super::swap;
+
+    std::weak_ordering operator<=>(const Levels& other) const = default;
+    bool operator==(const Levels& other) const = default;
+    bool operator==(const std::vector<Level>& other) const { return static_cast<std::vector<Level>>(*this) == other; }
+
+    Levels& set(State state, Level level = DEFAULT_LEVEL);
+    Levels& set(const std::vector<Level>& levels);
+    Levels& set(std::vector<Level>&& levels);
+
+    /**
+     * @brief Append @p levels_vector to the end of @c this.
+     *
+     * @param[in] levels_vector Vector of levels to be appended.
+     */
+    void append(const Levels& levels_vector);
+
+    /**
+     * @brief Count the number of occurrences of a level in @c this.
+     *
+     * @param[in] level Level to be counted.
+     */
+    size_t count(const Level level) const { return static_cast<size_t>(std::count(begin(), end(), level)); }
+
+    /**
+     * @brief Get levels of states in @p states.
+     */
+    std::vector<Level> get_levels_of(const utils::SparseSet<State>& states) const;
+    /**
+     * @brief Get levels of states in @p states.
+     */
+    std::vector<Level> get_levels_of(const StateSet& states) const;
+
+    /**
+     * @brief Get the minimal level for the states in @p states.
+     *
+     * "Minimal level" is defined as the level with the lowest numerical value, i.e., `0 < 1 < 2 < ... < num_of_levels-1`.
+     * "Minimal" often relates to the current states ("What is the current state with minimal level?")
+     */
+    std::optional<Level> get_minimal_level_of(
+            const StateSet& states, LevelsOrdering::Compare levels_ordering = LevelsOrdering::Minimal) const;
+
+    /**
+     * @brief Get the minimal next level for the states in @p states.
+     *
+     * "Minimal next level" is defined as the minimal level in the next transition (that may follow another level),
+     *  i.e., `1 < 2 < ... < num_of_levels-1 < 0`.
+     * "Minimal next" relates to the next target states ("What is the next minimal level to target in a transition?").
+     */
+    std::optional<Level> get_minimal_next_level_of(const StateSet& states) const;
+
+    /**
+     * @brief Check whether a transition can be made from a state with level @p source_level to a state with level
+     *  @p target_level.
+     *
+     * A transition can be made if the target level is higher than the source level, or we can always jump to a state
+     *  with level 0.
+     *
+     * @param[in] source_level Level of the source state.
+     * @param[in] target_level Level of the target state.
+     * @return @c true if the transition can be made, @c false otherwise.
+     */
+    static bool can_follow(Level source_level, Level target_level);
+
+    /**
+     * @brief Check whether a transition can be made from @p source to @p target.
+     *
+     * A transition can be made if the level of @p target is higher than the level of @p source, or if the level of
+     *  @p target is 0.
+     *
+     * @param[in] source Source state.
+     * @param[in] target Target state.
+     * @return @c true if the transition can be made, @c false otherwise.
+     */
+    bool can_follow_for_states(State source, State target) const;
+
+    std::optional<size_t> num_of_levels_used() const { return num_of_levels_of(*this); }
+
+    static std::optional<size_t> num_of_levels_of(const Levels& levels) {
+        if (levels.empty()) { return std::nullopt; }
+        return std::ranges::max(levels) + 1;
+    }
+    static std::optional<size_t> num_of_levels_of(const std::vector<Level>& levels) {
+        if (levels.empty()) { return std::nullopt; }
+        return std::ranges::max(levels) + 1;
+    }
+    static std::optional<size_t> num_of_levels_of(const std::initializer_list<Level> levels) {
+        if (levels.size() == 0) { return std::nullopt; }
+        return std::ranges::max(levels) + 1;
+    }
+private:
+    bool check_levels_in_range_() const { return std::ranges::all_of(*this, [&](const Level level) { return level < num_of_levels; }); }
+};
 
 } // namespace mata::nft.
 

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -18,28 +18,6 @@ extern const std::string TYPE_NFT;
 
 using Level = unsigned;
 
-/**
- * @brief Classes for levels ordering in NFTs.
- */
-class LevelsOrdering {
-public:
-    using Compare = std::function<bool(Level, Level)>;
-    /**
-     * @brief Ordering for Levels in NFTs where lower levels precede higher levels.
-     *
-     * That is, levels are ordered as follows: 0 < 1 < 2 < ... < num_of_levels-1.
-     */
-    static bool Minimal(const Level lhs, const Level rhs) { return std::less()(lhs, rhs); }
-    /**
-     * @brief Ordering for levels in NFTs where lower levels precede higher levels, except for 0 which is the highest level.
-     *
-     * That is, levels are ordered as follows: 1 < 2 < ... < num_of_levels-1 < 0.
-     * This ordering is used when handling intermediate states (with non-zero levels) in NFTs for determining the next lowest
-     *  level of the next state.
-     */
-    static bool Next(const Level lhs, const Level rhs) { return lhs == 0 ? false : rhs == 0 ? true : lhs < rhs; }
-};
-
 using State = mata::nfa::State;
 using StateSet = mata::nfa::StateSet;
 
@@ -82,6 +60,26 @@ constexpr Level DEFAULT_NUM_OF_LEVELS{ 2 };
 class Levels: std::vector<Level> {
     using super = std::vector<Level>;
 public:
+    /// @brief Orderings of levels.
+    class Ordering {
+    public:
+        using Compare = std::function<bool(Level, Level)>;
+        /**
+         * @brief Ordering for Levels in NFTs where lower levels precede higher levels.
+         *
+         * That is, levels are ordered as follows: 0 < 1 < 2 < ... < num_of_levels-1.
+         */
+        static bool Minimal(const Level lhs, const Level rhs) { return std::less()(lhs, rhs); }
+        /**
+         * @brief Ordering for levels in NFTs where lower levels precede higher levels, except for 0 which is the highest level.
+         *
+         * That is, levels are ordered as follows: 1 < 2 < ... < num_of_levels-1 < 0.
+         * This ordering is used when handling intermediate states (with non-zero levels) in NFTs for determining the next lowest
+         *  level of the next state.
+         */
+        static bool Next(const Level lhs, const Level rhs) { return lhs == 0 ? false : rhs == 0 ? true : lhs < rhs; }
+    };
+
     /**
      * @brief Number of levels (tracks) the transducer recognizes. Each transducer transition will comprise
      *  @c num_of_levels of NFA transitions.
@@ -196,7 +194,7 @@ public:
      * "Minimal" often relates to the current states ("What is the current state with minimal level?")
      */
     std::optional<Level> get_minimal_level_of(
-            const StateSet& states, LevelsOrdering::Compare levels_ordering = LevelsOrdering::Minimal) const;
+            const StateSet& states, Ordering::Compare levels_ordering = Ordering::Minimal) const;
 
     /**
      * @brief Get the minimal next level for the states in @p states.
@@ -246,6 +244,7 @@ public:
         if (levels.size() == 0) { return std::nullopt; }
         return std::ranges::max(levels) + 1;
     }
+
 private:
     bool check_levels_in_range_() const { return std::ranges::all_of(*this, [&](const Level level) { return level < num_of_levels; }); }
 };

--- a/src/applications/strings/noodlification.cc
+++ b/src/applications/strings/noodlification.cc
@@ -1,6 +1,8 @@
 /* nfa-noodlification.cc -- Noodlification of NFAs
  */
 
+#include <ranges>
+
 #include "mata/utils/utils.hh"
 #include "mata/nfa/nfa.hh"
 #include "mata/nft/builder.hh"
@@ -20,9 +22,8 @@ namespace {
 size_t get_num_of_permutations(const seg_nfa::Segmentation::EpsilonDepthTransitions& epsilon_depths)
 {
     size_t num_of_permutations{ 1 };
-    for (const auto& segment: epsilon_depths)
-    {
-        num_of_permutations *= segment.second.size();
+    for (const auto& transitions_at_depth : epsilon_depths | std::views::values) {
+        num_of_permutations *= transitions_at_depth.size();
     }
     return num_of_permutations;
 }
@@ -46,7 +47,7 @@ void unify_initial_and_final_states(const std::vector<std::shared_ptr<Nfa>>& nfa
     }
 }
 
-Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol delimiter) {
+Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, const mata::Symbol delimiter) {
     Nfa concatenation{*nfas[0]};
     for (size_t i = 1; i < nfas.size(); ++i) {
         concatenation = mata::nfa::algorithms::concatenate_eps(concatenation, *nfas[i], delimiter, true);
@@ -63,7 +64,7 @@ Nfa concatenate_with(const std::vector<std::shared_ptr<Nfa>>& nfas, mata::Symbol
  * coming from the initial state have epsilon on the first tape.
  */
 bool is_nft_homomorphic(const std::shared_ptr<Nft> nft) {
-    if (nft->num_of_levels != 2) {
+    if (nft->levels.num_of_levels != 2) {
         return false;
     }
 
@@ -463,7 +464,7 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
     Nft concatenated_output_nft(std::move(concatenated_output));
 
     auto add_self_loop_for_every_default_state = [](Nft& nft, Symbol symbol) {
-        Word sym_word(nft.num_of_levels, symbol);
+        Word sym_word(nft.levels.num_of_levels, symbol);
 
         size_t original_num_of_states = nft.num_of_states();
         for (State s{ 0 }; s < original_num_of_states; s++) {
@@ -498,6 +499,7 @@ std::vector<seg_nfa::TransducerNoodle> seg_nfa::noodlify_for_transducer(
         intersection = *nft;
         // we intersect input nfa with nft on the input track but we need to add INPUT_DELIMITER as an "epsilon transition" of nft
         add_self_loop_for_every_default_state(intersection, INPUT_DELIMITER);
+
         intersection = mata::nft::compose(concatenated_input_nft, intersection, 0, 0, false);
     }
     intersection.trim();

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -192,9 +192,9 @@ Nfa mata::applications::strings::replace::reluctant_nfa(Nfa nfa) {
 Nft mata::applications::strings::replace::create_identity(Alphabet const* const alphabet, const size_t num_of_levels) {
     if (num_of_levels == 0) { throw std::runtime_error("NFT must have at least one level"); }
     const auto alphabet_symbols{ alphabet->get_alphabet_symbols() };
-//    const size_t additional_states_per_symbol_num{ num_of_levels - 1 };
-//    const size_t num_of_states{ alphabet_symbols.size() * additional_states_per_symbol_num + 1 };
-    Nft nft{ 1, { 0 }, { 0 }, { 0 }, num_of_levels };
+    // const size_t additional_states_per_symbol_num{ num_of_levels - 1 };
+    // const size_t num_of_states{ alphabet_symbols.size() * additional_states_per_symbol_num + 1 };
+    Nft nft{ Nft::with_levels({num_of_levels, { 0 } }, 1, { 0 }, { 0 }) };
     nft.insert_identity(0, alphabet_symbols.to_vector());
     return nft;
 }
@@ -460,7 +460,7 @@ Nft applications::strings::replace::replace_reluctant_literal(const Word& litera
 Nft ReluctantReplace::replace_literal_nft(const Word& literal, const Word& replacement, Alphabet const* const alphabet,
                                       const Symbol end_marker, ReplaceMode replace_mode) {
     Nft nft{};
-    nft.num_of_levels = 2;
+    nft.levels.num_of_levels = 2;
     State init_state{ nft.add_state_with_level(0) };
     nft.initial.insert(init_state);
     const std::vector<std::pair<State, Word>> state_word_pairs{
@@ -538,15 +538,15 @@ Nft ReluctantReplace::replace_literal(const Word& literal, const Word& replaceme
     // ; by t’, starting with the first occurrence and proceeding in
     // ; left-to-right order.
     // (str.replace_all String String String String)
-    if (replace_mode == ReplaceMode::All && literal == Word{}) {
+    if (replace_mode == ReplaceMode::All && literal.empty()) {
         return applications::strings::replace::create_identity(alphabet);
     }
 
     ReluctantReplace reluctant_replace{};
     Nft nft_end_marker{ [&]() {
         Nft nft_end_marker{ create_identity(alphabet) };
-        State middle{ nft_end_marker.add_state_with_level(1) };
-        State end_marker_state{ nft_end_marker.add_state_with_level(0) };
+        const State middle{ nft_end_marker.add_state_with_level(1) };
+        const State end_marker_state{ nft_end_marker.add_state_with_level(0) };
         nft_end_marker.delta.add(*nft_end_marker.initial.begin(), EPSILON, middle);
         nft_end_marker.delta.add(middle, end_marker, end_marker_state);
         nft_end_marker.final.clear();

--- a/src/applications/strings/strings.cc
+++ b/src/applications/strings/strings.cc
@@ -212,10 +212,10 @@ bool mata::applications::strings::is_lang_eps(const Nfa& aut) {
 }
 
 std::optional<std::vector<mata::Word>> mata::applications::strings::get_words_of_lengths(const Nft& nft, std::vector<unsigned> lengths) {
-    assert(nft.num_of_levels == lengths.size());
+    assert(nft.levels.num_of_levels == lengths.size());
     assert(!nft.contains_jump_transitions());
     if (nft.initial.empty() || nft.final.empty()) { return std::nullopt; }
-    if (nft.initial.intersects_with(nft.final) && std::ranges::all_of(lengths, [](int x) { return x == 0; })) { return std::vector<mata::Word>(nft.num_of_levels, mata::Word()); }
+    if (nft.initial.intersects_with(nft.final) && std::ranges::all_of(lengths, [](int x) { return x == 0; })) { return std::vector<mata::Word>(nft.levels.num_of_levels, mata::Word()); }
 
     for (const State initial_state: nft.initial) {
         /// Current state, its state post iterator, its end iterator, and iterator in the current symbol post to target states.
@@ -271,8 +271,8 @@ std::optional<std::vector<mata::Word>> mata::applications::strings::get_words_of
                 if (!worklist.empty()) {
                     auto& [prev_state, prev_state_post_it, prev_state_post_end, prev_targets_it]{ worklist.back() };
                     assert(prev_state_post_it != prev_state_post_end);
-                    Symbol prev_symbol = prev_state_post_it->symbol;
-                    nft::Level prev_level = nft.levels[prev_state];
+                    const Symbol prev_symbol = prev_state_post_it->symbol;
+                    const nft::Level prev_level = nft.levels[prev_state];
                     if (prev_symbol != EPSILON) {
                         assert(!result[prev_level].empty() && result[prev_level].back() == prev_symbol);
                         result[prev_level].pop_back();

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -486,20 +486,16 @@ Nfa mata::nfa::revert(const Nfa& aut) {
 
 bool mata::nfa::Nfa::is_deterministic() const {
     if (initial.size() != 1) { return false; }
-
     if (delta.empty()) { return true; }
 
-    const size_t aut_size = num_of_states();
+    const size_t aut_size{ num_of_states() };
     for (size_t i = 0; i < aut_size; ++i) {
-        for (const auto& symStates : delta[i]) {
-            if (symStates.num_of_targets() != 1) { return false; }
-        }
+        for (const auto& symbol_post : delta[i]) { if (symbol_post.num_of_targets() != 1) { return false; } }
     }
-
     return true;
 }
 
-bool Nfa::is_complete(Alphabet const* const alphabet) const {
+bool Nfa::is_complete(const Alphabet* const alphabet) const {
     return is_complete(get_symbols_to_work_with(*this, alphabet));
 }
 

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -104,7 +104,7 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
             if (level < 0) {
                 throw std::runtime_error("Bad format of levels: level " + it->second[0] + " is out of range.");
             }
-            aut.num_of_levels = static_cast<Level>(level);
+            aut.levels.num_of_levels = static_cast<Level>(level);
         } catch (const std::invalid_argument&) {
             throw std::runtime_error("Bad format of levels: unsupported level " + it->second[0]);
         } catch (const std::out_of_range&) {
@@ -227,18 +227,18 @@ Nft builder::create_single_word_nft(const std::vector<std::string>& word, mata::
 
 Nft builder::create_empty_string_nft(const size_t num_of_levels) {
     Nft nft{ nfa::builder::create_empty_string_nfa() };
-    nft.num_of_levels = num_of_levels;
+    nft.levels.num_of_levels = num_of_levels;
     return nft;
 }
 
 Nft builder::create_sigma_star_nft(const size_t num_of_levels) {
-    Nft nft{ 1, { 0 }, { 0 }, { 0 }, num_of_levels };
+    Nft nft{ Nft::with_levels({num_of_levels, { 0 } }, 1, { 0 }, { 0 })};
     nft.delta.add(0, DONT_CARE, 0);
     return nft;
 }
 
 Nft builder::create_sigma_star_nft(const mata::Alphabet* alphabet, const size_t num_of_levels) {
-    Nft nft{1, { 0 }, { 0 }, { 0 }, num_of_levels};
+    Nft nft{ Nft::with_levels({num_of_levels, { 0 } }, 1, { 0 }, { 0 }) };
     nft.insert_identity(0, alphabet->get_alphabet_symbols().to_vector());
     return nft;
 }
@@ -285,12 +285,8 @@ Nft builder::from_nfa_with_levels_zero(const mata::nfa::Nfa& nfa, const size_t n
     }
 
     const size_t nfa_num_of_states{ nfa.num_of_states() };
-    Nft nft{ nfa_num_of_states, nfa.initial, nfa.final, {}, num_of_levels };
+    Nft nft{ Nft::with_levels(num_of_levels, nfa_num_of_states, nfa.initial, nfa.final) };
 
-    State first_level_state;
-    State inner_src;
-    State inner_tgt;
-    Symbol inner_symbol;
     for(State src{ 0 }; src < nfa_num_of_states; ++src) {
         for (const SymbolPost& symbol_post: nfa.delta[src]) {
             if (symbol_post.symbol == EPSILON && (!next_levels_symbol.has_value() || next_levels_symbol.value() == EPSILON)) {
@@ -298,17 +294,17 @@ Nft builder::from_nfa_with_levels_zero(const mata::nfa::Nfa& nfa, const size_t n
                 continue;
             }
 
-            first_level_state = nft.add_state_with_level(1);
-            inner_symbol = next_levels_symbol.has_value() ? next_levels_symbol.value() : symbol_post.symbol;
+            const State first_level_state = nft.add_state_with_level(1);
+            const Symbol inner_symbol = next_levels_symbol.has_value() ? next_levels_symbol.value() : symbol_post.symbol;
             for (const State tgt: symbol_post.targets) {
                 // Transition from level 0 to level 1
                 nft.delta.add(src, symbol_post.symbol, first_level_state);
-                inner_src = first_level_state;
+                State inner_src = first_level_state;
 
                 // Transition from level 1 to level num_of_levels-1
                 if (explicit_transitions) {
                     for (Level tgt_level{ 2 }; tgt_level < num_of_levels; ++tgt_level) {
-                        inner_tgt = nft.add_state_with_level(tgt_level);
+                        const State inner_tgt = nft.add_state_with_level(tgt_level);
                         nft.delta.add(inner_src, inner_symbol, inner_tgt);
                         inner_src = inner_tgt;
                     }
@@ -325,14 +321,13 @@ Nft builder::from_nfa_with_levels_zero(const mata::nfa::Nfa& nfa, const size_t n
 
 Nft builder::from_nfa_with_levels_advancing(mata::nfa::Nfa nfa, size_t num_of_levels) {
     Nft result{ std::move(nfa) };
-    result.levels = Levels(result.num_of_states(), static_cast<Level>(num_of_levels)); // num_of_levels represents that the state does not have level assigned yet
-    result.num_of_levels = num_of_levels;
+    std::vector<Level> levels( result.num_of_states(), static_cast<Level>(num_of_levels)); // num_of_levels represents that the state does not have level assigned yet
 
     // We apply simple DFS
     StateSet worklist; // worklist for DFS
     for (State initial_state : result.initial) {
         // start with initial states, which should be level 0
-        result.levels[initial_state] = 0;
+        levels[initial_state] = 0;
         worklist.insert(initial_state);
     }
 
@@ -340,21 +335,22 @@ Nft builder::from_nfa_with_levels_advancing(mata::nfa::Nfa nfa, size_t num_of_le
         State state_to_process = worklist.back();
         worklist.pop_back();
         for (State tgt : result.delta[state_to_process].get_successors()) {
-            Level next_level = result.levels[state_to_process] + 1;
+            Level next_level = levels[state_to_process] + 1;
             if (next_level == num_of_levels) {
                 next_level = 0;
             }
-            if (result.levels[tgt] == num_of_levels) { // tgt does not have a level yet
+            if (levels[tgt] == num_of_levels) { // tgt does not have a level yet
                 if (next_level != 0 && result.final.contains(tgt)) {
                     throw std::runtime_error("Creating Nft from Nfa that does not represent a valid Nft (final state is not at level 0) in mata::nft::Nft::from_nfa_with_levels_advancing()");
                 }
-                result.levels[tgt] = next_level;
+                levels[tgt] = next_level;
                 worklist.insert(tgt);
-            } else if (result.levels[tgt] != next_level) {
+            } else if (levels[tgt] != next_level) {
                 throw std::runtime_error("Creating Nft from Nfa that does not represent a valid Nft (a state has more possible levels) in mata::nft::Nft::from_nfa_with_levels_advancing()");
             }
         }
     }
+    result.levels = Levels{ num_of_levels, std::move(levels) };
 
     return result;
 }

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -20,8 +20,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
     // The loop word is constructed using the EPSILON symbol for all levels, except for the levels
     // where is_dcare_on_transition is true, in which case the DONT_CARE symbol is used.
     auto insert_self_loops = [&](Nft &nft, const BoolVector &is_dcare_on_transition) {
-        Word loop_word(nft.num_of_levels, EPSILON);
-        for (size_t i{ 0 }; i < nft.num_of_levels; i++) {
+        Word loop_word(nft.levels.num_of_levels, EPSILON);
+        for (size_t i{ 0 }; i < nft.levels.num_of_levels; i++) {
             if (is_dcare_on_transition[i]) {
                 loop_word[i] = DONT_CARE;
             }
@@ -60,8 +60,8 @@ Nft compose(const Nft& lhs, const Nft& rhs, const OrdVector<Level>& lhs_sync_lev
         ++rhs_sync_levels_it;
     }
     // After the last synchronization level (i == |sync|)
-    lhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(lhs.num_of_levels) - *(lhs_sync_levels_it - 1) - 1);
-    rhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(rhs.num_of_levels) - *(rhs_sync_levels_it - 1) - 1);
+    lhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(lhs.levels.num_of_levels) - *(lhs_sync_levels_it - 1) - 1);
+    rhs_nonsync_levels_cnt.push_back(static_cast<unsigned>(rhs.levels.num_of_levels) - *(rhs_sync_levels_it - 1) - 1);
 
     // Construct a mask for new levels in lhs and rhs.
     // For each synchronization block (non-synchronization levels up to a synchronization transition),

--- a/src/nft/concatenation.cc
+++ b/src/nft/concatenation.cc
@@ -15,7 +15,7 @@ Nft concatenate(const Nft& lhs, const Nft& rhs, bool use_epsilon,
 }
 
 Nft& Nft::concatenate(const Nft& aut) {
-    assert(num_of_levels == aut.num_of_levels);
+    assert(levels.num_of_levels == aut.levels.num_of_levels);
     size_t n = this->num_of_states();
     auto upd_fnc = [&](State st) {
         return st + n;
@@ -61,25 +61,25 @@ Nft& Nft::concatenate(const Nft& aut) {
 
 Nft algorithms::concatenate_eps(const Nft& lhs, const Nft& rhs, const Symbol& epsilon, bool use_epsilon,
                                 StateRenaming* lhs_state_renaming, StateRenaming* rhs_state_renaming) {
-    assert(lhs.num_of_levels == rhs.num_of_levels);
+    assert(lhs.levels.num_of_levels == rhs.levels.num_of_levels);
     // Compute concatenation of given automata.
     // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
 
     if (lhs.num_of_states() == 0 || rhs.num_of_states() == 0 || lhs.initial.empty() || lhs.final.empty() ||
         rhs.initial.empty() || rhs.final.empty()) {
-        return Nft::with_levels(lhs.num_of_levels);
+        return Nft::with_levels(lhs.levels.num_of_levels);
     }
 
     const unsigned long lhs_states_num{ lhs.num_of_states() };
     const unsigned long rhs_states_num{ rhs.num_of_states() };
-    Nft result{ Nft::with_levels(lhs.num_of_levels) }; // Concatenated automaton.
+    Nft result{ Nft::with_levels(lhs.levels.num_of_levels) }; // Concatenated automaton.
     StateRenaming _lhs_states_renaming{}; // Map mapping rhs states to result states.
     StateRenaming _rhs_states_renaming{}; // Map mapping rhs states to result states.
 
     const size_t result_num_of_states{lhs_states_num + rhs_states_num};
-    if (result_num_of_states == 0) { return Nft{ Nft::with_levels(lhs.num_of_levels) }; }
+    if (result_num_of_states == 0) { return Nft{ Nft::with_levels(lhs.levels.num_of_levels) }; }
 
-    result = Nft::with_levels(lhs.num_of_levels);
+    result = Nft::with_levels(lhs.levels.num_of_levels);
     result.delta = lhs.delta;
     result.initial = lhs.initial;
     result.add_state(result_num_of_states-1);
@@ -103,7 +103,7 @@ Nft algorithms::concatenate_eps(const Nft& lhs, const Nft& rhs, const Symbol& ep
 
     // Add epsilon transitions connecting lhs and rhs automata.
     // The epsilon transitions lead from lhs original final states to rhs original initial states.
-    std::vector<Symbol> nft_epsilon(result.num_of_levels, epsilon);
+    const std::vector<Symbol> nft_epsilon(result.levels.num_of_levels, epsilon);
     for (const auto& lhs_final_state: lhs.final) {
         for (const auto& rhs_initial_state: rhs.initial) {
             result.add_transition(lhs_final_state, nft_epsilon,

--- a/src/nft/inclusion.cc
+++ b/src/nft/inclusion.cc
@@ -38,7 +38,7 @@ bool mata::nft::algorithms::is_included_antichains(
     Run*                   cex,
     const JumpMode         jump_mode)
 { // {{{
-    if (smaller.num_of_levels != bigger.num_of_levels) { return false; }
+    if (smaller.levels.num_of_levels != bigger.levels.num_of_levels) { return false; }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {
@@ -96,7 +96,7 @@ bool mata::nft::is_included(
 
 bool mata::nft::are_equivalent(const Nft& lhs, const Nft& rhs, const Alphabet *alphabet, const JumpMode jump_mode, const ParameterMap& params)
 {
-    if (lhs.num_of_levels != rhs.num_of_levels) { return false; }
+    if (lhs.levels.num_of_levels != rhs.levels.num_of_levels) { return false; }
 
     OrdVector<mata::Symbol> symbols;
     if (alphabet == nullptr) {

--- a/src/nft/intersection.cc
+++ b/src/nft/intersection.cc
@@ -33,10 +33,10 @@ Nft intersection(const Nft& lhs, const Nft& rhs, ProductMap *prod_map, const Jum
 
 //TODO: move this method to nft.hh? It is something one might want to use (e.g. for union, inclusion, equivalence of DFAs).
 Nft mata::nft::algorithms::product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State)>&& final_condition, ProductMap *product_map, const JumpMode jump_mode, const State lhs_first_aux_state, const State rhs_first_aux_state) {
-    assert(lhs.num_of_levels == rhs.num_of_levels);
+    assert(lhs.levels.num_of_levels == rhs.levels.num_of_levels);
 
     Nft product{}; // The product automaton.
-    product.num_of_levels = lhs.num_of_levels;
+    product.levels.num_of_levels = lhs.levels.num_of_levels;
     utils::TwoDimensionalMap<State> product_storage{lhs.num_of_states(), rhs.num_of_states()};
     std::deque<State> worklist{}; // Set of product states to process.
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -703,12 +703,19 @@ Nft Nft::apply(const Word& word, const Level level_to_apply_on, const bool proje
     return apply(nfa::builder::create_single_word_nfa(word), level_to_apply_on, project_out_applied_level, jump_mode);
 }
 
-bool Nft::make_complete(const Alphabet* const alphabet, const std::optional<std::vector<State>>& sink_states) {
-    return make_complete(get_symbols_to_work_with(*this, alphabet), sink_states);
+bool Nft::make_complete(
+        const Alphabet* const alphabet,
+        const OrdVector<Symbol>& epsilons,
+        const std::optional<std::vector<State>>& sink_states) {
+    return make_complete(get_symbols_to_work_with(*this, alphabet), epsilons, sink_states);
 }
 
-bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<std::vector<State>>& sink_states) {
+bool Nft::make_complete(
+        const OrdVector<Symbol>& symbols,
+        const OrdVector<Symbol>& epsilons,
+        const std::optional<std::vector<State>>& sink_states) {
     const size_t num_of_states_orig{ this->num_of_states() };
+    if (num_of_states_orig == 0) { return false; }
 
     const std::vector<State> sinks{ [&]{
         auto sinks_val{ sink_states.value_or(std::vector<State>{}) };
@@ -745,19 +752,28 @@ bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<st
     for (State state{ 0 }; state < num_of_states_orig; ++state) {
         used_symbols.clear();
         for (const SymbolPost& symbol_post : delta[state]) { used_symbols.insert(symbol_post.symbol); }
-        for (const auto unused_symbols{ symbols.difference(used_symbols) }; const Symbol symbol : unused_symbols) {
-            delta.add(state, symbol, sinks[next_level(levels[state])]);
-            transition_added = true;
-        }
+
+        auto add_transitions_to_sinks = [&](const auto& symbols_to_add) {
+            for (const Symbol symbol : symbols_to_add) {
+                delta.add(state, symbol, sinks[next_level(levels[state])]);
+                transition_added = true;
+            }
+        };
+        add_transitions_to_sinks(symbols.difference(used_symbols));
+        add_transitions_to_sinks(epsilons.difference(used_symbols));
     }
 
     // Add loops on sink states (from sink to a sink of the next level).
     if (transition_added && num_of_states_orig < this->num_of_states()) {
-        for (const Symbol symbol : symbols) {
+        auto add_transitions_between_sinks = [&](const auto& symbols_to_add) {
             for (Level level{ 0 }; level < levels.num_of_levels; ++level) {
-                delta.add(sinks[level], symbol, sinks[next_level(level)]);
+                for (const Symbol symbol : symbols_to_add) {
+                    delta.add(sinks[level], symbol, sinks[next_level(level)]);
+                }
             }
-        }
+        };
+        add_transitions_between_sinks(symbols);
+        add_transitions_between_sinks(epsilons);
     }
 
     return transition_added;

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -25,6 +25,64 @@ using StateBoolArray = std::vector<bool>; ///< Bool array for states in the auto
 
 constexpr std::string mata::nft::TYPE_NFT = "NFT";
 
+Levels::Levels(const size_t num_of_levels, const size_t count, const Level value): super(count, value), num_of_levels{ num_of_levels } {
+   assert(value < num_of_levels && "Levels::Levels: level is out of range of the set number of levels.");
+}
+
+Levels::Levels(const size_t num_of_levels, const std::initializer_list<Level> levels): super{ levels }, num_of_levels{ num_of_levels } {
+    assert(check_levels_in_range_() && "Levels::Levels: level is out of range of the set number of levels.");
+}
+
+Levels::Levels(const size_t num_of_levels, const iterator first, const iterator last): super{ first, last }, num_of_levels{ num_of_levels } {
+    assert(check_levels_in_range_() && "Levels::Levels: level is out of range of the set number of levels.");
+}
+
+Levels& Levels::operator=(const std::initializer_list<Level> other) {
+    super::operator=(other);
+    num_of_levels = num_of_levels_used().value_or(DEFAULT_NUM_OF_LEVELS);
+    return *this;
+}
+
+Levels& Levels::operator=(const std::vector<Level>& levels) {
+    if (this != &levels) {
+        super::operator=(levels);
+        num_of_levels = num_of_levels_used().value_or(DEFAULT_NUM_OF_LEVELS);
+    }
+    return *this;
+}
+
+Levels& Levels::operator=(std::vector<Level>&& levels) {
+    if (this != &levels) {
+        super::operator=(std::move(levels));
+        num_of_levels = num_of_levels_used().value_or(DEFAULT_NUM_OF_LEVELS);
+    }
+    return *this;
+}
+
+Levels& Levels::set(const State state, const Level level) {
+    assert(level < num_of_levels && "Levels::set: level is out of range of the set number of levels.");
+    if (size() <= state) { resize(state + 1, DEFAULT_LEVEL); }
+    (*this)[state] = level;
+    return *this;
+}
+
+Levels& Levels::set(const std::vector<Level>& levels) {
+    assert(check_levels_in_range_() && "Levels::set: level is out of range of the set number of levels.");
+    assign(levels.begin(), levels.end());
+    return *this;
+}
+
+Levels& Levels::set(std::vector<Level>&& levels) {
+    assert(check_levels_in_range_() && "Levels::set: level is out of range of the set number of levels.");
+    assign(std::make_move_iterator(levels.begin()), std::make_move_iterator(levels.end()));
+    return *this;
+}
+
+void Levels::append(const Levels& levels_vector) {
+    reserve(size() + levels_vector.size());
+    std::ranges::copy(levels_vector, std::back_inserter(*this));
+}
+
 std::vector<Level> Levels::get_levels_of(const utils::SparseSet<State>& states) const {
     std::vector<Level> result;
     result.reserve(states.size());
@@ -38,15 +96,13 @@ std::vector<Level> Levels::get_levels_of(const StateSet& states) const {
     return result;
 }
 
-Level Levels::get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering) const {
-    if (states.empty()) {
-        throw std::runtime_error("Levels::get_minimal_level_of: states is empty, no level can be obtained.");
-    }
+std::optional<Level> Levels::get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering) const {
+    if (states.empty()) { return std::nullopt; }
     auto levels = states | std::views::transform([&](const State& state) { return (*this)[state]; });
     return std::ranges::min(levels, std::move(levels_ordering));
 }
 
-Level Levels::get_minimal_next_level_of(const StateSet& states) const {
+std::optional<Level> Levels::get_minimal_next_level_of(const StateSet& states) const {
     return get_minimal_level_of(states, LevelsOrdering::Next);
 }
 
@@ -87,16 +143,18 @@ Nft& Nft::trim(StateRenaming* state_renaming) {
     final.filter(is_state_useful);
 
     // Specific for levels
-    //////////////////////
     State move_index{ 0 };
-    std::erase_if(levels,
-         [&](Level&) -> bool {
-             State prev{ move_index };
-             ++move_index;
-             return !useful_states[prev];
-         }
+    levels.erase(
+        std::ranges::remove_if(
+            levels,
+            [&](Level&) -> bool {
+                State prev{ move_index };
+                ++move_index;
+                return !useful_states[prev];
+            }
+        ).begin(),
+        levels.end()
     );
-    //////////////////////
 
     auto rename_state = [&](State q){return renaming[q];};
     initial.rename(rename_state);
@@ -312,7 +370,7 @@ void Nft::print_to_mata(std::ostream &output) const {
         }
         output << std::endl;
     }
-    output << "%LevelsNum " << num_of_levels << std::endl;
+    output << "%LevelsNum " << levels.num_of_levels << std::endl;
 
     for (const Transition& trans: delta.transitions()) {
         output << "q" << trans.source << " " << trans.symbol << " q" << trans.target << std::endl;
@@ -327,16 +385,16 @@ void Nft::print_to_mata(const std::string& filename) const {
     print_to_mata(output);
 }
 
-Nft Nft::get_one_letter_aut(const std::set<Level>& levels_to_keep, Symbol abstract_symbol) const {
-    mata::nft::Nft one_symbol_transducer{num_of_states(), initial, final, levels, num_of_levels};
-    for (mata::nfa::State source_state = 0; source_state < delta.num_of_states(); ++source_state) {
-        mata::nfa::StatePost& state_post_of_new_source_state = one_symbol_transducer.delta.mutable_state_post(source_state);
+Nft Nft::get_one_letter_aut(const std::set<Level>& levels_to_keep, const Symbol abstract_symbol) const {
+    Nft one_symbol_transducer{ Nft::with_levels(levels, num_of_states(), initial, final) };
+    for (nfa::State source_state = 0; source_state < delta.num_of_states(); ++source_state) {
+        nfa::StatePost& state_post_of_new_source_state = one_symbol_transducer.delta.mutable_state_post(source_state);
         if (levels_to_keep.contains(levels[source_state])) {
             state_post_of_new_source_state = delta[source_state];
         } else {
-            mata::nfa::SymbolPost new_transition{abstract_symbol};
-            for (const mata::nfa::SymbolPost& symbol_post : delta[source_state]) {
-                if (symbol_post.symbol == mata::nft::EPSILON) {
+            nfa::SymbolPost new_transition{abstract_symbol};
+            for (const nfa::SymbolPost& symbol_post : delta[source_state]) {
+                if (symbol_post.symbol == EPSILON) {
                     state_post_of_new_source_state.insert(symbol_post);
                 } else {
                     new_transition.targets.insert(symbol_post.targets);
@@ -374,16 +432,15 @@ void Nft::unwind_jumps_inplace(const utils::OrdVector<Symbol> &dont_care_symbol_
         }
     };
 
-    Level src_lvl, trg_lvl, diff_lvl;
-    for (const auto &transition : delta.transitions()) {
-        src_lvl = levels[transition.source];
-        trg_lvl = levels[transition.target];
-        diff_lvl = (trg_lvl == 0) ? (static_cast<Level>(num_of_levels) - src_lvl) : trg_lvl - src_lvl;
+    for (const auto& transition : delta.transitions()) {
+        const Level src_lvl = levels[transition.source];
+        const Level trg_lvl = levels[transition.target];
 
-        if (diff_lvl == 1 && transition.symbol == DONT_CARE && !dcare_for_dcare) {
+        if (const Level diff_lvl = (trg_lvl == 0) ? (static_cast<Level>(levels.num_of_levels) - src_lvl) : trg_lvl - src_lvl;
+            diff_lvl == 1 && transition.symbol == DONT_CARE && !dcare_for_dcare) {
             transitions_to_del.push_back(transition);
             for (const Symbol replace_symbol : dont_care_symbol_replacements) {
-                transitions_to_add.emplace_back( transition.source, replace_symbol, transition.target );
+                transitions_to_add.emplace_back(transition.source, replace_symbol, transition.target);
             }
         } else if (diff_lvl > 1) {
             transitions_to_del.push_back(transition);
@@ -400,8 +457,9 @@ void Nft::unwind_jumps_inplace(const utils::OrdVector<Symbol> &dont_care_symbol_
             inner_trg_lvl++;
 
             // Iterations 1 to n-1 connecting inner states.
-            Level pre_trg_lvl = (trg_lvl == 0) ? (static_cast<Level>(num_of_levels) - 1) : (trg_lvl - 1);
-            for (; inner_src_lvl < pre_trg_lvl; inner_src_lvl++, inner_trg_lvl++) {
+            for (const Level pre_trg_lvl = (trg_lvl == 0)
+                 ? (static_cast<Level>(levels.num_of_levels) - 1) : (trg_lvl - 1);
+                 inner_src_lvl < pre_trg_lvl; inner_src_lvl++, inner_trg_lvl++) {
                 inner_trg = add_state();
                 levels[inner_trg] = inner_trg_lvl;
 
@@ -414,12 +472,8 @@ void Nft::unwind_jumps_inplace(const utils::OrdVector<Symbol> &dont_care_symbol_
         }
     }
 
-    for (const Transition &transition : transitions_to_add) {
-        delta.add(transition);
-    }
-    for (const Transition &transition : transitions_to_del) {
-        delta.remove(transition);
-    }
+    for (const Transition& transition : transitions_to_add) { delta.add(transition); }
+    for (const Transition& transition : transitions_to_del) { delta.remove(transition); }
 }
 
 Nft Nft::unwind_jumps(const utils::OrdVector<Symbol> &dont_care_symbol_replacements, const JumpMode jump_mode) const {
@@ -440,7 +494,7 @@ Nft& Nft::operator=(Nft&& other) noexcept {
     if (this != &other) {
         mata::nfa::Nfa::operator=(other);
         levels = std::move(other.levels);
-        num_of_levels = other.num_of_levels;
+        levels.num_of_levels = other.levels.num_of_levels;
     }
     return *this;
 }
@@ -450,7 +504,7 @@ Nft& Nft::operator=(const mata::nfa::Nfa& other) noexcept {
     if (this != &other) {
         mata::nfa::Nfa::operator=(other);
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
-        num_of_levels = 1;
+        levels.num_of_levels = 1;
     }
     return *this;
 }
@@ -459,7 +513,7 @@ Nft& Nft::operator=(mata::nfa::Nfa&& other) noexcept {
     if (this != &other) {
         mata::nfa::Nfa::operator=(other);
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
-        num_of_levels = 1;
+        levels.num_of_levels = 1;
     }
     return *this;
 }
@@ -498,9 +552,9 @@ State Nft::insert_word(const State source, const Word &word, const State target)
     const size_t num_of_states_after = num_of_states();
     const Level source_level = levels[source];
 
-    Level lvl = (num_of_levels == 1) ? source_level : (source_level + 1) % static_cast<Level>(num_of_levels);
+    Level lvl = (levels.num_of_levels == 1) ? source_level : (source_level + 1) % static_cast<Level>(levels.num_of_levels);
     for (State state{ first_new_state }; state < num_of_states_after;
-         ++state, lvl = (lvl + 1) % static_cast<Level>(num_of_levels)) { add_state_with_level(state, lvl); }
+         ++state, lvl = (lvl + 1) % static_cast<Level>(levels.num_of_levels)) { add_state_with_level(state, lvl); }
 
     assert(levels[word_target] == 0 || levels[num_of_states_after - 1] < levels[word_target]);
 
@@ -513,7 +567,7 @@ State Nft::insert_word(const State source, const Word& word) {
 }
 
 State Nft::insert_word_by_parts(const State source, const std::vector<Word> &word_parts_on_levels, const State target) {
-    assert(word_parts_on_levels.size() == num_of_levels);
+    assert(word_parts_on_levels.size() == levels.num_of_levels);
     assert(source < num_of_states());
     assert(target < num_of_states());
     assert(source < levels.size());
@@ -521,14 +575,14 @@ State Nft::insert_word_by_parts(const State source, const std::vector<Word> &wor
     assert(levels[source] == levels[target]);
     const Level from_to_level{ levels[source] };
 
-    if (num_of_levels == 1) {
+    if (levels.num_of_levels == 1) {
         return Nft::insert_word(source, word_parts_on_levels[0], target);
     }
 
-    std::vector<mata::Word::const_iterator> word_part_it_v(num_of_levels);
-    for (Level lvl{ from_to_level }, i{ 0 }; i < static_cast<Level>(num_of_levels); ++i) {
+    std::vector<mata::Word::const_iterator> word_part_it_v(levels.num_of_levels);
+    for (Level lvl{ from_to_level }, i{ 0 }; i < static_cast<Level>(levels.num_of_levels); ++i) {
         word_part_it_v[lvl] = word_parts_on_levels[lvl].begin();
-        lvl = (lvl + 1) % static_cast<Level>(num_of_levels);
+        lvl = (lvl + 1) % static_cast<Level>(levels.num_of_levels);
     }
 
     // This function retrieves the next symbol from a word part at a specified level and advances the corresponding iterator.
@@ -541,7 +595,7 @@ State Nft::insert_word_by_parts(const State source, const std::vector<Word> &wor
     };
 
     // Add transition source --> inner_state.
-    Level inner_lvl = (num_of_levels == 1 ) ? 0 : (from_to_level + 1) % static_cast<Level>(num_of_levels);
+    Level inner_lvl = (levels.num_of_levels == 1 ) ? 0 : (from_to_level + 1) % static_cast<Level>(levels.num_of_levels);
     State inner_state = add_state_with_level(inner_lvl);
     delta.add(source, get_next_symbol(from_to_level), inner_state);
 
@@ -553,10 +607,10 @@ State Nft::insert_word_by_parts(const State source, const std::vector<Word> &wor
         word_parts_on_levels.end(),
         [](const Word& a, const Word& b) { return a.size() < b.size(); }
     )->size();
-    const size_t word_total_len = num_of_levels * max_word_part_len;
+    const size_t word_total_len = levels.num_of_levels * max_word_part_len;
     if (word_total_len != 0) {
         for (size_t symbol_idx{ 1 }; symbol_idx < word_total_len - 1; symbol_idx++) {
-            inner_lvl = (prev_lvl + 1) % static_cast<Level>(num_of_levels);
+            inner_lvl = (prev_lvl + 1) % static_cast<Level>(levels.num_of_levels);
             inner_state = add_state_with_level(inner_lvl);
             delta.add(prev_state, get_next_symbol(prev_lvl), inner_state);
             prev_state = inner_state;
@@ -596,22 +650,22 @@ Nft& Nft::insert_identity(const State state, const Symbol symbol, const JumpMode
     // FIXME(nft): Allow symbol jump transitions?
 //    if (jump_mode == JumpMode::RepeatSymbol) {
 //        delta.add(state, symbol, state);
-//        insert_word(state, Word(num_of_levels, symbol), state);
+//        insert_word(state, Word(levels.num_of_levels, symbol), state);
 //    } else {
-        insert_word(state, Word(num_of_levels, symbol), state);
+        insert_word(state, Word(levels.num_of_levels, symbol), state);
 //    }
     return *this;
 }
 
 bool Nft::contains_jump_transitions() const {
-    if (num_of_levels == 1) { return false; }
+    if (levels.num_of_levels == 1) { return false; }
 
     for (const Transition& transition : delta.transitions()) {
         const Level src_level{ levels[transition.source] };
         Level tgt_level{ levels[transition.target] };
         if (tgt_level == 0) {
-            // we want to check if the difference between src and tgt levels is at most 1 modulo num_of_levels
-            tgt_level = tgt_level + static_cast<Level>(num_of_levels);
+            // we want to check if the difference between src and tgt levels is at most 1 modulo levels.num_of_levels
+            tgt_level = tgt_level + static_cast<Level>(levels.num_of_levels);
         }
         if (tgt_level - src_level != 1) {
             return true;
@@ -626,14 +680,9 @@ void Nft::clear() {
 }
 
 bool Nft::is_identical(const Nft& aut) const {
-    return num_of_levels == aut.num_of_levels && levels == aut.levels && mata::nfa::Nfa::is_identical(aut);
+    return levels.num_of_levels == aut.levels.num_of_levels && levels == aut.levels && mata::nfa::Nfa::is_identical(aut);
 }
 
-Levels& Levels::set(const State state, const Level level) {
-    if (size() <= state) { resize(state + 1, DEFAULT_LEVEL); }
-    (*this)[state] = level;
-    return *this;
-}
 
 mata::nfa::Nfa Nft::to_nfa_update_copy(
     const utils::OrdVector<Symbol>& dont_care_symbol_replacements, const JumpMode jump_mode) const {
@@ -659,16 +708,22 @@ bool Nft::make_complete(const Alphabet* const alphabet, const std::optional<std:
 }
 
 bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<std::vector<State>>& sink_states) {
-    bool transition_added{ false };
-    const size_t num_of_states{ this->num_of_states() };
+    const size_t num_of_states_orig{ this->num_of_states() };
+
     const std::vector<State> sinks{ [&]{
         auto sinks_val{ sink_states.value_or(std::vector<State>{}) };
         if (sinks_val.empty()) {
-            for (Level level{ 0 }; level < num_of_levels; ++level) { sinks_val.push_back(add_state_with_level(level)); }
+            for (Level level{ 0 }; level < levels.num_of_levels; ++level) {
+                sinks_val.push_back(add_state_with_level(level));
+            }
         }
         assert(
+            sinks_val.size() == levels.num_of_levels &&
+            "Nft::make_complete: sink_states size must be equal to num_of_levels."
+        );
+        assert(
             [&]{
-                for (Level level{ 0 }; level < num_of_levels; ++level) {
+                for (Level level{ 0 }; level < levels.num_of_levels; ++level) {
                     const State sink_state{ sinks_val[level] };
                     if (sink_state >= this->num_of_states() || levels[sink_state] != level) {
                         return false;
@@ -681,11 +736,13 @@ bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<st
     }() };
 
     auto next_level = [&](const Level level) {
-        return (num_of_levels == 1) ? level : (level + 1) % static_cast<Level>(num_of_levels);
+        return (levels.num_of_levels == 1) ? level : (level + 1) % static_cast<Level>(levels.num_of_levels);
     };
 
+    // Add missing transitions from original states to sink states.
     OrdVector<Symbol> used_symbols{};
-    for (State state{ 0 }; state < num_of_states; ++state) {
+    bool transition_added{ false };
+    for (State state{ 0 }; state < num_of_states_orig; ++state) {
         used_symbols.clear();
         for (const SymbolPost& symbol_post : delta[state]) { used_symbols.insert(symbol_post.symbol); }
         for (const auto unused_symbols{ symbols.difference(used_symbols) }; const Symbol symbol : unused_symbols) {
@@ -694,9 +751,10 @@ bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<st
         }
     }
 
-    if (transition_added && num_of_states <= this->num_of_states()) {
+    // Add loops on sink states (from sink to a sink of the next level).
+    if (transition_added && num_of_states_orig < this->num_of_states()) {
         for (const Symbol symbol : symbols) {
-            for (Level level{ 0 }; level < num_of_levels; ++level) {
+            for (Level level{ 0 }; level < levels.num_of_levels; ++level) {
                 delta.add(sinks[level], symbol, sinks[next_level(level)]);
             }
         }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -96,14 +96,14 @@ std::vector<Level> Levels::get_levels_of(const StateSet& states) const {
     return result;
 }
 
-std::optional<Level> Levels::get_minimal_level_of(const StateSet& states, LevelsOrdering::Compare levels_ordering) const {
+std::optional<Level> Levels::get_minimal_level_of(const StateSet& states, Ordering::Compare levels_ordering) const {
     if (states.empty()) { return std::nullopt; }
     auto levels = states | std::views::transform([&](const State& state) { return (*this)[state]; });
     return std::ranges::min(levels, std::move(levels_ordering));
 }
 
 std::optional<Level> Levels::get_minimal_next_level_of(const StateSet& states) const {
-    return get_minimal_level_of(states, LevelsOrdering::Next);
+    return get_minimal_level_of(states, Ordering::Next);
 }
 
 bool Levels::can_follow(const Level source_level, const Level target_level) {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -52,7 +52,7 @@ namespace {
 
     Nft reduce_size_by_simulation(const Nft& aut, StateRenaming &state_renaming) {
         Nft result;
-        result.num_of_levels = aut.num_of_levels;
+        result.levels.num_of_levels = aut.levels.num_of_levels;
         const auto sim_relation = algorithms::compute_relation(
                 aut, ParameterMap{{ "relation", "simulation"}, { "direction", "forward"}});
 
@@ -67,8 +67,8 @@ namespace {
 
         // map each state q of aut to the state of the reduced automaton representing the simulation class of q
         for (State q = 0; q < num_of_states; ++q) {
-            const State qReprState = quot_proj[q];
-            if (state_renaming.count(qReprState) == 0) { // we need to map q's class to a new state in reducedAut
+            if (const State qReprState = quot_proj[q]; !state_renaming.contains(qReprState)) {
+                // we need to map q's class to a new state in reducedAut
                 assert(aut.levels[q] == aut.levels[qReprState]);
                 const State qClass = result.add_state_with_level(aut.levels[qReprState]);
                 state_renaming[qReprState] = qClass;
@@ -144,7 +144,7 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
     for (State state = 0; state != num_of_states; ++state) {
         if (aut.levels[state] == DEFAULT_LEVEL) {
             std::vector<std::vector<State>> state_safe_epsilon_runs{ {state} };
-            for (Level cur_level = 0; cur_level < aut.num_of_levels; ++cur_level) {
+            for (Level cur_level = 0; cur_level < aut.levels.num_of_levels; ++cur_level) {
                 std::vector<std::vector<State>> new_state_safe_epsilon_runs;
                 for (const std::vector<State>& safe_epsilon_run : state_safe_epsilon_runs) {
                     State state_s = safe_epsilon_run.back();
@@ -155,14 +155,14 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
                             // for levels > DEFAULT_LEVEL we do not want to have transitions that are not with empty symbol
                             continue;
                         }
-                        if (cur_level != aut.num_of_levels-1 && eps_move_it_s->targets.size() > 1) {
+                        if (cur_level != aut.levels.num_of_levels-1 && eps_move_it_s->targets.size() > 1) {
                             // if we are not at the last level (next level will be 0), we do not allow multiple epsilon transitions
                             // from state_s, as one could be on the path of fully epsilon run, while the other would not be, so we
                             // would mark something as safe epsilon run, which would not be safe
                             continue;
                         }
                         for (State target : eps_move_it_s->targets) {
-                            if (cur_level == aut.num_of_levels-1) {
+                            if (cur_level == aut.levels.num_of_levels-1) {
                                 // we are at the last level, next level will be 0
                                 assert(aut.levels[target] == DEFAULT_LEVEL);
                                 std::vector<State> new_safe_epsilon_run = safe_epsilon_run;
@@ -254,16 +254,16 @@ Nft mata::nft::remove_epsilon(const Nft& aut, Symbol epsilon) {
 
 Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels_to_project, const JumpMode jump_mode) {
     assert(!levels_to_project.empty());
-    assert(*std::max_element(levels_to_project.begin(), levels_to_project.end()) < nft.num_of_levels);
+    assert(*std::ranges::max_element(levels_to_project) < nft.levels.num_of_levels);
 
     // Checks if a given state is being projected out based on the levels_to_project vector.
-    auto is_projected_out = [&](State s) {
-        return levels_to_project.find(nft.levels[s]) != levels_to_project.end();
+    auto is_projected_out = [&](const State state) {
+        return levels_to_project.find(nft.levels[state]) != levels_to_project.end();
     };
 
     // Checks if each level between given states is being projected out.
-    auto is_projected_along_path = [&](State src, State tgt) {
-        Level stop_lvl = (nft.levels[tgt] == 0) ? static_cast<Level>(nft.num_of_levels) : nft.levels[tgt];
+    auto is_projected_along_path = [&](const State src, const State tgt) {
+        Level stop_lvl = (nft.levels[tgt] == 0) ? static_cast<Level>(nft.levels.num_of_levels) : nft.levels[tgt];
         for (Level lvl{ nft.levels[src] }; lvl < stop_lvl; lvl++) {
             if (levels_to_project.find(lvl) == levels_to_project.end()) {
                 return false;
@@ -273,39 +273,40 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     };
 
     // Determines the transition length between two states based on their levels.
-    auto get_trans_len = [&](State src, State tgt) {
-        return (nft.levels[src] == 0) ? (nft.num_of_levels - nft.levels[src]) : (nft.levels[tgt] - nft.levels[src]);
+    auto get_trans_len = [&](const State src, const State tgt) {
+        return (nft.levels[src] == 0) ? (nft.levels.num_of_levels - nft.levels[src]) : (nft.levels[tgt] - nft.levels[src]);
     };
 
-    // Returns one-state automaton it the case of projecting all levels.
-    if (nft.num_of_levels == levels_to_project.size()) {
-        if (nft.is_lang_empty()) {
-            return Nft(1, {0}, {}, {}, 0);
-        }
-        return Nft(1, {0}, {0}, {}, 0);
+    if (nft.levels.num_of_levels == levels_to_project.size()) {
+        throw std::invalid_argument("Cannot project out all levels of the NFT.");
+        // TODO: Returning an empty NFT with 0 levels as a boolean automaton, equivalent to a bool flag?
+        //  - no accepted words = empty set = false
+        //  - { epsilon } = true
+        // if (nft.is_lang_empty()) { return Nft{ Nft::with_levels(0)}; }
+        // return Nft(1, {0}, {0}, Levels{ 0 }, nullptr);
     }
 
-    // Calculates the smallest level 0 < k < num_of_levels that starts a consecutive ascending sequence
-    // of levels k, k+1, k+2, ..., num_of_levels-1 in the ordered-vector levels_to_project.
-    // If there is no such sequence, then k == num_of_levels.
-    size_t seq_start_idx = nft.num_of_levels;
-    const std::vector<Level> levels_to_proj_v = levels_to_project.to_vector();
+    // Calculates the smallest level 0 < k < levels.num_of_levels that starts a consecutive ascending sequence
+    // of levels k, k+1, k+2, ..., levels.num_of_levels-1 in the ordered-vector levels_to_project.
+    // If there is no such sequence, then k == levels.num_of_levels.
+    size_t seq_start_idx = nft.levels.num_of_levels;
+    const std::vector<Level>& levels_to_proj_v = levels_to_project.to_vector();
     for (auto levels_to_proj_v_revit = levels_to_proj_v.rbegin();
          levels_to_proj_v_revit != levels_to_proj_v.rend() && *levels_to_proj_v_revit == seq_start_idx - 1;
-         ++levels_to_proj_v_revit, --seq_start_idx);
+         ++levels_to_proj_v_revit, --seq_start_idx) {}
 
     // Only states whose level is part of the sequence (will have level 0) can additionally be marked as final.
     auto can_be_final = [&](State s) {
         return seq_start_idx <= nft.levels[s];
     };
 
-    // Builds a vector of size num_of_levels. Each index k contains a new level for level k.
+    // Builds a vector of size levels.num_of_levels. Each index k contains a new level for level k.
     // Sets levels to 0 starting from seq_start_idx.
     // Example:
     // old levels    0 1 2 3 4 5 6
     // project out     x   x   x x
     // new levels    0 0 1 2 2 0 0
-    std::vector<Level> new_levels(nft.num_of_levels , 0);
+    std::vector<Level> new_levels(nft.levels.num_of_levels , 0);
     Level lvl_sub{ 0 };
     for (Level lvl_old{ 0 }; lvl_old < seq_start_idx; lvl_old++) {
         new_levels[lvl_old] = static_cast<Level>(lvl_old - lvl_sub);
@@ -359,7 +360,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     }
 
     // Construct the automaton with projected levels.
-    Nft result{ Delta{}, nft.initial, nft.final, nft.levels, nft.num_of_levels, nft.alphabet };
+    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.alphabet) };
     for (State src_state{ 0 }; src_state < num_of_states_in_delta; src_state++) { // For every state.
         for (State cls_state : closure[src_state]) { // For every state in its epsilon closure.
             if (nft.final[cls_state] && can_be_final(src_state)) result.final.insert(src_state);
@@ -397,7 +398,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     for (State s{ 0 }; s < result.levels.size(); s++) {
         result.levels[s] = new_levels[result.levels[s]];
     }
-    result.num_of_levels = static_cast<Level>(result.num_of_levels - levels_to_project.size());
+    result.levels.num_of_levels = static_cast<Level>(result.levels.num_of_levels - levels_to_project.size());
 
     return result;
 }
@@ -407,11 +408,10 @@ Nft mata::nft::project_out(const Nft& nft, const Level level_to_project, const J
 }
 
 Nft mata::nft::project_to(const Nft& nft, const OrdVector<Level>& levels_to_project, const JumpMode jump_mode) {
-    OrdVector<Level> all_levels{ OrdVector<Level>::with_reserved(nft.num_of_levels) };
-    for (Level level{ 0 }; level < nft.num_of_levels; ++level) { all_levels.push_back(level); }
-    OrdVector<Level> levels_to_project_out{ OrdVector<Level>::with_reserved(nft.num_of_levels) };
-    std::set_difference(all_levels.begin(), all_levels.end(), levels_to_project.begin(),
-                        levels_to_project.end(), std::back_inserter(levels_to_project_out) );
+    OrdVector<Level> all_levels{ OrdVector<Level>::with_reserved(nft.levels.num_of_levels) };
+    for (Level level{ 0 }; level < nft.levels.num_of_levels; ++level) { all_levels.push_back(level); }
+    OrdVector<Level> levels_to_project_out{ OrdVector<Level>::with_reserved(nft.levels.num_of_levels) };
+    std::ranges::set_difference(all_levels, levels_to_project, std::back_inserter(levels_to_project_out) );
     return project_out(nft, levels_to_project_out, jump_mode);
 }
 
@@ -420,15 +420,15 @@ Nft mata::nft::project_to(const Nft& nft, Level level_to_project, const JumpMode
 }
 
 Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const JumpMode jump_mode) {
-    assert(0 < nft.num_of_levels);
-    assert(nft.num_of_levels <= new_levels_mask.size());
-    assert(static_cast<size_t>(std::count(new_levels_mask.begin(), new_levels_mask.end(), false)) == nft.num_of_levels);
+    assert(0 < nft.levels.num_of_levels);
+    assert(nft.levels.num_of_levels <= new_levels_mask.size());
+    assert(static_cast<size_t>(std::ranges::count(new_levels_mask, false)) == nft.levels.num_of_levels);
 
-    if (nft.num_of_levels == new_levels_mask.size()) {
+    if (nft.levels.num_of_levels == new_levels_mask.size()) {
          return { nft };
     }
 
-    // Construct a vector of size equal to num_of_levels. Each index k in this vector represents a new level for the original level k.
+    // Construct a vector of size equal to levels.num_of_levels. Each index k in this vector represents a new level for the original level k.
     // Note: The 0th index always remains zero.
     // Here are a couple of examples to illustrate this:
     // Example 1:
@@ -439,10 +439,10 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     //   Input (levels)      : 0 1 2
     //   Mask                : 1 1 0 1 1 0 0
     //   Output (new levels) : 0 3 6
-    std::vector<Level> updated_levels(nft.num_of_levels, 0);
+    std::vector<Level> updated_levels(nft.levels.num_of_levels, 0);
     Level old_lvl = 0;
     Level new_lvl = 0;
-    auto mask_it = std::find(new_levels_mask.begin(), new_levels_mask.end(), false);
+    auto mask_it = std::ranges::find(new_levels_mask, false);
     if (new_levels_mask[0]) {
         old_lvl = 1;
         new_lvl = static_cast<Level>(std::distance(new_levels_mask.begin(), mask_it) + 1);
@@ -467,7 +467,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     //  Output (JumpMode::AppendDontCares):    3 3 3 5 5 8 8 8 12 12 12 12
     const size_t mask_size = new_levels_mask.size();
     std::vector<Level> next_inner_levels(mask_size);
-    Level next_level = static_cast<Level>(mask_size);
+    auto next_level = static_cast<Level>(mask_size);
     size_t i = mask_size - 1;
     for (auto it = new_levels_mask.rbegin(); it != new_levels_mask.rend(); ++it, --i) {
         next_inner_levels[i] = next_level;
@@ -480,7 +480,12 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     }
 
     // Construct an empty automaton with updated levels.
-    Nft result(Delta(nft.num_of_states()), nft.initial, nft.final, new_state_levels, static_cast<unsigned int>(new_levels_mask.size()), nft.alphabet);
+    Nft result(
+        Nft::with_levels(
+            Levels{ new_levels_mask.size(), new_state_levels },
+            nft.num_of_states(), nft.initial, nft.final, nft.alphabet
+        )
+    );
 
     // Function to create a transition between source and target states.
     // The transition symbol is determined based on the parameters:
@@ -520,13 +525,14 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     for (const auto &trans : nft.delta.transitions()) {
         State src = trans.source;
         Level src_lvl = result.levels[trans.source];
-        State inner;
-        const Level stop_level = static_cast<Level>((result.levels[trans.target] == 0) ? (new_levels_mask.size() - 1) : (result.levels[trans.target] - 1));
+        const auto stop_level = static_cast<Level>((result.levels[trans.target] == 0) ? (new_levels_mask.size() - 1) : (result.levels[trans.target] - 1));
 
         // Construct the first n-1 parts of the original transition.
         bool is_old_level_processed = false;
         while (next_inner_levels[src_lvl] < next_inner_levels[stop_level]) {
-            inner = get_inner_state(trans.source, next_inner_levels[src_lvl], new_levels_mask[src_lvl], is_old_level_processed);
+            const State inner = get_inner_state(
+                    trans.source, next_inner_levels[src_lvl], new_levels_mask[src_lvl], is_old_level_processed
+                    );
             create_transition(src, trans.symbol, inner, new_levels_mask[src_lvl], is_old_level_processed);
             if (!new_levels_mask[src_lvl]) {
                 is_old_level_processed = true;
@@ -544,11 +550,11 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 
 Nft mata::nft::insert_level(const Nft& nft, const Level new_level, const JumpMode jump_mode) {
     // TODO(nft): Optimize the insertion of just one level by using move.
-    BoolVector new_levels_mask(nft.num_of_levels + 1, false);
+    BoolVector new_levels_mask(nft.levels.num_of_levels + 1, false);
     if (new_level < new_levels_mask.size()) {
         new_levels_mask[new_level] = true;
     } else {
-        new_levels_mask[nft.num_of_levels] = true;
+        new_levels_mask[nft.levels.num_of_levels] = true;
         new_levels_mask.resize(new_level + 1, true);
     }
     return insert_levels(nft, new_levels_mask, jump_mode);
@@ -762,13 +768,16 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
         new_final.insert(renaming[s]);
     }
     // Create new automaton
-    Nft aut_inv = Nft(num_of_zerostates, std::move(new_initial), std::move(new_final), Levels(num_of_zerostates, 0), aut.num_of_levels, aut.alphabet);
+    Nft aut_inv = Nft::with_levels(
+        { aut.levels.num_of_levels, num_of_zerostates, DEFAULT_LEVEL },
+        num_of_zerostates, std::move(new_initial), std::move(new_final), aut.alphabet
+    );
 
     // Creates new states with inverted levels for each inner state in the path.
     auto create_states_with_inverted_levels = [&](const std::vector<State>& path_states) {
         for (const State s: path_states) {
             if (aut.levels[s] == 0) { continue; }
-            renaming[s] = aut_inv.add_state_with_level(static_cast<Level>(aut.num_of_levels - aut.levels[s]));
+            renaming[s] = aut_inv.add_state_with_level(static_cast<Level>(aut.levels.num_of_levels - aut.levels[s]));
         }
     };
 
@@ -794,7 +803,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
         std::unordered_map<std::pair<State, State>, State> auxiliary_states;
         auto get_aux_state = [&](const State src, const State tgt, const Level level) {
             const std::pair<State, State> key{ src, tgt };
-            if (auxiliary_states.find(key) == auxiliary_states.end()) {
+            if (!auxiliary_states.contains(key)) {
                 auxiliary_states[key] = aut_inv.add_state_with_level(level);
             }
             return auxiliary_states[key];
@@ -805,8 +814,8 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
             if (is_src_head && is_tgt_tail) {
                 // It is a direct transition between two zero-states (the head and the tail).
                 // Just copy it.
-                if (jump_mode == JumpMode::AppendDontCares && aut.num_of_levels > 1) {
-                    const State aux_state = get_aux_state(src, tgt, static_cast<Level>(aut.num_of_levels - 1));
+                if (jump_mode == JumpMode::AppendDontCares && aut.levels.num_of_levels > 1) {
+                    const State aux_state = get_aux_state(src, tgt, static_cast<Level>(aut.levels.num_of_levels - 1));
                     aut_inv.delta.add(renaming[src], DONT_CARE, aux_state);
                     aut_inv.delta.add(aux_state, symbol, renaming[tgt]);
                 } else {
@@ -816,7 +825,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
                 // It is a transition from a zero-state (head) to a nonzero-state (inner state).
                 // Map it as transition from that nonzero-state (inner state) to the tail (zero-states).
                 if (jump_mode == JumpMode::AppendDontCares && aut.levels[tgt] > 1) {
-                    const State aux_state = get_aux_state(src, tgt, static_cast<Level>(aut.num_of_levels - 1));
+                    const State aux_state = get_aux_state(src, tgt, static_cast<Level>(aut.levels.num_of_levels - 1));
                     aut_inv.delta.add(renaming[tgt], DONT_CARE, aux_state);
                     aut_inv.delta.add(aux_state, symbol, renaming[tail]);
                 } else {
@@ -826,7 +835,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
             } else if (is_tgt_tail) {
                 // It is a transition from a nonzero-state (inner state) to a zero-state (tail).
                 // Map it as transition from the zero-state (head) to that nonzero-state (inner state).
-                if (jump_mode == JumpMode::AppendDontCares && (aut.num_of_levels - aut.levels[src]) > 1) {
+                if (jump_mode == JumpMode::AppendDontCares && (aut.levels.num_of_levels - aut.levels[src]) > 1) {
                     const State aux_state = get_aux_state(src, tgt, static_cast<Level>(aut_inv.levels[renaming[src]] - 1));
                     aut_inv.delta.add(renaming[head], DONT_CARE, aux_state);
                     aut_inv.delta.add(aux_state, symbol, renaming[src]);
@@ -872,7 +881,7 @@ Nft mata::nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
                 // Extend the path.
                 std::vector<State> new_path = path;
                 new_path.push_back(tgt);
-                stack.push({ tgt, std::move(new_path) });
+                stack.emplace(tgt, std::move(new_path));
             }
         }
     }
@@ -1023,7 +1032,7 @@ Nft mata::nft::reduce(const Nft &aut, StateRenaming *state_renaming, const Param
 }
 
 Nft mata::nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset_map) {
-    Nft result{ Nft::with_levels(nft.num_of_levels) };
+    Nft result{ Nft::with_levels(nft.levels.num_of_levels) };
     result.alphabet = nft.alphabet;
     if (nft.initial.empty()) { return result; }
 
@@ -1088,7 +1097,7 @@ Nft mata::nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* 
                 next_level = result.levels[target_res];
             } else {
                 // Create target of the minimal level between all the original targets.
-                next_level = nft.levels.get_minimal_next_level_of(targets);
+                next_level = *nft.levels.get_minimal_next_level_of(targets);
                 if (next_level != 0) {
                     for (const State state : targets) {
                         (nft.levels[state] == next_level ? targets_resolved : targets_partial).push_back(state);
@@ -1172,21 +1181,21 @@ std::set<mata::Word> mata::nft::Nft::get_words(const size_t max_length) const {
 }
 
 bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
-    if (track_words.size() != num_of_levels) {
-        throw std::runtime_error("Invalid number of tracks. Expected " + std::to_string(num_of_levels) + ".");
+    if (track_words.size() != levels.num_of_levels) {
+        throw std::runtime_error("Invalid number of tracks. Expected " + std::to_string(levels.num_of_levels) + ".");
     }
-    std::vector<Word::const_iterator> track_words_begins(num_of_levels);
-    for (size_t track{ 0 }; track < num_of_levels; ++track) {
+    std::vector<Word::const_iterator> track_words_begins(levels.num_of_levels);
+    for (size_t track{ 0 }; track < levels.num_of_levels; ++track) {
         track_words_begins[track] = track_words[track].begin();
     }
 
     const std::vector<Word::const_iterator> track_words_ends{
         [&](){
-            std::vector<Word::const_iterator> track_words_ends(num_of_levels);
-            for (size_t track{ 0 }; track < num_of_levels; ++track) {
-                track_words_ends[track] = track_words[track].end();
+            std::vector<Word::const_iterator> val(levels.num_of_levels);
+            for (size_t track{ 0 }; track < levels.num_of_levels; ++track) {
+                val[track] = track_words[track].end();
             }
-            return track_words_ends;
+            return val;
         }()
     };
 
@@ -1205,11 +1214,10 @@ bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
     for (const State state: initial) {
         worklist.emplace_back(state, track_words_begins);
     }
-    Level level;
     while (!worklist.empty()) {
         const auto [state, words_its]{ std::move(worklist.front()) };
         worklist.pop_front();
-        level = levels[state];
+        const Level level = levels[state];
         const StatePost& state_post{ delta[state] };
         const auto state_post_end{ state_post.end() };
         const Word::const_iterator word_symbol_it{ words_its[level] };
@@ -1242,8 +1250,8 @@ bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
                             continue_to_next_target = true;
                         }
                         ++next_words_its[level_in_transition];
-                        level_in_transition = (level_in_transition + 1) % static_cast<Level>(num_of_levels);
-                    } while(level_in_transition % num_of_levels != levels[target] && !continue_to_next_target);
+                        level_in_transition = (level_in_transition + 1) % static_cast<Level>(levels.num_of_levels);
+                    } while(level_in_transition % levels.num_of_levels != levels[target] && !continue_to_next_target);
                     if (continue_to_next_target) { continue; }
                     if (are_all_track_words_read(next_words_its) && final.contains(target)) { return true; }
                     worklist.emplace_back(target, next_words_its);

--- a/tests/applications/strings/noodlification.cc
+++ b/tests/applications/strings/noodlification.cc
@@ -18,41 +18,41 @@ using namespace mata::nfa::builder;
 
 // Automaton A
 #define FILL_WITH_AUT_A(x) \
-	x.initialstates = {1, 3}; \
-	x.finalstates = {5}; \
-	x.delta.add(1, 'a', 3); \
-	x.delta.add(1, 'a', 10); \
-	x.delta.add(1, 'b', 7); \
-	x.delta.add(3, 'a', 7); \
-	x.delta.add(3, 'b', 9); \
-	x.delta.add(9, 'a', 9); \
-	x.delta.add(7, 'b', 1); \
-	x.delta.add(7, 'a', 3); \
-	x.delta.add(7, 'c', 3); \
-	x.delta.add(10, 'a', 7); \
-	x.delta.add(10, 'b', 7); \
-	x.delta.add(10, 'c', 7); \
-	x.delta.add(7, 'a', 5); \
-	x.delta.add(5, 'a', 5); \
-	x.delta.add(5, 'c', 9); \
+	(x).initialstates = {1, 3}; \
+	(x).finalstates = {5}; \
+	(x).delta.add(1, 'a', 3); \
+	(x).delta.add(1, 'a', 10); \
+	(x).delta.add(1, 'b', 7); \
+	(x).delta.add(3, 'a', 7); \
+	(x).delta.add(3, 'b', 9); \
+	(x).delta.add(9, 'a', 9); \
+	(x).delta.add(7, 'b', 1); \
+	(x).delta.add(7, 'a', 3); \
+	(x).delta.add(7, 'c', 3); \
+	(x).delta.add(10, 'a', 7); \
+	(x).delta.add(10, 'b', 7); \
+	(x).delta.add(10, 'c', 7); \
+	(x).delta.add(7, 'a', 5); \
+	(x).delta.add(5, 'a', 5); \
+	(x).delta.add(5, 'c', 9); \
 
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
-	x.initialstates = {4}; \
-	x.finalstates = {2, 12}; \
-	x.delta.add(4, 'c', 8); \
-	x.delta.add(4, 'a', 8); \
-	x.delta.add(8, 'b', 4); \
-	x.delta.add(4, 'a', 6); \
-	x.delta.add(4, 'b', 6); \
-	x.delta.add(6, 'a', 2); \
-	x.delta.add(2, 'b', 2); \
-	x.delta.add(2, 'a', 0); \
-	x.delta.add(0, 'a', 2); \
-	x.delta.add(2, 'c', 12); \
-	x.delta.add(12, 'a', 14); \
-	x.delta.add(14, 'b', 12); \
+	(x).initialstates = {4}; \
+	(x).finalstates = {2, 12}; \
+	(x).delta.add(4, 'c', 8); \
+	(x).delta.add(4, 'a', 8); \
+	(x).delta.add(8, 'b', 4); \
+	(x).delta.add(4, 'a', 6); \
+	(x).delta.add(4, 'b', 6); \
+	(x).delta.add(6, 'a', 2); \
+	(x).delta.add(2, 'b', 2); \
+	(x).delta.add(2, 'a', 0); \
+	(x).delta.add(0, 'a', 2); \
+	(x).delta.add(2, 'c', 12); \
+	(x).delta.add(12, 'a', 14); \
+	(x).delta.add(14, 'b', 12); \
 
 // }}}
 
@@ -575,7 +575,7 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
     SECTION("Simple - 1 input, 1 output") {
         x = create_from_regex("(a|b)*");
         y = create_from_regex("(a|b)*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, { 0 }, { 0 });
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'b'}, 0);
         Nft copy = t;
@@ -594,7 +594,7 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         x = create_from_regex("(a|b)*");
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, {0}, {0});
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'b'}, 0);
         Nft copy = t;
@@ -619,7 +619,7 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         x = create_from_regex("(a|b)*");
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, { 0 }, { 0 });
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'b'}, 0);
         Nft copy = t;
@@ -645,7 +645,7 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
         w = create_from_regex("(a|b)*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, {0}, {0});
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'b'}, 0);
         Nft copy = t;
@@ -712,7 +712,7 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
         w = create_from_regex("a*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, {0}, {0});
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'a'}, 0);
         Nft copy = t;
@@ -737,10 +737,10 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         x = create_from_regex("(a|b)*");
         y = create_from_regex("b+");
         z = create_from_regex("(a|b)*");
-        t = Nft::with_levels(2, 1, {}, {0}, {0});
+        t = Nft::with_levels(2, 1, { 0 }, { 0 });
         t.add_transition(0, {'a', 'a'}, 0);
         t.add_transition(0, {'b', 'a'}, 0);
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x), std::make_shared<Nfa>(z)}, {std::make_shared<Nfa>(y)});
-        REQUIRE(noodles.size() == 0);
+        CHECK(noodles.empty());
     }
 }

--- a/tests/applications/strings/replace.cc
+++ b/tests/applications/strings/replace.cc
@@ -45,8 +45,8 @@ TEST_CASE("nft::create_identity()") {
         nft.delta.add(0, 3, 7);
         nft.delta.add(7, 3, 8);
         nft.delta.add(8, 3, 0);
-        nft.num_of_levels = 3;
-        nft.levels.resize(nft.num_of_levels * (alphabet.get_number_of_symbols() - 1));
+        nft.levels.num_of_levels = 3;
+        nft.levels.resize(nft.levels.num_of_levels * (alphabet.get_number_of_symbols() - 1));
         nft.levels[0] = 0;
         nft.levels[1] = 1;
         nft.levels[2] = 2;
@@ -63,7 +63,7 @@ TEST_CASE("nft::create_identity()") {
     SECTION("identity nft no symbols") {
         EnumAlphabet alphabet{};
         nft.alphabet = &alphabet;
-        nft.num_of_levels = 3;
+        nft.levels.num_of_levels = 3;
         nft.levels.resize(1);
         nft.levels[0] = 0;
         Nft nft_identity{ create_identity(&alphabet, 3) };
@@ -73,7 +73,7 @@ TEST_CASE("nft::create_identity()") {
     SECTION("identity nft one symbol") {
         EnumAlphabet alphabet{ 0 };
         nft.alphabet = &alphabet;
-        nft.num_of_levels = 2;
+        nft.levels.num_of_levels = 2;
         nft.levels.resize(2);
         nft.levels[0] = 0;
         nft.levels[1] = 1;
@@ -92,7 +92,7 @@ TEST_CASE("nft::create_identity()") {
         nft.delta.add(0, 1, 0);
         nft.delta.add(0, 2, 0);
         nft.delta.add(0, 3, 0);
-        nft.num_of_levels = 1;
+        nft.levels.num_of_levels = 1;
         nft.levels.resize(1);
         nft.levels[0] = 0;
         Nft nft_identity{ create_identity(&alphabet, 1) };
@@ -115,7 +115,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.delta.add(3, 2, 0);
         expected.delta.add(0, 3, 4);
         expected.delta.add(4, 3, 0);
-        expected.num_of_levels = 2;
+        expected.levels.num_of_levels = 2;
         expected.levels.resize(5);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
@@ -134,7 +134,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
     SECTION("identity nft one symbol") {
         EnumAlphabet alphabet{ 0 };
         expected.alphabet = &alphabet;
-        expected.num_of_levels = 2;
+        expected.levels.num_of_levels = 2;
         expected.levels.resize(2);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
@@ -159,7 +159,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.delta.add(3, 2, 0);
         expected.delta.add(0, 3, 4);
         expected.delta.add(4, 3, 0);
-        expected.num_of_levels = 2;
+        expected.levels.num_of_levels = 2;
         expected.levels.resize(9);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
@@ -185,7 +185,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.delta.add(3, 2, 0);
         expected.delta.add(0, 3, 4);
         expected.delta.add(4, 3, 0);
-        expected.num_of_levels = 2;
+        expected.levels.num_of_levels = 2;
         expected.levels.resize(5);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
@@ -199,7 +199,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
     SECTION("identity expected one symbol with word replace") {
         EnumAlphabet alphabet{ 0 };
         expected.alphabet = &alphabet;
-        expected.num_of_levels = 2;
+        expected.levels.num_of_levels = 2;
         expected.levels.resize(2);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
@@ -258,8 +258,8 @@ TEST_CASE("nft::reluctant_replacement()") {
         CHECK(nfa::are_equivalent(dfa_end_marker, dfa_expected_end_marker));
         Nft dft_end_marker{ reluctant_replace.end_marker_dft(dfa_end_marker, END_MARKER) };
         Nft dft_expected_end_marker{};
-        dft_expected_end_marker.num_of_levels = 2;
-        dft_expected_end_marker.levels = { 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1 };
+        dft_expected_end_marker.levels.num_of_levels = 2;
+        dft_expected_end_marker.levels.set({ 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1 });
         dft_expected_end_marker.initial = { 0 };
         dft_expected_end_marker.final = { 9 };
         dft_expected_end_marker.delta.add(0, 'c', 1);
@@ -300,7 +300,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 4, 7, 14 };
-        dft_expected.num_of_levels = 2;
+        dft_expected.levels.num_of_levels = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 0);
         dft_expected.delta.add(0, 'b', 2);
@@ -371,7 +371,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft dft_expected{};
         dft_expected.initial.insert(0);
         dft_expected.final = { 0, 2, 7, 14 };
-        dft_expected.num_of_levels = 2;
+        dft_expected.levels.num_of_levels = 2;
         dft_expected.delta.add(0, 'a', 1);
         dft_expected.delta.add(1, 'a', 2);
         dft_expected.delta.add(0, 'b', 3);
@@ -442,7 +442,7 @@ TEST_CASE("nft::reluctant_replacement()") {
         Nft nft_expected{};
         nft_expected.initial.insert(0);
         nft_expected.final.insert(1);
-        nft_expected.num_of_levels = 2;
+        nft_expected.levels.num_of_levels = 2;
         nft_expected.delta.add(0, EPSILON, 1);
         nft_expected.delta.add(0, EPSILON, 2);
         nft_expected.delta.add(0, EPSILON, 3);

--- a/tests/applications/strings/segmentation.cc
+++ b/tests/applications/strings/segmentation.cc
@@ -20,41 +20,41 @@ using Symbol = mata::Symbol;
 
 // Automaton A
 #define FILL_WITH_AUT_A(x) \
-	x.initial = {1, 3}; \
-	x.final = {5}; \
-	x.delta.add(1, 'a', 3); \
-	x.delta.add(1, 'a', 10); \
-	x.delta.add(1, 'b', 7); \
-	x.delta.add(3, 'a', 7); \
-	x.delta.add(3, 'b', 9); \
-	x.delta.add(9, 'a', 9); \
-	x.delta.add(7, 'b', 1); \
-	x.delta.add(7, 'a', 3); \
-	x.delta.add(7, 'c', 3); \
-	x.delta.add(10, 'a', 7); \
-	x.delta.add(10, 'b', 7); \
-	x.delta.add(10, 'c', 7); \
-	x.delta.add(7, 'a', 5); \
-	x.delta.add(5, 'a', 5); \
-	x.delta.add(5, 'c', 9); \
+	(x).initial = {1, 3}; \
+	(x).final = {5}; \
+	(x).delta.add(1, 'a', 3); \
+	(x).delta.add(1, 'a', 10); \
+	(x).delta.add(1, 'b', 7); \
+	(x).delta.add(3, 'a', 7); \
+	(x).delta.add(3, 'b', 9); \
+	(x).delta.add(9, 'a', 9); \
+	(x).delta.add(7, 'b', 1); \
+	(x).delta.add(7, 'a', 3); \
+	(x).delta.add(7, 'c', 3); \
+	(x).delta.add(10, 'a', 7); \
+	(x).delta.add(10, 'b', 7); \
+	(x).delta.add(10, 'c', 7); \
+	(x).delta.add(7, 'a', 5); \
+	(x).delta.add(5, 'a', 5); \
+	(x).delta.add(5, 'c', 9); \
 
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
-	x.initialstates = {4}; \
-	x.finalstates = {2, 12}; \
-	x.delta.add(4, 'c', 8); \
-	x.delta.add(4, 'a', 8); \
-	x.delta.add(8, 'b', 4); \
-	x.delta.add(4, 'a', 6); \
-	x.delta.add(4, 'b', 6); \
-	x.delta.add(6, 'a', 2); \
-	x.delta.add(2, 'b', 2); \
-	x.delta.add(2, 'a', 0); \
-	x.delta.add(0, 'a', 2); \
-	x.delta.add(2, 'c', 12); \
-	x.delta.add(12, 'a', 14); \
-	x.delta.add(14, 'b', 12); \
+	(x).initialstates = {4}; \
+	(x).finalstates = {2, 12}; \
+	(x).delta.add(4, 'c', 8); \
+	(x).delta.add(4, 'a', 8); \
+	(x).delta.add(8, 'b', 4); \
+	(x).delta.add(4, 'a', 6); \
+	(x).delta.add(4, 'b', 6); \
+	(x).delta.add(6, 'a', 2); \
+	(x).delta.add(2, 'b', 2); \
+	(x).delta.add(2, 'a', 0); \
+	(x).delta.add(0, 'a', 2); \
+	(x).delta.add(2, 'c', 12); \
+	(x).delta.add(12, 'a', 14); \
+	(x).delta.add(14, 'b', 12); \
 
 // }}}
 

--- a/tests/applications/strings/string-solving.cc
+++ b/tests/applications/strings/string-solving.cc
@@ -23,41 +23,41 @@ using Word = mata::Word;
 
 // Automaton A
 #define FILL_WITH_AUT_A(x) \
-	x.initial = {1, 3}; \
-	x.final = {5}; \
-	x.delta.add(1, 'a', 3); \
-	x.delta.add(1, 'a', 10); \
-	x.delta.add(1, 'b', 7); \
-	x.delta.add(3, 'a', 7); \
-	x.delta.add(3, 'b', 9); \
-	x.delta.add(9, 'a', 9); \
-	x.delta.add(7, 'b', 1); \
-	x.delta.add(7, 'a', 3); \
-	x.delta.add(7, 'c', 3); \
-	x.delta.add(10, 'a', 7); \
-	x.delta.add(10, 'b', 7); \
-	x.delta.add(10, 'c', 7); \
-	x.delta.add(7, 'a', 5); \
-	x.delta.add(5, 'a', 5); \
-	x.delta.add(5, 'c', 9); \
+	(x).initial = {1, 3}; \
+	(x).final = {5}; \
+	(x).delta.add(1, 'a', 3); \
+	(x).delta.add(1, 'a', 10); \
+	(x).delta.add(1, 'b', 7); \
+	(x).delta.add(3, 'a', 7); \
+	(x).delta.add(3, 'b', 9); \
+	(x).delta.add(9, 'a', 9); \
+	(x).delta.add(7, 'b', 1); \
+	(x).delta.add(7, 'a', 3); \
+	(x).delta.add(7, 'c', 3); \
+	(x).delta.add(10, 'a', 7); \
+	(x).delta.add(10, 'b', 7); \
+	(x).delta.add(10, 'c', 7); \
+	(x).delta.add(7, 'a', 5); \
+	(x).delta.add(5, 'a', 5); \
+	(x).delta.add(5, 'c', 9); \
 
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
-	x.initial = {4}; \
-	x.final = {2, 12}; \
-	x.delta.add(4, 'c', 8); \
-	x.delta.add(4, 'a', 8); \
-	x.delta.add(8, 'b', 4); \
-	x.delta.add(4, 'a', 6); \
-	x.delta.add(4, 'b', 6); \
-	x.delta.add(6, 'a', 2); \
-	x.delta.add(2, 'b', 2); \
-	x.delta.add(2, 'a', 0); \
-	x.delta.add(0, 'a', 2); \
-	x.delta.add(2, 'c', 12); \
-	x.delta.add(12, 'a', 14); \
-	x.delta.add(14, 'b', 12); \
+	(x).initial = {4}; \
+	(x).final = {2, 12}; \
+	(x).delta.add(4, 'c', 8); \
+	(x).delta.add(4, 'a', 8); \
+	(x).delta.add(8, 'b', 4); \
+	(x).delta.add(4, 'a', 6); \
+	(x).delta.add(4, 'b', 6); \
+	(x).delta.add(6, 'a', 2); \
+	(x).delta.add(2, 'b', 2); \
+	(x).delta.add(2, 'a', 0); \
+	(x).delta.add(0, 'a', 2); \
+	(x).delta.add(2, 'c', 12); \
+	(x).delta.add(12, 'a', 14); \
+	(x).delta.add(14, 'b', 12); \
 
 // }}}
 
@@ -343,15 +343,15 @@ TEST_CASE("mata::applications::strings::get_accepted_symbols()") {
     }
 
     SECTION("advanced 2") {
-        x.delta.add(0, 'a', 1);
-        x.delta.add(0, 'b', 1);
-        x.delta.add(2, 'c', 3);
-        x.delta.add(2, 'd', 4);
-        x.delta.add(4, 'e', 2);
-        x.delta.add(2, 'f', 2);
-        x.delta.add(5, 'g', 1);
-        x.initial = {0, 2, 4};
-        x.final = {1, 3, 2};
+        (x).delta.add(0, 'a', 1);
+        (x).delta.add(0, 'b', 1);
+        (x).delta.add(2, 'c', 3);
+        (x).delta.add(2, 'd', 4);
+        (x).delta.add(4, 'e', 2);
+        (x).delta.add(2, 'f', 2);
+        (x).delta.add(5, 'g', 1);
+        (x).initial = {0, 2, 4};
+        (x).final = {1, 3, 2};
         symbols = {'a', 'b', 'c', 'e', 'f'};
         CHECK(get_accepted_symbols(x) == symbols);
     }

--- a/tests/nft/builder.cc
+++ b/tests/nft/builder.cc
@@ -36,7 +36,7 @@ TEST_CASE("nft::from_nfa_with_levels_zero()") {
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q4\n%Levels q0:0 q1:1 q2:0 q3:0 q4:0 q5:1 q6:1\n%LevelsNum 2\nq0 1 q1\nq1 1 q2\nq2 3 q5\nq3 4294967295 q4\nq4 2 q6\nq5 3 q0\nq5 3 q3\nq6 2 q4\n")
         );
-        expected.num_of_levels = NUM_OF_LEVELS;
+        expected.levels.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 
@@ -53,7 +53,7 @@ TEST_CASE("nft::from_nfa_with_levels_zero()") {
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:2 q3:0 q4:0 q5:0 q6:1 q7:2 q8:1 q9:2\n%LevelsNum 3\nq0 1 q1\nq1 1 q2\nq2 1 q3\nq3 3 q6\nq4 4294967295 q5\nq5 2 q8\nq6 3 q7\nq7 3 q0\nq7 3 q4\nq8 2 q9\nq9 2 q5\n")
         );
-        expected.num_of_levels = NUM_OF_LEVELS;
+        expected.levels.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 
@@ -70,7 +70,7 @@ TEST_CASE("nft::from_nfa_with_levels_zero()") {
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsNum 2\nq0 99 q1\nq1 99 q2\nq2 98 q3\nq3 98 q2\nq3 98 q4\nq4 97 q5\nq5 97 q4\nq5 97 q6\n")
         );
-        expected.num_of_levels = NUM_OF_LEVELS;
+        expected.levels.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 
@@ -87,7 +87,7 @@ TEST_CASE("nft::from_nfa_with_levels_zero()") {
         expected = mata::nft::builder::parse_from_mata(
             std::string("@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q6\n%Levels q0:0 q1:1 q2:0 q3:1 q4:0 q5:1 q6:0\n%LevelsNum 2\nq0 99 q1\nq1 4294967295 q2\nq2 98 q3\nq3 4294967295 q2\nq3 4294967295 q4\nq4 97 q5\nq5 4294967295 q4\nq5 4294967295 q6\n")
         );
-        expected.num_of_levels = NUM_OF_LEVELS;
+        expected.levels.num_of_levels = NUM_OF_LEVELS;
         CHECK(mata::nft::are_equivalent(nft, expected));
     }
 }
@@ -99,7 +99,7 @@ TEST_CASE("mata::nft::parse_from_mata()") {
         delta.add(0, 0, 0);
         delta.add(0, 1, 1);
         delta.add(1, 2, 0);
-        Nft nft{ delta, { 0 }, { 1 }, { 0, 0 }, 1};
+        Nft nft{ Nft::with_levels({1, { 0, 0 } }, delta, { 0 }, { 1 }) };
 
         SECTION("from string") {
             Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
@@ -145,17 +145,17 @@ TEST_CASE("mata::nft::parse_from_mata()") {
         nft.delta.add(1, 'b', 40);
         nft.delta.add(51, 'z', 42);
         nft.final = { 3, 103 };
-        nft.levels = Levels(nft.num_of_states(), 0);
+        nft.levels = Levels(43, nft.num_of_states(), 0);
         nft.levels[3] = 42;
         nft.levels[103] = 42;
-        nft.num_of_levels = 43;
+        nft.levels.num_of_levels = 43;
 
         SECTION("from string") {
             Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.num_of_levels == 43);
+            CHECK(parsed.levels.num_of_levels == 43);
 
             Levels test_levels(parsed.levels);
             for (const State &s : parsed.final) {
@@ -174,9 +174,9 @@ TEST_CASE("mata::nft::parse_from_mata()") {
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.num_of_levels == 43);
+            CHECK(parsed.levels.num_of_levels == 43);
 
-            std::vector test_levels(parsed.levels);
+            auto test_levels(parsed.levels);
             for (const State &s : parsed.final) {
                 CHECK(test_levels[s] == 42);
                 test_levels[s] = 0;
@@ -197,9 +197,9 @@ TEST_CASE("mata::nft::parse_from_mata()") {
             parsed.final.contains(103);
             parsed.initial.contains(50);
             parsed.delta.contains(51, 'z', 42);
-            CHECK(parsed.num_of_levels == 43);
+            CHECK(parsed.levels.num_of_levels == 43);
 
-            std::vector test_levels(parsed.levels);
+            auto test_levels(parsed.levels);
             for (const State &s : parsed.final) {
                 CHECK(test_levels[s] == 42);
                 test_levels[s] = 0;
@@ -225,15 +225,15 @@ TEST_CASE("mata::nft::parse_from_mata()") {
             nft.delta.add(9, 1, 10);
             nft.initial.insert(0);
             nft.final.insert(10);
-            nft.levels = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            nft.num_of_levels = 11;
+            nft.levels.num_of_levels = 11;
+            nft.levels.set({ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
 
             SECTION("from string") {
                 Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -255,7 +255,7 @@ TEST_CASE("mata::nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -280,7 +280,7 @@ TEST_CASE("mata::nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 0;
                 while (s != *parsed.final.begin()) {
@@ -310,15 +310,15 @@ TEST_CASE("mata::nft::parse_from_mata()") {
             nft.delta.add(9, 1, 10);
             nft.initial.insert(0);
             nft.final.insert(10);
-            nft.levels = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-            nft.num_of_levels = 11;
+            nft.levels.num_of_levels = 11;
+            nft.levels.set({ 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
 
             SECTION("from string") {
                 Nft parsed{ mata::nft::builder::parse_from_mata(nft.print_to_mata()) };
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {
@@ -340,7 +340,7 @@ TEST_CASE("mata::nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {
@@ -365,7 +365,7 @@ TEST_CASE("mata::nft::parse_from_mata()") {
 
                 REQUIRE(parsed.initial.size() == 1);
                 REQUIRE(parsed.final.size() == 1);
-                CHECK(parsed.num_of_levels == 11);
+                CHECK(parsed.levels.num_of_levels == 11);
                 State s{ *parsed.initial.begin() };
                 Level level = 10;
                 while (s != *parsed.final.begin()) {

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -20,7 +20,7 @@ TEST_CASE("Mata::nft::compose()") {
         SECTION("Linear structure") {
 
             SECTION("Epsilon free") {
-                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 lhs.delta.add(0, 'e', 1);
                 lhs.delta.add(1, 'a', 2);
                 lhs.delta.add(2, 'g', 3);
@@ -28,7 +28,7 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(4, 'i', 5);
                 lhs.delta.add(5, 'c', 6);
 
-                rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 rhs.delta.add(0, 'a', 1);
                 rhs.delta.add(1, 'f', 2);
                 rhs.delta.add(2, 'b', 3);
@@ -36,7 +36,7 @@ TEST_CASE("Mata::nft::compose()") {
                 rhs.delta.add(4, 'c', 5);
                 rhs.delta.add(5, 'j', 6);
 
-                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 expected.delta.add(0, 'e', 1);
                 expected.delta.add(1, 'f', 2);
                 expected.delta.add(2, 'g', 3);
@@ -50,7 +50,7 @@ TEST_CASE("Mata::nft::compose()") {
             }
 
             SECTION("Epsilon perfectly matches.") {
-                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 lhs.delta.add(0, 'e', 1);
                 lhs.delta.add(1, 'a', 2);
                 lhs.delta.add(2, 'g', 3);
@@ -58,7 +58,7 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(4, EPSILON, 5);
                 lhs.delta.add(5, 'c', 6);
 
-                rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 rhs.delta.add(0, 'a', 1);
                 rhs.delta.add(1, EPSILON, 2);
                 rhs.delta.add(2, EPSILON, 3);
@@ -66,7 +66,7 @@ TEST_CASE("Mata::nft::compose()") {
                 rhs.delta.add(4, 'c', 5);
                 rhs.delta.add(5, 'j', 6);
 
-                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 expected.delta.add(0, 'e', 1);
                 expected.delta.add(1, EPSILON, 2);
                 expected.delta.add(2, 'g', 3);
@@ -91,7 +91,7 @@ TEST_CASE("Mata::nft::compose()") {
         SECTION("Branching") {
 
             SECTION("Epsilon free") {
-                lhs = Nft(8, { 0 }, { 6, 7 }, { 0, 1, 0, 0, 1, 1, 0, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 0, 1, 1, 0, 0 } }, 8, { 0 }, { 6, 7 });
                 lhs.delta.add(0, 'e', 1);
                 lhs.delta.add(1, 'a', 2);
                 lhs.delta.add(2, 'c', 4);
@@ -100,7 +100,7 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(3, 'd', 5);
                 lhs.delta.add(5, 'f', 7);
 
-                rhs = Nft(11, { 0 }, { 8, 9, 10 }, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 } }, 11, { 0 }, { 8, 9, 10 });
                 rhs.delta.add(0, 'e', 1);
                 rhs.delta.add(1, 'a', 3);
                 rhs.delta.add(3, 'c', 5);
@@ -112,7 +112,7 @@ TEST_CASE("Mata::nft::compose()") {
                 rhs.delta.add(4, 'f', 7);
                 rhs.delta.add(7, 'h', 10);
 
-                expected = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0 } }, 5, { 0 }, { 4 });
                 expected.delta.add(0, 'e', 1);
                 expected.delta.add(1, 'd', 2);
                 expected.delta.add(2, 'd', 3);
@@ -125,7 +125,7 @@ TEST_CASE("Mata::nft::compose()") {
             }
 
             SECTION("Epsilon perfectly matches.") {
-                lhs = Nft(8, { 0 }, { 6, 7 }, { 0, 1, 0, 0, 1, 1, 0, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 0, 1, 1, 0, 0 } }, 8, { 0 }, { 6, 7 });
                 lhs.delta.add(0, 'e', 1);
                 lhs.delta.add(1, 'a', 2);
                 lhs.delta.add(2, 'c', 4);
@@ -134,7 +134,7 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(3, EPSILON, 5);
                 lhs.delta.add(5, 'f', 7);
 
-                rhs = Nft(11, { 0 }, { 8, 9, 10 }, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 } }, 11, { 0 }, { 8, 9, 10 });
                 rhs.delta.add(0, EPSILON, 1);
                 rhs.delta.add(1, 'a', 3);
                 rhs.delta.add(3, 'c', 5);
@@ -146,7 +146,7 @@ TEST_CASE("Mata::nft::compose()") {
                 rhs.delta.add(4, 'f', 7);
                 rhs.delta.add(7, 'h', 10);
 
-                expected = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0 } }, 5, { 0 }, { 4 });
                 expected.delta.add(0, 'e', 1);
                 expected.delta.add(1, 'd', 2);
                 expected.delta.add(2, EPSILON, 3);
@@ -160,14 +160,14 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("Cycle") {
-            lhs = Nft(5, { 0 }, { 2, 4 }, { 0, 1, 0, 1, 0 }, 2);
+            lhs = Nft::with_levels({2, { 0, 1, 0, 1, 0 } }, 5, { 0 }, { 2, 4 });
             lhs.delta.add(0, 'a', 1);
             lhs.delta.add(1, 'b', 2);
             lhs.delta.add(2, 'c', 3);
             lhs.delta.add(3, 'e', 4);
             lhs.delta.add(3, 'd', 2);
 
-            rhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+            rhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
             rhs.delta.add(0, 'b', 1);
             rhs.delta.add(1, 'x', 2);
             rhs.delta.add(2, 'd', 3);
@@ -176,7 +176,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(4, 'd', 5);
             rhs.delta.add(5, 'z', 6);
 
-            expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+            expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'x', 2);
             expected.delta.add(2, 'c', 3);
@@ -193,7 +193,7 @@ TEST_CASE("Mata::nft::compose()") {
         SECTION("Epsilon does not match on synchronization level.") {
 
             SECTION("Epsilon only on synchronization levels") {
-                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 lhs.delta.add(0, 'x', 1);
                 lhs.delta.add(1, EPSILON, 2);
                 lhs.delta.add(2, 'y', 3);
@@ -201,13 +201,13 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(4, 'x', 5);
                 lhs.delta.add(5, 'c', 6);
 
-                rhs = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 0, 1, 0 } }, 5, { 0 }, { 4 });
                 rhs.delta.add(0, 'a', 1);
                 rhs.delta.add(1, 'b', 2);
                 rhs.delta.add(2, 'c', 3);
                 rhs.delta.add(3, 'd', 4);
 
-                expected = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 expected.delta.add(0, 'x', 1);
                 expected.delta.add(1, EPSILON, 2);
                 expected.delta.add(2, 'y', 3);
@@ -222,7 +222,7 @@ TEST_CASE("Mata::nft::compose()") {
             }
 
             SECTION("Epsilon is even on non-synchronization levels") {
-                lhs = Nft(7, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2);
+                lhs = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, 7, { 0 }, { 6 });
                 lhs.delta.add(0, 'x', 1);
                 lhs.delta.add(1, EPSILON, 2);
                 lhs.delta.add(2, EPSILON, 3);
@@ -230,13 +230,13 @@ TEST_CASE("Mata::nft::compose()") {
                 lhs.delta.add(4, 'x', 5);
                 lhs.delta.add(5, EPSILON, 6);
 
-                rhs = Nft(5, { 0 }, { 4 }, { 0, 1, 0, 1, 0 }, 2);
+                rhs = Nft::with_levels({2, { 0, 1, 0, 1, 0 } }, 5, { 0 }, { 4 });
                 rhs.delta.add(0, 'a', 1);
                 rhs.delta.add(1, 'b', 2);
                 rhs.delta.add(2, EPSILON, 3);
                 rhs.delta.add(3, 'd', 4);
 
-                expected = Nft(13, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1 } }, 13, { 0 }, { 6 });
                 expected.delta.add(0, 'x', 1);
                 expected.delta.add(1, EPSILON, 2);
                 expected.delta.add(2, EPSILON, 3);
@@ -262,19 +262,19 @@ TEST_CASE("Mata::nft::compose()") {
 
     SECTION("lhs.num_of_levels != rhs.num_of_levels") {
         SECTION("lhs.num_of_levels > rhs.num_of_levels") {
-            lhs = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            lhs = Nft::with_levels({5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             lhs.delta.add(0, 'a', 1);
             lhs.delta.add(1, 'b', 2);
             lhs.delta.add(2, 'c', 3);
             lhs.delta.add(3, 'e', 4);
             lhs.delta.add(4, 'd', 5);
 
-            rhs = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            rhs = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             rhs.delta.add(0, 'b', 1);
             rhs.delta.add(1, 'd', 2);
             rhs.delta.add(2, 'f', 3);
 
-            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'c', 2);
             expected.delta.add(2, 'e', 3);
@@ -286,19 +286,19 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("lhs.num_of_levels < rhs.num_of_levels") {
-            lhs = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            lhs = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             lhs.delta.add(0, 'b', 1);
             lhs.delta.add(1, 'd', 2);
             lhs.delta.add(2, 'f', 3);
 
-            rhs = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            rhs = Nft::with_levels({5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             rhs.delta.add(0, 'a', 1);
             rhs.delta.add(1, 'b', 2);
             rhs.delta.add(2, 'c', 3);
             rhs.delta.add(3, 'e', 4);
             rhs.delta.add(4, 'd', 5);
 
-            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'c', 2);
             expected.delta.add(2, 'e', 3);
@@ -313,7 +313,7 @@ TEST_CASE("Mata::nft::compose()") {
     SECTION("num_of_levels == 4") {
 
         SECTION("Epsilon free") {
-            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             lhs.delta.add(0, 'i', 1);
             lhs.delta.add(1, 'b', 2);
             lhs.delta.add(2, 'c', 3);
@@ -323,7 +323,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(6, 'g', 7);
             lhs.delta.add(7, 'l', 8);
 
-            rhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             rhs.delta.add(0, 'a', 1);
             rhs.delta.add(1, 'i', 2);
             rhs.delta.add(2, 'j', 3);
@@ -333,7 +333,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(6, 'l', 7);
             rhs.delta.add(7, 'h', 8);
 
-            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected= Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'c', 3);
@@ -349,7 +349,7 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("Epsilon perfectly matches") {
-            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             lhs.delta.add(0, 'i', 1);
             lhs.delta.add(1, 'b', 2);
             lhs.delta.add(2, 'c', 3);
@@ -359,7 +359,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(6, 'g', 7);
             lhs.delta.add(7, 'l', 8);
 
-            rhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             rhs.delta.add(0, 'a', 1);
             rhs.delta.add(1, 'i', 2);
             rhs.delta.add(2, EPSILON, 3);
@@ -369,7 +369,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(6, 'l', 7);
             rhs.delta.add(7, 'h', 8);
 
-            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected= Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'c', 3);
@@ -385,7 +385,7 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("Epsilon only on synchronization levels") {
-            lhs = Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            lhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             lhs.delta.add(0, EPSILON, 1);
             lhs.delta.add(1, 'c', 2);
             lhs.delta.add(2, 'd', 3);
@@ -395,7 +395,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(6, 'h', 7);
             lhs.delta.add(7, 'a', 8);
 
-            rhs = Nft(9, { 0 }, { 4, 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            rhs = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 4, 8 });
             rhs.delta.add(0, 'e', 1);
             rhs.delta.add(1, 'b', 2);
             rhs.delta.add(2, 'a', 3);
@@ -405,7 +405,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(6, 'y', 7);
             rhs.delta.add(7, 'j', 8);
 
-            expected= Nft(9, { 0 }, { 8 }, { 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+            expected= Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, 9, { 0 }, { 8 });
             expected.delta.add(0, EPSILON, 1);
             expected.delta.add(1, 'c', 2);
             expected.delta.add(2, 'd', 3);
@@ -423,7 +423,7 @@ TEST_CASE("Mata::nft::compose()") {
 
     SECTION("level ordering") {
         SECTION("no jump") {
-            lhs = Nft(13, { 0 }, { 12 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs = Nft::with_levels({12, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 } }, 13, { 0 }, { 12 });
             lhs.delta.add(0, 'u', 1);
             lhs.delta.add(1, 'a', 2);
             lhs.delta.add(2, 'b', 3);
@@ -437,7 +437,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(10, 'z', 11);
             lhs.delta.add(11, 'f', 12);
 
-            rhs = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            rhs = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 } }, 14, { 0 }, { 13 });
             rhs.delta.add(0, 'g', 1);
             rhs.delta.add(1, 'h', 2);
             rhs.delta.add(2, 'u', 3);
@@ -452,7 +452,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(11, 'm', 12);
             rhs.delta.add(12, 'z', 13);
 
-            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 } }, 14, { 0 }, { 13 });
             expected.delta.add(0, 'g', 1);
             expected.delta.add(1, 'h', 2);
             expected.delta.add(2, 'a', 3);
@@ -473,7 +473,7 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("long jump - JumpMode::RepeatSymbol") {
-            lhs = Nft(12, { 0 }, { 11 }, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs = Nft::with_levels({12, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 } }, 12, { 0 }, { 11 });
             lhs.delta.add(0, 'u', 1);
             lhs.delta.add(1, 'a', 2);
             lhs.delta.add(2, 'v', 3);
@@ -486,7 +486,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(9, 'z', 10);
             lhs.delta.add(10, 'f', 11);
 
-            rhs = Nft(11, { 0 }, { 10 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 }, 13);
+            rhs = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 } }, 11, { 0 }, { 10 });
             rhs.delta.add(0, 'g', 1);
             rhs.delta.add(1, 'h', 2);
             rhs.delta.add(2, 'u', 3);
@@ -498,7 +498,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(8, 'y', 9);
             rhs.delta.add(9, 'z', 10);
 
-            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 } }, 14, { 0 }, { 13 });
             expected.delta.add(0, 'g', 1);
             expected.delta.add(1, 'h', 2);
             expected.delta.add(2, 'a', 3);
@@ -519,7 +519,7 @@ TEST_CASE("Mata::nft::compose()") {
         }
 
         SECTION("long jump - JumpMode::AppendDontCares") {
-            lhs = Nft(12, { 0 }, { 11 }, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 }, 12);
+            lhs = Nft::with_levels({12, { 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0 } }, 12, { 0 }, { 11 });
             lhs.delta.add(0, 'u', 1);
             lhs.delta.add(1, 'a', 2);
             lhs.delta.add(2, 'v', 3);
@@ -532,7 +532,7 @@ TEST_CASE("Mata::nft::compose()") {
             lhs.delta.add(9, 'z', 10);
             lhs.delta.add(10, 'f', 11);
 
-            rhs = Nft(11, { 0 }, { 10 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 }, 13);
+            rhs = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 0 } }, 11, { 0 }, { 10 });
             rhs.delta.add(0, 'g', 1);
             rhs.delta.add(1, 'h', 2);
             rhs.delta.add(2, 'u', 3);
@@ -544,7 +544,7 @@ TEST_CASE("Mata::nft::compose()") {
             rhs.delta.add(8, 'y', 9);
             rhs.delta.add(9, 'z', 10);
 
-            expected = Nft(14, { 0 }, { 13 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 }, 13);
+            expected = Nft::with_levels({13, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0 } }, 14, { 0 }, { 13 });
             expected.delta.add(0, 'g', 1);
             expected.delta.add(1, 'h', 2);
             expected.delta.add(2, 'a', 3);

--- a/tests/nft/nft-concatenation.cc
+++ b/tests/nft/nft-concatenation.cc
@@ -62,9 +62,9 @@ using Symbol = mata::Symbol;
 
 TEST_CASE("mata::nft::concatenate()") {
     Nft lhs{};
-    lhs.num_of_levels = 1;
+    lhs.levels.num_of_levels = 1;
     Nft rhs{};
-    rhs.num_of_levels = 1;
+    rhs.levels.num_of_levels = 1;
     Nft result{};
 
     SECTION("Empty automaton without states") {
@@ -353,9 +353,9 @@ TEST_CASE("mata::nft::concatenate()") {
 
 TEST_CASE("mata::nft::concatenate() over epsilon symbol") {
     Nft lhs{};
-    lhs.num_of_levels = 1;
+    lhs.levels.num_of_levels = 1;
     Nft rhs{};
-    rhs.num_of_levels = 1;
+    rhs.levels.num_of_levels = 1;
     Nft result{};
 
     SECTION("Empty automaton") {
@@ -582,9 +582,9 @@ TEST_CASE("mata::nft::concatenate() over epsilon symbol") {
 }
 
 TEST_CASE("mata::nft::(a|b)*") {
-    Nft aut1{ mata::nfa::builder::create_from_regex("a*") };
-    Nft aut2{ mata::nfa::builder::create_from_regex("b*") };
-    Nft aut3{ mata::nfa::builder::create_from_regex("a*b*") };
+    const Nft aut1{ mata::nfa::builder::create_from_regex("a*") };
+    const Nft aut2{ mata::nfa::builder::create_from_regex("b*") };
+    const Nft aut3{ mata::nfa::builder::create_from_regex("a*b*") };
     const Nft concatenated_aut{ concatenate(aut1, aut2) };
     CHECK(are_equivalent(concatenated_aut, aut3));
 }
@@ -612,7 +612,7 @@ TEST_CASE("mata::nft::Bug with epsilon transitions") {
     const Nft result{ concatenate(nft1, nft2, true) };
 
     Nft expected{ nft1 };
-    assert(expected.num_of_levels == nft1.num_of_levels);
+    assert(expected.levels.num_of_levels == nft1.levels.num_of_levels);
     expected.delta.add(3, EPSILON, 4);
     expected.delta.add(4, 97, 4);
     expected.delta.add(4, 98, 4);

--- a/tests/nft/nft-intersection.cc
+++ b/tests/nft/nft-intersection.cc
@@ -175,11 +175,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
     Nft expected;
     SECTION("Intersection of transducers with epsilon transitions.") {
         SECTION("The intersection results in an empty language.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            a = Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, EPSILON, 1);
             a.delta.add(1, 'b', 2);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            b = Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'b', 1);
             b.delta.add(1, EPSILON, 2);
 
@@ -191,21 +191,21 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("Epsilon is treated as an alphabet symbol.") {
-            a = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 1, 0, 0 }, 2);
+            a = Nft::with_levels({2, { 0, 1, 1, 0, 0 } }, 5, { 0 }, { 3, 4 });
             a.delta.add(0, EPSILON, 1);
             a.delta.add(0, 'b', 2);
             a.delta.add(1, 'a', 3);
             a.delta.add(2, 'a', 4);
             a.delta.add(4, EPSILON, 4);
 
-            b = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            b = Nft::with_levels({2, { 0, 1, 1, 0 } }, 4, { 0 }, { 3 });
             b.delta.add(0, EPSILON, 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(1, 'a', 3);
             b.delta.add(1, 'b', 3);
             b.delta.add(2, 'a', 3);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            expected = Nft::with_levels({2, { 0, 1, 1, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, EPSILON, 1);
             expected.delta.add(0, 'b', 2);
             expected.delta.add(1, 'a', 3);
@@ -219,16 +219,16 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
 
     SECTION("Intersection of linear transducers with multiple levels.") {
         SECTION("Intersection 1") {
-            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a = Nft::with_levels({4, { 0, 1, 3, 0 } }, 4, { 0 }, { 3 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'b', 2);
             a.delta.add(2, 'c', 3);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b = Nft::with_levels({4, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'b', 2);
 
-            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'b', 3);
@@ -240,10 +240,10 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("Intersection 2") {
-            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a = Nft::with_levels({2, { 0, 0 } }, 2, { 0 }, { 1 });
             a.delta.add(0, 'a', 1);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b = Nft::with_levels({2, { 0, 1, 0} }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'b', 2);
 
@@ -255,12 +255,12 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("Intersection 3") {
-            a = Nft(4, { 0 }, { 3 }, { 0, 2, 3, 0 }, 5);
+            a = Nft::with_levels({5, { 0, 2, 3, 0 } }, 4, { 0 }, { 3 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'b', 2);
             a.delta.add(2, 'a', 3);
 
-            b = Nft(5, { 0 }, { 4 }, { 0, 1, 3, 4, 0 }, 5);
+            b = Nft::with_levels({5, { 0, 1, 3, 4, 0 } }, 5, { 0 }, { 4 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'c', 2);
             b.delta.add(2, 'b', 3);
@@ -279,7 +279,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
     }
 
     SECTION("Intersection of complex transducers with multiple levels and an epsilon transition") {
-        a = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 1, 2, 2, 0, 0, 0 }, 3);
+        a = Nft::with_levels({3, { 0, 1, 1, 2, 2, 0, 0, 0 } }, 8, { 0 }, { 5, 6, 7 });
         a.delta.add(0, 'a', 1);
         a.delta.add(0, 'b', 2);
         a.delta.add(0, 'a', 4);
@@ -292,7 +292,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         a.delta.add(6, EPSILON, 4);
         a.delta.add(7, 'c', 2);
 
-        b = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 2, 0, 0 }, 3);
+        b = Nft::with_levels({3, { 0, 1, 2, 0, 0 } }, 5, { 0 }, { 3, 4 });
         b.delta.add(0, 'a', 1);
         b.delta.add(0, 'b', 1);
         b.delta.add(0, 'a', 3);
@@ -302,7 +302,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         b.delta.add(3, 'c', 3);
         b.delta.add(4, EPSILON, 4);
 
-        expected = Nft(12, { 0 }, { 4, 5, 9, 11 }, { 0, 1, 1, 2, 0, 0, 2, 1, 2, 0, 2, 0 }, 3);
+        expected = Nft::with_levels({3, { 0, 1, 1, 2, 0, 0, 2, 1, 2, 0, 2, 0 } }, 12, { 0 }, { 4, 5, 9, 11 });
         expected.delta.add(0, 'b', 1);
         expected.delta.add(0, 'a', 2);
         expected.delta.add(0, 'a', 7);
@@ -325,11 +325,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
 
     SECTION("Intersection of transducers with the DONT_CARE symbol") {
         SECTION("DONT_CARE is in the lhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, DONT_CARE, 1);
             a.delta.add(1, 'c', 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, 'a', 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(0, 'a', 3);
@@ -337,7 +337,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
             b.delta.add(2, 'd', 5);
             b.delta.add(3, 'e', 6);
 
-            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 } }, 10, { 0 }, { 7, 8, 9 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(0, 'b', 2);
             expected.delta.add(0, 'a', 3);
@@ -354,11 +354,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("DONT_CARE is in the rhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'c', 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, DONT_CARE, 1);
             b.delta.add(0, DONT_CARE, 2);
             b.delta.add(0, DONT_CARE, 3);
@@ -366,7 +366,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
             b.delta.add(2, 'd', 5);
             b.delta.add(3, 'e', 6);
 
-            expected = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 2, 2, 0, 0, 0 } }, 8, { 0 }, { 5, 6, 7 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'c', 2);
             expected.delta.add(1, 'd', 3);
@@ -381,11 +381,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a higher level than it is in rhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, DONT_CARE, 1);
             a.delta.add(1, DONT_CARE, 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, DONT_CARE, 1);
             b.delta.add(0, DONT_CARE, 2);
             b.delta.add(0, DONT_CARE, 3);
@@ -393,7 +393,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
             b.delta.add(2, 'd', 5);
             b.delta.add(3, 'e', 6);
 
-            expected = Nft(10, { 0 }, { 7, 8, 9 }, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 1, 1, 2, 2, 2, 0, 0, 0 } }, 10, { 0 }, { 7, 8, 9 });
             expected.delta.add(0, DONT_CARE, 1);
             expected.delta.add(0, DONT_CARE, 2);
             expected.delta.add(0, DONT_CARE, 3);
@@ -410,15 +410,15 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
         }
 
         SECTION("DONT_CARE is in the rhs at a higher level than it is in the lhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 1, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, DONT_CARE, 2);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, DONT_CARE, 2);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, DONT_CARE, 2);
             expected.delta.add(2, DONT_CARE, 3);
@@ -550,11 +550,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
     Nft expected;
     SECTION("Intersection of transducers with epsilon transitions.") {
         SECTION("The intersection results in an empty language.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            a = Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, EPSILON, 1);
             a.delta.add(1, 'b', 2);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            b = Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'b', 1);
             b.delta.add(1, EPSILON, 2);
 
@@ -566,21 +566,21 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("Epsilon is treated as an alphabet symbol.") {
-            a = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 1, 0, 0 }, 2);
+            a = Nft::with_levels({2, { 0, 1, 1, 0, 0 } }, 5, { 0 }, { 3, 4 });
             a.delta.add(0, EPSILON, 1);
             a.delta.add(0, 'b', 2);
             a.delta.add(1, 'a', 3);
             a.delta.add(2, 'a', 4);
             a.delta.add(4, EPSILON, 4);
 
-            b = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            b = Nft::with_levels({2, { 0, 1, 1, 0 } }, 4, { 0 }, { 3 });
             b.delta.add(0, EPSILON, 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(1, 'a', 3);
             b.delta.add(1, 'b', 3);
             b.delta.add(2, 'a', 3);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 1, 0 }, 2);
+            expected = Nft::with_levels({2, { 0, 1, 1, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, EPSILON, 1);
             expected.delta.add(0, 'b', 2);
             expected.delta.add(1, 'a', 3);
@@ -594,16 +594,16 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
 
     SECTION("Intersection of linear transducers with multiple levels.") {
         SECTION("Intersection 1") {
-            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a = Nft::with_levels({4, { 0, 1, 3, 0 } }, 4, { 0 }, { 3 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'b', 2);
             a.delta.add(2, 'c', 3);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b = Nft::with_levels({4, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'b', 2);
 
-            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'b', 3);
@@ -616,16 +616,16 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("Intersection 2") {
-            a = Nft(4, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+            a = Nft::with_levels({4, { 0, 1, 3, 0 } }, 4, { 0 }, { 3 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'a', 2);
             a.delta.add(2, 'a', 3);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 4);
+            b = Nft::with_levels({4, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'a', 2);
 
-            expected = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'a', 3);
@@ -637,10 +637,10 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("Intersection 3") {
-            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a = Nft::with_levels({2, { 0, 0 } }, 2, { 0 }, { 1 });
             a.delta.add(0, 'a', 1);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b = Nft::with_levels({2, { 0, 1, 0} }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'b', 2);
 
@@ -652,10 +652,10 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("Intersection 4") {
-            a = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            a = Nft::with_levels({2, { 0, 0 } }, 2, { 0 }, { 1 });
             a.delta.add(0, 'a', 1);
 
-            b = Nft(3, { 0 }, { 2 }, { 0, 1, 0}, 1);
+            b = Nft::with_levels({2, { 0, 1, 0} }, 3, { 0 }, { 2 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'a', 2);
 
@@ -667,18 +667,18 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("Intersection 5") {
-            a = Nft(4, { 0 }, { 3 }, { 0, 2, 3, 0 }, 5);
+            a = Nft::with_levels({5, { 0, 2, 3, 0 } }, 4, { 0 }, { 3 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'a', 2);
             a.delta.add(2, 'b', 3);
 
-            b = Nft(5, { 0 }, { 4 }, { 0, 1, 3, 4, 0 }, 5);
+            b = Nft::with_levels({5, { 0, 1, 3, 4, 0 } }, 5, { 0 }, { 4 });
             b.delta.add(0, 'a', 1);
             b.delta.add(1, 'a', 2);
             b.delta.add(2, 'b', 3);
             b.delta.add(3, 'b', 4);
 
-            expected = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected = Nft::with_levels({5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'a', 3);
@@ -692,7 +692,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
     }
 
     SECTION("Intersection of complex transducers with multiple levels and an epsilon transition") {
-        a = Nft(8, { 0 }, { 5, 6, 7 }, { 0, 1, 1, 2, 2, 0, 0, 0 }, 3);
+        a = Nft::with_levels({3, { 0, 1, 1, 2, 2, 0, 0, 0 } }, 8, { 0 }, { 5, 6, 7 });
         a.delta.add(0, 'a', 1);
         a.delta.add(0, 'b', 2);
         a.delta.add(0, 'a', 4);
@@ -705,7 +705,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         a.delta.add(6, EPSILON, 4);
         a.delta.add(7, 'c', 2);
 
-        b = Nft(5, { 0 }, { 3, 4 }, { 0, 1, 2, 0, 0 }, 3);
+        b = Nft::with_levels({3, { 0, 1, 2, 0, 0 } }, 5, { 0 }, { 3, 4 });
         b.delta.add(0, 'a', 1);
         b.delta.add(0, 'b', 1);
         b.delta.add(0, 'a', 3);
@@ -715,7 +715,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         b.delta.add(3, EPSILON, 3);
         b.delta.add(4, 'c', 4);
 
-        expected = Nft(6, { 0 }, { 3, 5 }, { 0, 1, 2, 0, 1, 0}, 3);
+        expected = Nft::with_levels({3, { 0, 1, 2, 0, 1, 0} }, 6, { 0 }, { 3, 5 });
         expected.delta.add(0, 'a', 1);
         expected.delta.add(0, 'b', 1);
         expected.delta.add(0, 'b', 4);
@@ -731,11 +731,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
 
     SECTION("Intersection of transducers with the DONT_CARE symbol") {
         SECTION("DONT_CARE is in the lhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, DONT_CARE, 1);
             a.delta.add(1, 'c', 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, 'a', 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(0, 'a', 3);
@@ -743,7 +743,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
             b.delta.add(2, 'd', 5);
             b.delta.add(3, 'e', 6);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'c', 2);
             expected.delta.add(2, 'c', 3);
@@ -754,11 +754,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("DONT_CARE is in the rhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, 'c', 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, 'a', 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(0, 'a', 3);
@@ -766,7 +766,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
             b.delta.add(2, DONT_CARE, 5);
             b.delta.add(3, DONT_CARE, 6);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'c', 3);
@@ -777,11 +777,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("DONT_CARE is in both lhs and rhs. In lhs, DONT_CARE is at a smaller level than it is in rhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, DONT_CARE, 1);
             a.delta.add(1, 'c', 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, 'a', 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(0, 'a', 3);
@@ -789,7 +789,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
             b.delta.add(2, DONT_CARE, 5);
             b.delta.add(3, DONT_CARE, 6);
 
-            expected = Nft(3, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 0 } }, 3, { 0 }, { 3 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, DONT_CARE, 2);
@@ -801,11 +801,11 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
         }
 
         SECTION("DONT_CARE is in the rhs at a smaller level than it is in the lhs.") {
-            a = Nft(3, { 0 }, { 2 }, { 0, 2, 0 }, 3);
+            a = Nft::with_levels({3, { 0, 2, 0 } }, 3, { 0 }, { 2 });
             a.delta.add(0, 'a', 1);
             a.delta.add(1, DONT_CARE, 2);
 
-            b = Nft(7, { 0 }, { 4, 5, 6 }, { 0, 1, 1, 1, 0, 0, 0 }, 3);
+            b = Nft::with_levels({3, { 0, 1, 1, 1, 0, 0, 0 } }, 7, { 0 }, { 4, 5, 6 });
             b.delta.add(0, 'a', 1);
             b.delta.add(0, 'b', 2);
             b.delta.add(0, 'a', 3);
@@ -813,7 +813,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") 
             b.delta.add(2, DONT_CARE, 5);
             b.delta.add(3, DONT_CARE, 6);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, 'a', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, DONT_CARE, 3);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -27,16 +27,14 @@ using namespace mata::applications::strings;
 using namespace mata::nft::plumbing;
 using namespace mata::utils;
 using namespace mata::parser;
-using Symbol = mata::Symbol;
-using Word = mata::Word;
 using IntAlphabet = mata::IntAlphabet;
 using OnTheFlyAlphabet = mata::OnTheFlyAlphabet;
 
 TEST_CASE("mata::nft::Nft()") {
     Nft nft{};
     nft.levels.resize(3);
-    nft.num_of_levels = 5;
-    CHECK(nft.num_of_levels == 5);
+    nft.levels.num_of_levels = 5;
+    CHECK(nft.levels.num_of_levels == 5);
     CHECK(nft.levels.size() == 3);
     nft.levels[0] = 0;
     nft.levels[1] = 3;
@@ -328,9 +326,8 @@ TEST_CASE("mata::nft::is_acyclic")
         REQUIRE(!aut.is_acyclic());
     }
 
-    SECTION("Automaton with self-loops")
-    {
-        Nft aut(2);
+    SECTION("Automaton with self-loops") {
+        aut = Nft{ 2 };
         aut.initial = {0};
         aut.final = {1};
         aut.delta.add(0, 'c', 1);
@@ -341,7 +338,7 @@ TEST_CASE("mata::nft::is_acyclic")
 
 TEST_CASE("mata::nft::get_word_for_path()")
 { // {{{
-    Nft aut(5);
+    Nft aut{ 5 };
     Run path;
     Word word;
 
@@ -449,29 +446,42 @@ TEST_CASE("mata::nft::determinize()") {
     Nft result;
     std::unordered_map<StateSet, State> subset_map;
 
+    const auto CHECK_SHARED = [&] {
+        CHECK(result.initial.size() <= 1);
+        for (const auto& state_post : result.delta) {
+            for (const auto& [symbol, targets] : state_post) { CHECK(targets.size() == 1); }
+        }
+        CHECK(result.levels.num_of_levels == 3);
+        CHECK(are_equivalent(nft, result));
+        CHECK(result.num_of_states() == result.get_reachable_states().size());
+    };
+
     SECTION("empty automaton") {
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
     SECTION("simple automaton 1") {
         nft.initial = { 0 };
         nft.final = { 0 };
-        nft.levels = { 0 };
+        nft.levels.set(std::vector<Level>{ 0 });
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
     SECTION("simple automaton 2") {
         nft.initial = { 0 };
         nft.final = { 1 };
         nft.delta.add(0, 'a', 1);
-        nft.levels = { 0, 0 };
+        nft.levels.set({ 0, 0 });
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
     SECTION("simple automaton with epsilons") {
         nft.initial = { 0 };
         nft.final = { 3, 4, 6 };
-        nft.levels = { 0, 1, 2, 0, 0, 2, 0 };
+        nft.levels.set({ 0, 1, 2, 0, 0, 2, 0 });
         nft.delta.reserve(7);
         nft.delta.add(0, EPSILON, 3);
         nft.delta.add(0, EPSILON, 5);
@@ -480,12 +490,13 @@ TEST_CASE("mata::nft::determinize()") {
         nft.delta.add(1, EPSILON, 2);
         nft.delta.add(2, EPSILON, 4);
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
     SECTION("simple automaton with epsilons") {
         nft.initial = { 0 };
         nft.final = { 3, 4, 6 };
-        nft.levels = { 0, 1, 2, 0, 0, 2, 0 };
+        nft.levels.set({ 0, 1, 2, 0, 0, 2, 0 });
         nft.delta.reserve(7);
         nft.delta.add(0, 'a', 3);
         nft.delta.add(0, 'a', 5);
@@ -494,12 +505,13 @@ TEST_CASE("mata::nft::determinize()") {
         nft.delta.add(1, 'a', 2);
         nft.delta.add(2, 'a', 4);
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
     SECTION("nft with loops") {
         nft.initial = { 0 };
         nft.final = { 3, 4 };
-        nft.levels = { 0, 2, 1, 0, 0 };
+        nft.levels.set({ 0, 2, 1, 0, 0 });
         nft.delta.add(0, 'a', 2);
         nft.delta.add(0, 'a', 1);
         nft.delta.add(0, 'a', 0);
@@ -509,13 +521,14 @@ TEST_CASE("mata::nft::determinize()") {
         nft.delta.add(3, 'c', 3);
         nft.delta.add(4, 'd', 4);
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
 
 
     SECTION("simple automaton with symbols and epsilons") {
         nft.initial = { 0 };
         nft.final = { 3, 4, 6, 9, 10 };
-        nft.levels = { 0, 1, 2, 0, 0, 2, 0, 1, 2, 0, 0, 1 };
+        nft.levels.set({ 0, 1, 2, 0, 0, 2, 0, 1, 2, 0, 0, 1 });
         nft.delta.add(0, EPSILON, 3);
         nft.delta.add(0, EPSILON, 5);
         nft.delta.add(5, 'a', 6);
@@ -531,17 +544,8 @@ TEST_CASE("mata::nft::determinize()") {
         nft.delta.add(9, 'g', 11);
         nft.delta.add(11, 'g', 9);
         result = determinize(nft, &subset_map);
+        CHECK_SHARED();
     }
-
-    CHECK(result.initial.size() <= 1);
-    for (const auto& state_post: result.delta) {
-        for (const auto& [symbol, targets]: state_post) {
-            CHECK(targets.size() == 1);
-        }
-    }
-    CHECK(result.num_of_levels == 3);
-    CHECK(are_equivalent(nft, result));
-    CHECK(result.num_of_states() == result.get_reachable_states().size());
 
     // SECTION("This broke Delta when delta[q] could cause re-allocation of post")
     // {
@@ -953,42 +957,59 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls")
 TEST_CASE("mata::nft::make_complete()") {
     Nft nft{ Nft::with_levels(3) };
     Nft result{ Nft::with_levels(3) };
-    EnumAlphabet alphabet{ 'a', 'b', 'c'};
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
     nft.alphabet = &alphabet;
     result.alphabet = &alphabet;
 
-     SECTION("empty automaton, empty alphabet") {
-         alphabet.clear();
-         nft.make_complete(&alphabet);
-     }
+    const auto CHECK_SHARED = [&]{
+        CHECK(are_equivalent(nft, result));
+        for (State source{ 0 }; source < result.num_of_states(); ++source) {
+            for (const auto symbol : alphabet.get_alphabet_symbols()) {
+                const auto& state_post{ result.delta[source] };
+                auto state_post_it{ state_post.find(symbol) };
+                REQUIRE(state_post_it != state_post.end());
+                for (const auto target : state_post_it->targets) { CHECK(result.levels.can_follow_for_states(source, target)); }
+            }
+        }
+        CHECK(result.is_complete());
+        CHECK(result.levels.num_of_levels == nft.levels.num_of_levels);
+    };
 
-    SECTION("make_complete with num_of_levels == 1") {
-        nft.num_of_levels = 1;
+    SECTION("empty automaton, empty alphabet") {
+        alphabet.clear();
+        nft.make_complete(&alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("make_complete with levels.num_of_levels == 1") {
+        nft.levels.num_of_levels = 1;
         nft.initial = { 0 };
         nft.final = { 2 };
         nft.delta.add(0, 'a', 1);
         nft.delta.add(1, 'b', 2);
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
     }
 
-    SECTION("make_complete with num_of_levels == 2") {
-        nft.num_of_levels = 2;
+    SECTION("make_complete with levels.num_of_levels == 2") {
+        nft.levels.num_of_levels = 2;
         nft.initial = { 0 };
         nft.final = { 4 };
-        nft.levels = { 0, 1, 0, 1, 0 };
+        nft.levels.set({ 0, 1, 0, 1, 0 });
         nft.delta.add(0, 'a', 1);
         nft.delta.add(1, 'b', 2);
         nft.delta.add(2, 'a', 3);
         nft.delta.add(3, 'b', 4);
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
     }
 
-    SECTION("make_complete with num_of_levels == 3") {
+    SECTION("make_complete with levels.num_of_levels == 3") {
         nft.initial = { 0 };
         nft.final = { 4 };
-        nft.levels = { 0, 1, 2, 0, 1, 0 };
+        nft.levels.set({ 0, 1, 2, 0, 1, 0 });
         nft.delta.add(0, 'a', 1);
         nft.delta.add(1, 'b', 2);
         nft.delta.add(2, 'a', 3);
@@ -996,23 +1017,25 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(4, 'a', 5);
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
     }
 
     SECTION("self loops and jumps") {
-         nft.initial = { 0 };
-         nft.final = { 4 };
-         nft.levels = { 0, 1, 2, 0, 1, 0 };
-         nft.delta.add(0, 'a', 1);
-         nft.delta.add(0, 'b', 0);
-         nft.delta.add(0, 'a', 2);
-         nft.delta.add(0, 'b', 3);
-         nft.delta.add(1, 'b', 2);
-         nft.delta.add(2, 'a', 3);
-         nft.delta.add(3, 'b', 4);
-         nft.delta.add(4, 'a', 5);
-         result = nft;
-         result.make_complete(&alphabet);
-     }
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels.set({ 0, 1, 2, 0, 1, 0 });
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(0, 'b', 0);
+        nft.delta.add(0, 'a', 2);
+        nft.delta.add(0, 'b', 3);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
+        result = nft;
+        result.make_complete(&alphabet);
+        CHECK_SHARED();
+    }
 
     SECTION("with sinks") {
          nft.initial = { 0 };
@@ -1048,8 +1071,8 @@ TEST_CASE("mata::nft::make_complete()") {
                 REQUIRE(result.levels.can_follow_for_states(source, target));
             }
         }
+        CHECK_SHARED();
     }
-    CHECK(result.is_complete());
 }
 
 #ifdef MATA_NFT_NOT_IMPLEMENTED
@@ -1904,13 +1927,43 @@ TEST_CASE("mata::nft::revert()")
 } // }}}
 
 TEST_CASE("mata::nft::Levels") {
+    Levels levels{};
+
     SECTION("empty") {
-        Levels levels;
         CHECK(levels.count(3) == 0);
     }
 
+    SECTION("construction") {
+        levels = Levels{ 1 };
+        CHECK(levels.num_of_levels == 1);
+        CHECK(levels.empty());
+    }
+
+    SECTION("construction 2") {
+        levels = Levels{ 1, 2 };
+        CHECK(levels.num_of_levels == 1);
+        CHECK(levels.size() == 2);
+        CHECK(std::ranges::all_of(levels, [](const Level level) { return level == DEFAULT_LEVEL; }));
+    }
+
+    SECTION("construction 3") {
+        levels = Levels{ 3, { 2 } };
+        CHECK(levels.num_of_levels == 3);
+        CHECK(levels.size() == 1);
+        CHECK(levels == std::vector<Level>{ 2 });
+        CHECK(levels != Levels{ 2 });
+    }
+
+    SECTION("construction 4") {
+        levels = { 3, 2 };
+        CHECK(levels.num_of_levels == 4);
+        CHECK(levels.size() == 2);
+        CHECK(levels == std::vector<Level>{ 3, 2 });
+        CHECK(levels != Levels{ 3, { 2 } });
+    }
+
     SECTION("existing") {
-        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        levels = { 1, 0, 1, 0, 4, 2, 0 };
         CHECK(levels.count(0) == 3);
         CHECK(levels.count(1) == 2);
         CHECK(levels.count(2) == 1);
@@ -1918,20 +1971,20 @@ TEST_CASE("mata::nft::Levels") {
     }
 
     SECTION("non-existing") {
-        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+       levels ={ 1, 0, 1, 0, 4, 2, 0 };
         CHECK(levels.count(3) == 0);
         CHECK(levels.count(5) == 0);
     }
 
     SECTION("mata::nft::Levels::get_levels_of()") {
-        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        levels = { 1, 0, 1, 0, 4, 2, 0 };
         StateSet states = { 0, 2, 4, 5 };
         std::vector<Level> expected_levels = { 1, 1, 4, 2 };
         CHECK(levels.get_levels_of(states) == expected_levels);
     }
 
     SECTION("mata::nft::Levels::get_minimal_next_level_of()") {
-        Levels levels = { 1, 0, 1, 0, 4, 2, 0 };
+        levels = { 1, 0, 1, 0, 4, 2, 0 };
         StateSet states = { 0, 1, 4, 5 };
         CHECK(levels.get_minimal_next_level_of(states) == 1);
         states.erase(0);
@@ -1949,8 +2002,7 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(3);
             aut.initial.insert(0);
             aut.final.insert(2);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0 };
+            aut.levels = { 2, { 0, 1, 0} };
             aut.delta.add(0, 'a', 1);
             aut.delta.add(0, 'b', 1);
             aut.delta.add(1, 'c', 2);
@@ -1960,8 +2012,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(3);
             expected.initial.insert(0);
             expected.final.insert(2);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 0 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 0 });
             expected.delta.add(0, 'c', 1);
             expected.delta.add(0, 'd', 1);
             expected.delta.add(1, 'a', 2);
@@ -1977,8 +2029,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(0, 'b', 2);
             aut.delta.add(1, 'c', 3);
@@ -1988,8 +2040,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(4);
             expected.initial.insert(0);
             expected.final.insert(3);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 1, 0 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 1, 0 });
             expected.delta.add(0, 'c', 1);
             expected.delta.add(0, 'd', 2);
             expected.delta.add(1, 'a', 3);
@@ -2005,8 +2057,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(1, 'c', 3);
@@ -2016,8 +2068,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.initial.insert(0);
             expected.final.insert(4);
             expected.final.insert(5);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 1, 0, 0 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 1, 0, 0 });
             expected.delta.add(0, 'b', 1);
             expected.delta.add(0, 'c', 2);
             expected.delta.add(1, 'a', 3);
@@ -2043,8 +2095,7 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(3);
             aut.initial.insert(1);
             aut.final.insert(2);
-            aut.num_of_levels = 1;
-            aut.levels = { 1, 0, 0 };
+            aut.levels = { 2, { 1, 0, 0 } };
             Nft aut_new = invert_levels(aut);
             CHECK(aut_new.is_lang_empty());
             CHECK(aut_new.delta.num_of_transitions() == 0);
@@ -2056,8 +2107,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(3);
             aut.initial.insert(0);
             aut.final.insert(2);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             Nft aut_new = invert_levels(aut);
@@ -2065,8 +2116,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(3);
             expected.initial.insert(0);
             expected.final.insert(2);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 0 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 0 });
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, 'a', 2);
 
@@ -2080,8 +2131,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(5);
             aut.initial.insert(0);
             aut.final.insert(4);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2091,8 +2142,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(5);
             expected.initial.insert(0);
             expected.final.insert(4);
-            expected.num_of_levels = 2;
-            expected.levels = {0, 1, 0, 1, 0};
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({0, 1, 0, 1, 0});
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'd', 3);
@@ -2108,8 +2159,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 3;
-            aut.levels = { 0, 1, 2, 0 };
+            aut.levels.num_of_levels = 3;
+            aut.levels.set({ 0, 1, 2, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2119,8 +2170,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(4);
             expected.initial.insert(0);
             expected.final.insert(3);
-            expected.num_of_levels = 3;
-            expected.levels = {0, 1, 2, 0};
+            expected.levels.num_of_levels = 3;
+            expected.levels.set({0, 1, 2, 0});
             expected.delta.add(0, 'd', 3);
             expected.delta.add(0, 'c', 1);
             expected.delta.add(1, 'b', 2);
@@ -2136,8 +2187,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 4;
-            aut.levels = { 0, 1, 3, 0 };
+            aut.levels.num_of_levels = 4;
+            aut.levels.set({ 0, 1, 3, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2147,8 +2198,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(5);
             expected.initial.insert(0);
             expected.final.insert(4);
-            expected.num_of_levels = 4;
-            expected.levels = {0, 1, 3, 1, 0};
+            expected.levels.num_of_levels = 4;
+            expected.levels.set({0, 1, 3, 1, 0});
             expected.delta.add(0, 'c', 1);
             expected.delta.add(1, 'b', 2);
             expected.delta.add(2, 'a', 4);
@@ -2166,8 +2217,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.initial.insert(0);
             aut.final.insert(2);
             aut.final.insert(4);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(1, 'd', 4);
@@ -2181,8 +2232,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.initial.insert(0);
             expected.final.insert(2);
             expected.final.insert(6);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 0, 1, 1, 1, 0, 1, 1 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 0, 1, 1, 1, 0, 1, 1 });
             expected.delta.add(0, 'b', 1);
             expected.delta.add(0, 'd', 8);
             expected.delta.add(1, 'a', 2);
@@ -2207,8 +2258,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.initial.insert(0);
             aut.final.insert(3);
             aut.final.insert(4);
-            aut.num_of_levels = 3;
-            aut.levels = { 0, 1, 2, 0, 0, 2 };
+            aut.levels.num_of_levels = 3;
+            aut.levels.set({ 0, 1, 2, 0, 0, 2 });
             aut.delta.add(0, 'a', 3);
             aut.delta.add(0, 'b', 2);
             aut.delta.add(0, 'c', 1);
@@ -2225,8 +2276,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.initial.insert(0);
             expected.final.insert(10);
             expected.final.insert(11);
-            expected.num_of_levels = 3;
-            expected.levels = { 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1 };
+            expected.levels.num_of_levels = 3;
+            expected.levels.set({ 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1 });
             expected.delta.add(0, 'a', 10);
             expected.delta.add(0, 'e', 1);
             expected.delta.add(0, 'e', 2);
@@ -2267,8 +2318,7 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(3);
             aut.initial.insert(1);
             aut.final.insert(2);
-            aut.num_of_levels = 1;
-            aut.levels = { 1, 0, 0 };
+            aut.levels = { 2, { 1, 0, 0 } };
             Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
             CHECK(aut_new.is_lang_empty());
             CHECK(aut_new.delta.num_of_transitions() == 0);
@@ -2280,8 +2330,7 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(3);
             aut.initial.insert(0);
             aut.final.insert(2);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0 };
+            aut.levels = { 2, { 0, 1, 0} };
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             Nft aut_new = invert_levels(aut, JumpMode::AppendDontCares);
@@ -2289,8 +2338,7 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(3);
             expected.initial.insert(0);
             expected.final.insert(2);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 0 };
+            expected.levels = { 2, { 0, 1, 0} };
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, 'a', 2);
 
@@ -2304,8 +2352,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(5);
             aut.initial.insert(0);
             aut.final.insert(4);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2315,8 +2363,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(5);
             expected.initial.insert(0);
             expected.final.insert(4);
-            expected.num_of_levels = 2;
-            expected.levels = {0, 1, 0, 1, 0};
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({0, 1, 0, 1, 0});
             expected.delta.add(0, 'b', 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'd', 3);
@@ -2332,8 +2380,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(2);
             aut.initial.insert(0);
             aut.final.insert(1);
-            aut.num_of_levels = 4;
-            aut.levels = { 0, 0 };
+            aut.levels.num_of_levels = 4;
+            aut.levels.set({ 0, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(0, 'b', 1);
             aut.delta.add(0, 'c', 1);
@@ -2343,8 +2391,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(3);
             expected.initial.insert(0);
             expected.final.insert(2);
-            expected.num_of_levels = 4;
-            expected.levels = { 0, 3, 0 };
+            expected.levels.num_of_levels = 4;
+            expected.levels.set({ 0, 3, 0 });
             expected.delta.add(0, DONT_CARE, 1);
             expected.delta.add(1, 'a', 2);
             expected.delta.add(1, 'b', 2);
@@ -2361,8 +2409,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 3;
-            aut.levels = { 0, 1, 2, 0 };
+            aut.levels.num_of_levels = 3;
+            aut.levels.set({ 0, 1, 2, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2372,8 +2420,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(5);
             expected.initial.insert(0);
             expected.final.insert(3);
-            expected.num_of_levels = 3;
-            expected.levels = {0, 1, 2, 0, 2};
+            expected.levels.num_of_levels = 3;
+            expected.levels.set({0, 1, 2, 0, 2});
             expected.delta.add(0, 'c', 1);
             expected.delta.add(0, DONT_CARE, 4);
             expected.delta.add(1, 'b', 2);
@@ -2390,8 +2438,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft aut(4);
             aut.initial.insert(0);
             aut.final.insert(3);
-            aut.num_of_levels = 4;
-            aut.levels = { 0, 1, 3, 0 };
+            aut.levels.num_of_levels = 4;
+            aut.levels.set({ 0, 1, 3, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(2, 'c', 3);
@@ -2401,8 +2449,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             Nft expected = Nft(7);
             expected.initial.insert(0);
             expected.final.insert(4);
-            expected.num_of_levels = 4;
-            expected.levels = { 0, 1, 2, 3, 0, 1, 3 };
+            expected.levels.num_of_levels = 4;
+            expected.levels.set({ 0, 1, 2, 3, 0, 1, 3 });
             expected.delta.add(0, 'c', 1);
             expected.delta.add(0, 'c', 5);
             expected.delta.add(1, DONT_CARE, 2);
@@ -2422,8 +2470,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.initial.insert(0);
             aut.final.insert(2);
             aut.final.insert(4);
-            aut.num_of_levels = 2;
-            aut.levels = { 0, 1, 0, 1, 0 };
+            aut.levels.num_of_levels = 2;
+            aut.levels.set({ 0, 1, 0, 1, 0 });
             aut.delta.add(0, 'a', 1);
             aut.delta.add(1, 'b', 2);
             aut.delta.add(1, 'd', 4);
@@ -2437,8 +2485,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.initial.insert(0);
             expected.final.insert(2);
             expected.final.insert(6);
-            expected.num_of_levels = 2;
-            expected.levels = { 0, 1, 0, 1, 1, 1, 0, 1, 1 };
+            expected.levels.num_of_levels = 2;
+            expected.levels.set({ 0, 1, 0, 1, 1, 1, 0, 1, 1 });
             expected.delta.add(0, 'b', 1);
             expected.delta.add(0, 'd', 8);
             expected.delta.add(1, 'a', 2);
@@ -2463,8 +2511,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             aut.initial.insert(0);
             aut.final.insert(3);
             aut.final.insert(4);
-            aut.num_of_levels = 3;
-            aut.levels = { 0, 1, 2, 0, 0, 2 };
+            aut.levels.num_of_levels = 3;
+            aut.levels.set({ 0, 1, 2, 0, 0, 2 });
             aut.delta.add(0, 'a', 3);
             aut.delta.add(0, 'b', 2);
             aut.delta.add(0, 'c', 1);
@@ -2481,8 +2529,8 @@ TEST_CASE("mata::nft::Nft::invert_levels()") {
             expected.initial.insert(0);
             expected.final.insert(10);
             expected.final.insert(11);
-            expected.num_of_levels = 3;
-            expected.levels = { 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1, 2, 2, 1, 1, 2 };
+            expected.levels.num_of_levels = 3;
+            expected.levels.set({ 0, 1, 1, 2, 2, 2, 1, 2, 1, 2, 0, 0, 1, 2, 2, 1, 1, 2 });
             expected.delta.add(0, 'e', 1);
             expected.delta.add(0, 'e', 2);
             expected.delta.add(0, 'g', 6);
@@ -2708,7 +2756,6 @@ TEST_CASE("mata::nft::fw-direct-simulation()")
 
     SECTION("more than one level")
     {
-        Nft aut;
         aut.add_state_with_level(0, 0);
         aut.add_state_with_level(1, 0);
         aut.add_state_with_level(2, 1);
@@ -2869,7 +2916,7 @@ TEST_CASE("mata::nft::reduce_size_by_simulation()")
         CHECK(middle_state == state_renaming.at(4));
         CHECK(result.delta.contains(state_renaming.at(0), 'a', middle_state));
         CHECK(result.delta.contains(middle_state, 'a', state_renaming.at(1)));
-        REQUIRE(result.num_of_levels == 2);
+        REQUIRE(result.levels.num_of_levels == 2);
         CHECK(result.levels[state_renaming.at(0)] == 0);
         CHECK(result.levels[state_renaming.at(1)] == 0);
         CHECK(result.levels[middle_state] == 1);
@@ -3036,7 +3083,7 @@ TEST_CASE("mata::nft::remove_epsilon()") {
 
     SECTION("3 tapes") {
         Nft aut{4, {0}, {2}};
-        aut.num_of_levels = 3;
+        aut.levels.num_of_levels = 3;
         aut.add_transition(0, {'a', 'a', 'a'}, 1);
         aut.add_transition(0, {'b', 'a', 'a'}, 3);
         aut.add_transition(3, {'a', 'a', 'a'}, 2);
@@ -3057,13 +3104,13 @@ TEST_CASE("mata::nft::remove_epsilon()") {
     }
 
     SECTION("issue #565") {
-        Nft lhs(4, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft lhs(Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 3 }));
         lhs.delta.add(0, EPSILON, 1);
         lhs.delta.add(0, EPSILON, 3);
         lhs.delta.add(1, 'a', 2);
         lhs.delta.add(2, 'b', 3);
 
-        Nft rhs(4, { 0 }, { 0, 3 }, { 0, 1, 2, 0 }, 3);
+        Nft rhs(Nft::with_levels({3, { 0, 1, 2, 0 } }, 4, { 0 }, { 0, 3 }));
         rhs.delta.add(0, 'c', 1);
         rhs.delta.add(1, EPSILON, 2);
         rhs.delta.add(2, 'd', 3);
@@ -3477,7 +3524,7 @@ TEST_CASE("mata::nft::Nft::get_delta.epsilon_symbol_posts()") {
     CHECK(aut.delta.epsilon_symbol_posts(19) == aut.delta.state_post(19).end());
 
     StatePost state_post{ aut.delta[0] };
-    state_eps_trans = aut.delta.epsilon_symbol_posts(state_post);
+    state_eps_trans = mata::nfa::Delta::epsilon_symbol_posts(state_post);
     CHECK(state_eps_trans->symbol == EPSILON);
     CHECK(state_eps_trans->targets == StateSet{3 });
     state_post = aut.delta[3];
@@ -3646,9 +3693,9 @@ TEST_CASE("mata::nft::get_useful_states_tarjan") {
 TEST_CASE("mata::nft::Nft::get_words") {
     SECTION("empty") {
         Nft aut;
-        CHECK(aut.get_words(0) == std::set<mata::Word>());
-        CHECK(aut.get_words(1) == std::set<mata::Word>());
-        CHECK(aut.get_words(5) == std::set<mata::Word>());
+        CHECK(aut.get_words(0).empty());
+        CHECK(aut.get_words(1).empty());
+        CHECK(aut.get_words(5).empty());
     }
 
     SECTION("empty word") {
@@ -3662,8 +3709,8 @@ TEST_CASE("mata::nft::Nft::get_words") {
         Nft aut(3, {0}, {2});
         aut.delta.add(0, 0, 1);
         aut.delta.add(1, 1, 2);
-        CHECK(aut.get_words(0) == std::set<mata::Word>{});
-        CHECK(aut.get_words(1) == std::set<mata::Word>{});
+        CHECK(aut.get_words(0).empty());
+        CHECK(aut.get_words(1).empty());
         CHECK(aut.get_words(2) == std::set<mata::Word>{{0, 1}});
         CHECK(aut.get_words(3) == std::set<mata::Word>{{0, 1}});
         CHECK(aut.get_words(5) == std::set<mata::Word>{{0, 1}});
@@ -3673,7 +3720,7 @@ TEST_CASE("mata::nft::Nft::get_words") {
         Nft aut(3, {0}, {1,2});
         aut.delta.add(0, 0, 1);
         aut.delta.add(1, 1, 2);
-        CHECK(aut.get_words(0) == std::set<mata::Word>{});
+        CHECK(aut.get_words(0).empty());
         CHECK(aut.get_words(1) == std::set<mata::Word>{{0}});
         CHECK(aut.get_words(2) == std::set<mata::Word>{{0}, {0, 1}});
         CHECK(aut.get_words(3) == std::set<mata::Word>{{0}, {0, 1}});
@@ -3723,14 +3770,14 @@ TEST_CASE("mata::nft::Nft::get_words") {
 TEST_CASE("mata::nft::Nft::unwind_jump") {
     #define REPLACE_DONT_CARE(delta, src, trg)\
                 delta.add(src, 0, trg);\
-                delta.add(src, 1, trg);\
+                (delta).add(src, 1, trg);\
 
     #define SPLIT_TRANSITION(delta, src, symbol, inter, trg)\
-                ((symbol == DONT_CARE) ? (delta.add(src, 0, inter), delta.add(src, 1, inter)) : (delta.add(src, symbol, inter)));\
+                (((symbol) == DONT_CARE) ? ((delta).add(src, 0, inter), (delta).add(src, 1, inter)) : ((delta).add(src, symbol, inter)));\
                 REPLACE_DONT_CARE(delta, inter, trg);\
 
     SECTION("level_cnt == 1") {
-        Nft aut{ Nft::with_levels(1, 5, {0}, {3, 4}) };
+        Nft aut{ Nft::with_levels({5, { 3, 4 } }, 5, {0}) };
         aut.delta.add(0, 0, 1);
         aut.delta.add(0, 1, 2);
         aut.delta.add(1, 0, 1);
@@ -3742,7 +3789,7 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         aut.delta.add(4, 1, 2);
         aut.delta.add(4, DONT_CARE, 4);
 
-        Nft expected{ Nft::with_levels(1, 5, {0}, {3, 4}) };
+        Nft expected{ Nft::with_levels({ 5, { 3, 4 } }, 5, { 0 }) };
         expected.delta.add(0, 0, 1);
         expected.delta.add(0, 1, 2);
         expected.delta.add(1, 0, 1);
@@ -3760,7 +3807,7 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
     }
 
     SECTION("level_cnt == 2") {
-        Nft aut(7, {0}, {5, 6}, {0, 1, 1, 0, 0, 0, 0}, 2);
+        Nft aut{ Nft::with_levels({2, {0, 1, 1, 0, 0, 0, 0} }, 7, {0}, {5, 6}) };
         aut.delta.add(0, 0, 1);
         aut.delta.add(0, 1, 2);
         aut.delta.add(1, DONT_CARE, 3);
@@ -3774,7 +3821,7 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         aut.delta.add(6, DONT_CARE, 6);
         aut.delta.add(6, 1, 4);
 
-        Nft expected(15, {0}, {5, 6}, {0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1}, 2);
+        Nft expected{ Nft::with_levels({2, {0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1} }, 15, {0}, {5, 6}) };
         expected.delta.add(0, 0, 1);
         expected.delta.add(0, 1, 2);
         REPLACE_DONT_CARE(expected.delta, 1, 3);
@@ -3795,7 +3842,9 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
     }
 
     SECTION("level_cnt == 4") {
-        Nft aut(17, {0}, {15, 16}, {0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0}, 4);
+        Nft aut{ Nft::with_levels(
+            { 4, { 0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0 } }, 17, { 0 }, { 15, 16 }
+        ) };
         aut.delta.add(0, 0, 1);
         aut.delta.add(0, 1, 2);
         aut.delta.add(1, 0, 3);
@@ -3815,7 +3864,7 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
         aut.delta.add(13, 0, 15);
         aut.delta.add(14, DONT_CARE, 16);
 
-        Nft expected(31, {0}, {15, 16}, {0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0, 2, 2, 2, 1, 1, 3, 3, 1, 2, 1, 3, 3, 3, 3}, 4);
+        Nft expected{ Nft::with_levels({4, {0, 1, 1, 3, 3, 0, 0, 2, 2, 0, 0, 1, 1, 2, 2, 0, 0, 2, 2, 2, 1, 1, 3, 3, 1, 2, 1, 3, 3, 3, 3} }, 31, {0}, {15, 16}) };
         expected.delta.add(0, 0, 1);
         expected.delta.add(0, 1, 2);
         SPLIT_TRANSITION(expected.delta, 1, 0, 17, 3);
@@ -3849,7 +3898,7 @@ TEST_CASE("mata::nft::Nft::unwind_jump") {
 }
 
 TEST_CASE("mata::nft::Nft::add_state()") {
-    Nft nft{};
+    Nft nft{ Nft::with_levels(4)};
     State state{ nft.add_state() };
     CHECK(state == 0);
     CHECK(nft.levels[state] == 0);
@@ -3876,11 +3925,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
 
-        Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft atm(Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0 = project_out(atm, OrdVector<Level>{ 0 }, JumpMode::AppendDontCares);
-            Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_expected.delta.add(0, 1, 1);
             proj0_expected.delta.add(1, 2, 2);
             CHECK(are_equivalent(proj0, proj0_expected, JumpMode::AppendDontCares));
@@ -3889,7 +3938,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 1") {
             Nft proj1 = project_out(atm, 1, JumpMode::AppendDontCares);
-            Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_expected.delta.add(0, 0, 1);
             proj1_expected.delta.add(1, 2, 2);
             CHECK(are_equivalent(proj1, proj1_expected, JumpMode::AppendDontCares));
@@ -3897,7 +3946,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 2") {
             Nft proj2 = project_out(atm, 2, JumpMode::AppendDontCares);
-            Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_expected.delta.add(0, 0, 1);
             proj2_expected.delta.add(1, 1, 2);
             CHECK(are_equivalent(proj2, proj2_expected, JumpMode::AppendDontCares));
@@ -3913,11 +3962,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
         delta.add(0, 3, 0);
         delta.add(3, 4, 3);
 
-        Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft atm_loop(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0_loop = project_out(atm_loop, 0, JumpMode::AppendDontCares);
-            Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_loop_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_loop_expected.delta.add(0, DONT_CARE, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
             proj0_loop_expected.delta.add(1, 2, 2);
@@ -3927,7 +3976,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 1") {
             Nft proj1_loop = project_out(atm_loop, 1, JumpMode::AppendDontCares);
-            Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_loop_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_loop_expected.delta.add(0, 3, 0);
             proj1_loop_expected.delta.add(0, 0, 1);
             proj1_loop_expected.delta.add(1, 2, 2);
@@ -3937,7 +3986,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 2") {
             Nft proj2_loop = project_out(atm_loop, 2, JumpMode::AppendDontCares);
-            Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_loop_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_loop_expected.delta.add(0, 3, 0);
             proj2_loop_expected.delta.add(0, 0, 1);
             proj2_loop_expected.delta.add(1, 1, 2);
@@ -3946,9 +3995,10 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
-            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, JumpMode::AppendDontCares);
-            CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0), JumpMode::AppendDontCares));
+            Nft atm_empty(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, {}));
+            CHECK_THROWS_AS(project_out(atm_empty, { 0, 1, 2 }, JumpMode::AppendDontCares), std::invalid_argument);
+            // Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 }, JumpMode::AppendDontCares);
+            // CHECK(are_equivalent(proj012_empty, Nft::with_levels(0), JumpMode::AppendDontCares));
         }
     }
 
@@ -3960,11 +4010,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
         delta.add(0, 3, 3);
         delta.add(3, 4, 2);
 
-        Nft nft_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft nft_complex(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0_complex = project_out(nft_complex, 0, JumpMode::AppendDontCares);
-            Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_complex_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_complex_expected.delta.add(0, 1, 1);
             proj0_complex_expected.delta.add(0, DONT_CARE, 2);
             proj0_complex_expected.delta.add(1, 2, 2);
@@ -3974,7 +4024,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 1") {
             Nft proj1_complex = project_out(nft_complex, 1, JumpMode::AppendDontCares);
-            Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_complex_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_complex_expected.delta.add(0, 0, 1);
             proj1_complex_expected.delta.add(0, 3, 2);
             proj1_complex_expected.delta.add(1, 2, 2);
@@ -3984,7 +4034,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 2") {
             Nft proj2_complex = project_out(nft_complex, OrdVector<Level>{ 2 }, JumpMode::AppendDontCares);
-            Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_complex_expected{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_complex_expected.delta.add(0, 0, 1);
             proj2_complex_expected.delta.add(0, 3, 2);
             proj2_complex_expected.delta.add(1, 1, 2);
@@ -3992,7 +4042,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
             CHECK(are_equivalent(proj2_complex, proj2_complex_expected, JumpMode::AppendDontCares));
 
             proj2_complex = project_to(nft_complex, OrdVector<Level>{ 2 });
-            proj2_complex_expected = Nft(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            proj2_complex_expected = Nft::with_levels({ 1, { 0, 0 } }, 2, { 0 }, { 1 });
             proj2_complex_expected.delta.add(0, 2, 1);
             proj2_complex_expected.delta.add(0, 3, 1);
             proj2_complex_expected.delta.add(1, 2, 1);
@@ -4003,7 +4053,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 0, 1") {
             Nft proj01_complex = project_out(nft_complex, { 0, 1 }, JumpMode::AppendDontCares);
-            Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj01_complex_expected{ Nft::with_levels({ 1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj01_complex_expected.delta.add(0, 2, 1);
             proj01_complex_expected.delta.add(0, DONT_CARE, 1);
             proj01_complex_expected.delta.add(1, 2, 1);
@@ -4012,7 +4062,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 0, 2") {
             Nft proj02_complex = project_out(nft_complex, { 0, 2 }, JumpMode::AppendDontCares);
-            Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj02_complex_expected{ Nft::with_levels({ 1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj02_complex_expected.delta.add(0, 1, 1);
             proj02_complex_expected.delta.add(0, DONT_CARE, 1);
             proj02_complex_expected.delta.add(1, DONT_CARE, 1);
@@ -4021,7 +4071,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         SECTION("project 1, 2") {
             Nft proj12_complex = project_out(nft_complex, { 1, 2 }, JumpMode::AppendDontCares);
-            Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj12_complex_expected{ Nft::with_levels({ 1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj12_complex_expected.delta.add(0, 0, 1);
             proj12_complex_expected.delta.add(0, 3, 1);
             proj12_complex_expected.delta.add(1, 4, 1);
@@ -4029,14 +4079,15 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, JumpMode::AppendDontCares);
-            Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
-            CHECK(are_equivalent(proj012_complex, proj012_complex_expected, JumpMode::AppendDontCares));
+            CHECK_THROWS_AS(project_out(nft_complex, { 0, 1, 2 }, JumpMode::AppendDontCares), std::invalid_argument);
+            // Nft proj012_complex = project_out(nft_complex, { 0, 1, 2 }, JumpMode::AppendDontCares);
+            // Nft proj012_complex_expected{ Nft::with_levels(0, 1, { 0 }, { 0 }) };
+            // CHECK(are_equivalent(proj012_complex, proj012_complex_expected, JumpMode::AppendDontCares));
         }
     }
 
     SECTION("HARD") {
-        Nft atm_hard(Delta{}, { 0 , 2 }, { 7 }, { 0, 1, 0, 2, 3, 4, 5, 0 }, 6);
+        Nft atm_hard(Nft::with_levels({6, { 0, 1, 0, 2, 3, 4, 5, 0 } }, {}, { 0 , 2 }, { 7 }));
         atm_hard.delta.add(0, 1, 1);
         atm_hard.delta.add(2, 2, 1);
         atm_hard.delta.add(2, 3, 2);
@@ -4051,7 +4102,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::AppendDontCares)") {
 
         Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, JumpMode::AppendDontCares);
 
-        Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
+        Nft proj_hard_expected{ Nft::with_levels({2, { 0, 0, 1, 0 } }, 4, { 0, 1 }, { 3 }) };
         proj_hard_expected.delta.add(0, 0, 2);
         proj_hard_expected.delta.add(0, 10, 3);
         proj_hard_expected.delta.add(1, 0, 2);
@@ -4073,11 +4124,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
 
-        Nft atm(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft atm(Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0 = project_out(atm, 0);
-            Nft proj0_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_expected.delta.add(0, 1, 1);
             proj0_expected.delta.add(1, 2, 2);
             CHECK(are_equivalent(proj0, proj0_expected, JumpMode::AppendDontCares));
@@ -4086,7 +4137,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 1") {
             Nft proj1 = project_out(atm, 1);
-            Nft proj1_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_expected.delta.add(0, 0, 1);
             proj1_expected.delta.add(1, 2, 2);
             CHECK(are_equivalent(proj1, proj1_expected, JumpMode::AppendDontCares));
@@ -4094,7 +4145,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 2") {
             Nft proj2 = project_out(atm, 2);
-            Nft proj2_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_expected.delta.add(0, 0, 1);
             proj2_expected.delta.add(1, 1, 2);
             CHECK(are_equivalent(proj2, proj2_expected, JumpMode::AppendDontCares));
@@ -4110,11 +4161,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
         delta.add(0, 3, 0);
         delta.add(3, 4, 3);
 
-        Nft atm_loop(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft atm_loop(Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0_loop = project_out(atm_loop, 0);
-            Nft proj0_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_loop_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_loop_expected.delta.add(0, 3, 0);
             proj0_loop_expected.delta.add(0, 1, 1);
             proj0_loop_expected.delta.add(1, 2, 2);
@@ -4124,7 +4175,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 1") {
             Nft proj1_loop = project_out(atm_loop, 1);
-            Nft proj1_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_loop_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_loop_expected.delta.add(0, 3, 0);
             proj1_loop_expected.delta.add(0, 0, 1);
             proj1_loop_expected.delta.add(1, 2, 2);
@@ -4134,7 +4185,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 2") {
             Nft proj2_loop = project_out(atm_loop, 2);
-            Nft proj2_loop_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_loop_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_loop_expected.delta.add(0, 3, 0);
             proj2_loop_expected.delta.add(0, 0, 1);
             proj2_loop_expected.delta.add(1, 1, 2);
@@ -4143,9 +4194,10 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft atm_empty(delta, { 0 }, {}, { 0, 1, 2, 0 }, 3);
-            Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 });
-            CHECK(are_equivalent(proj012_empty, Nft(1, {}, {}, {}, 0), JumpMode::AppendDontCares));
+            Nft atm_empty(Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, {}));
+            CHECK_THROWS_AS(project_out(atm_empty, { 0, 1, 2 }), std::invalid_argument);
+            // Nft proj012_empty = project_out(atm_empty, { 0, 1, 2 });
+            // CHECK(are_equivalent(proj012_empty, Nft::with_levels(0), JumpMode::AppendDontCares));
         }
     }
 
@@ -4157,11 +4209,11 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
         delta.add(0, 3, 3);
         delta.add(3, 4, 2);
 
-        Nft atm_complex(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        Nft atm_complex(Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }));
 
         SECTION("project 0") {
             Nft proj0_complex = project_out(atm_complex, 0);
-            Nft proj0_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj0_complex_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj0_complex_expected.delta.add(0, 1, 1);
             proj0_complex_expected.delta.add(0, 3, 2);
             proj0_complex_expected.delta.add(1, 2, 2);
@@ -4171,7 +4223,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 1") {
             Nft proj1_complex = project_out(atm_complex, 1);
-            Nft proj1_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj1_complex_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj1_complex_expected.delta.add(0, 0, 1);
             proj1_complex_expected.delta.add(0, 3, 2);
             proj1_complex_expected.delta.add(1, 2, 2);
@@ -4181,7 +4233,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 2") {
             Nft proj2_complex = project_out(atm_complex, 2);
-            Nft proj2_complex_expected(3, { 0 }, { 2 }, { 0, 1, 0 }, 2);
+            Nft proj2_complex_expected{ Nft::with_levels({2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
             proj2_complex_expected.delta.add(0, 0, 1);
             proj2_complex_expected.delta.add(0, 3, 2);
             proj2_complex_expected.delta.add(1, 1, 2);
@@ -4191,7 +4243,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 0, 1") {
             Nft proj01_complex = project_out(atm_complex, { 0, 1 });
-            Nft proj01_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj01_complex_expected{ Nft::with_levels({1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj01_complex_expected.delta.add(0, 2, 1);
             proj01_complex_expected.delta.add(0, 3, 1);
             proj01_complex_expected.delta.add(1, 2, 1);
@@ -4200,7 +4252,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 0, 2") {
             Nft proj02_complex = project_out(atm_complex, { 0, 2 });
-            Nft proj02_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj02_complex_expected{ Nft::with_levels({1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj02_complex_expected.delta.add(0, 1, 1);
             proj02_complex_expected.delta.add(0, 3, 1);
             proj02_complex_expected.delta.add(1, 4, 1);
@@ -4209,7 +4261,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         SECTION("project 1, 2") {
             Nft proj12_complex = project_out(atm_complex, { 1, 2 });
-            Nft proj12_complex_expected(2, { 0 }, { 1 }, { 0, 0 }, 1);
+            Nft proj12_complex_expected{ Nft::with_levels({1, { 0, 0 } }, 2, { 0 }, { 1 }) };
             proj12_complex_expected.delta.add(0, 0, 1);
             proj12_complex_expected.delta.add(0, 3, 1);
             proj12_complex_expected.delta.add(1, 4, 1);
@@ -4217,14 +4269,15 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
         }
 
         SECTION("project 0, 1, 2") {
-            Nft proj012_complex = project_out(atm_complex, { 0, 1, 2 });
-            Nft proj012_complex_expected(1, { 0 }, { 0 }, {}, 0);
-            CHECK(are_equivalent(proj012_complex, proj012_complex_expected, JumpMode::AppendDontCares));
+            CHECK_THROWS_AS(project_out(atm_complex, { 0, 1, 2 }), std::invalid_argument);
+            // Nft proj012_complex = project_out(atm_complex, { 0, 1, 2 });
+            // Nft proj012_complex_expected{ Nft::with_levels({0, {} }, 1, { 0 }, { 0 }) };
+            // CHECK(are_equivalent(proj012_complex, proj012_complex_expected, JumpMode::AppendDontCares));
         }
     }
 
     SECTION("HARD") {
-        Nft atm_hard(Delta{}, { 0 , 2 }, { 7 }, { 0, 1, 0, 2, 3, 4, 5, 0 }, 6);
+        Nft atm_hard(Nft::with_levels({6, { 0, 1, 0, 2, 3, 4, 5, 0 } }, {}, { 0 , 2 }, { 7 }));
         atm_hard.delta.add(0, 1, 1);
         atm_hard.delta.add(2, 2, 1);
         atm_hard.delta.add(2, 3, 2);
@@ -4239,7 +4292,7 @@ TEST_CASE("mata::nft::project_out(jump_mode == JumpMode::RepeatSymbol)") {
 
         Nft proj_hard = project_out(atm_hard, { 0, 3, 4, 5 }, JumpMode::RepeatSymbol);
 
-        Nft proj_hard_expected(4, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
+        Nft proj_hard_expected{ Nft::with_levels({2, { 0, 0, 1, 0 } }, 4, { 0, 1 }, { 3 }) };
         proj_hard_expected.delta.add(0, 0, 2);
         proj_hard_expected.delta.add(0, 10, 3);
         proj_hard_expected.delta.add(1, 0, 2);
@@ -4259,18 +4312,18 @@ TEST_CASE("mata::nft::project_to()") {
     Nft expected;
 
     SECTION("linear") {
-        nft = Nft{ {}, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0 } }, {}, { 0 }, { 3 });
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 1, 2);
         nft.delta.add(2, 2, 3);
         projection = project_to(nft, 2);
-        expected = Nft{ 2, { 0 }, { 1 }, { 0, 0 }, 1 };
+        expected = Nft::with_levels({1, { 0, 0 } }, 2, { 0 }, { 1 });
         expected.delta.add(0, 2, 1);
         CHECK(nft::are_equivalent(projection, expected));
     }
 
     SECTION("linear longer") {
-        nft = Nft{ {}, { 0 }, { 6 }, { 0, 1, 2, 0, 1, 2, 0 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0, 1, 2, 0 } }, {}, { 0 }, { 6 });
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 1, 2);
         nft.delta.add(2, 2, 3);
@@ -4278,14 +4331,14 @@ TEST_CASE("mata::nft::project_to()") {
         nft.delta.add(4, 4, 5);
         nft.delta.add(5, 5, 6);
         projection = project_to(nft, 2);
-        expected = Nft{ {}, { 0 }, { 2 }, { 0, 0, 0 }, 1 };
+        expected = Nft::with_levels({1, { 0, 0, 0 } }, {}, { 0 }, { 2 });
         expected.delta.add(0, 2, 1);
         expected.delta.add(1, 5, 2);
         CHECK(nft::are_equivalent(projection, expected));
     }
 
     SECTION("linear longer symbol long jump") {
-        nft = Nft{ {}, { 0 }, { 6 }, { 0, 1, 2, 0, 1, 2, 0 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0, 1, 2, 0 } }, {}, { 0 }, { 6 });
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 1, 2);
         nft.delta.add(2, 2, 3);
@@ -4294,7 +4347,7 @@ TEST_CASE("mata::nft::project_to()") {
         nft.delta.add(5, 5, 6);
         nft.delta.add(0, 'j', 6);
         projection = project_to(nft, 2);
-        expected = Nft{ {}, { 0 }, { 2 }, { 0, 0, 0 }, 1 };
+        expected = Nft::with_levels({1, { 0, 0, 0 } }, {}, { 0 }, { 2 });
         expected.delta.add(0, 2, 1);
         expected.delta.add(1, 5, 2);
         expected.delta.add(0, 'j', 2);
@@ -4304,7 +4357,7 @@ TEST_CASE("mata::nft::project_to()") {
     }
 
     SECTION("cycle longer") {
-        nft = Nft{ {}, { 0 }, { 6 }, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 } }, {}, { 0 }, { 6 });
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 1, 2);
         nft.delta.add(2, 2, 3);
@@ -4318,7 +4371,7 @@ TEST_CASE("mata::nft::project_to()") {
         nft.delta.add(9, 9, 10);
         nft.delta.add(10, 10, 0);
         projection = project_to(nft, 2);
-        expected = Nft{ {}, { 0 }, { 2 }, { 0, 0, 0 }, 1 };
+        expected = Nft::with_levels({1, { 0, 0, 0 } }, {}, { 0 }, { 2 });
         expected.delta.add(0, 2, 1);
         expected.delta.add(1, 8, 0);
         expected.delta.add(1, 5, 2);
@@ -4327,7 +4380,7 @@ TEST_CASE("mata::nft::project_to()") {
     }
 
     SECTION("cycle longer project to { 0, 2 }") {
-        nft = Nft{ {}, { 0 }, { 6 }, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 } }, {}, { 0 }, { 6 });
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 1, 2);
         nft.delta.add(2, 2, 3);
@@ -4341,7 +4394,7 @@ TEST_CASE("mata::nft::project_to()") {
         nft.delta.add(9, 9, 10);
         nft.delta.add(10, 10, 0);
         projection = project_to(nft, { 0, 2 });
-        expected = Nft{ {}, { 0 }, { 6 }, { 0, 1, 0, 1, 0, 1, 0 }, 2 };
+        expected = Nft::with_levels({2, { 0, 1, 0, 1, 0, 1, 0 } }, {}, { 0 }, { 6 });
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 2, 3);
         expected.delta.add(3, 6, 4);
@@ -4354,7 +4407,7 @@ TEST_CASE("mata::nft::project_to()") {
     }
 
     SECTION("cycle longer project to { 0, 2 } with epsilon and dont care symbols") {
-        nft = Nft{ {}, { 0 }, { 6 }, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 }, 3 };
+        nft = Nft::with_levels({3, { 0, 1, 2, 0, 1, 2, 0, 1, 2, 1, 2 } }, {}, { 0 }, { 6 });
         nft.delta.add(0, EPSILON, 2);
         nft.delta.add(2, 2, 3);
         nft.delta.add(3, 3, 4);
@@ -4367,7 +4420,7 @@ TEST_CASE("mata::nft::project_to()") {
         nft.delta.add(9, 10, 10);
         nft.delta.add(10, 11, 0);
         projection = project_to(nft, { 0, 2 });
-        expected = Nft{ {}, { 0 }, { 6 }, { 0, 1, 0, 0, 1, 1, 0, 1 }, 2 };
+        expected = Nft::with_levels({2, { 0, 1, 0, 0, 1, 1, 0, 1 } }, {}, { 0 }, { 6 });
         expected.delta.add(0, EPSILON, 1);
         expected.delta.add(1, 2, 3);
         expected.delta.add(3, EPSILON, 4);
@@ -4389,11 +4442,11 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        input_nft = Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
             output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4403,7 +4456,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 1") {
             output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4413,7 +4466,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 2") {
             output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, DONT_CARE, 3);
@@ -4423,7 +4476,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 3") {
             output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, 2, 3);
@@ -4433,7 +4486,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 4") {
             output_nft = insert_level(input_nft, 4, JumpMode::AppendDontCares);
-            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected_nft = Nft::with_levels({5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, 2, 3);
@@ -4444,7 +4497,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add levels according to the mask 100011") {
             output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
+            expected_nft = Nft::with_levels({6, { 0, 1, 2, 3, 4, 5, 0 } }, 7, { 0 }, { 6 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4460,11 +4513,11 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(1, 1, 2);
         delta.add(2, 2, 3);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        input_nft = Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
             output_nft = insert_level(input_nft, 0);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4475,7 +4528,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 1") {
             output_nft = insert_level(input_nft, 1);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4485,7 +4538,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 2") {
             output_nft = insert_level(input_nft, 2);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, DONT_CARE, 3);
@@ -4495,7 +4548,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 3") {
             output_nft = insert_level(input_nft, 3);
-            expected_nft = Nft(5, { 0 }, { 4 }, { 0, 1, 2, 3, 0 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, 2, 3);
@@ -4505,7 +4558,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 4") {
             output_nft = insert_level(input_nft, 4);
-            expected_nft = Nft(6, { 0 }, { 5 }, { 0, 1, 2, 3, 4, 0 }, 5);
+            expected_nft = Nft::with_levels({5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
             expected_nft.delta.add(2, 2, 3);
@@ -4517,7 +4570,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add levels according to the mask 100011") {
             output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 });
-            expected_nft = Nft(7, { 0 }, { 6 }, { 0, 1, 2, 3, 4, 5, 0 }, 6);
+            expected_nft = Nft::with_levels({6, { 0, 1, 2, 3, 4, 5, 0 } }, 7, { 0 }, { 6 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
             expected_nft.delta.add(2, 1, 3);
@@ -4536,11 +4589,11 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(2, 2, 3);
         delta.add(3, 5, 3);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        input_nft = Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
             output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 1 } }, 7, { 0 }, { 4 });
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 4, 0);
             expected_nft.delta.add(0, DONT_CARE, 1);
@@ -4554,7 +4607,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 1") {
             output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
-            expected_nft = Nft(11, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3}, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3} }, 11, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
@@ -4572,7 +4625,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 2") {
             output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
-            expected_nft = Nft(9, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 2, 3, 2, 3 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0, 2, 3, 2, 3 } }, 9, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
             expected_nft.delta.add(8, DONT_CARE, 0);
@@ -4588,7 +4641,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 3") {
             output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 4 }, { 0, 1, 2, 3, 0, 3, 3 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 2, 3, 0, 3, 3 } }, 7, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 0);
             expected_nft.delta.add(0, 0, 1);
@@ -4602,7 +4655,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add levels according to the mask 1010011") {
             output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
-            expected_nft = Nft(20, { 0 }, { 7 }, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 }, 7);
+            expected_nft = Nft::with_levels({7, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 } }, 20, { 0 }, { 7 });
             expected_nft.delta.add(0, DONT_CARE, 8);
             expected_nft.delta.add(8, 4, 9);
             expected_nft.delta.add(9, DONT_CARE, 10);
@@ -4637,11 +4690,11 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(2, 2, 3);
         delta.add(3, 3, 0);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 2, 0 }, 3);
+        input_nft = Nft::with_levels({3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
             output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 3 }, { 0, 2, 3, 0, 1, 1, 1 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 2, 3, 0, 1, 1, 1 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, DONT_CARE, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(4, 0, 1);
@@ -4656,7 +4709,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 1") {
             output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
-            expected_nft = Nft(8, { 0 }, { 3 }, { 0, 1, 3, 0, 2, 2, 2, 2 }, 4);
+            expected_nft = Nft::with_levels({4, { 0, 1, 3, 0, 2, 2, 2, 2 } }, 8, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 6);
             expected_nft.delta.add(1, DONT_CARE, 4);
@@ -4672,7 +4725,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 2") {
             output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 2, 3, 2 }, 4 );
+            expected_nft = Nft::with_levels({4, {0, 1, 2, 0, 2, 3, 2 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
             expected_nft.delta.add(1, 1, 2);
@@ -4687,7 +4740,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add level 3") {
             output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
-            expected_nft = Nft(7, { 0 }, { 3 }, {0, 1, 2, 0, 3, 3, 3 }, 4 );
+            expected_nft = Nft::with_levels({4, {0, 1, 2, 0, 3, 3, 3 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
             expected_nft.delta.add(1, 1, 2);
@@ -4702,7 +4755,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         SECTION("add levels according to the mask 1010011") {
             output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
-            expected_nft = Nft(21, { 0 }, { 3 }, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 }, 7);
+            expected_nft = Nft::with_levels({7, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 } }, 21, { 0 }, { 3 });
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 0, 1);
             expected_nft.delta.add(0, DONT_CARE, 4);
@@ -4738,7 +4791,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(1, 3, 2);
         delta.add(2, 4, 3);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+        input_nft = Nft::with_levels({4, { 0, 1, 3, 0 } }, delta, { 0 }, { 3 });
 
         output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::RepeatSymbol);
         CHECK(output_nft.num_of_states() == 13);
@@ -4752,7 +4805,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         delta.add(1, 3, 2);
         delta.add(2, 4, 3);
 
-        input_nft = Nft(delta, { 0 }, { 3 }, { 0, 1, 3, 0 }, 4);
+        input_nft = Nft::with_levels({4, { 0, 1, 3, 0 } }, delta, { 0 }, { 3 });
 
         output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::AppendDontCares);
         CHECK(output_nft.num_of_states() == 9);
@@ -4772,56 +4825,56 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     Nft nft, expected;
 
     SECTION("Insert 'a'") {
-        SECTION("num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+        SECTION("levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+        SECTION("self-loop, levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+        SECTION("self-loop, levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
         SECTION("tgt is not specified") {
-            nft = Nft(delta, { 0 }, {}, { 0, 0, 0, 0, 0 }, 1);
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, {});
             State new_tgt = nft.insert_word(1, {'a'});
             nft.final.insert(new_tgt);
 
-            expected = Nft(3, { 0 }, { 2 }, { 0, 0, 0, 0}, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0} }, 3, { 0 }, { 2 });
             expected.delta.add(0, 0, 1);
             expected.delta.add(0, 4, 0);
             expected.delta.add(1, 5, 1);
@@ -4833,48 +4886,48 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     }
 
     SECTION("Insert 'ab'") {
-        SECTION("num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a', 'b'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 5);
             expected.delta.add(5, 'b', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+        SECTION("levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a', 'b'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1 }, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0, 1 } }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 5);
             expected.delta.add(5, 'b', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 1);
+        SECTION("self-loop, levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a', 'b'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 5);
             expected.delta.add(5, 'b', 3);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0 }, 3);
+        SECTION("self-loop, levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0 } }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a', 'b'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1 }, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0, 1 } }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 5);
             expected.delta.add(5, 'b', 3);
 
@@ -4882,11 +4935,11 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
         }
 
         SECTION("tgt is not specified") {
-            nft = Nft(delta, { 0 }, {}, { 0, 0, 0, 0, 0 }, 1);
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, {});
             State new_tgt = nft.insert_word(1, {'a', 'b'});
             nft.final.insert(new_tgt);
 
-            expected = Nft(4, { 0 }, { 3 }, { 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, 4, { 0 }, { 3 });
             expected.delta.add(0, 0, 1);
             expected.delta.add(0, 4, 0);
             expected.delta.add(1, 5, 1);
@@ -4898,12 +4951,12 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
     }
 
     SECTION("Insert 'abcd'") {
-        SECTION("num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
+        SECTION("levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 5);
             expected.delta.add(5, 'b', 6);
             expected.delta.add(6, 'c', 7);
@@ -4912,12 +4965,12 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
+        SECTION("levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(1, {'a', 'b', 'c', 'd'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1, 2, 0}, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0, 1, 2, 0} }, delta, { 0 }, { 4 });
             expected.delta.add(1, 'a', 5);
             expected.delta.add(5, 'b', 6);
             expected.delta.add(6, 'c', 7);
@@ -4926,12 +4979,12 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 1);
+        SECTION("self-loop, levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 5);
             expected.delta.add(5, 'b', 6);
             expected.delta.add(6, 'c', 7);
@@ -4940,12 +4993,12 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("self-loop, num_of_levels == 3") {
-            nft = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0}, 3);
+        SECTION("self-loop, levels.num_of_levels == 3") {
+            nft = Nft::with_levels({3, { 0, 0, 0, 0, 0} }, delta, { 0 }, { 4 });
             State new_tgt = nft.insert_word(3, {'a', 'b', 'c', 'd'}, 3);
             CHECK(new_tgt == 3);
 
-            expected = Nft(delta, { 0 }, { 4 }, { 0, 0, 0, 0, 0, 1, 2, 0}, 3);
+            expected = Nft::with_levels({3, { 0, 0, 0, 0, 0, 1, 2, 0} }, delta, { 0 }, { 4 });
             expected.delta.add(3, 'a', 5);
             expected.delta.add(5, 'b', 6);
             expected.delta.add(6, 'c', 7);
@@ -4955,11 +5008,11 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
         }
 
         SECTION("tgt is not specified") {
-            nft = Nft(delta, { 0 }, {}, { 0, 0, 0, 0, 0 }, 1);
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0 }, {});
             State new_tgt = nft.insert_word(1, {'a', 'b', 'c', 'd'});
             nft.final.insert(new_tgt);
 
-            expected = Nft(6, { 0 }, { 5 }, { 0, 0, 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0, 0, 0 } }, 6, { 0 }, { 5 });
             expected.delta.add(0, 0, 1);
             expected.delta.add(0, 4, 0);
             expected.delta.add(1, 5, 1);
@@ -4977,7 +5030,7 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
         nft.add_transition(0, { 'a', 'b', 'c' }, 1);
         nft.add_transition(1, { 'd', 'e', 'f' }, 2);
 
-        expected = Nft::with_levels(3, {}, { 0, 0, 0, 1, 2, 1, 2 });
+        expected = Nft::with_levels({3, { 0, 0, 0, 1, 2, 1, 2 } }, {});
         expected.delta.add(0, 'a', 3);
         expected.delta.add(3, 'b', 4);
         expected.delta.add(4, 'c', 1);
@@ -4993,24 +5046,24 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
     Nft nft, expected;
     SECTION("Creating an identity on two states (both initial and final) with empty delta.") {
         Delta delta{};
-        SECTION("num_of_levels == 1") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
 
-            expected = Nft(2, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0 } }, 2, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 0);
             expected.delta.add(1, 'b', 1);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 2") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+        SECTION("levels.num_of_levels == 2") {
+            nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             nft.insert_identity(0, 'a');
             nft.insert_identity(1, 'b');
 
-            expected = Nft(4, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 1 }, 2);
+            expected = Nft::with_levels({2, { 0, 0, 1, 1 } }, 4, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 2);
             expected.delta.add(2, 'a', 0);
             expected.delta.add(1, 'b', 3);
@@ -5019,12 +5072,12 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
-        SECTION("num_of_levels == 4") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+        SECTION("levels.num_of_levels == 4") {
+            nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             nft.insert_identity(0, 'a', JumpMode::AppendDontCares);
             nft.insert_identity(1, 'b', JumpMode::AppendDontCares);
 
-            expected = Nft(8, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 1, 2, 2, 3, 3 }, 4);
+            expected = Nft::with_levels({4, { 0, 0, 1, 1, 2, 2, 3, 3 } }, 8, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 2);
             expected.delta.add(2, 'a', 4);
             expected.delta.add(4, 'a', 6);
@@ -5043,23 +5096,23 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         delta.add(0, 'a', 1);
         delta.add(1, 'b', 2);
 
-        SECTION("num_of_levels == 1") {
+        SECTION("levels.num_of_levels == 1") {
 
             SECTION("symbols cnt == 1") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+                nft = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, 'c', JumpMode::AppendDontCares);
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+                expected = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 expected.delta.add(1, 'c', 1);
 
                 CHECK(are_equivalent(nft, expected, JumpMode::AppendDontCares));
             }
 
             SECTION("symbols cnt == 2") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+                nft = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, {'c', 'd'});
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 1);
+                expected = Nft::with_levels({1, { 0, 0, 0, 0 } }, delta, { 0 }, { 2 });
                 expected.insert_identity(1, 'c');
                 expected.insert_identity(1, 'd');
 
@@ -5067,13 +5120,13 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             }
         }
 
-        SECTION("num_of_levels == 2") {
+        SECTION("levels.num_of_levels == 2") {
 
             SECTION("symbols cnt == 1") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, 'c');
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 0, 1 } }, delta, { 0 }, { 2 });
                 expected.delta.add(1, 'c', 3);
                 expected.delta.add(3, 'c', 1);
 
@@ -5081,10 +5134,10 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             }
 
             SECTION("symbols cnt == 2") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, {'c', 'd'}, JumpMode::AppendDontCares);
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 0, 1 } }, delta, { 0 }, { 2 });
                 expected.insert_identity(1, 'c', JumpMode::AppendDontCares);
                 expected.insert_identity(1, 'd', JumpMode::AppendDontCares);
 
@@ -5092,13 +5145,13 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             }
         }
 
-        SECTION("num_of_levels == 4") {
+        SECTION("levels.num_of_levels == 4") {
 
             SECTION("symbols cnt == 1") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, 'c');
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 0, 1, 2, 3 } }, delta, { 0 }, { 2 });
                 expected.delta.add(1, 'c', 3);
                 expected.delta.add(3, 'c', 4);
                 expected.delta.add(4, 'c', 5);
@@ -5108,10 +5161,10 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
             }
 
             SECTION("symbols cnt == 4") {
-                nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 nft.insert_identity(1, {'c', 'd', 'e', 'f'});
 
-                expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 0 } }, delta, { 0 }, { 2 });
                 expected.insert_identity(1, 'c');
                 expected.insert_identity(1, 'd');
                 expected.insert_identity(1, 'e');
@@ -5128,32 +5181,32 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
         delta.add(0, 'a', 1);
         delta.add(1, 'b', 2);
 
-        SECTION("num_of_levels == 1") {
-            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1") {
+            nft = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0 }, { 2 });
             nft.insert_identity(2, 'c');
 
-            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0 }, { 2 });
             expected.delta.add(2, 'c', 2);
 
             CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
-        SECTION("num_of_levels == 2") {
-            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 2);
+        SECTION("levels.num_of_levels == 2") {
+            nft = Nft::with_levels({2, { 0, 0, 0 } }, delta, { 0 }, { 2 });
             nft.insert_identity(2, 'c');
 
-            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1 }, 2);
+            expected = Nft::with_levels({2, { 0, 0, 0, 1 } }, delta, { 0 }, { 2 });
             expected.delta.add(2, 'c', 3);
             expected.delta.add(3, 'c', 2);
 
             CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
 
-        SECTION("num_of_levels == 4") {
-            nft = Nft(delta, { 0 }, { 2 }, { 0, 0, 0 }, 4);
+        SECTION("levels.num_of_levels == 4") {
+            nft = Nft::with_levels({4, { 0, 0, 0 } }, delta, { 0 }, { 2 });
             nft.insert_identity(2, 'c');
 
-            expected = Nft(delta, { 0 }, { 2 }, { 0, 0, 0, 1, 2, 3 }, 4);
+            expected = Nft::with_levels({4, { 0, 0, 0, 1, 2, 3 } }, delta, { 0 }, { 2 });
             expected.delta.add(2, 'c', 3);
             expected.delta.add(3, 'c', 4);
             expected.delta.add(4, 'c', 5);
@@ -5171,35 +5224,35 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
         Delta delta{};
 
-        SECTION("num_of_levels == 1 && word_part.size() == 1") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1 && word_part.size() == 1") {
+            nft = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             State new_tgt = nft.insert_word_by_parts(0, { {'a'} } , 1);
             CHECK(new_tgt == 1);
 
-            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 1);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 1 && word_part.size() == 2") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1 && word_part.size() == 2") {
+            nft = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'} } , 1);
             CHECK(new_tgt == 1);
 
-            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 2);
             expected.delta.add(2, 'b', 1);
 
             CHECK(are_equivalent(nft, expected));
         }
 
-        SECTION("num_of_levels == 1 && word_part.size() == 4") {
-            nft = Nft(delta, { 0, 1 }, { 0, 1  }, { 0, 0, 0, 0, 0 }, 1);
+        SECTION("levels.num_of_levels == 1 && word_part.size() == 4") {
+            nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1  });
             State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'} }, 1);
             CHECK(new_tgt == 1);
 
-            expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 0, 0, 0 }, 1);
+            expected = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
             expected.delta.add(0, 'a', 2);
             expected.delta.add(2, 'b', 3);
             expected.delta.add(3, 'c', 4);
@@ -5216,25 +5269,25 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         delta.add(0, 'y', 1);
         delta.add(1, 'x', 1);
         delta.add(1, 'z', 0);
-        SECTION("num_of_levels == 2") {
+        SECTION("levels.num_of_levels == 2") {
 
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'} } , 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'b', 1);
                 CHECK(are_equivalent(nft, expected));
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'} } , 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5244,11 +5297,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1, 0, 1, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5262,14 +5315,14 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
         }
 
-        SECTION("num_of_levels == 4") {
+        SECTION("levels.num_of_levels == 4") {
 
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'}, {'c'}, {'d'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'b', 3);
                 expected.delta.add(3, 'c', 4);
@@ -5279,11 +5332,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, 'e', 4);
@@ -5297,11 +5350,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'i', 4);
@@ -5331,13 +5384,13 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         delta.add(1, 'x', 1);
         delta.add(1, 'z', 0);
 
-        SECTION("num_of_levels == 2") {
+        SECTION("levels.num_of_levels == 2") {
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 3 }, { 0, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0 } }, delta, { 0, 1 }, { 3 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'b', 3);
 
@@ -5345,11 +5398,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 5 }, { 0, 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0 } }, delta, { 0, 1 }, { 5 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5359,11 +5412,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 9 }, { 0, 0, 1, 0, 1, 0, 1, 0, 1, 0 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1, 0 } }, delta, { 0, 1 }, { 9 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5377,13 +5430,13 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
         }
 
-        SECTION("num_of_levels == 4") {
+        SECTION("levels.num_of_levels == 4") {
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'}, {'c'}, {'d'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 5 }, { 0, 0, 1, 2, 3, 0 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 5 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'b', 3);
                 expected.delta.add(3, 'c', 4);
@@ -5393,11 +5446,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 9 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 9 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, 'e', 4);
@@ -5411,11 +5464,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 17 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 17 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'i', 4);
@@ -5437,11 +5490,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("The lengths of word pats dont have the same length.") {
-                nft = Nft(delta, { 0, 1 }, {}, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {} });
                 nft.final.insert(new_tgt);
 
-                expected = Nft(delta, { 0, 1 }, { 17 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 17 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'i', 4);
@@ -5471,13 +5524,13 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         delta.add(1, 'x', 1);
         delta.add(1, 'z', 0);
 
-        SECTION("num_of_levels == 2") {
+        SECTION("levels.num_of_levels == 2") {
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {}, {'b'} } , 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, EPSILON, 2);
                 expected.delta.add(2, 'b', 1);
 
@@ -5485,11 +5538,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c'} } , 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5499,11 +5552,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 2);
+                nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 0, 1, 0, 1, 0, 1 }, 2);
+                expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'b', 4);
@@ -5517,13 +5570,13 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
         }
 
-        SECTION("num_of_levels == 4") {
+        SECTION("levels.num_of_levels == 4") {
             SECTION("word_part.size() == 1") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {}, {'c'}, {} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, EPSILON, 3);
                 expected.delta.add(3, 'c', 4);
@@ -5533,11 +5586,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 2") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'c', 'd'}, {}, {'g'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, 'a', 2);
                 expected.delta.add(2, 'c', 3);
                 expected.delta.add(3, EPSILON, 4);
@@ -5551,11 +5604,11 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             }
 
             SECTION("word_part.size() == 4") {
-                nft = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0 }, 4);
+                nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
                 State new_tgt = nft.insert_word_by_parts(0, { {}, {'e', 'f'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
                 CHECK(new_tgt == 1);
 
-                expected = Nft(delta, { 0, 1 }, { 0, 1 }, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 }, 4);
+                expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
                 expected.delta.add(0, EPSILON, 2);
                 expected.delta.add(2, 'e', 3);
                 expected.delta.add(3, 'i', 4);
@@ -5581,12 +5634,12 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
     SECTION("begin insertion from levels != 0") {
         SECTION("from level 1") {
             nft = Nft{};
-            nft.num_of_levels = 3;
+            nft.levels.num_of_levels = 3;
             const State state_lvl1{ nft.add_state_with_level(1) };
             const State target{ nft.insert_word_by_parts(state_lvl1, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
             CHECK(nft.levels[target] == 1);
             expected = Nft{};
-            expected.num_of_levels = 3;
+            expected.levels.num_of_levels = 3;
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'd', 3);
             expected.delta.add(3, 'f', 4);
@@ -5596,18 +5649,18 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             expected.delta.add(7, 'c', 8);
             expected.delta.add(8, EPSILON, 9);
             expected.delta.add(9, EPSILON, 10);
-            expected.levels = { 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1 };
+            expected.levels.set({ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1 });
             CHECK(are_equivalent(nft, expected));
         }
 
         SECTION("from level 2") {
             nft = Nft{};
-            nft.num_of_levels = 3;
+            nft.levels.num_of_levels = 3;
             const State state_lvl2{ nft.add_state_with_level(2) };
             const State target{ nft.insert_word_by_parts(state_lvl2, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
             CHECK(nft.levels[target] == 2);
             expected = Nft{};
-            expected.num_of_levels = 3;
+            expected.levels.num_of_levels = 3;
             expected.delta.add(1, 'a', 2);
             expected.delta.add(2, 'd', 3);
             expected.delta.add(3, 'f', 4);
@@ -5617,7 +5670,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             expected.delta.add(7, 'c', 8);
             expected.delta.add(8, EPSILON, 9);
             expected.delta.add(9, EPSILON, 10);
-            expected.levels = { 0, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2 };
+            expected.levels.set({ 0, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2 });
             CHECK(are_equivalent(nft, expected));
         }
     }
@@ -5660,9 +5713,9 @@ TEST_CASE("mata::nft::Nft::apply()") {
 
     SECTION("apply with 5 tapes") {
         Nfa nfa = nfa::builder::create_from_regex("(a|b)*");
-        Nft nft{1, {0}, {0}, {{0,0}}, 5};
+        Nft nft{ Nft::with_levels({5, {0,0} }, 1, {0}, {0}) };
         nft.insert_identity(0, 'a');
-        CHECK(nft.apply(nfa).num_of_levels == 4);
-        CHECK(nft.apply(nfa, 3, false).num_of_levels == 5);
+        CHECK(nft.apply(nfa).levels.num_of_levels == 4);
+        CHECK(nft.apply(nfa, 3, false).levels.num_of_levels == 5);
     }
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -960,24 +960,57 @@ TEST_CASE("mata::nft::make_complete()") {
     EnumAlphabet alphabet{ 'a', 'b', 'c' };
     nft.alphabet = &alphabet;
     result.alphabet = &alphabet;
+    auto alphabet_symbols = [&]{ return alphabet.get_alphabet_symbols(); };
+    OrdVector<Symbol> epsilons{};
+    auto alphabet_symbols_with_epsilons = [&] {
+        OrdVector<Symbol> symbols{ alphabet_symbols() };
+        symbols.insert(epsilons);
+        return symbols;
+    };
+    OrdVector<Symbol> symbols{ alphabet_symbols() };
+
+    std::optional<std::vector<State>> sinks{ std::nullopt };
 
     const auto CHECK_SHARED = [&]{
         CHECK(are_equivalent(nft, result));
         for (State source{ 0 }; source < result.num_of_states(); ++source) {
-            for (const auto symbol : alphabet.get_alphabet_symbols()) {
+            for (const auto symbol : symbols) {
                 const auto& state_post{ result.delta[source] };
                 auto state_post_it{ state_post.find(symbol) };
                 REQUIRE(state_post_it != state_post.end());
-                for (const auto target : state_post_it->targets) { CHECK(result.levels.can_follow_for_states(source, target)); }
+                for (const auto target : state_post_it->targets) {
+                    CHECK(result.levels.can_follow_for_states(source, target));
+                }
             }
         }
-        CHECK(result.is_complete());
+        CHECK(result.is_complete(symbols));
         CHECK(result.levels.num_of_levels == nft.levels.num_of_levels);
+
+
+        // Check sinks if any were provided.
+        // CHECK(not result.make_complete(&alphabet, epsilons_to_check, std::vector<State>{ sinks }));
+        for (auto sinks_val{ sinks.value_or(std::vector<State>{}) }; const State sink : sinks_val) {
+            for (const auto symbol : alphabet_symbols()) {
+                CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks_val.size()) + *sinks_val.begin()));
+            }
+            for (const auto symbol : epsilons) {
+                CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks_val.size()) + *sinks_val.begin()));
+            }
+        }
+        // auto CHECK_SECTION = [&](const OrdVector<Symbol>& epsilons_to_check = {}) {
     };
 
     SECTION("empty automaton, empty alphabet") {
         alphabet.clear();
-        nft.make_complete(&alphabet);
+
+        result = nft;
+        result.make_complete(&alphabet, epsilons, sinks);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons, sinks);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -987,8 +1020,15 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.final = { 2 };
         nft.delta.add(0, 'a', 1);
         nft.delta.add(1, 'b', 2);
+
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -1001,8 +1041,15 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(1, 'b', 2);
         nft.delta.add(2, 'a', 3);
         nft.delta.add(3, 'b', 4);
+
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -1015,8 +1062,15 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(2, 'a', 3);
         nft.delta.add(3, 'b', 4);
         nft.delta.add(4, 'a', 5);
+
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -1032,45 +1086,42 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(2, 'a', 3);
         nft.delta.add(3, 'b', 4);
         nft.delta.add(4, 'a', 5);
+
         result = nft;
         result.make_complete(&alphabet);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
     SECTION("with sinks") {
-         nft.initial = { 0 };
-         nft.final = { 4 };
-         nft.levels = { 0, 1, 2, 0, 1, 0, 0, 1, 2 };
-         nft.delta.add(0, 'a', 1);
-         nft.delta.add(0, 'b', 0);
-         nft.delta.add(0, 'a', 2);
-         nft.delta.add(0, 'b', 3);
-         nft.delta.add(1, 'b', 2);
-         nft.delta.add(1, 'c', 8);
-         nft.delta.add(2, 'a', 3);
-         nft.delta.add(3, 'b', 4);
-         nft.delta.add(4, 'a', 5);
-         result = nft;
-         const std::vector<State> sinks{ 6, 7, 8 };
-         result.make_complete(&alphabet, sinks);
-         CHECK(not result.make_complete(&alphabet, std::vector<State>{ sinks }));
-         for (const State sink : sinks) {
-             for (const auto symbol : alphabet.get_alphabet_symbols()) {
-                 CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks.size()) + *sinks.begin()));
-             }
-         }
-     }
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels = { 0, 1, 2, 0, 1, 0, 0, 1, 2 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(0, 'b', 0);
+        nft.delta.add(0, 'a', 2);
+        nft.delta.add(0, 'b', 3);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(1, 'c', 8);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
 
-    CHECK(are_equivalent(nft, result));
-    for (State source{ 0 }; source < result.num_of_states(); ++source) {
-        for (const auto symbol : alphabet.get_alphabet_symbols()) {
-            const auto& state_post{ result.delta[source] };
-            auto state_post_it{ state_post.find(symbol) };
-            REQUIRE(state_post_it != state_post.end());
-            for (const auto target : state_post_it->targets) {
-                REQUIRE(result.levels.can_follow_for_states(source, target));
-            }
-        }
+        sinks = { 6, 7, 8 };
+
+        result = nft;
+        result.make_complete(&alphabet, epsilons, sinks);
+        CHECK_SHARED();
+
+        result = nft;
+        epsilons = { EPSILON };
+        result.make_complete(&alphabet, epsilons, sinks);
+        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 }

--- a/tests/nft/utils.hh
+++ b/tests/nft/utils.hh
@@ -3,111 +3,111 @@
 
 // Automaton A
 #define FILL_WITH_AUT_A(x) \
-	x.num_of_levels = 1; \
-    x.initial = {1, 3}; \
-	x.final = {5}; \
-	x.delta.add(1, 'a', 3); \
-	x.delta.add(1, 'a', 10); \
-	x.delta.add(1, 'b', 7); \
-	x.delta.add(3, 'a', 7); \
-	x.delta.add(3, 'b', 9); \
-	x.delta.add(9, 'a', 9); \
-	x.delta.add(7, 'b', 1); \
-	x.delta.add(7, 'a', 3); \
-	x.delta.add(7, 'c', 3); \
-	x.delta.add(10, 'a', 7); \
-	x.delta.add(10, 'b', 7); \
-	x.delta.add(10, 'c', 7); \
-	x.delta.add(7, 'a', 5); \
-	x.delta.add(5, 'a', 5); \
-	x.delta.add(5, 'c', 9); \
-	x.levels.set(10); \
+    (x).levels.num_of_levels = 1; \
+    (x).initial = {1, 3}; \
+    (x).final = {5}; \
+    (x).delta.add(1, 'a', 3); \
+    (x).delta.add(1, 'a', 10); \
+    (x).delta.add(1, 'b', 7); \
+    (x).delta.add(3, 'a', 7); \
+    (x).delta.add(3, 'b', 9); \
+    (x).delta.add(9, 'a', 9); \
+    (x).delta.add(7, 'b', 1); \
+    (x).delta.add(7, 'a', 3); \
+    (x).delta.add(7, 'c', 3); \
+    (x).delta.add(10, 'a', 7); \
+    (x).delta.add(10, 'b', 7); \
+    (x).delta.add(10, 'c', 7); \
+    (x).delta.add(7, 'a', 5); \
+    (x).delta.add(5, 'a', 5); \
+    (x).delta.add(5, 'c', 9); \
+    (x).levels.set(10); \
 
 // Automaton B
 #define FILL_WITH_AUT_B(x) \
-	x.num_of_levels = 1; \
-	x.add_state(14); \
-	x.initial = {4}; \
-	x.final = {2, 12}; \
-	x.delta.add(4, 'c', 8); \
-	x.delta.add(4, 'a', 8); \
-	x.delta.add(8, 'b', 4); \
-	x.delta.add(4, 'a', 6); \
-	x.delta.add(4, 'b', 6); \
-	x.delta.add(6, 'a', 2); \
-	x.delta.add(2, 'b', 2); \
-	x.delta.add(2, 'a', 0); \
-	x.delta.add(0, 'a', 2); \
-	x.delta.add(2, 'c', 12); \
-	x.delta.add(12, 'a', 14); \
-	x.delta.add(14, 'b', 12); \
-	x.levels.set(14); \
+    (x).levels.num_of_levels = 1; \
+    (x).add_state(14); \
+    (x).initial = {4}; \
+    (x).final = {2, 12}; \
+    (x).delta.add(4, 'c', 8); \
+    (x).delta.add(4, 'a', 8); \
+    (x).delta.add(8, 'b', 4); \
+    (x).delta.add(4, 'a', 6); \
+    (x).delta.add(4, 'b', 6); \
+    (x).delta.add(6, 'a', 2); \
+    (x).delta.add(2, 'b', 2); \
+    (x).delta.add(2, 'a', 0); \
+    (x).delta.add(0, 'a', 2); \
+    (x).delta.add(2, 'c', 12); \
+    (x).delta.add(12, 'a', 14); \
+    (x).delta.add(14, 'b', 12); \
+    (x).levels.set(14); \
 
 // Automaton C
 // the same as B, but with small symbols
 #define FILL_WITH_AUT_C(x) \
-	x.num_of_levels = 1; \
-	x.initial = {4}; \
-	x.final = {2, 12}; \
-	x.delta.add(4, 3, 8); \
-	x.delta.add(4, 1, 8); \
-	x.delta.add(8, 2, 4); \
-	x.delta.add(4, 1, 6); \
-	x.delta.add(4, 2, 6); \
-	x.delta.add(6, 1, 2); \
-	x.delta.add(2, 2, 2); \
-	x.delta.add(2, 1, 0); \
-	x.delta.add(0, 1, 2); \
-	x.delta.add(2, 3, 12); \
-	x.delta.add(12, 1, 14); \
-	x.delta.add(14, 2, 12);   \
-	x.levels.set(14); \
+    (x).levels.num_of_levels = 1; \
+    (x).initial = {4}; \
+    (x).final = {2, 12}; \
+    (x).delta.add(4, 3, 8); \
+    (x).delta.add(4, 1, 8); \
+    (x).delta.add(8, 2, 4); \
+    (x).delta.add(4, 1, 6); \
+    (x).delta.add(4, 2, 6); \
+    (x).delta.add(6, 1, 2); \
+    (x).delta.add(2, 2, 2); \
+    (x).delta.add(2, 1, 0); \
+    (x).delta.add(0, 1, 2); \
+    (x).delta.add(2, 3, 12); \
+    (x).delta.add(12, 1, 14); \
+    (x).delta.add(14, 2, 12);   \
+    (x).levels.set(14); \
 
-// Automaton D // shomewhat larger
+// Automaton D // somewhat larger
 #define FILL_WITH_AUT_D(x) \
-	x.num_of_levels = 1; \
-    x.initial = {0}; \
-    x.final = {3}; \
-    x.delta.add(0, 46, 0); \
-    x.delta.add(0, 47, 0); \
-    x.delta.add(0, 58, 0); \
-    x.delta.add(0, 58, 1); \
-    x.delta.add(0, 64, 1); \
-    x.delta.add(0, 64, 1); \
-    x.delta.add(0, 82, 2); \
-    x.delta.add(0, 92, 2); \
-    x.delta.add(0, 98, 2); \
-    x.delta.add(0, 100, 1);\
-    x.delta.add(0, 103, 0);\
-    x.delta.add(0, 109, 0);\
-    x.delta.add(0, 110, 1);\
-    x.delta.add(0, 111, 2);\
-    x.delta.add(0, 114, 0);\
-    x.delta.add(1, 47, 2); \
-    x.delta.add(2, 47, 3); \
-    x.delta.add(3, 46, 2); \
-    x.delta.add(3, 47, 0); \
-    x.delta.add(3, 58, 2); \
-    x.delta.add(3, 64, 3); \
-    x.delta.add(3, 82, 2); \
-    x.delta.add(3, 92, 0); \
-    x.delta.add(3, 98, 2); \
-    x.delta.add(3, 100, 2);\
-    x.delta.add(3, 103, 3);\
-    x.delta.add(3, 109, 2);\
-    x.delta.add(3, 110, 3);\
-    x.delta.add(3, 111, 2);\
-    x.delta.add(3, 114, 3);\
-	x.levels.set(3); \
+    (x).levels.num_of_levels = 1; \
+    (x).initial = {0}; \
+    (x).final = {3}; \
+    (x).delta.add(0, 46, 0); \
+    (x).delta.add(0, 47, 0); \
+    (x).delta.add(0, 58, 0); \
+    (x).delta.add(0, 58, 1); \
+    (x).delta.add(0, 64, 1); \
+    (x).delta.add(0, 64, 1); \
+    (x).delta.add(0, 82, 2); \
+    (x).delta.add(0, 92, 2); \
+    (x).delta.add(0, 98, 2); \
+    (x).delta.add(0, 100, 1);\
+    (x).delta.add(0, 103, 0);\
+    (x).delta.add(0, 109, 0);\
+    (x).delta.add(0, 110, 1);\
+    (x).delta.add(0, 111, 2);\
+    (x).delta.add(0, 114, 0);\
+    (x).delta.add(1, 47, 2); \
+    (x).delta.add(2, 47, 3); \
+    (x).delta.add(3, 46, 2); \
+    (x).delta.add(3, 47, 0); \
+    (x).delta.add(3, 58, 2); \
+    (x).delta.add(3, 64, 3); \
+    (x).delta.add(3, 82, 2); \
+    (x).delta.add(3, 92, 0); \
+    (x).delta.add(3, 98, 2); \
+    (x).delta.add(3, 100, 2);\
+    (x).delta.add(3, 103, 3);\
+    (x).delta.add(3, 109, 2);\
+    (x).delta.add(3, 110, 3);\
+    (x).delta.add(3, 111, 2);\
+    (x).delta.add(3, 114, 3);\
+    (x).levels.set(3); \
 
 // Automaton E
 #define FILL_WITH_AUT_E(x) \
-	x.num_of_levels = 1; \
-	x.add_state(4); \
-	x.initial = {1, 3}; \
-	x.final = {4}; \
-	x.delta.add(1, 'b', 2); \
-	x.delta.add(2, 'a', 4); \
-	x.delta.add(1, 'a', 3); \
+	(x).levels.num_of_levels = 1; \
+	(x).add_state(4); \
+	(x).initial = {1, 3}; \
+	(x).final = {4}; \
+	(x).delta.add(1, 'b', 2); \
+	(x).delta.add(2, 'a', 4); \
+	(x).delta.add(1, 'a', 3); \
 
 #endif // UTILS_HH


### PR DESCRIPTION
This PR moves `Nft::num_of_levels` into `Nft::levels::num_of_levels`. This allows us to check that the levels in the NFT are valid, as well as cleans up the data structure a bit. As a consequence, this also fixes some inconsistencies with the parameters and their order in NFT creation.