### PR TITLE
feat(cmake): Update C++ standard to C++23

### DIFF
--- a/3rdparty/cudd/CMakeLists.txt
+++ b/3rdparty/cudd/CMakeLists.txt
@@ -134,7 +134,7 @@ add_library(cudd OBJECT
         util/util.h
     )
 
-target_compile_features(cudd PUBLIC cxx_std_20)
+target_compile_features(cudd PUBLIC cxx_std_23)
 
 add_library(cudd_headers INTERFACE)
 target_include_directories(cudd_headers

--- a/3rdparty/re2/CMakeLists.txt
+++ b/3rdparty/re2/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(re2 OBJECT
         util/utf.h
         util/util.h)
 
-target_compile_features(re2 PUBLIC cxx_std_20)
+target_compile_features(re2 PUBLIC cxx_std_23)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     target_link_libraries(re2 PUBLIC pthread)

--- a/3rdparty/simlib/CMakeLists.txt
+++ b/3rdparty/simlib/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(simlib OBJECT src/explicit_lts_sim.cc)
 
-target_compile_features(simlib PUBLIC cxx_std_20)
+target_compile_features(simlib PUBLIC cxx_std_23)
 
 add_library(simlib_headers INTERFACE)
 target_include_directories(simlib_headers

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,7 @@ add_library (libmata STATIC
 	$<TARGET_OBJECTS:re2>
 )
 
-# libmata needs at least c++20
-target_compile_features (libmata PUBLIC cxx_std_20)
+target_compile_features (libmata PUBLIC cxx_std_23)
 
 set_target_properties (libmata PROPERTIES
 	OUTPUT_NAME mata


### PR DESCRIPTION
This PR updates C++ standard used in Mata to C++23.