### PR TITLE
 feat!: Unify naming using '_by_levels' suffix

### DIFF
--- a/examples/nft.cc
+++ b/examples/nft.cc
@@ -28,7 +28,7 @@ int main() {
     // Then transduce a sequence of 'bc' to 'BC'.
     next_state = nft.insert_word(next_state, { 'b', 'B', 'c', 'C' });
     // Then transduce a sequence 'd' to 'DEF' (non-length-preserving operation).
-    nft.insert_word_by_parts(next_state, { { 'd' }, { 'D', 'E', 'F' } }, final);
+    nft.insert_word_by_levels(next_state, { { 'd' }, { 'D', 'E', 'F' } }, final);
     // Finally, accept the same suffix on all tapes.
     nft.insert_identity(final, &alphabet);
     // NFT nft transduces a sequence of 'abcd' to 'ABCDEF', accepting the same suffix on all tapes.
@@ -57,7 +57,7 @@ int main() {
     nft2.final.insert(final2);
     State next2{ nft2.add_transition(initial2, { 'A', '1' }) };
     next2 = nft2.insert_word(next2, { 'B', '2', 'C', '3' });
-    nft2.insert_word_by_parts(next2, { { 'D' }, { '4', '5', '6' } }, final2);
+    nft2.insert_word_by_levels(next2, { { 'D' }, { '4', '5', '6' } }, final2);
     nft2.insert_identity(final2, &alphabet);
     Nft nft_composed{ mata::nft::compose(nft, nft2) }; // Compose, by default on tape 1 of nft and tape 0 of nft2, giving the composition nft2 after nft.
     // Print the composed NFT in dot format, labeling the states as `state_number:level`.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -46,7 +46,7 @@
  *
  * There are some utility functions to simplify creating this NFA-like Delta data structure for NFTs such as
  *  @c mata::nft::Nft::insert_word() (inserting the NFA-like sequence of transitions on different tapes: 'abcd' which means to
- *  read 'ac' on tape 0 and 'bd' on tape 1), and @c mata::nft::Nft::insert_word_by_parts() (inserting word for each tape
+ *  read 'ac' on tape 0 and 'bd' on tape 1), and @c mata::nft::Nft::insert_word_by_levels() (inserting word for each tape
  *  separately: {'ac', 'bd'} to achieve the same as in the previous).
  * If you however want precise control over the created transitions, you can omit using the utility NFT functions and
  *  build your NFT like an NFA using the Nft::Delta::* operations directly, adding a single symbol on a single tape per
@@ -340,7 +340,7 @@ public:
      * @param target The target state where the word ends. @p target must already exist and be of a level 0.
      * @return The state @p target where the inserted @p word_parts_on_levels ends.
      */
-    State insert_word_by_parts(State source, const std::vector<Word>& word_parts_on_levels, State target);
+    State insert_word_by_levels(State source, const std::vector<Word>& word_parts_on_levels, State target);
 
     /**
      * @brief Inserts a word, which is created by interleaving parts from @p word_parts_on_levels, into the NFT
@@ -355,7 +355,7 @@ public:
      * @param word_parts_on_levels The vector of word parts, with each part corresponding to a different level.
      * @return The newly created target where the inserted @p word_parts_on_levels ends.
      */
-    State insert_word_by_parts(State source, const std::vector<Word>& word_parts_on_levels);
+    State insert_word_by_levels(State source, const std::vector<Word>& word_parts_on_levels);
 
     /**
      * Inserts identity transitions into the NFT.
@@ -656,7 +656,7 @@ public:
      * That is, the function checks whether a tuple @p track_words (word1, word2, word3, ..., wordn) is in the regular
      *  relation accepted by the transducer with 'n' levels (tracks).
      */
-    bool is_tuple_in_lang(const std::vector<Word>& track_words);
+    bool is_in_lang_by_levels(const std::vector<Word>& track_words);
 
     std::pair<Run, bool> get_word_for_path(const Run& run) const;
 

--- a/src/applications/strings/replace.cc
+++ b/src/applications/strings/replace.cc
@@ -423,14 +423,14 @@ Nft ReluctantReplace::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet const* const
     }
     nft_reluctant_leftmost.levels[curr_state] = 1;
     // Output the replacement.
-    curr_state = nft_reluctant_leftmost.insert_word_by_parts(curr_state, { {}, replacement });
+    curr_state = nft_reluctant_leftmost.insert_word_by_levels(curr_state, { {}, replacement });
     State next_state{ nft_reluctant_leftmost.add_state_with_level(0) };
     nft_reluctant_leftmost.delta.add(curr_state, EPSILON, next_state);
     nft_reluctant_leftmost.final.insert(next_state);
     nft_reluctant_leftmost.final.clear();
     switch (replace_mode) {
         case ReplaceMode::All: { // Return to beginning to possibly repeat replacement.
-            nft_reluctant_leftmost.insert_word_by_parts(next_state, { { EPSILON }, { EPSILON } }, initial);
+            nft_reluctant_leftmost.insert_word_by_levels(next_state, { { EPSILON }, { EPSILON } }, initial);
             break;
         };
         case ReplaceMode::Single: { // End the replacement mode.
@@ -438,7 +438,7 @@ Nft ReluctantReplace::reluctant_leftmost_nft(nfa::Nfa nfa, Alphabet const* const
             const State final{ next_state };
             nft_reluctant_leftmost.final.insert(final);
             nft_reluctant_leftmost.insert_identity(final, alphabet_symbols.to_vector());
-            nft_reluctant_leftmost.insert_word_by_parts(final, { { begin_marker }, { EPSILON } }, final);
+            nft_reluctant_leftmost.insert_word_by_levels(final, { { begin_marker }, { EPSILON } }, final);
             break;
         };
         default: {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -574,7 +574,7 @@ State Nft::insert_word(const State source, const Word& word) {
     return insert_word(source, word, add_state_with_level(levels[source]));
 }
 
-State Nft::insert_word_by_parts(const State source, const std::vector<Word> &word_parts_on_levels, const State target) {
+State Nft::insert_word_by_levels(const State source, const std::vector<Word> &word_parts_on_levels, const State target) {
     assert(word_parts_on_levels.size() == levels.num_of_levels);
     assert(source < num_of_states());
     assert(target < num_of_states());
@@ -630,9 +630,9 @@ State Nft::insert_word_by_parts(const State source, const std::vector<Word> &wor
     return target;
 }
 
-State Nft::insert_word_by_parts(const State source, const std::vector<Word> &word_parts_on_levels) {
+State Nft::insert_word_by_levels(const State source, const std::vector<Word> &word_parts_on_levels) {
    assert(source < levels.size());
-   return insert_word_by_parts(source, word_parts_on_levels, add_state_with_level(levels[source]));
+   return insert_word_by_levels(source, word_parts_on_levels, add_state_with_level(levels[source]));
 }
 
 State Nft::add_transition(const State source, const std::vector<Symbol>& symbols, const State target) {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1180,9 +1180,9 @@ std::set<mata::Word> mata::nft::Nft::get_words(const size_t max_length) const {
     return result;
 }
 
-bool Nft::is_tuple_in_lang(const std::vector<Word>& track_words) {
+bool Nft::is_in_lang_by_levels(const std::vector<Word>& track_words) {
     if (track_words.size() != levels.num_of_levels) {
-        throw std::runtime_error("Invalid number of tracks. Expected " + std::to_string(levels.num_of_levels) + ".");
+        throw std::invalid_argument("Invalid number of tracks. Expected " + std::to_string(levels.num_of_levels) + ".");
     }
     std::vector<Word::const_iterator> track_words_begins(levels.num_of_levels);
     for (size_t track{ 0 }; track < levels.num_of_levels; ++track) {

--- a/tests/applications/strings/replace.cc
+++ b/tests/applications/strings/replace.cc
@@ -480,12 +480,12 @@ TEST_CASE("nft::reluctant_replacement()") {
         nft_expected.levels[10] = 1;
         nft_expected.levels[11] = 1;
         CHECK(nft::are_equivalent(nft_begin_marker, nft_expected));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'b', 'c' }, Word{ 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', BEGIN_MARKER, 'a', 'b', 'c' } }));
-        CHECK(nft_begin_marker.is_tuple_in_lang({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'a', 'b', 'b', 'c', 'c', 'c' }, Word{ BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'a', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'b', 'c' }, Word{ 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'a', 'a', 'b', 'b', 'b', 'a', 'b', 'c' }, Word{ 'a', 'a', 'b', 'b', 'b', BEGIN_MARKER, 'a', 'b', 'c' } }));
+        CHECK(nft_begin_marker.is_in_lang_by_levels({ Word{ 'a', 'a', 'b', 'b', 'b', 'c', 'a', 'b', 'c' }, Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c' } }));
     }
 
     SECTION("nft::begin_marker_nft() regex ab+a+") {
@@ -548,11 +548,11 @@ TEST_CASE("mata::applications::strings::reluctant_leftmost_nft()") {
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q22 q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:1 q21:0 q22:0 q23:1 q24:1 q25:1 q26:1\n%LevelsNum 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 4294967295 q21\nq20 4294967295 q22\nq21 4294967295 q20\nq22 97 q23\nq22 98 q24\nq22 99 q25\nq22 4294967195 q26\nq23 97 q22\nq24 98 q22\nq25 99 q22\nq26 4294967295 q22\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
-        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
+        CHECK(nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'c', 'b', 'a', 'b', 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
     }
 
     SECTION("All 'a+b+c' replaced with 'd'") {
@@ -561,11 +561,11 @@ TEST_CASE("mata::applications::strings::reluctant_leftmost_nft()") {
             "@NFT-explicit\n%Alphabet-auto\n%Initial q14\n%Final q14\n%Levels q0:0 q1:1 q2:0 q3:1 q4:1 q5:1 q6:0 q7:1 q8:1 q9:1 q10:0 q11:1 q12:0 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0\n%LevelsNum 2\nq0 97 q1\nq0 4294967195 q3\nq1 4294967295 q2\nq2 97 q4\nq2 98 q5\nq2 4294967195 q7\nq3 4294967295 q0\nq4 4294967295 q2\nq5 4294967295 q6\nq6 98 q8\nq6 99 q9\nq6 4294967195 q11\nq7 4294967295 q2\nq8 4294967295 q6\nq9 4294967295 q10\nq10 4294967295 q19\nq11 4294967295 q6\nq12 4294967195 q13\nq13 4294967295 q12\nq14 97 q15\nq14 98 q16\nq14 99 q17\nq14 4294967195 q18\nq15 97 q14\nq16 98 q14\nq17 99 q14\nq18 4294967295 q0\nq19 100 q20\nq20 4294967295 q21\nq21 4294967295 q22\nq22 4294967295 q14\n"
         ));
         CHECK(nft::are_equivalent(nft, expected));
-        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
-        CHECK(!nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
+        CHECK(nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'd', 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'b', 'a', 'c' } }));
+        CHECK(!nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'c' }, Word{ 'c', 'c', 'b', 'a', 'c' } }));
+        CHECK(nft.is_in_lang_by_levels({ Word{ BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', BEGIN_MARKER, 'a', 'b', 'b', 'c', 'c', 'b', 'a', 'b', BEGIN_MARKER, 'a', 'b', 'c', BEGIN_MARKER, 'a', 'b', 'c', 'b' }, Word{ 'd', 'c', 'b', 'a', 'b', 'd', 'd', 'b' } }));
     }
 }
 
@@ -577,7 +577,7 @@ TEST_CASE("mata::applications::strings::literal_replace_nft()") {
 
     SECTION("'abcc' replace with 'a' replace all") {
         nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, END_MARKER, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', END_MARKER },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsNum 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
@@ -587,7 +587,7 @@ TEST_CASE("mata::applications::strings::literal_replace_nft()") {
 
     SECTION("'abcc' replace with 'bbb' replace single") {
         nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'b', 'c', 'c' }, Word{ 'b', 'b', 'b' },  &alphabet, END_MARKER, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'b', 'b', 'b', 'a', 'a', 'b', 'c', 'c' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q45 q46\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:1 q36:0 q37:1 q38:0 q39:1 q40:0 q41:1 q42:1 q43:1 q44:1 q45:0 q46:0 q47:1 q48:1 q49:1 q50:0 q51:1 q52:1 q53:0 q54:1 q55:0 q56:1\n%LevelsNum 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967196 q47\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967196 q48\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967196 q49\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967196 q52\nq4 4294967295 q35\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq35 98 q36\nq36 4294967295 q37\nq37 98 q38\nq38 4294967295 q39\nq39 98 q40\nq40 97 q41\nq40 98 q42\nq40 99 q43\nq40 4294967196 q44\nq41 97 q40\nq42 98 q40\nq43 99 q40\nq44 4294967295 q45\nq47 4294967295 q46\nq48 97 q46\nq49 97 q50\nq50 4294967295 q51\nq51 98 q46\nq52 97 q53\nq53 4294967295 q54\nq54 98 q55\nq55 4294967295 q56\nq56 99 q46\n"
@@ -598,7 +598,7 @@ TEST_CASE("mata::applications::strings::literal_replace_nft()") {
     SECTION("'aabac' replace with 'd' replace all") {
         nft = reluctant_replace.replace_literal_nft(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet, END_MARKER,
                                   ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', END_MARKER },
                                      { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q54\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:0 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:1 q18:1 q19:0 q20:1 q21:0 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:1 q32:0 q33:1 q34:0 q35:1 q36:0 q37:1 q38:1 q39:0 q40:1 q41:0 q42:1 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:1 q53:1 q54:0 q55:1 q56:1 q57:1 q58:0 q59:1 q60:1 q61:0 q62:1 q63:0 q64:1 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsNum 2\nq0 97 q6\nq0 98 q7\nq0 99 q8\nq0 4294967196 q55\nq1 97 q9\nq1 98 q10\nq1 99 q13\nq1 4294967196 q56\nq2 97 q16\nq2 98 q17\nq2 99 q18\nq2 4294967196 q57\nq3 97 q23\nq3 98 q24\nq3 99 q31\nq3 4294967196 q60\nq4 97 q38\nq4 98 q43\nq4 99 q52\nq4 4294967196 q65\nq5 4294967295 q53\nq6 4294967295 q1\nq7 98 q0\nq8 99 q0\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 98 q0\nq13 97 q14\nq14 4294967295 q15\nq15 99 q0\nq16 97 q2\nq17 4294967295 q3\nq18 97 q19\nq19 4294967295 q20\nq20 97 q21\nq21 4294967295 q22\nq22 99 q0\nq23 4294967295 q4\nq24 97 q25\nq25 4294967295 q26\nq26 97 q27\nq27 4294967295 q28\nq28 98 q29\nq29 4294967295 q30\nq30 98 q0\nq31 97 q32\nq32 4294967295 q33\nq33 97 q34\nq34 4294967295 q35\nq35 98 q36\nq36 4294967295 q37\nq37 99 q0\nq38 97 q39\nq39 4294967295 q40\nq40 97 q41\nq41 4294967295 q42\nq42 98 q2\nq43 97 q44\nq44 4294967295 q45\nq45 97 q46\nq46 4294967295 q47\nq47 98 q48\nq48 4294967295 q49\nq49 97 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q5\nq53 100 q0\nq55 4294967295 q54\nq56 97 q54\nq57 97 q58\nq58 4294967295 q59\nq59 97 q54\nq60 97 q61\nq61 4294967295 q62\nq62 97 q63\nq63 4294967295 q64\nq64 98 q54\nq65 97 q66\nq66 4294967295 q67\nq67 97 q68\nq68 4294967295 q69\nq69 98 q70\nq70 4294967295 q71\nq71 97 q54\n"
@@ -614,42 +614,42 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_literal()") {
 
     SECTION("'' replace with 'abc' replace single") {
         nft = applications::strings::replace::replace_reluctant_literal(Word{}, Word{ 'a', 'b', 'c' },  &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b' },
                                    { 'a', 'b', 'c', 'b', 'b' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b' },
                                    { 'a', 'b', 'c', 'a', 'b' } }));
      }
 
     SECTION("'' replace with 'abc' replace all") {
         nft = applications::strings::replace::replace_reluctant_literal(Word{}, Word{ 'a', 'b', 'c' },  &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b' },
                                    { 'b', 'b' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b' },
                                    { 'a', 'b' } }));
      }
 
     SECTION("'abcc' replace with 'a' replace all") {
         nft = applications::strings::replace::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'a' },  &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b', 'c', 'c' },
                                    { 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'b', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'b', 'c', 'c' },
                                    { 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'c', 'a', 'b', 'c', 'c' },
                                    { 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'c', 'a', 'b', 'c', 'c', 'a' },
                                    { 'c', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
                                    { 'c', 'a', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'c', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c' },
                                    { 'a', 'c', 'a', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
                                    { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'a', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { }, { } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { }, { } }));
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b', 'c' },
                                    { 'a', 'b', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b', 'c' },
                                    { 'a', 'b', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'c', 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'c', 'c', 'c' },
                                    { 'c', 'c', 'c' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q35\n%Levels q0:0 q1:0 q2:0 q3:0 q4:0 q5:1 q6:1 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:1 q14:0 q15:1 q16:1 q17:0 q18:1 q19:0 q20:1 q21:1 q22:1 q23:0 q24:1 q25:0 q26:1 q27:1 q28:0 q29:1 q30:0 q31:1 q32:0 q33:1 q34:1 q35:0 q36:1 q37:1 q38:1 q39:1 q40:0 q41:1 q42:1 q43:0 q44:1 q45:0 q46:1\n%LevelsNum 2\nq0 97 q5\nq0 98 q6\nq0 99 q7\nq0 4294967295 q37\nq1 97 q8\nq1 98 q9\nq1 99 q10\nq1 4294967295 q38\nq2 97 q13\nq2 98 q16\nq2 99 q21\nq2 4294967295 q39\nq3 97 q22\nq3 98 q27\nq3 99 q34\nq3 4294967295 q42\nq4 4294967295 q36\nq5 4294967295 q1\nq6 98 q0\nq7 99 q0\nq8 97 q1\nq9 4294967295 q2\nq10 97 q11\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq14 4294967295 q15\nq15 98 q1\nq16 97 q17\nq17 4294967295 q18\nq18 98 q19\nq19 4294967295 q20\nq20 98 q0\nq21 4294967295 q3\nq22 97 q23\nq23 4294967295 q24\nq24 98 q25\nq25 4294967295 q26\nq26 99 q1\nq27 97 q28\nq28 4294967295 q29\nq29 98 q30\nq30 4294967295 q31\nq31 99 q32\nq32 4294967295 q33\nq33 98 q0\nq34 4294967295 q4\nq36 97 q0\nq37 4294967295 q35\nq38 97 q35\nq39 97 q40\nq40 4294967295 q41\nq41 98 q35\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 99 q35\n"
@@ -659,9 +659,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_literal()") {
 
    SECTION("'abcc' replace with 'dd' replace single") {
        nft = applications::strings::replace::replace_reluctant_literal(Word{ 'a', 'b', 'c', 'c' }, Word{ 'd', 'd' },  &alphabet, ReplaceMode::Single);
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
+       CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'c', 'a', 'a', 'b', 'c', 'c', 'a' },
                                   { 'a', 'a', 'a', 'b', 'a', 'a', 'd', 'd', 'a', 'a', 'b', 'c', 'c', 'a' } }));
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c' },
+       CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c' },
                                   { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c' } }));
        expected = nft::builder::parse_from_mata(std::string(
          "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:1 q16:1 q17:1 q18:0 q19:1 q20:0 q21:1 q22:1 q23:1 q24:1 q25:0 q26:1 q27:0 q28:1 q29:0 q30:1 q31:0 q32:1 q33:0 q34:1 q35:1 q36:1 q37:1 q38:0 q39:1 q40:0 q41:1 q42:0 q43:1 q44:0 q45:1 q46:0 q47:1 q48:0 q49:1 q50:0 q51:1 q52:0 q53:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 97 q6\nq8 4294967295 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 97 q14\nq13 98 q15\nq13 99 q16\nq13 4294967295 q17\nq14 97 q52\nq15 97 q48\nq16 4294967295 q20\nq17 97 q18\nq18 4294967295 q19\nq19 98 q5\nq20 97 q21\nq20 98 q22\nq20 99 q23\nq20 4294967295 q24\nq21 97 q44\nq22 97 q38\nq23 4294967295 q29\nq24 97 q25\nq25 4294967295 q26\nq26 98 q27\nq27 4294967295 q28\nq28 99 q5\nq29 4294967295 q30\nq30 100 q31\nq31 4294967295 q32\nq32 100 q33\nq33 97 q34\nq33 98 q35\nq33 99 q36\nq33 4294967295 q37\nq34 97 q33\nq35 98 q33\nq36 99 q33\nq37 4294967295 q5\nq38 4294967295 q39\nq39 98 q40\nq40 4294967295 q41\nq41 99 q42\nq42 4294967295 q43\nq43 98 q0\nq44 4294967295 q45\nq45 98 q46\nq46 4294967295 q47\nq47 99 q6\nq48 4294967295 q49\nq49 98 q50\nq50 4294967295 q51\nq51 98 q0\nq52 4294967295 q53\nq53 98 q6\n"
@@ -672,10 +672,10 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_literal()") {
    SECTION("'aabac' replace with 'd' replace all") {
        nft = applications::strings::replace::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{ 'd' }, &alphabet,
                                                    ReplaceMode::All);
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+       CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                   { 'a', 'a', 'a', 'b', 'a', 'd', 'a' } }));
-       CHECK(nft.is_tuple_in_lang({ { }, { } }));
-       CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+       CHECK(nft.is_in_lang_by_levels({ { }, { } }));
+       CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                   { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
        expected = nft::builder::parse_from_mata(std::string(
           "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:0 q63:1 q64:0 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q68\nq49 97 q60\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 100 q0\nq60 4294967295 q61\nq61 97 q62\nq62 4294967295 q63\nq63 98 q64\nq64 4294967295 q65\nq65 97 q66\nq66 4294967295 q67\nq67 98 q0\nq68 4294967295 q69\nq69 97 q70\nq70 4294967295 q71\nq71 98 q15\n"
@@ -686,12 +686,12 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_literal()") {
     SECTION("drop all 'aabac'") {
         nft = applications::strings::replace::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{}, &alphabet,
                                                       ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
                                      { 'a', 'a', 'a', 'b', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { }, { } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { }, { } }));
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:0 q63:1 q64:0 q65:1 q66:0 q67:1 q68:0 q69:1 q70:0 q71:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q68\nq49 97 q60\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 4294967295 q0\nq60 4294967295 q61\nq61 97 q62\nq62 4294967295 q63\nq63 98 q64\nq64 4294967295 q65\nq65 97 q66\nq66 4294967295 q67\nq67 98 q0\nq68 4294967295 q69\nq69 97 q70\nq70 4294967295 q71\nq71 98 q15\n"
@@ -702,10 +702,10 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_literal()") {
     SECTION("drop single 'aabac'") {
         nft = applications::strings::replace::replace_reluctant_literal(Word{ 'a', 'a', 'b', 'a', 'c' }, Word{}, &alphabet,
                                                       ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a', 'a', 'b', 'a', 'c' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c'} }));
-        CHECK(nft.is_tuple_in_lang({ { }, { } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { }, { } }));
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q5\n%Levels q0:0 q1:1 q2:1 q3:1 q4:1 q5:0 q6:0 q7:1 q8:1 q9:1 q10:1 q11:0 q12:1 q13:0 q14:1 q15:0 q16:1 q17:1 q18:1 q19:1 q20:0 q21:1 q22:0 q23:1 q24:0 q25:1 q26:0 q27:1 q28:1 q29:1 q30:1 q31:0 q32:1 q33:0 q34:1 q35:0 q36:1 q37:0 q38:1 q39:0 q40:1 q41:0 q42:1 q43:0 q44:1 q45:0 q46:1 q47:0 q48:1 q49:1 q50:1 q51:1 q52:0 q53:1 q54:0 q55:1 q56:0 q57:1 q58:0 q59:1 q60:0 q61:1 q62:1 q63:1 q64:1 q65:0 q66:1 q67:0 q68:1 q69:0 q70:1 q71:0 q72:1 q73:0 q74:1 q75:0 q76:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq0 4294967295 q4\nq1 4294967295 q6\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq6 97 q7\nq6 98 q8\nq6 99 q9\nq6 4294967295 q10\nq7 4294967295 q15\nq8 97 q13\nq9 97 q11\nq10 97 q5\nq11 4294967295 q12\nq12 99 q0\nq13 4294967295 q14\nq14 98 q0\nq15 97 q16\nq15 98 q17\nq15 99 q18\nq15 4294967295 q19\nq16 97 q15\nq17 4294967295 q26\nq18 97 q22\nq19 97 q20\nq20 4294967295 q21\nq21 97 q5\nq22 4294967295 q23\nq23 97 q24\nq24 4294967295 q25\nq25 99 q0\nq26 97 q27\nq26 98 q28\nq26 99 q29\nq26 4294967295 q30\nq27 4294967295 q47\nq28 97 q41\nq29 97 q35\nq30 97 q31\nq31 4294967295 q32\nq32 97 q33\nq33 4294967295 q34\nq34 98 q5\nq35 4294967295 q36\nq36 97 q37\nq37 4294967295 q38\nq38 98 q39\nq39 4294967295 q40\nq40 99 q0\nq41 4294967295 q42\nq42 97 q43\nq43 4294967295 q44\nq44 98 q45\nq45 4294967295 q46\nq46 98 q0\nq47 97 q48\nq47 98 q49\nq47 99 q50\nq47 4294967295 q51\nq48 97 q73\nq49 97 q65\nq50 4294967295 q58\nq51 97 q52\nq52 4294967295 q53\nq53 97 q54\nq54 4294967295 q55\nq55 98 q56\nq56 4294967295 q57\nq57 97 q5\nq58 4294967295 q59\nq59 4294967295 q60\nq60 97 q61\nq60 98 q62\nq60 99 q63\nq60 4294967295 q64\nq61 97 q60\nq62 98 q60\nq63 99 q60\nq64 4294967295 q5\nq65 4294967295 q66\nq66 97 q67\nq67 4294967295 q68\nq68 98 q69\nq69 4294967295 q70\nq70 97 q71\nq71 4294967295 q72\nq72 98 q0\nq73 4294967295 q74\nq74 97 q75\nq75 4294967295 q76\nq76 98 q15\n"
@@ -722,11 +722,11 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
     SECTION("'a' replace with 'b' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', 'd', &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'd' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 100 q0\nq2 98 q0\nq3 99 q0\n"
@@ -735,11 +735,11 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
 
         // Use replace symbol with literal containing a single symbol.
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', Word{ 'd' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'd' } }));
         CHECK(nft::are_equivalent(nft, expected));
     }
@@ -747,11 +747,11 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
     SECTION("'a' replace with 'b' replace single") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', 'd', &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q4\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1 q6:1 q7:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 100 q4\nq2 98 q0\nq3 99 q0\nq4 97 q5\nq4 98 q6\nq4 99 q7\nq5 97 q4\nq6 98 q4\nq7 99 q4\n"
@@ -760,24 +760,24 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
 
         // Use replace symbol with literal containing a single symbol.
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', Word{ 'd' }, &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'd', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b', 'b', 'b', 'a', 'a', 'a', 'b', 'a', 'a' },
                                      { 'b', 'b', 'b', 'b', 'd', 'a', 'a', 'b', 'a', 'a' } }));
         CHECK(nft::are_equivalent(nft, expected));
     }
 
     SECTION("'a' replace with 'bb' replace all") {
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', Word{ 'b', 'b' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'c', 'b', 'b' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
                                      { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 98 q4\nq2 98 q0\nq3 99 q0\nq4 4294967295 q5\nq5 98 q0\n"
@@ -787,11 +787,11 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
 
     SECTION("drop all 'a'") {
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', Word{}, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'b', 'b', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
                                      { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0\n%Levels q0:0 q1:1 q2:1 q3:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 4294967295 q0\nq2 98 q0\nq3 99 q0\n"
@@ -801,11 +801,11 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_single_symbol
 
     SECTION("drop single 'a'") {
         nft = applications::strings::replace::replace_reluctant_single_symbol('a', Word{}, &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' },
                                      { 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b', 'b' } }));
         expected = nft::builder::parse_from_mata(std::string(
             "@NFT-explicit\n%Alphabet-auto\n%Initial q0\n%Final q0 q4\n%Levels q0:0 q1:1 q2:1 q3:1 q4:0 q5:1 q6:1 q7:1\n%LevelsNum 2\nq0 97 q1\nq0 98 q2\nq0 99 q3\nq1 4294967295 q4\nq2 98 q0\nq3 99 q0\nq4 97 q5\nq4 98 q6\nq4 99 q7\nq5 97 q4\nq6 98 q4\nq7 99 q4\n"
@@ -821,32 +821,32 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
 
     SECTION("'' replace with 'abc' replace single") {
         nft = applications::strings::replace::replace_reluctant_regex("a*", Word{ 'b', 'b', 'b' },  &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'b', 'b' },
                                    { 'b', 'b', 'b', 'a', 'b', 'b' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'c', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'c', 'c' },
                                    { 'b', 'b', 'b', 'c', 'c' } }));
      }
 
     SECTION("'' replace with 'abc' replace all") {
         nft = applications::strings::replace::replace_reluctant_regex("a*", Word{ 'a', 'b', 'c' },  &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'b', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'b', 'b' },
                                    { 'b', 'b' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'b' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'b' },
                                    { 'a', 'b', 'c', 'a', 'b', 'c', 'b' } }));
      }
 
     SECTION("'a+b+c' replace with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a+b+c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'b', 'c', 'c', 'a', 'a' },
                                      { 'a', 'a', 'a', 'b', 'd', 'd', 'c', 'a', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'b', 'a', 'a', 'b', 'c', 'c', 'a', 'b', 'a', 'c' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'b', 'd', 'd', 'c', 'a', 'b', 'a', 'c' } }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -856,9 +856,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("'a' replace with 'd' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a", Word{ 'd' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'b', 'd', 'd', 'd', 'b', 'd', 'c', 'd' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -868,9 +868,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("drop 'a' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'b', 'b', 'c' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -880,9 +880,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("drop 'a' replace single") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a", Word{}, &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -892,9 +892,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("drop 'a+b' replace single") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -904,9 +904,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("drop 'a+b' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a+b", Word{}, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -916,9 +916,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("replace 'a+b' with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'd', 'd', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -928,9 +928,9 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("replace 'a+b' with 'dd' replace single") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a+b", Word{ 'd', 'd' }, &alphabet, ReplaceMode::Single);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'd', 'd', 'a', 'a', 'a', 'b', 'a', 'c', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -940,13 +940,13 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
     SECTION("replace 'a*b*c' with 'dd' replace all") {
         // Use replace symbol with symbol.
         nft = applications::strings::replace::replace_reluctant_regex("a*b*c", Word{ 'd', 'd' }, &alphabet, ReplaceMode::All);
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'a', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'd', 'd', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'a', 'a', 'a', 'b', 'c', 'a' },
                                      { 'a', 'a', 'a', 'b', 'd', 'd', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'c', 'a' },
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a', 'a', 'b', 'c', 'a', 'a', 'a', 'b', 'c', 'a' },
                                      { 'd', 'd', 'd', 'd', 'a' } }));
-        CHECK(nft.is_tuple_in_lang({ {},
+        CHECK(nft.is_in_lang_by_levels({ {},
                                      {} }));
 //        expected = nft::builder::parse_from_mata(std::string(
 //        ));
@@ -961,17 +961,17 @@ TEST_CASE("mata::applications::strings::replace::replace_reluctant_regex()") {
         alphabet = mata::EnumAlphabet{ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 60, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 78, 79, 80, 82, 83, 84, 86, 87, 92, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 112, 114, 115, 116, 119, 120, 121, 196608 };
         nft = applications::strings::replace::replace_reluctant_regex(regex, replacement, &alphabet, ReplaceMode::All);
 
-        CHECK(nft.is_tuple_in_lang({ { '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
+        CHECK(nft.is_in_lang_by_levels({ { '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
                                      { 'B', 'L', 'O', 'C', 'K', 'E', 'D', '<', '<', '<', '<' } }));
-        CHECK(nft.is_tuple_in_lang({ { '<', '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
+        CHECK(nft.is_in_lang_by_levels({ { '<', '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
                                      { '<', 'B', 'L', 'O', 'C', 'K', 'E', 'D', '<', '<', '<', '<' } }));
-        CHECK(nft.is_tuple_in_lang({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
+        CHECK(nft.is_in_lang_by_levels({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', '<', '<', '<', '<' },
                                      { '<', 'S', 'B', 'L', 'O', 'C', 'K', 'E', 'D', '<', '<', '<', '<' } }));
-        CHECK(nft.is_tuple_in_lang({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', 'T', 'T', '<', '<' },
+        CHECK(nft.is_in_lang_by_levels({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', 'T', 'T', '<', '<' },
                                      { '<', 'S', 'B', 'L', 'O', 'C', 'K', 'E', 'D', 'T', 'T', '<', '<' } }));
-        CHECK(!nft.is_tuple_in_lang({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', 'T', 'T', '<', '<' },
+        CHECK(!nft.is_in_lang_by_levels({ { '<', 'S', '<', 'S', 'C', 'R', 'I', 'P', 'T', 'T', 'T', '<', '<' },
                                      { '<', 'S', 'B', 'L', 'O', 'C', 'K', 'E', 'D', 'T', '<', '<' } }));
-        CHECK(!nft.is_tuple_in_lang({ { '<', 's', '<', 's', 'c', 'r', 'i', 'p', 't', 't', 't', '<', '<' },
+        CHECK(!nft.is_in_lang_by_levels({ { '<', 's', '<', 's', 'c', 'r', 'i', 'p', 't', 't', 't', '<', '<' },
                                      { '<', 's', 'B', 'L', 'O', 'C', 'K', 'E', 'D', 't', 't', '<', '<' } }));
     }
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -5268,7 +5268,7 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
     }
 }
 
-TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
+TEST_CASE("mata::nft::Nft::insert_word_by_levels()") {
     Nft nft, expected;
 
     SECTION("Inserting a word between two states (both initial and final) with empty delta.") {
@@ -5277,7 +5277,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
         SECTION("levels.num_of_levels == 1 && word_part.size() == 1") {
             nft = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-            State new_tgt = nft.insert_word_by_parts(0, { {'a'} } , 1);
+            State new_tgt = nft.insert_word_by_levels(0, { {'a'} } , 1);
             CHECK(new_tgt == 1);
 
             expected = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5288,7 +5288,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
         SECTION("levels.num_of_levels == 1 && word_part.size() == 2") {
             nft = Nft::with_levels({1, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-            State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'} } , 1);
+            State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'} } , 1);
             CHECK(new_tgt == 1);
 
             expected = Nft::with_levels({1, { 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5300,7 +5300,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
         SECTION("levels.num_of_levels == 1 && word_part.size() == 4") {
             nft = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1  });
-            State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'} }, 1);
+            State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'} }, 1);
             CHECK(new_tgt == 1);
 
             expected = Nft::with_levels({1, { 0, 0, 0, 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5324,7 +5324,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'} } , 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {'b'} } , 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5335,7 +5335,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'} } , 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'c', 'd'} } , 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5349,7 +5349,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5370,7 +5370,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'}, {'c'}, {'d'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {'b'}, {'c'}, {'d'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5384,7 +5384,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5402,7 +5402,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5438,7 +5438,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         SECTION("levels.num_of_levels == 2") {
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {'b'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0 } }, delta, { 0, 1 }, { 3 });
@@ -5450,7 +5450,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'c', 'd'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0 } }, delta, { 0, 1 }, { 5 });
@@ -5464,7 +5464,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1, 0 } }, delta, { 0, 1 }, { 9 });
@@ -5484,7 +5484,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         SECTION("levels.num_of_levels == 4") {
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'b'}, {'c'}, {'d'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {'b'}, {'c'}, {'d'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 5 });
@@ -5498,7 +5498,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'c', 'd'}, {'e', 'f'}, {'g', 'h'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 9 });
@@ -5516,7 +5516,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 17 });
@@ -5542,7 +5542,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("The lengths of word pats dont have the same length.") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, {});
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {} });
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'e', 'f', 'g', 'h'}, {'i', 'j', 'k', 'l'}, {} });
                 nft.final.insert(new_tgt);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0 } }, delta, { 0, 1 }, { 17 });
@@ -5578,7 +5578,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         SECTION("levels.num_of_levels == 2") {
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {}, {'b'} } , 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {}, {'b'} } , 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5590,7 +5590,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b'}, {'c'} } , 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b'}, {'c'} } , 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5604,7 +5604,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({2, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a', 'b', 'c', 'd'}, {'e'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a', 'b', 'c', 'd'}, {'e'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({2, { 0, 0, 1, 0, 1, 0, 1, 0, 1 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5624,7 +5624,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
         SECTION("levels.num_of_levels == 4") {
             SECTION("word_part.size() == 1") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {}, {'c'}, {} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {}, {'c'}, {} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5638,7 +5638,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 2") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {'a'}, {'c', 'd'}, {}, {'g'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {'a'}, {'c', 'd'}, {}, {'g'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5656,7 +5656,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
 
             SECTION("word_part.size() == 4") {
                 nft = Nft::with_levels({4, { 0, 0 } }, delta, { 0, 1 }, { 0, 1 });
-                State new_tgt = nft.insert_word_by_parts(0, { {}, {'e', 'f'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
+                State new_tgt = nft.insert_word_by_levels(0, { {}, {'e', 'f'}, {'i', 'j', 'k', 'l'}, {'m', 'n', 'o', 'p'} }, 1);
                 CHECK(new_tgt == 1);
 
                 expected = Nft::with_levels({4, { 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3 } }, delta, { 0, 1 }, { 0, 1 });
@@ -5687,7 +5687,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             nft = Nft{};
             nft.levels.num_of_levels = 3;
             const State state_lvl1{ nft.add_state_with_level(1) };
-            const State target{ nft.insert_word_by_parts(state_lvl1, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
+            const State target{ nft.insert_word_by_levels(state_lvl1, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
             CHECK(nft.levels[target] == 1);
             expected = Nft{};
             expected.levels.num_of_levels = 3;
@@ -5708,7 +5708,7 @@ TEST_CASE("mata::nft::Nft::insert_word_by_parts()") {
             nft = Nft{};
             nft.levels.num_of_levels = 3;
             const State state_lvl2{ nft.add_state_with_level(2) };
-            const State target{ nft.insert_word_by_parts(state_lvl2, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
+            const State target{ nft.insert_word_by_levels(state_lvl2, { { 'a', 'b', 'c' }, { 'd', 'e' }, { 'f' } }) };
             CHECK(nft.levels[target] == 2);
             expected = Nft{};
             expected.levels.num_of_levels = 3;


### PR DESCRIPTION
This PR unifies the naming of functions using levels to use `_by_levels` suffix consistently.