### PR TITLE
feat(nft): Implement complementation for NFTs

### DIFF
--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -37,11 +37,9 @@ Nfa minimize_hopcroft(const Nfa& dfa_trimmed);
 
 /**
  * Complement implemented by determization, adding sink state and making automaton complete. Then it adds final states
- *  which were non final in the original automaton.
+ *  which were non-final in the original automaton.
  * @param[in] aut Automaton to be complemented.
  * @param[in] symbols Symbols needed to make the automaton complete.
- * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (brzozowski)
- *  minimization.
  * @return Complemented automaton.
  */
 Nfa complement_classical(const Nfa& aut, const mata::utils::OrdVector<Symbol>& symbols);
@@ -63,8 +61,7 @@ Nfa complement_brzozowski(const Nfa& aut, const mata::utils::OrdVector<Symbol>& 
  * @param[in] alphabet Alphabet of both automata (it is computed automatically, but it is more efficient to set it if
  *  you have it).
  * @param[out] cex A potential counterexample word which breaks inclusion
- * @return True if smaller language is included,
- * i.e., if the final intersection of smaller complement of bigger is empty.
+ * @return True if smaller language is included, i.e., if the final intersection of smaller complement of bigger is empty.
  */
 bool is_included_naive(const Nfa& smaller, const Nfa& bigger, const Alphabet* alphabet = nullptr, Run* cex = nullptr);
 
@@ -75,8 +72,7 @@ bool is_included_naive(const Nfa& smaller, const Nfa& bigger, const Alphabet* al
  * @param[in] bigger Automaton which language should include the smaller one
  * @param[in] alphabet Alphabet of both automata (not needed for antichain algorithm)
  * @param[out] cex A potential counterexample word which breaks inclusion
- * @return True if smaller language is included,
- * i.e., if the final intersection of smaller complement of bigger is empty.
+ * @return True if smaller language is included, i.e., if the final intersection of smaller complement of bigger is empty.
  */
 bool is_included_antichains(const Nfa& smaller, const Nfa& bigger, const Alphabet*  alphabet = nullptr, Run* cex = nullptr);
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -293,6 +293,15 @@ public:
     Nfa decode_utf8() const;
 
     /**
+     * @brief Get the epsilon closure of the given set of states.
+     *
+     * @param source_states Set of source states.
+     * @param epsilons Set of symbols to consider as epsilons when computing the closure.
+     * @return Epsilon closure of the given set of states.
+     */
+    StateSet mk_epsilon_closure(const StateSet& source_states, const std::vector<Symbol>& epsilons = { EPSILON }) const;
+
+    /**
      * @brief Returns vector ret where ret[q] is the length of the shortest path from any initial state to q
      */
     std::vector<State> distances_from_initial() const;

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -551,13 +551,13 @@ public:
     /**
      * @brief Check whether a run over the word (or its prefix) is in the language of an automaton.
      *
-     * @param word The run to check.
+     * @param run The run to check.
      * @param use_epsilon Whether the automaton uses epsilon transitions.
      * @param match_prefix Whether to also match the prefix of the word.
      *
      * @return True if the run (or its prefix) is in the language of the automaton, false otherwise.
      */
-    bool is_in_lang(const Run& word, bool use_epsilon = false, bool match_prefix = false) const;
+    bool is_in_lang(const Run& run, bool use_epsilon = false, bool match_prefix = false) const;
 
     /**
      * @brief Check whether a word (or its prefix) is in the language of an automaton.
@@ -628,7 +628,7 @@ public:
      *
      * @return True if the prefix of the run is in the language of the automaton, false otherwise.
      */
-    bool is_prefix_in_lang(const Run& word, const bool use_epsilon = false) const { return is_in_lang(word, use_epsilon, true); }
+    bool is_in_lang_prefix(const Run& word, const bool use_epsilon = false) const { return is_in_lang(word, use_epsilon, true); }
 
     /**
      * @brief Check whether a prefix of a word is in the language of an automaton.
@@ -638,7 +638,7 @@ public:
      *
      * @return True if the prefix of the word is in the language of the automaton, false otherwise.
      */
-    bool is_prefix_in_lang(const Word& word, const bool use_epsilon = false) const { return is_prefix_in_lang(Run{ word, {} }, use_epsilon); }
+    bool is_in_lang_prefix(const Word& word, const bool use_epsilon = false) const { return is_in_lang_prefix(Run{ word, {} }, use_epsilon); }
 
     std::pair<Run, bool> get_word_for_path(const Run& run) const;
 

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -623,12 +623,12 @@ public:
     /**
      * @brief Check whether a prefix of a run is in the language of an automaton.
      *
-     * @param word The run to check.
+     * @param run The run to check.
      * @param use_epsilon Whether the automaton uses epsilon transitions.
      *
      * @return True if the prefix of the run is in the language of the automaton, false otherwise.
      */
-    bool is_in_lang_prefix(const Run& word, const bool use_epsilon = false) const { return is_in_lang(word, use_epsilon, true); }
+    bool is_in_lang_prefix(const Run& run, const bool use_epsilon = false) const { return is_in_lang(run, use_epsilon, true); }
 
     /**
      * @brief Check whether a prefix of a word is in the language of an automaton.

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -38,12 +38,11 @@ Nft minimize_brzozowski(const Nft& aut);
  *  which were non-final in the original automaton.
  * @param[in] aut Automaton to be complemented.
  * @param[in] symbols Symbols needed to make the automaton complete.
- * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (brzozowski)
- *  minimization.
+ * @param[in] minimize_during_determinization Whether the determinized automaton is computed by (Brzozowski) minimization.
  * @return Complemented automaton.
  */
-Nft complement_classical(const Nft& aut, const mata::utils::OrdVector<Symbol>& symbols,
-                         bool minimize_during_determinization = false);
+Nft complement_classical(
+    const Nft& aut, const utils::OrdVector<Symbol>& symbols, bool minimize_during_determinization = false);
 
 /**
  * Inclusion implemented by complementation of bigger automaton, intersecting it with smaller, and then it checks
@@ -56,8 +55,7 @@ Nft complement_classical(const Nft& aut, const mata::utils::OrdVector<Symbol>& s
  * @param[in] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE.
- * @return True if smaller language is included,
- * i.e., if the final intersection of smaller complement of bigger is empty.
+ * @return True if smaller language is included, i.e., if the final intersection of smaller complement of bigger is empty.
  */
 bool is_included_naive(
     const Nft& smaller, const Nft& bigger, const Alphabet* alphabet = nullptr, Run* cex = nullptr,
@@ -72,8 +70,7 @@ bool is_included_naive(
  * @param[out] jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE.
- * @return True if smaller language is included,
- * i.e., if the final intersection of smaller complement of bigger is empty.
+ * @return True if smaller language is included, i.e., if the final intersection of smaller complement of bigger is empty.
  */
 bool is_included_antichains(
     const Nft& smaller, const Nft& bigger, const Alphabet* alphabet = nullptr, Run* cex = nullptr,
@@ -135,6 +132,6 @@ Nft product(const Nft& lhs, const Nft& rhs, const std::function<bool(State,State
 Nft concatenate_eps(const Nft& lhs, const Nft& rhs, const Symbol& epsilon, bool use_epsilon = false,
                     StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
-} // Namespace mata::nft::algorithms.
+}
 
-#endif // MATA_NFT_INTERNALS_HH_
+#endif

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -679,9 +679,10 @@ public:
      * you can get all words by calling
      *      aut.get_words(aut.num_of_states())
      * @param max_length Maximum length of words to be returned. Default: "no limit"; will infinitely loop if the language is infinite.
+     * @param jump_mode Specifies how to interpret the jump transitions.
      * @return Set of all words in the language of the automaton whose length is <= @p max_length.
      */
-    std::set<Word> get_words(size_t max_length = std::numeric_limits<size_t>::max()) const;
+    std::set<Word> get_words(size_t max_length = std::numeric_limits<size_t>::max(), JumpMode jump_mode = JumpMode::RepeatSymbol) const;
 
     /**
      * @brief Apply @p nfa to @c this.
@@ -770,7 +771,7 @@ public:
      * @brief Make NFT complete in place.
      *
      * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
-     *  transitions from given `state`) to `sink_states[next_level(level)]` where `level == this->levels[state]`.
+     *  transitions from given `state`) to `sink_states[next_level_after(level)]` where `level == this->levels[state]`.
      * If NFT does not contain any states, this function does nothing.
      *
      * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
@@ -791,7 +792,7 @@ public:
      * @brief Make NFT complete in place.
      *
      * For each state `state`, add transitions with "missing" symbols from @p alphabet (symbols that do not occur on
-     *  transitions from given `state`) to `sink_states[next_level(level)]` where `level == this->levels[state]`.
+     *  transitions from given `state`) to `sink_states[next_level_after(level)]` where `level == this->levels[state]`.
      * If NFT does not contain any states, this function does nothing.
      *
      * @note This overloaded version is a more efficient version which does not need to compute the set of symbols to

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -101,7 +101,7 @@ namespace mata::nft {
  */
 class Nft: public nfa::Nfa {
 private:
-    using super = nfa::Nfa;
+    using super = Nfa;
 public:
     /**
      * @brief Vector of levels giving each state a level in range from 0 to @c levels.num_of_levels - 1.
@@ -675,7 +675,29 @@ public:
      */
     bool is_in_lang_by_levels(const std::vector<Word>& track_words);
 
+    /**
+     * @brief Get a word for a given run if it exists.
+     *
+     * @param run The run containing a path to get the word for.
+     * @return A pair containing the word for the given run and a boolean indicating whether the word exists.
+     */
     std::pair<Run, bool> get_word_for_path(const Run& run) const;
+
+    /**
+     * @brief Convert a word to level words according to the levels of the automaton.
+     *
+     * @param word The word to convert.
+     * @return The level words corresponding to the input word.
+     */
+    std::vector<Word> mk_level_word_from_word(const Word& word) const;
+
+    /**
+     * @brief Convert level words to a word according to the levels of the automaton.
+     *
+     * @param level_words The level words to convert.
+     * @return The word corresponding to the input level words.
+     */
+    Word mk_word_from_level_word(const std::vector<Word>& level_words) const;
 
     /**
      * @brief Get the set of all words in the language of the automaton whose length is <= @p max_length

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -832,15 +832,12 @@ public:
      *
      * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
      *  defined, otherwise use @c this->delta.get_used_symbols().
-     * @param epsilons Epsilon symbols to include when computing "missing" symbols. Epsilon symbols are handled as normal
-     *  alphabet symbols.
      * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
      *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
         const Alphabet* alphabet = nullptr,
-        const utils::OrdVector<Symbol>& epsilons = {},
         const std::optional<std::vector<State>>& sink_states = std::nullopt
     );
 
@@ -856,15 +853,12 @@ public:
      *  to complete multiple automata over the same set of symbols.
      *
      * @param[in] symbols Symbols to compute "missing" symbols from.
-     * @param epsilons Epsilon symbols to include when computing "missing" symbols. Epsilon symbols are handled as normal
-     *  alphabet symbols.
      * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
      *  which new transitions are added. If @c std::nullopt, add new sink states.
      * @return @c true if a new transition was added to the NFA, @c false otherwise.
      */
     bool make_complete(
         const utils::OrdVector<Symbol>& symbols,
-        const utils::OrdVector<Symbol>& epsilons = {},
         const std::optional<std::vector<State>>& sink_states = std::nullopt
     );
 
@@ -974,40 +968,43 @@ Nft compose(const Nft& lhs, const Nft& rhs, Level lhs_sync_level = 1, Level rhs_
 Nft concatenate(const Nft& lhs, const Nft& rhs, bool use_epsilon = false,
                 StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
-
-#ifdef MATA_NFT_NOT_IMPLEMENTED
-// TODO(nft): Implement for NFTs.
 /**
- * @brief Compute automaton accepting complement of @p aut.
+ * @brief Compute automaton accepting a complement of @p nft.
  *
- * @param[in] aut Automaton whose complement to compute.
+ * @warning This function only supports NFTs without epsilon transitions (length-preserving NFTs).
+ *
+ * @param[in] nft Automaton whose complement to compute.
  * @param[in] alphabet Alphabet used for complementation.
  * @param[in] params Optional parameters to control the complementation algorithm:
  * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
- * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * - "minimize": (TODO: unimplemented) "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
  * @return Complemented automaton.
  */
-Nft complement(const Nft& aut, const Alphabet& alphabet,
+Nft complement(const Nft& nft, const Alphabet& alphabet,
                const ParameterMap& params = {{ "algorithm", "classical" }, { "minimize", "false" }});
 
 /**
  * @brief Compute automaton accepting complement of @p aut.
+ *
+ * @warning This function only supports NFTs without epsilon transitions (length-preserving NFTs).
  *
  * This overloaded version complements over an already created ordered set of @p symbols instead of an alphabet.
  * This is a more efficient solution in case you already have @p symbols precomputed or want to complement multiple
  *  automata over the same set of @c symbols: the function does not need to compute the ordered set of symbols from
  *  the alphabet again (and for each automaton).
  *
- * @param[in] aut Automaton whose complement to compute.
+ * @param[in] nft Automaton whose complement to compute.
  * @param[in] symbols Symbols to complement over.
  * @param[in] params Optional parameters to control the complementation algorithm:
  * - "algorithm": "classical" (classical algorithm determinizes the automaton, makes it complete and swaps final and non-final states);
- * - "minimize": "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
+ * - "minimize": (TODO: unimplemented) "true"/"false" (whether to compute minimal deterministic automaton for classical algorithm);
  * @return Complemented automaton.
  */
-Nft complement(const Nft& aut, const utils::OrdVector<Symbol>& symbols,
+Nft complement(const Nft& nft, const utils::OrdVector<Symbol>& symbols,
                const ParameterMap& params = {{ "algorithm", "classical" }, { "minimize", "false" }});
 
+#ifdef MATA_NFT_NOT_IMPLEMENTED
+// TODO(nft): Implement for NFTs.
 /**
  * @brief Compute minimal deterministic automaton.
  *
@@ -1264,7 +1261,19 @@ Nft insert_level(const Nft& nft, Level new_level, JumpMode jump_mode = JumpMode:
  // What are the symbol names and their sequences?
 Run encode_word(const Alphabet* alphabet, const std::vector<std::string>& input);
 
-} // namespace mata::nft.
+/**
+ * @brief Check whether two symbols match.
+ *
+ * Two symbols match if they are equal (`'a' == 'a'`; also `EPSILON == EPSILON`), or if at least one of them is
+ *  @c DONT_CARE and the other is not @c EPSILON.
+ *
+ * @param a First symbol to compare.
+ * @param b Second symbol to compare.
+ * @return @c true if the symbols match, @c false otherwise.
+ */
+bool symbols_match(Symbol a, Symbol b);
+
+}
 
 namespace std {
 std::ostream& operator<<(std::ostream& os, const mata::nft::Nft& nft);

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -18,16 +18,16 @@
  *
  * @section nft_design The design of NFTs in Mata
  *
- * In Mata, the classical transducers from textbook definitions (where a transition is a tuple of
+ * The classical transducers from textbook definitions (where a transition is a tuple of
  *  `(initial state, input symbol, final state, output string)`) are encoded using a simpler data structure for the
  *  transition relation, @c mata::nft::Delta The data structures can directly represent only transitions of the form
  *  `p -a-> s` where `a` is a single symbol or epsilon. A “high-level” transitions of the form `p -abc/def-> q` where
  * 'abc' is an input word and def is an output word are encoded as a sequence of these 'low level' transitions:
- *  `p -a- p’ -d-> q -b-> q' -e-> r -c-> r' -f-> s` (odd transitions read letters of the input track, even transitions read
- *  letters of the output track, a transition can have epsilon instead of a letter). The primed states are a sort of
- *  internal states, to where the automaton gets after reading a letter on the input tape. States are distinguished by
- *  their “level”. “Normal” states  p,q,r,s have level 0, the internal states p’,q’,r’ have in this case the levels 1
- *  (and you could have n-tape transducers where level can be larger than 1).
+ *  `p -a- p’ -d-> q -b-> q' -e-> r -c-> r' -f-> s` (odd transitions read letters of the input track, even transitions
+ *  read letters of the output track, a transition can have epsilon instead of a letter). The primed states are a sort of
+ *  internal states, to where the automaton gets after reading a letter on the input tape (in Mata called level). States
+ *  are distinguished by their “level”. “Normal” states  p,q,r,s have level 0, the internal states p’,q’,r’ have in this
+ *  case the levels 1 (and you could have n-tape transducers where level can be larger than 1).
  * In Mata, the @c mata::nft::Delta interface is used only for the manual handling of the internal delta representation,
  *  taking only (initial state, input symbol, final state)
  * We find it useful to think about NFTs in Mata as normal NFAs with a single symbol on a transition (because Mata uses
@@ -63,6 +63,20 @@
  *  by the jump.
  * Ideally, one should not even have to think about the levels and the intermediate states when properly using the
  *  utility functions (from the @c mata::nft::Nft class and the @c mata::nft namespace in general).
+ *
+ *
+ * @section nft_word Representing words in NFTs
+ *
+ * When working with NFTs, words on multiple levels need to be represented.
+ * We consider an NFT word with @c n levels as a vector of words of type @c mata::Word, where the word at index @c i
+ *  in the vector represents the word on the level @c i.
+ * Operations on NFT words either work on each level separately (named with `_by_levels` suffix) or on the interleaved
+ *  representation of the NFT word.
+ * E.g., the NFT word representing reading 'abc' on level 0 and 'def' on level 1 can be represented as either
+ *  `std::vector<Word>{ Word{ 'a', 'b', 'c }, Word{ 'd', 'e', 'f' } }` (using the `_by_levels` variant) or as a word
+ *  `Word{ 'a', 'd', 'b', 'e', 'c', 'f' }` (using the interleaved representation).
+ * Words may contain @c DONT_CARE (representing wildcards on the respective level, but not @c EPSILON) and @EPSILON
+ *  (representing reading an empty string on the respective level ).
  *
  * @see @ref examples/nft.cc example.
  *
@@ -624,56 +638,70 @@ public:
     bool is_universal(const Alphabet& alphabet, const ParameterMap& params) const;
 
     /**
-     * @brief Check whether a run over the word (or its prefix) is in the language of an automaton.
+     * @brief Check whether a @p run (or its prefix with @p match_prefix set) is in the language of an automaton.
      *
-     * @param word The run to check.
-     * @param use_epsilon Whether the automaton uses epsilon transitions.
+     * @param run The run to check.
      * @param match_prefix Whether to also match the prefix of the word.
-     *
-     * @return True if the run (or its prefix) is in the language of the automaton, false otherwise.
+     * @return @c true if @p run is in the language of the automaton, @c false otherwise.
      */
-    bool is_in_lang(const Run& word, bool use_epsilon = false, bool match_prefix = false) const;
+    bool is_in_lang(const Run& run, bool match_prefix = false) const;
+    bool is_in_lang(const Run&, bool, bool) const = delete;
 
     /**
-     * @brief Check whether a word (or its prefix) is in the language of an automaton.
+     * @brief Check whether a @p word (or its prefix with @p match_prefix set) is in the language of an automaton.
      *
      * @param word The word to check.
-     * @param use_epsilon Whether the automaton uses epsilon transitions.
      * @param match_prefix Whether to also match the prefix of the word.
-     *
-     * @return True if the word (or its prefix) is in the language of the automaton, false otherwise.
+     * @return @c true if @p word is in the language of the automaton, @c false otherwise.
      */
-    bool is_in_lang(const Word& word, const bool use_epsilon = false, const bool match_prefix = false) const {
-         return is_in_lang(Run{ word, {} }, use_epsilon, match_prefix);
+    bool is_in_lang(const Word& word, const bool match_prefix = false) const {
+        return is_in_lang(Run{ word, {} }, match_prefix);
     }
+    bool is_in_lang(const Word& word, bool, bool) const = delete;
 
     /**
-     * @brief Check whether a prefix of a run is in the language of an automaton.
+     * @brief Check whether a prefix of a @p run is in the language of an automaton.
      *
-     * @param word The run to check.
-     * @param use_epsilon Whether the automaton uses epsilon transitions.
-     *
-     * @return True if the prefix of the run is in the language of the automaton, false otherwise.
+     * @param run The run to check.
+     * @return @c true if the prefix of @p run is in the language of the automaton, @c false otherwise.
      */
-    bool is_prefix_in_lang(const Run& word, const bool use_epsilon = false) const { return is_in_lang(word, use_epsilon, true); }
+    bool is_in_lang_prefix(const Run& run) const { return is_in_lang(run, true); }
+    bool is_in_lang_prefix(const Run&, bool) const = delete;
+
 
     /**
-     * @brief Check whether a prefix of a word is in the language of an automaton.
+     * @brief Check whether a prefix of a @p word is in the language of an automaton.
      *
      * @param word The word to check.
-     * @param use_epsilon Whether the automaton uses epsilon transitions.
-     *
-     * @return True if the prefix of the word is in the language of the automaton, false otherwise.
+     * @return @c true if the prefix of @p word is in the language of the automaton, @c false otherwise.
      */
-    bool is_prefix_in_lang(const Word& word, const bool use_epsilon = false) const { return is_prefix_in_lang(Run{ word, {} }, use_epsilon); }
+    bool is_in_lang_prefix(const Word& word) const { return is_in_lang_prefix(Run{ word, {} }); }
+    bool is_in_lang_prefix(const Word&, bool) const = delete;
 
     /**
-     * @brief Checks whether track words are in the language of the transducer.
+     * @brief Checks whether @p track_words are in the language of the transducer.
      *
      * That is, the function checks whether a tuple @p track_words (word1, word2, word3, ..., wordn) is in the regular
      *  relation accepted by the transducer with 'n' levels (tracks).
+     *
+     * @param level_words The words to check.
+     * @param match_prefix Whether to also match the prefix of the word.
+     * @return @c true if @p word is in the language of the automaton, @c false otherwise.
      */
-    bool is_in_lang_by_levels(const std::vector<Word>& track_words);
+    bool is_in_lang_by_levels(const std::vector<Word>& level_words, bool match_prefix = false) const;
+
+    /**
+     * @brief Checks whether the prefix of @p track_words is in the language of the transducer.
+     *
+     * That is, the function checks whether a prefix a tuple @p track_words (word1, word2, word3, ..., wordn) is in the
+     * regular relation accepted by the transducer with 'n' levels (tracks).
+     *
+     * @param level_words The words to check.
+     * @return @c true if the prefix of @p word is in the language of the automaton, @c false otherwise.
+     */
+    bool is_in_lang_prefix_by_levels(const std::vector<Word>& level_words) const {
+        return is_in_lang_by_levels(level_words, true);
+    }
 
     /**
      * @brief Get a word for a given run if it exists.
@@ -710,6 +738,7 @@ public:
      * @return Set of all words in the language of the automaton whose length is <= @p max_length.
      */
     std::set<Word> get_words(size_t max_length = std::numeric_limits<size_t>::max(), JumpMode jump_mode = JumpMode::RepeatSymbol) const;
+
 
     /**
      * @brief Apply @p nfa to @c this.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -75,7 +75,7 @@
  * E.g., the NFT word representing reading 'abc' on level 0 and 'def' on level 1 can be represented as either
  *  `std::vector<Word>{ Word{ 'a', 'b', 'c }, Word{ 'd', 'e', 'f' } }` (using the `_by_levels` variant) or as a word
  *  `Word{ 'a', 'd', 'b', 'e', 'c', 'f' }` (using the interleaved representation).
- * Words may contain @c DONT_CARE (representing wildcards on the respective level, but not @c EPSILON) and @EPSILON
+ * Words may contain @c DONT_CARE (representing wildcards on the respective level, but not @c EPSILON) and @c EPSILON
  *  (representing reading an empty string on the respective level ).
  *
  * @see @ref examples/nft.cc example.
@@ -115,7 +115,7 @@ namespace mata::nft {
  */
 class Nft: public nfa::Nfa {
 private:
-    using super = Nfa;
+    using super = nfa::Nfa;
 public:
     /**
      * @brief Vector of levels giving each state a level in range from 0 to @c levels.num_of_levels - 1.
@@ -679,9 +679,9 @@ public:
     bool is_in_lang_prefix(const Word&, bool) const = delete;
 
     /**
-     * @brief Checks whether @p track_words are in the language of the transducer.
+     * @brief Checks whether @p level_words are in the language of the transducer.
      *
-     * That is, the function checks whether a tuple @p track_words (word1, word2, word3, ..., wordn) is in the regular
+     * That is, the function checks whether a tuple @p level_words (word1, word2, word3, ..., wordn) is in the regular
      *  relation accepted by the transducer with 'n' levels (tracks).
      *
      * @param level_words The words to check.
@@ -691,9 +691,9 @@ public:
     bool is_in_lang_by_levels(const std::vector<Word>& level_words, bool match_prefix = false) const;
 
     /**
-     * @brief Checks whether the prefix of @p track_words is in the language of the transducer.
+     * @brief Checks whether the prefix of @p level_words is in the language of the transducer.
      *
-     * That is, the function checks whether a prefix a tuple @p track_words (word1, word2, word3, ..., wordn) is in the
+     * That is, the function checks whether a prefix of a tuple @p level_words (word1, word2, word3, ..., wordn) is in the
      * regular relation accepted by the transducer with 'n' levels (tracks).
      *
      * @param level_words The words to check.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -577,7 +577,9 @@ public:
 
     /**
      * @brief Get the set of states reachable from the given set of states over the given symbol.
-     * TODO: Relict from VATA. What to do with inclusion/ universality/ this post function? Revise all of them.
+     *
+     * @warning If @p epsilon_closure_opt is set, computes epsilon closures over multiple levels.
+     * That is, the result might contain states of different levels.
      *
      * @param states Set of states to compute the post set from.
      * @param symbol Symbol to compute the post set for.
@@ -588,6 +590,9 @@ public:
 
     /**
      * @brief Get the set of states reachable from the given state over the given symbol.
+     *
+     * @warning If @p epsilon_closure_opt is set, computes epsilon closures over multiple levels.
+     * That is, the result might contain states of different levels.
      *
      * @param state A state to compute the post set from.
      * @param symbol Symbol to compute the post set for.

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -5,9 +5,9 @@
 #ifndef MATA_NFT_TYPES_HH
 #define MATA_NFT_TYPES_HH
 
+#include <concepts>
 #include <optional>
 #include <utility>
-#include <concepts>
 
 #include "mata/alphabet.hh"
 #include "mata/nfa/types.hh"
@@ -19,18 +19,23 @@ extern const std::string TYPE_NFT;
 
 using Level = unsigned;
 
-using State = mata::nfa::State;
-using StateSet = mata::nfa::StateSet;
+using State = nfa::State;
+using StateSet = nfa::StateSet;
 
-using Run = mata::nfa::Run;
-using EpsilonClosureOpt = mata::nfa::EpsilonClosureOpt;
+using Run = nfa::Run;
+using EpsilonClosureOpt = nfa::EpsilonClosureOpt;
 
-using StateRenaming = mata::nfa::StateRenaming;
+using StateRenaming = nfa::StateRenaming;
 
+/**
+ * @brief Concept defining an iterable container of states.
+ */
 template<typename States>
-concept MapLevelToStates = std::same_as<States, StateSet>
-                    || std::same_as<States, utils::SparseSet<State>>
-                    || std::same_as<States, std::vector<State>>;
+concept StatesContainerIterable = requires(States states) {
+    { states.begin() } -> std::input_or_output_iterator;
+    { states.end() } -> std::sentinel_for<decltype(states.begin())>;
+    requires std::convertible_to<typename States::value_type, State>;
+};
 
 /**
  * @brief Map of additional parameter name and value pairs.
@@ -130,9 +135,6 @@ public:
      * @param[in] levels Levels to be assigned.
      */
     Levels& operator=(std::vector<Level>&& levels);
-
-    template<class States>
-    std::vector<StateSet> map_levels_to(const States& states) const;
 
     using
         // Member types.
@@ -246,8 +248,12 @@ public:
     /**
      * @brief Get mapping of levels to sets of states from @p states.
      */
-    template<MapLevelToStates States>
-    std::vector<StateSet> map_levels_to(const States& states) const;
+    template<StatesContainerIterable States>
+    std::vector<StateSet> map_levels_to(const States& states) const {
+        std::vector<StateSet> result(num_of_levels);
+        for (const State state : states) { result[(*this)[state]].insert(state); }
+        return result;
+    }
 
     /**
      * @brief Get the next level that should follow after @p level.
@@ -318,13 +324,6 @@ private:
     bool check_levels_in_range_() const { return std::ranges::all_of(*this, [&](const Level level) { return level < num_of_levels; }); }
 };
 
-template<MapLevelToStates States>
-std::vector<StateSet> Levels::map_levels_to(const States& states) const {
-    std::vector<StateSet> result(num_of_levels);
-    for (const State state : states) { result[(*this)[state]].insert(state); }
-    return result;
 }
-
-} // namespace mata::nft.
 
 #endif

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <utility>
+#include <concepts>
 
 #include "mata/alphabet.hh"
 #include "mata/nfa/types.hh"
@@ -25,6 +26,11 @@ using Run = mata::nfa::Run;
 using EpsilonClosureOpt = mata::nfa::EpsilonClosureOpt;
 
 using StateRenaming = mata::nfa::StateRenaming;
+
+template<typename States>
+concept MapLevelToStates = std::same_as<States, StateSet>
+                    || std::same_as<States, utils::SparseSet<State>>
+                    || std::same_as<States, std::vector<State>>;
 
 /**
  * @brief Map of additional parameter name and value pairs.
@@ -124,6 +130,9 @@ public:
      * @param[in] levels Levels to be assigned.
      */
     Levels& operator=(std::vector<Level>&& levels);
+
+    template<class States>
+    std::vector<StateSet> map_levels_to(const States& states) const;
 
     using
         // Member types.
@@ -227,10 +236,25 @@ public:
      * @brief Get levels of states in @p states.
      */
     std::vector<Level> get_levels_of(const utils::SparseSet<State>& states) const;
+
     /**
      * @brief Get levels of states in @p states.
      */
     std::vector<Level> get_levels_of(const StateSet& states) const;
+
+
+    /**
+     * @brief Get mapping of levels to sets of states from @p states.
+     */
+    template<MapLevelToStates States>
+    std::vector<StateSet> map_levels_to(const States& states) const;
+
+    /**
+     * @brief Get the next level that should follow after @p level.
+     * @param level The current level.
+     * @return The next level.
+     */
+    Level next_level_after(const Level level) const { return (level + 1) % static_cast<Level>(num_of_levels); }
 
     /**
      * @brief Get the minimal level for the states in @p states.
@@ -293,6 +317,13 @@ public:
 private:
     bool check_levels_in_range_() const { return std::ranges::all_of(*this, [&](const Level level) { return level < num_of_levels; }); }
 };
+
+template<MapLevelToStates States>
+std::vector<StateSet> Levels::map_levels_to(const States& states) const {
+    std::vector<StateSet> result(num_of_levels);
+    for (const State state : states) { result[(*this)[state]].insert(state); }
+    return result;
+}
 
 } // namespace mata::nft.
 

--- a/justfile
+++ b/justfile
@@ -5,34 +5,41 @@
 #
 #default: lint build test
 # default recipe to display help information
-default:
-  @just --list
+[default]
+help:
+  just --list
 
 alias t := test
 alias tp := test-python
 alias vc := valgrind-callgrind
 alias c := clean
+alias r := release
 alias rd := release-debuginfo
 alias w := wip
 alias d := docs
-
-#check:
+alias h := help
 
 CXX := env_var_or_default("CXX", "g++")
 
 # Number of cores for parallel compilation.
 JOBS := env_var_or_default("JOBS", "6")
 
-test:
-    make debug BUILD_DIR="build/debug/{{CXX}}"
-    ./build/debug/{{CXX}}/tests/tests
+test *ARGS:
+    just build "debug"
+    just test-run "debug" {{ARGS}}
 
-    make release BUILD_DIR="build/release/{{CXX}}"
-    ./build/release/{{CXX}}/tests/tests
+    just build "release"
+    just test-run "release" {{ARGS}}
 
-wip BUILD_DIR_PATH BUILD_MODE="debug":
-    make {{BUILD_MODE}} BUILD_DIR="build/{{BUILD_DIR_PATH}}/{{CXX}}"
-    ./build/{{BUILD_DIR_PATH}}/{{CXX}}/tests/tests
+test-run BUILD_MODE="debug" *ARGS:
+    ./build/{{BUILD_MODE}}/{{CXX}}/tests/tests {{ARGS}}
+
+build BUILD_MODE="debug":
+    make {{BUILD_MODE}} BUILD_DIR="build/{{BUILD_MODE}}/{{CXX}}"
+
+wip BUILD_DIR BUILD_MODE="debug" *ARGS:
+    make {{BUILD_MODE}} BUILD_DIR="build/{{BUILD_DIR}}/{{CXX}}"
+    ./build/{{BUILD_DIR}}/{{CXX}}/tests/tests {{ARGS}}
 
 test-python:
     # source .venv/bin/activate.fish &&
@@ -45,8 +52,11 @@ valgrind-callgrind +ARGS:
 clean:
     make clean
 
+release:
+    just build "release"
+
 release-debuginfo:
-    make release-debuginfo BUILD_DIR="build/release-debuginfo"
+    just build "release-debuginfo"
 
 docs:
     make doc

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -3,19 +3,18 @@
  */
 
 #include <algorithm>
+#include <fstream>
+#include <iterator>
 #include <list>
 #include <optional>
-#include <iterator>
-#include <fstream>
-#include <string>
 #include <queue>
+#include <string>
 
-// MATA headers
-#include "mata/alphabet.hh"
-#include "mata/utils/sparse-set.hh"
 #include "mata/nfa/nfa.hh"
-#include "mata/nfa/algorithms.hh"
 #include <mata/simlib/explicit_lts.hh>
+#include "mata/alphabet.hh"
+#include "mata/nfa/algorithms.hh"
+#include "mata/utils/sparse-set.hh"
 
 using namespace mata::utils;
 using namespace mata::nfa;
@@ -625,27 +624,6 @@ void Nfa::get_one_letter_aut(Nfa& result) const {
 }
 
 StateSet Nfa::post(const StateSet& states, const Symbol symbol, const EpsilonClosureOpt epsilon_closure_opt) const {
-    auto get_epsilon_closure = [&](const StateSet& source_states) {
-        StateSet closure{ source_states };
-        std::queue<State> worklist;
-        for (const State state: source_states) {
-            worklist.push(state);
-        }
-        while (!worklist.empty()) {
-            const State state = worklist.front();
-            worklist.pop();
-            if (auto move_it{ delta[state].find(EPSILON) }; move_it != delta[state].end()) {
-                for (const State target: move_it->targets) {
-                    if (!closure.contains(target)) {
-                        closure.insert(target);
-                        worklist.push(target);
-                    }
-                }
-            }
-        }
-        return closure;
-    };
-
     StateSet res{};
 
     // If the symbol is EPSILON, we can stay in the same state.
@@ -938,4 +916,22 @@ Nfa Nfa::decode_utf8() const {
     }
 
     return result;
+}
+
+StateSet Nfa::mk_epsilon_closure(const StateSet& source_states, const std::vector<Symbol>& epsilons) const {
+    StateSet closure{ source_states };
+    std::queue<State> worklist;
+    for (const State state : source_states) { worklist.push(state); }
+    while (!worklist.empty()) {
+        const State state = worklist.front();
+        worklist.pop();
+        for (const Symbol epsilon : epsilons) {
+            if (auto move_it{ delta[state].find(epsilon) }; move_it != delta[state].end()) {
+                for (const State target : move_it->targets) {
+                    if (closure.insert(target).second) { worklist.push(target); }
+                }
+            }
+        }
+    }
+    return closure;
 }

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -638,7 +638,7 @@ StateSet Nfa::post(const StateSet& states, const Symbol symbol, const EpsilonClo
     StateSet from_states = states;
     if (epsilon_closure_opt == EpsilonClosureOpt::Before) {
         // Before making the step using the symbol, we compute the epsilon closure.
-        from_states = get_epsilon_closure(states);
+        from_states = mk_epsilon_closure(states);
     }
 
     // Now, we can make the step using the symbol.
@@ -651,7 +651,7 @@ StateSet Nfa::post(const StateSet& states, const Symbol symbol, const EpsilonClo
 
     if (epsilon_closure_opt == EpsilonClosureOpt::After) {
         // We need to compute the epsilon closure of the resulting states.
-        res = get_epsilon_closure(res);
+        res = mk_epsilon_closure(res);
     }
 
     return res;

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -586,7 +586,7 @@ std::optional<State> mata::nfa::Nfa::read_word_det(const Run& run) const {
 }
 
 //TODO: this is not efficient
-bool mata::nfa::Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bool match_prefix) const {
+bool Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bool match_prefix) const {
     if (match_prefix) {
         StateSet current_post(this->initial);
 

--- a/src/nfa/universal.cc
+++ b/src/nfa/universal.cc
@@ -12,20 +12,11 @@ using namespace mata::utils;
 //TODO: this could be merged with inclusion, or even removed, universality could be implemented using inclusion,
 // it is not something needed in practice, so some little overhead is ok
 
-
-/// naive universality check (complementation + emptiness)
 bool mata::nfa::algorithms::is_universal_naive(
-	const Nfa&         aut,
-	const Alphabet&    alphabet,
-	Run*               cex)
-{ // {{{
-	Nfa cmpl = complement(aut, alphabet);
+        const Nfa& aut,
+        const Alphabet& alphabet,
+        Run* cex) { return complement(aut, alphabet).is_lang_empty(cex); }
 
-	return cmpl.is_lang_empty(cex);
-} // is_universal_naive }}}
-
-
-/// universality check using Antichains
 bool mata::nfa::algorithms::is_universal_antichains(
     const Nfa&         aut,
     const Alphabet&    alphabet,

--- a/src/nft/complement.cc
+++ b/src/nft/complement.cc
@@ -8,70 +8,79 @@
 using namespace mata::nft;
 using namespace mata::utils;
 
-#ifdef MATA_NFT_NOT_IMPLEMENTED
-Nft mata::nft::algorithms::complement_classical(const Nft& aut, const OrdVector<Symbol>& symbols,
-                                                const bool minimize_during_determinization) {
+Nft algorithms::complement_classical(
+        const Nft& aut, const OrdVector<Symbol>& symbols, const bool minimize_during_determinization) {
     Nft result;
-    State sink_state;
     if (minimize_during_determinization) {
-        result = minimize_brzozowski(aut); // brzozowski minimization makes it deterministic
-        if (result.final.empty() && !result.initial.empty()) {
-            assert(result.initial.size() == 1);
-            // if automaton does not accept anything, then there is only one (initial) state
-            // which can be the sink state (so we do not create unnecessary one)
-            sink_state = *result.initial.begin();
-        } else {
-            sink_state = result.num_of_states();
-        }
-    } else {
-        std::unordered_map<StateSet, State> subset_map;
-        result = determinize(aut, &subset_map);
-        // check if a sink state was not created during determinization
-        if (const auto sink_state_iter = subset_map.find({}); sink_state_iter != subset_map.end()) {
-            sink_state = sink_state_iter->second;
-        } else {
-            sink_state = result.num_of_states();
-        }
+        throw std::runtime_error(
+                std::string(__func__) +
+                ": unimplemented option 'minimize' = 'true' for the complementation algorithm on NFTs."
+                );
+        // TODO(nft): implement minimization for NFTs.
+        // result = determinize_and_minimize(aut);
+        // result = minimize_brzozowski(aut); // brzozowski minimization makes it deterministic
+        // if (result.final.empty() && !result.initial.empty()) {
+        //     assert(result.initial.size() == 1);
+        //     // if automaton does not accept anything, then there is only one (initial) state
+        //     // which can be the sink state (so we do not create unnecessary one)
+        //     sink_state = *result.initial.begin();
+        // } else {
+        //     sink_state = result.num_of_states();
+        // }
+    } else { result = determinize(aut); }
+
+    result.make_complete(symbols);
+    // TODO(nft): Should empty nft produce a complement with one initial and final state accepting { {epsilon}, {epsilon}, {epsilon} }?
+    if (result.initial.empty()) {
+        const State initial{ result.add_state() };
+        result.initial.insert(initial);
     }
-
-    result.make_complete(symbols, sink_state);
-    result.final.complement(result.num_of_states());
-
+    SparseSet<State> new_final_states{};
+    const size_t num_of_states{ result.num_of_states() };
+    for (State state{ 0 }; state < num_of_states; ++state) {
+        if (result.levels[state] == 0 && !result.final.contains(state)) { new_final_states.insert(state); }
+    }
+    result.final = new_final_states;
     return result;
 }
 
-Nft mata::nft::complement(const Nft& aut, const Alphabet& alphabet, const ParameterMap& params) {
-    return mata::nft::complement(aut, alphabet.get_alphabet_symbols(), params);
+Nft mata::nft::complement(const Nft& nft, const Alphabet& alphabet, const ParameterMap& params) {
+    return complement(nft, alphabet.get_alphabet_symbols(), params);
 }
 
-Nft mata::nft::complement(const Nft& aut, const mata::utils::OrdVector<mata::Symbol>& symbols, const ParameterMap& params) {
-    Nft result;
+Nft mata::nft::complement(const Nft& nft, const OrdVector<Symbol>& symbols, const ParameterMap& params) {
     // Setting the requested algorithm.
     decltype(algorithms::complement_classical)* algo = algorithms::complement_classical;
     if (!haskey(params, "algorithm")) {
-        throw std::runtime_error(std::to_string(__func__) +
-                                 " requires setting the \"algorithm\" key in the \"params\" argument; "
-                                 "received: " + std::to_string(params));
+        throw std::runtime_error(
+                std::to_string(__func__) +
+                " requires setting the 'algorithm' key in the 'params' argument; "
+                "received: " + std::to_string(params)
+                );
     }
 
-    const std::string& str_algo = params.at("algorithm");
-    if ("classical" == str_algo) {  /* default */ }
-    else {
-        throw std::runtime_error(std::to_string(__func__) +
-                                 " received an unknown value of the \"algorithm\" key: " + str_algo);
+    if (const std::string& str_algo = params.at("algorithm"); "classical" == str_algo) { /* default */ } else {
+        throw std::runtime_error(
+            std::to_string(__func__) +
+            " received an unknown value of the 'algorithm' key: " + str_algo
+        );
     }
 
-    bool minimize_during_determinization = false;
+    bool minimize_during_determinization{ false };
     if (params.contains("minimize")) {
-        const std::string& minimize_arg = params.at("minimize");
-        if ("true" == minimize_arg) { minimize_during_determinization = true; }
-        else if ("false" == minimize_arg) { minimize_during_determinization = false; }
-        else {
-            throw std::runtime_error(std::to_string(__func__) +
-                                     " received an unknown value of the \"minimize\" key: " + str_algo);
+        if (const std::string& minimize_arg = params.at("minimize");
+            "true" == minimize_arg) {
+            throw std::runtime_error(
+                    std::to_string(__func__) +
+                    " received unimplemented option 'minimize' = 'true' for the complementation algorithm on NFTs."
+                    );
+            // TODO(nft): implement minimization for NFTs.
+            // minimize_during_determinization = true;
+        } else if ("false" == minimize_arg) { minimize_during_determinization = false; } else {
+            throw std::runtime_error(
+                    std::to_string(__func__) + " received an unknown value of the 'minimize' key: " + minimize_arg
+                    );
         }
     }
-
-    return algo(aut, symbols, minimize_during_determinization);
+    return algo(nft, symbols, minimize_during_determinization);
 }
-#endif

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -4,15 +4,16 @@
 
 #include <algorithm>
 #include <cassert>
-#include <optional>
+#include <format>
 #include <fstream>
+#include <optional>
+#include <ranges>
 #include <string>
 #include <utility>
-#include <ranges>
 
-#include "mata/utils/sparse-set.hh"
-#include "mata/nfa/builder.hh"
 #include "mata/nft/nft.hh"
+#include "mata/nfa/builder.hh"
+#include "mata/utils/sparse-set.hh"
 
 
 using namespace mata::utils;
@@ -538,16 +539,13 @@ State Nft::insert_word(const State source, const Word& word, const State target)
         throw std::invalid_argument{ "Inserting word between source and target states with different levels." };
     }
 
-    const State first_new_state = num_of_states();
-    const State word_target = Nfa::insert_word(source, word, target);
-    const size_t num_of_states_after = num_of_states();
-    const Level source_level = levels[source];
-
-    Level lvl = (levels.num_of_levels == 1)
-                    ? source_level
-                    : (source_level + 1) % static_cast<Level>(levels.num_of_levels);
+    const State first_new_state{ num_of_states() };
+    const State word_target{ Nfa::insert_word(source, word, target) };
+    const size_t num_of_states_after{ num_of_states() };
+    const Level source_level{ levels[source] };
+    Level lvl{ levels.next_level_after(source_level) };
     for (State state{ first_new_state }; state < num_of_states_after;
-         ++state, lvl = (lvl + 1) % static_cast<Level>(levels.num_of_levels)) { add_state_with_level(state, lvl); }
+         ++state, lvl = levels.next_level_after(lvl)) { add_state_with_level(state, lvl); }
 
     assert(levels[word_target] == 0 || levels[num_of_states_after - 1] < levels[word_target]);
 
@@ -574,7 +572,7 @@ State Nft::insert_word_by_levels(
     std::vector<Word::const_iterator> word_part_it_v(levels.num_of_levels);
     for (Level lvl{ from_to_level }, i{ 0 }; i < static_cast<Level>(levels.num_of_levels); ++i) {
         word_part_it_v[lvl] = word_parts_on_levels[lvl].begin();
-        lvl = (lvl + 1) % static_cast<Level>(levels.num_of_levels);
+        lvl = levels.next_level_after(lvl);
     }
 
     // This function retrieves the next symbol from a word part at a specified level and advances the corresponding iterator.
@@ -585,20 +583,22 @@ State Nft::insert_word_by_levels(
     };
 
     // Add transition source --> inner_state.
-    Level inner_lvl = (levels.num_of_levels == 1) ? 0 : (from_to_level + 1) % static_cast<Level>(levels.num_of_levels);
+    Level inner_lvl = levels.next_level_after(from_to_level);
     State inner_state = add_state_with_level(inner_lvl);
     delta.add(source, get_next_symbol(from_to_level), inner_state);
 
     // Add transition inner_state --> inner_state
     State prev_state = inner_state;
     Level prev_lvl = inner_lvl;
-    const size_t max_word_part_len = std::ranges::max_element(
-        word_parts_on_levels,
-        [](const Word& a, const Word& b) { return a.size() < b.size(); }
-    )->size();
+    const size_t max_word_part_len{
+        std::ranges::max_element(
+            word_parts_on_levels,
+            [](const Word& a, const Word& b) { return a.size() < b.size(); }
+        )->size()
+    };
     if (const size_t word_total_len = levels.num_of_levels * max_word_part_len; word_total_len != 0) {
         for (size_t symbol_idx{ 1 }; symbol_idx < word_total_len - 1; symbol_idx++) {
-            inner_lvl = (prev_lvl + 1) % static_cast<Level>(levels.num_of_levels);
+            inner_lvl = levels.next_level_after(prev_lvl);
             inner_state = add_state_with_level(inner_lvl);
             delta.add(prev_state, get_next_symbol(prev_lvl), inner_state);
             prev_state = inner_state;

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -10,6 +10,7 @@
 #include <ranges>
 #include <string>
 #include <utility>
+#include <queue>
 
 #include "mata/nft/nft.hh"
 #include "mata/nfa/builder.hh"
@@ -400,8 +401,50 @@ Nft Nft::get_one_letter_aut(const std::set<Level>& levels_to_keep, const Symbol 
 void Nft::get_one_letter_aut(Nft& result) const { result = get_one_letter_aut(); }
 
 StateSet Nft::post(const StateSet& states, const Symbol symbol, const EpsilonClosureOpt epsilon_closure_opt) const {
-    std::cerr << "Warning: Nft::post uses Nfa::post, which is not designed for NFT's jump transitions" << std::endl;
-    return Nfa::post(states, symbol, epsilon_closure_opt);
+    StateSet res{};
+
+    // If the symbol is EPSILON, we can stay in the same state.
+    if (symbol == EPSILON && epsilon_closure_opt != EpsilonClosureOpt::None) {
+        res = states;
+    }
+
+    if (delta.empty()) {
+        return res;
+    }
+
+    StateSet from_states = states;
+    if (epsilon_closure_opt == EpsilonClosureOpt::Before) {
+        // Before making the step using the symbol, we compute the epsilon closure.
+        from_states = mk_epsilon_closure(states);
+    }
+
+    // Now, we can make the step using the symbol.
+    for (const State state: from_states) {
+        if (symbol == DONT_CARE) {
+            for (const SymbolPost& symbol_post : delta[state]) {
+                if (symbol_post.symbol == EPSILON) { continue; }
+                res.insert(symbol_post.targets);
+            }
+            continue;
+        }
+
+        const StatePost& state_post{ delta[state] };
+        if (const auto move_it{ state_post.find(symbol) }; move_it != state_post.end()) {
+            res.insert(move_it->targets);
+        }
+
+        if (symbol == EPSILON) { continue; }
+        if (const auto move_it{ state_post.find(DONT_CARE) }; move_it != state_post.end()) {
+            res.insert(move_it->targets);
+        }
+    }
+
+    if (epsilon_closure_opt == EpsilonClosureOpt::After) {
+        // We need to compute the epsilon closure of the resulting states.
+        res = mk_epsilon_closure(res);
+    }
+
+    return res;
 }
 
 void Nft::unwind_jumps_inplace(
@@ -697,14 +740,12 @@ Nft Nft::apply(
 
 bool Nft::make_complete(
     const Alphabet* const alphabet,
-    const OrdVector<Symbol>& epsilons,
     const std::optional<std::vector<State>>& sink_states) {
-    return make_complete(get_symbols_to_work_with(*this, alphabet), epsilons, sink_states);
+    return make_complete(get_symbols_to_work_with(*this, alphabet), sink_states);
 }
 
 bool Nft::make_complete(
     const OrdVector<Symbol>& symbols,
-    const OrdVector<Symbol>& epsilons,
     const std::optional<std::vector<State>>& sink_states) {
     const size_t num_of_states_orig{ this->num_of_states() };
     if (num_of_states_orig == 0) { return false; }
@@ -755,7 +796,6 @@ bool Nft::make_complete(
             }
         };
         add_transitions_to_sinks(symbols.difference(used_symbols));
-        add_transitions_to_sinks(epsilons.difference(used_symbols));
     }
 
     // Add loops on sink states (from sink to a sink of the next level).
@@ -768,7 +808,6 @@ bool Nft::make_complete(
             }
         };
         add_transitions_between_sinks(symbols);
-        add_transitions_between_sinks(epsilons);
     }
 
     return transition_added;

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -898,10 +898,9 @@ Word Nft::mk_word_from_level_word(const std::vector<Word>& level_words) const {
     if (level_words.size() != levels.num_of_levels) {
         throw std::invalid_argument(
             std::to_string(__func__) +
-            ": received a level level_words whose number of levels does not correspond to the number of levels in the "
-            "NFT; number of levels in level level_words: "
-            + std::to_string(level_words.size()) + ", number of levels in the NFT: "
-            + std::to_string(levels.num_of_levels)
+            ": received level_words whose number of levels does not correspond to the number of levels in the NFT; "
+            "number of levels in level_words: " + std::to_string(level_words.size()) +
+            ", number of levels in the NFT: " + std::to_string(levels.num_of_levels)
         );
     }
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -862,6 +862,49 @@ std::pair<Run, bool> Nft::get_word_for_path(const Run& run) const {
     return { word, true };
 }
 
+std::vector<Word> Nft::mk_level_word_from_word(const Word& word) const {
+    if (word.size() % levels.num_of_levels != 0) {
+        throw std::invalid_argument(
+            std::to_string(__func__) +
+            ": received a word whose length does not correspond to the number of levels (not a multiple of number of "
+            "levels); " "word length: "
+            + std::to_string(word.size()) + ", number of levels: " + std::to_string(levels.num_of_levels)
+        );
+    }
+
+    std::vector<Word> level_words(levels.num_of_levels);
+    Level level{ 0 };
+    for (const auto symbol : word) {
+        level_words[level].push_back(symbol);
+        level = levels.next_level_after(level);
+    }
+    return level_words;
+}
+
+Word Nft::mk_word_from_level_word(const std::vector<Word>& level_words) const {
+    if (level_words.size() != levels.num_of_levels) {
+        throw std::invalid_argument(
+            std::to_string(__func__) +
+            ": received a level level_words whose number of levels does not correspond to the number of levels in the "
+            "NFT; number of levels in level level_words: "
+            + std::to_string(level_words.size()) + ", number of levels in the NFT: "
+            + std::to_string(levels.num_of_levels)
+        );
+    }
+
+    size_t word_length{ 0 };
+    for (const auto& level_word : level_words) { word_length += level_word.size(); }
+    Word word;
+    word.reserve(word_length);
+
+    for (const auto& level_word : level_words) {
+        for (const auto symbol : level_word) {
+            word.push_back(symbol);
+        }
+    }
+    return word;
+}
+
 Nft mata::nft::algorithms::minimize_brzozowski(const Nft& aut) {
     //compute the minimal deterministic automaton, Brzozovski algorithm
     return determinize(revert(determinize(revert(aut))));

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1085,11 +1085,11 @@ Run mata::nft::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return mata::nfa::encode_word(alphabet, input);
 }
 
-std::set<mata::Word> mata::nft::Nft::get_words(const size_t max_length) const {
-    std::set<mata::Word> result;
+std::set<Word> Nft::get_words(const size_t max_length, const JumpMode jump_mode) const {
+    std::set<Word> result;
 
     // contains a pair: a state s and the word with which we got to the state s
-    std::vector<std::pair<State, mata::Word>> worklist;
+    std::vector<std::pair<State, Word>> worklist;
     // initializing worklist
     for (State init_state : initial) {
         worklist.push_back({ init_state, {} });
@@ -1097,18 +1097,39 @@ std::set<mata::Word> mata::nft::Nft::get_words(const size_t max_length) const {
     }
 
     // will be used during the loop
-    std::vector<std::pair<State, mata::Word>> new_worklist;
+    std::vector<std::pair<State, Word>> new_worklist;
 
-    unsigned cur_length = 0;
+    size_t cur_length = 0;
     while (!worklist.empty() && cur_length < max_length) {
         new_worklist.clear();
-        for (const auto& [state, word] : worklist) {
-            for (const SymbolPost& sp : delta[state]) {
-                mata::Word new_word = word;
-                new_word.push_back(sp.symbol);
-                for (State s_to : sp.targets) {
-                    new_worklist.emplace_back(s_to, new_word);
-                    if (final.contains(s_to)) { result.insert(new_word); }
+        for (const auto& [source, word] : worklist) {
+            const auto level_next{ levels.next_level_after(levels[source]) };
+            for (const SymbolPost& symbol_post : delta[source]) {
+                auto targets{ symbol_post.targets };
+                auto map_level_targets{ levels.map_levels_to(targets) };
+                for (size_t target_level{ 0 }; target_level < map_level_targets.size(); ++target_level) {
+                    const auto& targets_for_level{ map_level_targets[target_level] };
+                    if (targets_for_level.empty()) { continue; }
+                    Word new_word{ word };
+                    new_word.push_back(symbol_post.symbol);
+                    if (target_level != level_next) {
+                        for (Level level{ level_next }; level != target_level; level = levels.next_level_after(level)) {
+                            switch (jump_mode) {
+                                case JumpMode::AppendDontCares:
+                                    new_word.push_back(DONT_CARE);
+                                    break;
+                                case JumpMode::RepeatSymbol:
+                                    new_word.push_back(symbol_post.symbol);
+                                    break;
+                                default:
+                                    throw std::runtime_error("Nft::get_words: Unsupported jump mode.");
+                            }
+                        }
+                    }
+                    for (auto target : targets_for_level) {
+                        new_worklist.emplace_back(target, new_word);
+                        if (final.contains(target)) { result.insert(new_word); }
+                    }
                 }
             }
         }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -829,25 +829,36 @@ Nft nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
     return aut_inv;
 }
 
-//TODO: Implement for NFT
-bool Nft::is_in_lang(const Run& run, const bool use_epsilon, const bool match_prefix) const {
-    std::cerr << "Warning: Nft::is_in_lang uses Nfa::is_in_lang, which is not designed for NFT's jump transitions" <<
-            std::endl;
-    return Nfa::is_in_lang(run, use_epsilon, match_prefix);
+bool Nft::is_in_lang(const Run& run, const bool match_prefix) const {
+    return is_in_lang_by_levels(mk_level_word_from_word(run.word), match_prefix);
 }
 
 std::pair<Run, bool> Nft::get_word_for_path(const Run& run) const {
     if (run.path.empty()) { return { {}, true }; }
 
     Run word;
-    State cur = run.path[0];
+    State state_curr{ run.path[0] };
+    Level level_curr{ levels[state_curr] };
     for (size_t i = 1; i < run.path.size(); ++i) {
-        const State new_st = run.path[i];
+        const State state_next = run.path[i];
         bool found = false;
-        if (!this->delta.empty()) {
-            for (const auto& symbol_map : this->delta[cur]) {
-                for (const State st : symbol_map.targets) {
-                    if (st == new_st) {
+        if (!delta.empty()) {
+            for (const auto& symbol_map : delta[state_curr]) {
+                for (const State target : symbol_map.targets) {
+                    const Level level_next{ levels[target] };
+                    if (target == state_next) {
+                        if (level_curr == 0 && level_next == 0) {
+                            for (Level level_loop{ 0 }; level_loop < levels.num_of_levels;
+                                 ++level_loop) {
+                                word.word.push_back(symbol_map.symbol);
+                            }
+                            found = true;
+                            break;
+                        }
+                        for (Level level_loop = level_curr; level_loop != level_next;
+                             level_loop = levels.next_level_after(level_loop)) {
+                            word.word.push_back(symbol_map.symbol);
+                        }
                         word.word.push_back(symbol_map.symbol);
                         found = true;
                         break;
@@ -857,7 +868,9 @@ std::pair<Run, bool> Nft::get_word_for_path(const Run& run) const {
             }
         }
         if (!found) { return { {}, false }; }
-        cur = new_st; // update current state
+
+        state_curr = state_next;
+        level_curr = levels[state_curr];
     }
     return { word, true };
 }
@@ -1128,6 +1141,12 @@ Run mata::nft::encode_word(const Alphabet* alphabet, const std::vector<std::stri
     return mata::nfa::encode_word(alphabet, input);
 }
 
+bool nft::symbols_match(const Symbol a, const Symbol b) {
+    return (a == EPSILON || b == EPSILON)
+               ? (a == EPSILON && b == EPSILON)
+               : (a == b || a == DONT_CARE || b == DONT_CARE);
+}
+
 std::set<Word> Nft::get_words(const size_t max_length, const JumpMode jump_mode) const {
     std::set<Word> result;
 
@@ -1183,32 +1202,35 @@ std::set<Word> Nft::get_words(const size_t max_length, const JumpMode jump_mode)
     return result;
 }
 
-bool Nft::is_in_lang_by_levels(const std::vector<Word>& track_words) {
-    if (track_words.size() != levels.num_of_levels) {
+bool Nft::is_in_lang_by_levels(const std::vector<Word>& level_words, const bool match_prefix) const {
+    if (level_words.size() != levels.num_of_levels) {
         throw std::invalid_argument("Invalid number of tracks. Expected " + std::to_string(levels.num_of_levels) + ".");
     }
     std::vector<Word::const_iterator> track_words_begins(levels.num_of_levels);
     for (size_t track{ 0 }; track < levels.num_of_levels; ++track) {
-        track_words_begins[track] = track_words[track].begin();
+        track_words_begins[track] = level_words[track].begin();
     }
 
-    const std::vector<Word::const_iterator> track_words_ends{
+    const std::vector track_words_ends{
         [&]() {
             std::vector<Word::const_iterator> val(levels.num_of_levels);
-            for (size_t track{ 0 }; track < levels.num_of_levels; ++track) { val[track] = track_words[track].end(); }
+            for (size_t track{ 0 }; track < levels.num_of_levels; ++track) { val[track] = level_words[track].end(); }
             return val;
         }()
     };
 
     auto are_all_track_words_read = [&](const std::vector<Word::const_iterator>& word_begins) {
-        for (size_t i{ 0 }; Word::const_iterator word_it : word_begins) {
-            if (word_it != track_words_ends[i]) { return false; }
-            ++i;
+        for (Level i{ 0 }; i < levels.num_of_levels; ++i) {
+            if (word_begins[i] != track_words_ends[i]) { return false; }
         }
         return true;
     };
 
-    if (are_all_track_words_read(track_words_begins) && final.intersects_with(initial)) { return true; }
+    auto words_match = [&](const std::vector<Word::const_iterator>& word_its) {
+        return match_prefix || are_all_track_words_read(word_its);
+    };
+
+    if (final.intersects_with(initial) && words_match(track_words_begins)) { return true; }
 
     using StateWordBeginsPair = std::pair<State, std::vector<Word::const_iterator>>;
     std::deque<StateWordBeginsPair> worklist{};
@@ -1219,55 +1241,82 @@ bool Nft::is_in_lang_by_levels(const std::vector<Word>& track_words) {
         const Level level = levels[state];
         const StatePost& state_post{ delta[state] };
         const auto state_post_end{ state_post.end() };
-        const Word::const_iterator word_symbol_it{ words_its[level] };
+        const auto word_symbol_it{ words_its[level] };
 
+        // Try epsilon transitions without reading input words.
+        // Allows moving between states even when no input symbols are left to read.
+        // This works for both jumps and single-level transitions.
+        // If all levels contain epsilon, we eventually achieve a simple change of state.
         auto symbol_post_it{ state_post.find(EPSILON) };
         if (symbol_post_it != state_post_end) {
             for (State target : symbol_post_it->targets) {
-                if (are_all_track_words_read(words_its) && final.contains(target)) { return true; }
+                if (levels[target] == 0 && final.contains(target) && words_match(words_its)) { return true; }
                 worklist.emplace_back(target, words_its);
             }
         }
 
-        if (word_symbol_it != track_words_ends[level]) {
-            //            auto symbol_post_it{ state_post.find(EPSILON) };
-            //            if (symbol_post_it != state_post_end) {
-            //                for (State target: symbol_post_it->targets) {
-            //                    if (are_all_track_words_read(words_its) && final.contains(target)) { return true; }
-            //                    worklist.emplace_back(target, words_its);
-            //                }
-            //            }
+        // No input words left to read at this level, and no epsilon transitions available.
+        // Thus, cannot proceed further from this state.
+        if (word_symbol_it == track_words_ends[level]) { continue; }
 
-            symbol_post_it = state_post.find(DONT_CARE);
-            if (*word_symbol_it != EPSILON && symbol_post_it != state_post_end) {
-                for (const State target : symbol_post_it->targets) {
-                    bool continue_to_next_target{ false };
-                    std::vector<Word::const_iterator> next_words_its{ words_its };
-                    Level level_in_transition{ level };
-                    do {
-                        if (next_words_its[level_in_transition] == track_words_ends[level_in_transition]) {
-                            continue_to_next_target = true;
-                        }
-                        ++next_words_its[level_in_transition];
-                        level_in_transition = (level_in_transition + 1) % static_cast<Level>(levels.num_of_levels);
-                    } while (level_in_transition % levels.num_of_levels != levels[target] && !continue_to_next_target);
-                    if (continue_to_next_target) { continue; }
-                    if (are_all_track_words_read(next_words_its) && final.contains(target)) { return true; }
-                    worklist.emplace_back(target, next_words_its);
-                }
-            }
-
-            symbol_post_it = state_post.find(*word_symbol_it);
-            if (*word_symbol_it != DONT_CARE && *word_symbol_it != EPSILON && symbol_post_it != state_post_end) {
+        auto handle_symbol_it{
+            [&] {
                 for (State target : symbol_post_it->targets) {
-                    std::vector<Word::const_iterator> next_words_its{ words_its };
-                    ++next_words_its[level];
-                    if (are_all_track_words_read(next_words_its) && final.contains(target)) { return true; }
+                    bool jump_failed{ false };
+                    const Level level_target{ levels[target] };
+                    auto next_words_its{ words_its };
+                    if (level == 0 && level_target == 0) {
+                        for (Level level_loop{ level }; level_loop < levels.num_of_levels; ++level_loop) {
+                            if (next_words_its[level_loop] == track_words_ends[level_loop] ||
+                                not symbols_match(*word_symbol_it, *next_words_its[level_loop])) {
+                                jump_failed = true;
+                                break;
+                            }
+                            ++next_words_its[level_loop];
+                        }
+                    } else {
+                        for (Level level_loop{ level }; level_loop != level_target;
+                             level_loop = levels.next_level_after(level_loop)) {
+                            if (next_words_its[level_loop] == track_words_ends[level_loop] ||
+                                not symbols_match(*word_symbol_it, *next_words_its[level_loop])) {
+                                jump_failed = true;
+                                break;
+                            }
+                            ++next_words_its[level_loop];
+                        }
+                    }
+                    if (jump_failed) { continue; }
+                    if (levels[target] == 0 && final.contains(target) && words_match(next_words_its)) { return true; }
                     worklist.emplace_back(target, next_words_its);
                 }
+                return false;
             }
-            // TODO(nft): Input words may contain epsilons and dont cares, theoretically. Handle that.
+        };
+
+        // Try all normal symbol transitions when the current input symbol is DONT_CARE.
+        // They allow proceeding without exactly matching the current input symbol, otherwise behaving like normal
+        //  non-epsilon transitions.
+        if (*word_symbol_it == DONT_CARE) {
+            symbol_post_it = state_post.begin();
+            for (; symbol_post_it != state_post_end; ++symbol_post_it) {
+                if (symbol_post_it->symbol == EPSILON) { continue; }
+                if (handle_symbol_it()) { return true; }
+            }
         }
+
+        // Try DONT_CARE transitions.
+        // They allow proceeding without matching the current input symbol, otherwise behaving like normal non-epsilon
+        //  transitions.
+        // Read the current input symbol on all levels involved in the transition (multiple if it is a jump).
+        symbol_post_it = state_post.find(DONT_CARE);
+        if (*word_symbol_it != EPSILON && symbol_post_it != state_post_end && handle_symbol_it()) { return true; }
+
+        // Try normal transitions with the current input symbol.
+        // They allow proceeding only after matching the current input symbol.
+        // Read the current input symbol on all levels involved in the transition (multiple if it is a jump).
+        // Note: EPSILON symbols behave like normal symbols here, but do not match with DONT_CARE.
+        symbol_post_it = state_post.find(*word_symbol_it);
+        if (symbol_post_it != state_post_end && handle_symbol_it()) { return true; }
     }
     return false;
 }

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -986,20 +986,20 @@ TEST_CASE("mata::nfa::Nfa::is_in_lang()") {
     }
 }
 
-TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
+TEST_CASE("mata::nfa::Nfa::is_in_lang_prefix()") {
     SECTION("without epsilon transitions") {
         SECTION("empty language") {
             Nfa nfa{};
-            CHECK(!nfa.is_prefix_in_lang(Word{}));
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }));
+            CHECK(!nfa.is_in_lang_prefix(Word{}));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }));
         }
 
         SECTION("epsilon language") {
             Nfa nfa{};
             nfa.initial = { 0 };
             nfa.final = { 0 };
-            CHECK(nfa.is_prefix_in_lang(Word{}));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }));
+            CHECK(nfa.is_in_lang_prefix(Word{}));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }));
         }
 
         SECTION("ab in ab|ac") {
@@ -1011,8 +1011,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(3, 'c', 4);
             nfa.final = { 2, 4 };
 
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }));
         }
 
         SECTION("ab not in abcd") {
@@ -1024,23 +1024,23 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(3, 'd', 4);
             nfa.final = { 4 };
 
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'a', 'b' }));
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'c', 'd', 'e' }));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'a', 'b' }));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'c', 'd', 'e' }));
         }
     }
 
     SECTION("with epsilon transitions") {
         SECTION("empty language") {
             Nfa nfa{};
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }, true));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }, true));
         }
 
         SECTION("epsilon language") {
             Nfa nfa{};
             nfa.initial = { 0 };
             nfa.final = { 0 };
-            CHECK(nfa.is_prefix_in_lang(Word{}, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{}, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }, true));
         }
 
         SECTION("epsilon language 2") {
@@ -1064,8 +1064,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(5, EPSILON, 3);
             nfa.delta.add(6, EPSILON, 0);
 
-            CHECK(nfa.is_prefix_in_lang(Word{}, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{}, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }, true));
         }
 
         SECTION("ab in ab|ac with EPSILON at the beginning") {
@@ -1079,8 +1079,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(5, 'c', 6);
             nfa.final = { 3, 6 };
 
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
         }
 
         SECTION("ab in ab|ac with EPSILON in the middle") {
@@ -1094,8 +1094,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(5, 'c', 6);
             nfa.final = { 3, 6 };
 
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
         }
 
         SECTION("ab in ab|cd with EPSILON at the end") {
@@ -1109,8 +1109,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(5, EPSILON, 6);
             nfa.final = { 3, 6 };
 
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
 
         }
 
@@ -1129,8 +1129,8 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(9, EPSILON, 10);
             nfa.final = { 5, 10 };
 
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
         }
 
         SECTION("complex ab, abc, abxxy") {
@@ -1149,16 +1149,16 @@ TEST_CASE("mata::nfa::Nfa::is_prefix_in_lang()") {
             nfa.delta.add(5, 'c', 7);
             nfa.delta.add(6, EPSILON, 5);
             nfa.final = { 5, 7 };
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'x', 'x', 'y' }, true));
-            CHECK(!nfa.is_prefix_in_lang(Word{ }, true));
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'a' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'c', 'c', 'd', 'e'  }, true));
-            CHECK(nfa.is_prefix_in_lang(Word{ 'a', 'b', 'x', 'x', 'y', 'c', 'd', 'e'  }, true));
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'c', 'd', 'e' }, true));
-            CHECK(!nfa.is_prefix_in_lang(Word{ 'a', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'x', 'x', 'y' }, true));
+            CHECK(!nfa.is_in_lang_prefix(Word{ }, true));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'a' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'd', 'e' }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'c', 'c', 'd', 'e'  }, true));
+            CHECK(nfa.is_in_lang_prefix(Word{ 'a', 'b', 'x', 'x', 'y', 'c', 'd', 'e'  }, true));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'c', 'd', 'e' }, true));
+            CHECK(!nfa.is_in_lang_prefix(Word{ 'a', 'c', 'd', 'e' }, true));
         }
     }
 }
@@ -2965,7 +2965,7 @@ TEST_CASE("mata::nfa::is_complete()")
     }
 } // }}}
 
-TEST_CASE("mata::nfa::is_prefix_in_lang()")
+TEST_CASE("mata::nfa::is_in_lang_prefix()")
 { // {{{
     Nfa aut('q'+1);
 
@@ -2973,10 +2973,10 @@ TEST_CASE("mata::nfa::is_prefix_in_lang()")
     {
         Run w;
         w.word = {'a', 'b', 'd'};
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        REQUIRE(!aut.is_in_lang_prefix(w));
 
         w.word = { };
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        REQUIRE(!aut.is_in_lang_prefix(w));
     }
 
     SECTION("automaton accepting only epsilon")
@@ -2986,10 +2986,10 @@ TEST_CASE("mata::nfa::is_prefix_in_lang()")
 
         Run w;
         w.word = { };
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = {'a', 'b'};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
     }
 
     SECTION("small automaton")
@@ -2998,28 +2998,28 @@ TEST_CASE("mata::nfa::is_prefix_in_lang()")
 
         Run w;
         w.word = {'b', 'a'};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = { };
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        REQUIRE(!aut.is_in_lang_prefix(w));
 
         w.word = {'c', 'b', 'a'};
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        REQUIRE(!aut.is_in_lang_prefix(w));
 
         w.word = {'c', 'b', 'a', 'a'};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = {'a', 'a'};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = {'c', 'b', 'b', 'a', 'c', 'b'};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = Word(100000, 'a');
-        REQUIRE(aut.is_prefix_in_lang(w));
+        REQUIRE(aut.is_in_lang_prefix(w));
 
         w.word = Word(100000, 'b');
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        REQUIRE(!aut.is_in_lang_prefix(w));
     }
 } // }}}
 

--- a/tests/nft/complement.cc
+++ b/tests/nft/complement.cc
@@ -1,0 +1,141 @@
+/** @file
+ * @brief Tests for @c mata::nft::complement().
+ */
+
+#include <algorithm>
+#include <unordered_set>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "mata/alphabet.hh"
+#include "mata/nft/types.hh"
+#include "mata/nfa/nfa.hh"
+#include "mata/nft/algorithms.hh"
+#include "mata/nft/builder.hh"
+
+using namespace mata::nft;
+using namespace mata::utils;
+using namespace mata;
+
+TEST_CASE("mata::nft::complement()") {
+    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    Nft nft{ Nft::with_levels(3, 10) };
+    nft.alphabet = &alphabet;
+    Nft nft_complemented{ Nft::with_levels(3) };
+    nft_complemented.alphabet = &alphabet;
+
+    const auto CHECK_SHARED = [&] {
+        CHECK(intersection(nft, nft_complemented).is_lang_empty());
+
+        std::unordered_set<Transition> visited{};
+        std::vector<std::tuple<State, Word>> stack{};
+        for (State init_state : nft.initial) { stack.push_back({ init_state, {} }); }
+        while (!stack.empty()) {
+            const auto [source, word] = std::move(stack.back());
+            stack.pop_back();
+            for (const auto& [symbol, target] : nft.delta[source].moves()) {
+                Transition transition{ source, symbol, target };
+                if (visited.contains(transition)) { continue; }
+                visited.insert(transition);
+                Word new_word{ word };
+                new_word.push_back(symbol);
+                stack.emplace_back(target, new_word);
+
+                if (nft.levels[target] == 0 && nft.final.contains(target)) {
+                    CHECK(nft.is_in_lang(new_word));
+                    CHECK(not nft_complemented.is_in_lang(new_word));
+                }
+            }
+        }
+
+        auto words_in_nft = nft.get_words(nft.levels.num_of_levels * 2);
+        auto words_in_nft_complemented = nft_complemented.get_words(nft_complemented.levels.num_of_levels * 2);
+        for (const auto& word : words_in_nft) {
+            CHECK(not words_in_nft_complemented.contains(word));
+        }
+        for (const auto& word : words_in_nft_complemented) {
+            CHECK(not words_in_nft.contains(word));
+        }
+    };
+
+    SECTION("empty automaton, empty alphabet") {
+        alphabet.clear();
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("make_complete with levels.num_of_levels == 1") {
+        nft.levels.num_of_levels = 1;
+        nft.initial = { 0 };
+        nft.final = { 2 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("make_complete with levels.num_of_levels == 2") {
+        nft.levels.num_of_levels = 2;
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels.set({ 0, 1, 0, 1, 0 });
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("make_complete with levels.num_of_levels == 3") {
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels.set({ 0, 1, 2, 0, 1, 0 });
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
+
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("self loops and jumps") {
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels.set({ 0, 1, 2, 0, 1, 0 });
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(0, 'b', 0);
+        nft.delta.add(0, 'a', 2);
+        nft.delta.add(0, 'b', 3);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
+
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+
+    SECTION("with sinks") {
+        nft.initial = { 0 };
+        nft.final = { 4 };
+        nft.levels = { 0, 1, 2, 0, 1, 0, 0, 1, 2 };
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(0, 'b', 0);
+        nft.delta.add(0, 'a', 2);
+        nft.delta.add(0, 'b', 3);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(1, 'c', 8);
+        nft.delta.add(2, 'a', 3);
+        nft.delta.add(3, 'b', 4);
+        nft.delta.add(4, 'a', 5);
+
+        nft_complemented = complement(nft, alphabet);
+        CHECK_SHARED();
+    }
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3629,86 +3629,127 @@ TEST_CASE("mata::nft::get_useful_states_tarjan") {
     }
 }
 
-TEST_CASE("mata::nft::Nft::get_words") {
+TEST_CASE("mata::nft::Nft::get_words()") {
+    Nft nft {Nft::with_levels(3)};
+    std::set<Word> words_expected{};
+
+    const auto CHECK_SHARED = [&]() {
+        if (words_expected.empty()) {
+            CHECK(nft.get_words().empty());
+            CHECK(nft.get_words(0).empty());
+            CHECK(nft.get_words(5).empty());
+            return;
+        }
+
+        const size_t word_length_max = std::ranges::max_element(
+                words_expected,
+                [](const Word& a, const Word& b) { return a.size() < b.size(); }
+                )->size();
+        const auto words_result{ nft.get_words(word_length_max) };
+        CHECK(words_result.size() == words_expected.size());
+        for (const Word& word: words_expected) {
+            CHECK(words_result.contains(word));
+        }
+    };
+
     SECTION("empty") {
-        Nft aut;
-        CHECK(aut.get_words(0).empty());
-        CHECK(aut.get_words(1).empty());
-        CHECK(aut.get_words(5).empty());
+        CHECK(nft.get_words().empty());
+        CHECK(nft.get_words(0).empty());
+        CHECK(nft.get_words(5).empty());
     }
 
     SECTION("empty word") {
-        Nft aut(1, { 0 }, { 0 });
-        CHECK(aut.get_words(0) == std::set<mata::Word>{{}});
-        CHECK(aut.get_words(1) == std::set<mata::Word>{{}});
-        CHECK(aut.get_words(5) == std::set<mata::Word>{{}});
+        nft = Nft{1, {0}, {0} };
+        words_expected = { {} };
+        CHECK_SHARED();
     }
 
     SECTION("noodle - one final") {
-        Nft aut(3, { 0 }, { 2 });
-        aut.delta.add(0, 0, 1);
-        aut.delta.add(1, 1, 2);
-        CHECK(aut.get_words(0).empty());
-        CHECK(aut.get_words(1).empty());
-        CHECK(aut.get_words(2) == std::set<mata::Word>{{0, 1}});
-        CHECK(aut.get_words(3) == std::set<mata::Word>{{0, 1}});
-        CHECK(aut.get_words(5) == std::set<mata::Word>{{0, 1}});
+        nft = Nft{ 7, { 0 }, { 6 }, { 3, { 0, 1, 2, 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(3, 0, 4);
+        nft.delta.add(4, 1, 5);
+        nft.delta.add(5, 2, 6);
+
+        words_expected = { { 0, 1, 2, 0, 1, 2 } };
+        CHECK_SHARED();
     }
 
-    SECTION("noodle - two finals") {
-        Nft aut(3, { 0 }, { 1, 2 });
-        aut.delta.add(0, 0, 1);
-        aut.delta.add(1, 1, 2);
-        CHECK(aut.get_words(0).empty());
-        CHECK(aut.get_words(1) == std::set<mata::Word>{{0}});
-        CHECK(aut.get_words(2) == std::set<mata::Word>{{0}, {0, 1}});
-        CHECK(aut.get_words(3) == std::set<mata::Word>{{0}, {0, 1}});
-        CHECK(aut.get_words(5) == std::set<mata::Word>{{0}, {0, 1}});
+    SECTION("noodle - two final") {
+        nft = Nft{ 7, { 0 }, { 3, 6 }, { 3, { 0, 1, 2, 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(3, 0, 4);
+        nft.delta.add(4, 1, 5);
+        nft.delta.add(5, 2, 6);
+
+        words_expected = { { 0, 1, 2 }, { 0, 1, 2, 0, 1, 2 } };
+        CHECK_SHARED();
     }
 
-    SECTION("noodle - three finals") {
-        Nft aut(3, { 0 }, { 0, 1, 2 });
-        aut.delta.add(0, 0, 1);
-        aut.delta.add(1, 1, 2);
-        CHECK(aut.get_words(0) == std::set<mata::Word>{{}});
-        CHECK(aut.get_words(1) == std::set<mata::Word>{{}, {0}});
-        CHECK(aut.get_words(2) == std::set<mata::Word>{{}, {0}, {0, 1}});
-        CHECK(aut.get_words(3) == std::set<mata::Word>{{}, {0}, {0, 1}});
-        CHECK(aut.get_words(5) == std::set<mata::Word>{{}, {0}, {0, 1}});
+    SECTION("noodle - one final with multiple paths") {
+        nft = Nft{ 7, { 0 }, { 6 }, { 3, { 0, 1, 2, 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(2, 3, 3);
+        nft.delta.add(3, 0, 4);
+        nft.delta.add(4, 1, 5);
+        nft.delta.add(2, 4, 3);
+        nft.delta.add(5, 2, 6);
+
+        words_expected = { { 0, 1, 2, 0, 1, 2 }, { 0, 1, 3, 0, 1, 2 }, { 0, 1, 4, 0, 1, 2 } };
+        CHECK_SHARED();
     }
 
-    SECTION("more complex") {
-        Nft aut(6, { 0, 1 }, { 1, 3, 4, 5 });
-        aut.delta.add(0, 0, 3);
-        aut.delta.add(3, 1, 4);
-        aut.delta.add(0, 2, 2);
-        aut.delta.add(3, 3, 2);
-        aut.delta.add(1, 4, 2);
-        aut.delta.add(2, 5, 5);
-        CHECK(aut.get_words(0) == std::set<mata::Word>{{}});
-        CHECK(aut.get_words(1) == std::set<mata::Word>{{}, {0}});
-        CHECK(aut.get_words(2) == std::set<mata::Word>{{}, {0}, {0, 1}, {2, 5}, {4, 5}});
-        CHECK(aut.get_words(3) == std::set<mata::Word>{{}, {0}, {0, 1}, {2, 5}, {4, 5}, {0, 3, 5}});
-        CHECK(aut.get_words(4) == std::set<mata::Word>{{}, {0}, {0, 1}, {2, 5}, {4, 5}, {0, 3, 5}});
-        CHECK(aut.get_words(5) == std::set<mata::Word>{{}, {0}, {0, 1}, {2, 5}, {4, 5}, {0, 3, 5}});
+    SECTION("noodle - one final with multiple paths with epsilons") {
+        nft = Nft{ 7, { 0 }, { 6 }, { 3, { 0, 1, 2, 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, EPSILON, 3);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(3, 0, 4);
+        nft.delta.add(4, 1, 5);
+        nft.delta.add(5, 3, 6);
+        nft.delta.add(5, EPSILON, 6);
+
+        words_expected = {
+            { 0, 1, EPSILON, 0, 1, EPSILON },
+            { 0, 1, 2, 0, 1, EPSILON },
+            { 0, 1, EPSILON, 0, 1, 3 },
+            { 0, 1, 2, 0, 1, 3 },
+        };
+        CHECK_SHARED();
     }
 
-    SECTION("cycle") {
-        Nft aut(6, { 0, 1 }, { 0, 1 });
-        aut.delta.add(0, 0, 1);
-        aut.delta.add(1, 1, 0);
-        CHECK(aut.get_words(0) == std::set<mata::Word>{{}});
-        CHECK(aut.get_words(1) == std::set<mata::Word>{{}, {0}, {1}});
-        CHECK(aut.get_words(2) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}});
-        CHECK(aut.get_words(3) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}, {0, 1, 0}, {1, 0, 1}});
-        CHECK(
-            aut.get_words(4) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0, 1},
-            {1, 0, 1, 0}}
-        );
-        CHECK(
-            aut.get_words(5) == std::set<mata::Word>{{}, {0}, {1}, {0, 1}, {1, 0}, {0, 1, 0}, {1, 0, 1}, {0, 1, 0, 1},
-            {1, 0, 1, 0}, {0, 1, 0, 1, 0}, {1, 0, 1, 0, 1}}
-        );
+    SECTION("Loop") {
+        nft = Nft{ 4, { 0 }, { 3 }, { 3, { 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(3, 0, 1);
+
+        words_expected = { { 0, 1, 2 }, { 0, 1, 2, 0, 1, 2}, { 0, 1, 2, 0, 1, 2, 0, 1, 2} };
+        CHECK_SHARED();
+    }
+
+    SECTION("Jumps") {
+        nft = Nft{ 7, { 0 }, { 6 }, { 3, { 0, 1, 2, 0, 1, 2, 0 } } };
+        nft.delta.add(0, 0, 1);
+        nft.delta.add(1, EPSILON, 3);
+        nft.delta.add(1, 1, 2);
+        nft.delta.add(2, 2, 3);
+        nft.delta.add(3, 3, 6);
+        nft.delta.add(3, 0, 4);
+        nft.delta.add(4, 1, 5);
+        nft.delta.add(5, 4, 6);
+
+        words_expected = { { 0, EPSILON, EPSILON, 3, 3, 3 }, { 0, 1, 2, 3, 3, 3 },
+                           { 0, EPSILON, EPSILON, 0, 1, 4 }, { 0, 1, 2, 0, 1, 4 } };
+        CHECK_SHARED();
     }
 }
 

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -337,7 +337,7 @@ TEST_CASE("mata::nft::get_word_for_path()") { // {{{
 
         auto word_bool_pair = aut.get_word_for_path(path);
         REQUIRE(word_bool_pair.second);
-        REQUIRE(word_bool_pair.first.word == Word({'c', 'b'}));
+        REQUIRE(word_bool_pair.first.word == Word({'c', 'c', 'b', 'b'}));
     }
 
     SECTION("longer word") {
@@ -354,12 +354,12 @@ TEST_CASE("mata::nft::get_word_for_path()") { // {{{
         auto word_bool_pair = aut.get_word_for_path(path);
         std::set<Word> possible(
             {
-                Word({ 'c', 'b', 'd', 'a' }),
-                Word({ 'a', 'b', 'd', 'a' })
+                Word({ 'c', 'c', 'b', 'b', 'd', 'd', 'a', 'a' }),
+                Word({ 'a', 'a', 'b', 'b', 'd', 'd', 'a', 'a' })
             }
         );
         REQUIRE(word_bool_pair.second);
-        REQUIRE(haskey(possible, word_bool_pair.first.word));
+        CHECK(haskey(possible, word_bool_pair.first.word));
     }
 
     SECTION("invalid path") {
@@ -580,7 +580,7 @@ TEST_CASE("mata::nft::construct() correct calls") { // {{{
 
         aut = builder::construct(parsec);
 
-        REQUIRE(aut.is_lang_empty());
+        CHECK(aut.is_lang_empty());
     }
 
     SECTION("construct a simple non-empty automaton accepting the empty word") {
@@ -590,7 +590,7 @@ TEST_CASE("mata::nft::construct() correct calls") { // {{{
 
         aut = builder::construct(parsec);
 
-        REQUIRE(!aut.is_lang_empty());
+        CHECK(not aut.is_lang_empty());
     }
 
     SECTION("construct an automaton with more than one initial/final states") {
@@ -600,8 +600,8 @@ TEST_CASE("mata::nft::construct() correct calls") { // {{{
 
         aut = builder::construct(parsec);
 
-        REQUIRE(aut.initial.size() == 2);
-        REQUIRE(aut.final.size() == 3);
+        CHECK(aut.initial.size() == 2);
+        CHECK(aut.final.size() == 3);
     }
 
     SECTION("construct a simple non-empty automaton accepting only the word 'a'") {
@@ -611,14 +611,15 @@ TEST_CASE("mata::nft::construct() correct calls") { // {{{
         parsec.body = { { "q1", "a", "q2" } };
 
         aut = builder::construct(parsec, &alphabet);
+        CHECK(aut.levels.num_of_levels == DEFAULT_NUM_OF_LEVELS);
 
         Run cex;
-        REQUIRE(!aut.is_lang_empty(&cex));
+        CHECK(not aut.is_lang_empty(&cex));
         auto word_bool_pair = aut.get_word_for_path(cex);
-        REQUIRE(word_bool_pair.second);
-        REQUIRE(word_bool_pair.first.word == encode_word(&alphabet, { "a"}).word);
+        CHECK(word_bool_pair.second);
+        CHECK(word_bool_pair.first.word == encode_word(&alphabet, { "a", "a"}).word);
 
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a"})));
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "a", "a"})));
     }
 
     SECTION("construct a more complicated non-empty automaton") {
@@ -644,16 +645,19 @@ TEST_CASE("mata::nft::construct() correct calls") { // {{{
         aut = builder::construct(parsec, &alphabet);
 
         // some samples
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "b", "a"})));
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a", "c", "a", "a"})));
-        REQUIRE(
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "b", "b", "a", "a"})));
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "a", "a", "c", "c", "a", "a", "a", "a"})));
+        CHECK(
             aut.is_in_lang(encode_word(&alphabet,
-                {"a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a"}))
+                {
+                "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a",
+                "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a"
+                }))
         );
         // some wrong samples
-        REQUIRE(!aut.is_in_lang(encode_word(&alphabet, { "b", "c"})));
-        REQUIRE(!aut.is_in_lang(encode_word(&alphabet, { "a", "c", "c", "a"})));
-        REQUIRE(!aut.is_in_lang(encode_word(&alphabet, { "b", "a", "c", "b"})));
+        CHECK(!aut.is_in_lang(encode_word(&alphabet, { "b", "b", "c", "c"})));
+        CHECK(!aut.is_in_lang(encode_word(&alphabet, { "a", "a", "c", "c", "c", "c", "a", "a"})));
+        CHECK(!aut.is_in_lang(encode_word(&alphabet, { "b", "b", "a", "a", "c", "c", "b","b"})));
     }
 } // }}}
 
@@ -776,14 +780,15 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls") { // {{{
         const auto auts = mata::IntermediateAut::parse_from_mf(parse_mf(file));
         inter_aut = auts[0];
         plumbing::construct(&aut, inter_aut, &alphabet);
+        CHECK(aut.levels.num_of_levels == DEFAULT_NUM_OF_LEVELS);
 
         Run cex;
         REQUIRE(!aut.is_lang_empty(&cex));
         auto word_bool_pair = aut.get_word_for_path(cex);
         REQUIRE(word_bool_pair.second);
-        REQUIRE(word_bool_pair.first.word == encode_word(&alphabet, { "a" }).word);
+        REQUIRE(word_bool_pair.first.word == encode_word(&alphabet, { "a", "a" }).word);
 
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a" })));
+        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a", "a" })));
     }
 
     SECTION("construct a more complicated non-empty automaton from intermediate automaton") {
@@ -814,8 +819,8 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls") { // {{{
         plumbing::construct(&aut, inter_aut, &alphabet);
 
         // some samples
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "b", "a"})));
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a", "c", "a", "a"})));
+        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "b", "b", "a", "a"})));
+        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a", "a", "c", "c", "a", "a", "a", "a"})));
         REQUIRE(
             aut.is_in_lang(encode_word(&alphabet,
                 {"a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a", "a"}))
@@ -844,11 +849,11 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls") { // {{{
         inter_aut = auts[0];
 
         plumbing::construct(&aut, inter_aut, &alphabet);
-        REQUIRE(aut.final.size() == 4);
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a1", "a2"})));
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a1", "a2", "a3"})));
-        REQUIRE(!aut.is_in_lang(encode_word(&alphabet, { "a1", "a2", "a3", "a4"})));
-        REQUIRE(aut.is_in_lang(encode_word(&alphabet, { "a1", "a2", "a3", "a5", "a7"})));
+        CHECK(aut.final.size() == 4);
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "a1", "a1", "a2", "a2"})));
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "a1", "a1", "a2", "a2", "a3", "a3"})));
+        CHECK(!aut.is_in_lang(encode_word(&alphabet, { "a1", "a1", "a2", "a2", "a3", "a3", "a4", "a4"})));
+        CHECK(aut.is_in_lang(encode_word(&alphabet, { "a1", "a1", "a2", "a2", "a3", "a3", "a5", "a5", "a7", "a7"})));
     }
 
     SECTION("construct - final states given as true") {
@@ -912,12 +917,6 @@ TEST_CASE("mata::nft::make_complete()") {
     nft.alphabet = &alphabet;
     result.alphabet = &alphabet;
     auto alphabet_symbols = [&] { return alphabet.get_alphabet_symbols(); };
-    OrdVector<Symbol> epsilons{};
-    auto alphabet_symbols_with_epsilons = [&] {
-        OrdVector<Symbol> symbols{ alphabet_symbols() };
-        symbols.insert(epsilons);
-        return symbols;
-    };
     OrdVector<Symbol> symbols{ alphabet_symbols() };
 
     std::optional<std::vector<State>> sinks{ std::nullopt };
@@ -939,29 +938,18 @@ TEST_CASE("mata::nft::make_complete()") {
 
 
         // Check sinks if any were provided.
-        // CHECK(not result.make_complete(&alphabet, epsilons_to_check, std::vector<State>{ sinks }));
+        // CHECK(not result.make_complete(&alphabet, std::vector<State>{ sinks }));
         for (auto sinks_val{ sinks.value_or(std::vector<State>{}) }; const State sink : sinks_val) {
             for (const auto symbol : alphabet_symbols()) {
                 CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks_val.size()) + *sinks_val.begin()));
             }
-            for (const auto symbol : epsilons) {
-                CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks_val.size()) + *sinks_val.begin()));
-            }
         }
-        // auto CHECK_SECTION = [&](const OrdVector<Symbol>& epsilons_to_check = {}) {
     };
 
     SECTION("empty automaton, empty alphabet") {
         alphabet.clear();
-
         result = nft;
-        result.make_complete(&alphabet, epsilons, sinks);
-        CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons, sinks);
-        symbols = alphabet_symbols_with_epsilons();
+        result.make_complete(&alphabet, sinks);
         CHECK_SHARED();
     }
 
@@ -974,12 +962,6 @@ TEST_CASE("mata::nft::make_complete()") {
 
         result = nft;
         result.make_complete(&alphabet);
-        CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons);
-        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -996,12 +978,6 @@ TEST_CASE("mata::nft::make_complete()") {
         result = nft;
         result.make_complete(&alphabet);
         CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons);
-        symbols = alphabet_symbols_with_epsilons();
-        CHECK_SHARED();
     }
 
     SECTION("make_complete with levels.num_of_levels == 3") {
@@ -1016,12 +992,6 @@ TEST_CASE("mata::nft::make_complete()") {
 
         result = nft;
         result.make_complete(&alphabet);
-        CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons);
-        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -1040,12 +1010,6 @@ TEST_CASE("mata::nft::make_complete()") {
 
         result = nft;
         result.make_complete(&alphabet);
-        CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons);
-        symbols = alphabet_symbols_with_epsilons();
         CHECK_SHARED();
     }
 
@@ -1066,166 +1030,10 @@ TEST_CASE("mata::nft::make_complete()") {
         sinks = { 6, 7, 8 };
 
         result = nft;
-        result.make_complete(&alphabet, epsilons, sinks);
-        CHECK_SHARED();
-
-        result = nft;
-        epsilons = { EPSILON };
-        result.make_complete(&alphabet, epsilons, sinks);
-        symbols = alphabet_symbols_with_epsilons();
+        result.make_complete(&alphabet, sinks);
         CHECK_SHARED();
     }
 }
-
-#ifdef MATA_NFT_NOT_IMPLEMENTED
-TEST_CASE ("mata::nft::complement()") {
-    Nft aut(3);
-    Nft cmpl;
-
-    SECTION("empty automaton, empty alphabet") {
-        OnTheFlyAlphabet alph{};
-        cmpl = complement(
-            aut, alph, { { "algorithm", "classical" },
-                         { "minimize", "false" } }
-        );
-        Nft empty_string_nft{ nft::builder::create_sigma_star_nft(&alph) };
-        CHECK(are_equivalent(cmpl, empty_string_nft));
-    }
-
-    SECTION("empty automaton") {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "false" } }
-                );
-
-        REQUIRE(cmpl.is_in_lang({}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["b"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
-
-        Nft sigma_star_nft{ nft::builder::create_sigma_star_nft(&alph) };
-        CHECK(are_equivalent(cmpl, sigma_star_nft));
-    }
-
-    SECTION("empty automaton accepting epsilon, empty alphabet") {
-        OnTheFlyAlphabet alph{};
-        aut.initial = { 1 };
-        aut.final = { 1 };
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "false" } }
-                );
-
-        CHECK(cmpl.is_lang_empty());
-    }
-
-    SECTION("empty automaton accepting epsilon") {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = { 1 };
-        aut.final = { 1 };
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "false" } }
-                );
-
-        REQUIRE(!cmpl.is_in_lang({}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["b"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["b"], alph["b"], alph["a"]}, {}}));
-        REQUIRE(cmpl.initial.size() == 1);
-        REQUIRE(cmpl.final.size() == 1);
-        REQUIRE(cmpl.delta.num_of_transitions() == 4);
-    }
-
-    SECTION("non-empty automaton accepting a*b*") {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = { 1, 2 };
-        aut.final = { 1, 2 };
-
-        aut.delta.add(1, alph["a"], 1);
-        aut.delta.add(1, alph["a"], 2);
-        aut.delta.add(2, alph["b"], 2);
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "false" } }
-                );
-
-        REQUIRE(!cmpl.is_in_lang(Word{}));
-        REQUIRE(!cmpl.is_in_lang(Word{ alph["a"] }));
-        REQUIRE(!cmpl.is_in_lang(Word{ alph["b"] }));
-        REQUIRE(!cmpl.is_in_lang(Word{ alph["a"], alph["a"] }));
-        REQUIRE(cmpl.is_in_lang(Word{ alph["a"], alph["b"], alph["b"], alph["a"] }));
-        REQUIRE(!cmpl.is_in_lang(Word{ alph["a"], alph["a"], alph["b"], alph["b"] }));
-        REQUIRE(cmpl.is_in_lang(Word{ alph["b"], alph["a"], alph["a"], alph["a"] }));
-
-        REQUIRE(cmpl.initial.size() == 1);
-        REQUIRE(cmpl.final.size() == 1);
-        REQUIRE(cmpl.delta.num_of_transitions() == 6);
-    }
-
-    SECTION("empty automaton, empty alphabet, minimization") {
-        OnTheFlyAlphabet alph{};
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "true" } }
-                );
-        Nft empty_string_nft{ nft::builder::create_sigma_star_nft(&alph) };
-        CHECK(are_equivalent(empty_string_nft, cmpl));
-    }
-
-    SECTION("empty automaton, minimization") {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "true" } }
-                );
-
-        REQUIRE(cmpl.is_in_lang({}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["b"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
-
-        Nft sigma_star_nft{ nft::builder::create_sigma_star_nft(&alph) };
-        CHECK(are_equivalent(sigma_star_nft, cmpl));
-    }
-
-    SECTION("minimization vs no minimization") {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
-        aut.initial = { 0, 1 };
-        aut.final = { 1, 2 };
-
-        aut.delta.add(1, alph["b"], 1);
-        aut.delta.add(1, alph["a"], 2);
-        aut.delta.add(2, alph["b"], 2);
-        aut.delta.add(0, alph["a"], 1);
-        aut.delta.add(0, alph["a"], 2);
-
-        cmpl = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "false" } }
-                );
-
-        Nft cmpl_min = complement(
-                aut, alph, { { "algorithm", "classical" },
-                             { "minimize", "true" } }
-                );
-
-        CHECK(are_equivalent(cmpl, cmpl_min, &alph));
-        CHECK(cmpl_min.num_of_states() == 4);
-        CHECK(cmpl.num_of_states() == 5);
-    }
-}
-#endif
 
 TEST_CASE("mata::nft::is_universal()") {
     Nft aut(6);
@@ -2610,59 +2418,62 @@ TEST_CASE("mata::nft::Nft::is_deterministic()") { // {{{
     }
 } // }}}
 
-TEST_CASE("mata::nft::is_prefix_in_lang()") { // {{{
-    Nft aut('q' + 1);
+TEST_CASE("mata::nft::Nft::is_in_lang[_prefix][_by_levels]()") {
+    Nft nft{ Nft::with_levels(3) };
+    EnumAlphabet alphabet{ 'a', 'b', 'c', 'd', 'e' };
+    nft.alphabet = &alphabet;
 
     SECTION("empty automaton") {
-        Run w;
-        w.word = { 'a', 'b', 'd' };
-        REQUIRE(!aut.is_prefix_in_lang(w));
-
-        w.word = {};
-        REQUIRE(!aut.is_prefix_in_lang(w));
+        CHECK(nft.is_lang_empty());
+        CHECK(not nft.is_in_lang(Word{}));
+        CHECK(not nft.is_in_lang(Word{ 'a', 'b', 'c' }));
+        CHECK(not nft.is_in_lang_prefix(Word{ 'a', 'a', 'c' }));
+        CHECK(not nft.is_in_lang_by_levels({ {'a'}, {'a'}, { 'a' } }));
+        CHECK(not nft.is_in_lang_prefix_by_levels({ { 'a' }, { 'a' }, { 'a' } }));
+        CHECK_THROWS_AS(nft.is_in_lang(Word{ 'a' }), std::invalid_argument);
+        CHECK_THROWS_AS(nft.is_in_lang_prefix(Word{ 'a' }), std::invalid_argument);
+        CHECK_THROWS_AS(nft.is_in_lang_by_levels({ { 'a' } }), std::invalid_argument);
+        CHECK_THROWS_AS(nft.is_in_lang_prefix_by_levels({ { 'a' } }), std::invalid_argument);
     }
 
-    SECTION("automaton accepting only epsilon") {
-        aut.initial.insert('q');
-        aut.final.insert('q');
+    SECTION("simple automaton") {
+        nft.add_state_with_level(0, 0);
+        nft.add_state_with_level(1, 1);
+        nft.add_state_with_level(2, 2);
+        nft.add_state_with_level(3, 0);
+        nft.initial.insert(0);
+        nft.final.insert(3);
+        nft.delta.add(0, 'a', 1);
+        nft.delta.add(1, 'b', 2);
+        nft.delta.add(1, EPSILON, 2);
+        nft.delta.add(1, EPSILON, 3);
+        nft.delta.add(1, DONT_CARE, 2);
+        nft.delta.add(1, DONT_CARE, 3);
+        nft.delta.add(2, 'c', 3);
+        nft.delta.add(3, 'd', 0);
+        nft.delta.add(1, 'e', 3);
+        nft.delta.add(3, EPSILON, 0);
+        CHECK(not nft.is_lang_empty());
+        CHECK(nft.is_in_lang({ 'a', 'b', 'c' }));
+        CHECK(nft.is_in_lang_by_levels({ { 'a' }, { 'b' }, { 'c' } }));
+        CHECK(nft.is_in_lang(Word{ 'a', 'e', 'e', 'a', 'b', 'c' }));
+        CHECK(nft.is_in_lang_by_levels({ { 'a', 'a' }, { 'e', 'b' }, { 'e', 'c' } }));
 
-        Run w;
-        w.word = {};
-        REQUIRE(aut.is_prefix_in_lang(w));
+        CHECK(nft.is_in_lang({ 'a', 'b', 'c', 'a', 'e', 'e' }, true));
+        CHECK(nft.is_in_lang(Word{ 'a', 'e', 'e', 'a', 'b', 'c' }, true));
 
-        w.word = { 'a', 'b' };
-        REQUIRE(aut.is_prefix_in_lang(w));
+        CHECK(nft.is_in_lang(Word{ 'a', 'e', 'e', EPSILON, EPSILON, EPSILON, 'a', 'b', 'c' }));
+        CHECK(nft.is_in_lang(Word{ DONT_CARE, DONT_CARE, 'c', DONT_CARE, 'b', DONT_CARE }));
+        CHECK(nft.is_in_lang(Word{ 'a', 'e', 'e', DONT_CARE, DONT_CARE, 'c', 'a', 'b', 'c' }));
+        CHECK(
+            nft.is_in_lang(Word{ DONT_CARE, EPSILON, EPSILON, DONT_CARE, DONT_CARE, 'c', 'a', DONT_CARE, DONT_CARE })
+        );
+        CHECK(nft.is_in_lang(Word{ 'a', EPSILON, 'c', 'a', EPSILON, EPSILON, 'a', 'b', 'c' }));
+        CHECK(nft.is_in_lang(Word{ 'a', DONT_CARE, 'c', 'a', DONT_CARE, DONT_CARE, 'a', 'b', 'c' }));
+
+        CHECK_THROWS_AS(nft.is_in_lang_prefix(Word{ 'a', 'b' }), std::invalid_argument);
     }
-
-    SECTION("small automaton") {
-        FILL_WITH_AUT_B(aut);
-
-        Run w;
-        w.word = { 'b', 'a' };
-        REQUIRE(aut.is_prefix_in_lang(w));
-
-        w.word = {};
-        REQUIRE(!aut.is_prefix_in_lang(w));
-
-        w.word = { 'c', 'b', 'a' };
-        REQUIRE(!aut.is_prefix_in_lang(w));
-
-        w.word = { 'c', 'b', 'a', 'a' };
-        REQUIRE(aut.is_prefix_in_lang(w));
-
-        w.word = { 'a', 'a' };
-        REQUIRE(aut.is_prefix_in_lang(w));
-
-        w.word = { 'c', 'b', 'b', 'a', 'c', 'b' };
-        REQUIRE(aut.is_prefix_in_lang(w));
-
-        w.word = Word(100000, 'a');
-        REQUIRE(aut.is_prefix_in_lang(w));
-
-        w.word = Word(100000, 'b');
-        REQUIRE(!aut.is_prefix_in_lang(w));
-    }
-} // }}}
+}
 
 TEST_CASE("mata::nft::fw-direct-simulation()") { // {{{
     Nft aut;
@@ -2898,59 +2709,59 @@ TEST_CASE("mata::nft::reduce_size_by_simulation()") {
     }
 }
 
-TEST_CASE("mata::nft::union_norename()") {
-    Run one{ { 1 }, {} };
-    Run zero{ { 0 }, {} };
+TEST_CASE("mata::nft::union_nondet() minimal") {
+    Run one{ { 1, 1 }, {} };
+    Run zero{ { 0, 0 }, {} };
 
     Nft lhs(2);
     lhs.initial.insert(0);
     lhs.delta.add(0, 0, 1);
     lhs.final.insert(1);
-    REQUIRE(!lhs.is_in_lang(one));
-    REQUIRE(lhs.is_in_lang(zero));
+    CHECK(not lhs.is_in_lang(one));
+    CHECK(lhs.is_in_lang(zero));
 
     Nft rhs(2);
     rhs.initial.insert(0);
     rhs.delta.add(0, 1, 1);
     rhs.final.insert(1);
-    REQUIRE(rhs.is_in_lang(one));
-    REQUIRE(!rhs.is_in_lang(zero));
+    CHECK(rhs.is_in_lang(one));
+    CHECK(not rhs.is_in_lang(zero));
 
     SECTION("failing minimal scenario") {
         Nft result = union_nondet(lhs, rhs);
-        REQUIRE(result.is_in_lang(one));
-        REQUIRE(result.is_in_lang(zero));
+        CHECK(result.is_in_lang(one));
+        CHECK(result.is_in_lang(zero));
     }
 }
 
-TEST_CASE("mata::nft::union_inplace") {
-    Run one{ { 1 }, {} };
-    Run zero{ { 0 }, {} };
+TEST_CASE("mata::nft::unite_nondet_with()") {
+    Run one{ { 1, 1 }, {} };
+    Run zero{ { 0, 0 }, {} };
 
     Nft lhs(2);
     lhs.initial.insert(0);
     lhs.delta.add(0, 0, 1);
     lhs.final.insert(1);
-    REQUIRE(!lhs.is_in_lang(one));
-    REQUIRE(lhs.is_in_lang(zero));
+    CHECK(!lhs.is_in_lang(one));
+    CHECK(lhs.is_in_lang(zero));
 
     Nft rhs(2);
     rhs.initial.insert(0);
     rhs.delta.add(0, 1, 1);
     rhs.final.insert(1);
-    REQUIRE(rhs.is_in_lang(one));
-    REQUIRE(!rhs.is_in_lang(zero));
+    CHECK(rhs.is_in_lang(one));
+    CHECK(!rhs.is_in_lang(zero));
 
     SECTION("failing minimal scenario") {
         Nft result = lhs.unite_nondet_with(rhs);
-        REQUIRE(result.is_in_lang(one));
-        REQUIRE(result.is_in_lang(zero));
+        CHECK(result.is_in_lang(one));
+        CHECK(result.is_in_lang(zero));
     }
 
     SECTION("same automata") {
         size_t lhs_states = lhs.num_of_states();
         Nft result = lhs.unite_nondet_with(lhs);
-        REQUIRE(result.num_of_states() == lhs_states * 2);
+        CHECK(result.num_of_states() == lhs_states * 2);
     }
 }
 
@@ -2959,11 +2770,11 @@ TEST_CASE("mata::nft::remove_final()") {
 
     SECTION("Automaton B") {
         FILL_WITH_AUT_B(aut);
-        REQUIRE(aut.final[2]);
-        REQUIRE(aut.final[12]);
+        CHECK(aut.final[2]);
+        CHECK(aut.final[12]);
         aut.final.erase(12);
-        REQUIRE(aut.final[2]);
-        REQUIRE(!aut.final[12]);
+        CHECK(aut.final[2]);
+        CHECK(!aut.final[12]);
     }
 }
 
@@ -2976,40 +2787,40 @@ TEST_CASE("mata::nft::delta.remove()") {
         aut.delta.add(1, 3, 5);
 
         SECTION("Simple remove") {
-            REQUIRE(aut.delta.contains(1, 3, 4));
-            REQUIRE(aut.delta.contains(1, 3, 5));
+            CHECK(aut.delta.contains(1, 3, 4));
+            CHECK(aut.delta.contains(1, 3, 5));
             aut.delta.remove(1, 3, 5);
-            REQUIRE(aut.delta.contains(1, 3, 4));
-            REQUIRE(!aut.delta.contains(1, 3, 5));
+            CHECK(aut.delta.contains(1, 3, 4));
+            CHECK(!aut.delta.contains(1, 3, 5));
         }
 
-        SECTION("Remove missing transition") { REQUIRE_THROWS_AS(aut.delta.remove(1, 1, 5), std::invalid_argument); }
+        SECTION("Remove missing transition") { CHECK_THROWS_AS(aut.delta.remove(1, 1, 5), std::invalid_argument); }
 
         SECTION("Remove the last state_to from targets") {
-            REQUIRE(aut.delta.contains(6, 'a', 2));
+            CHECK(aut.delta.contains(6, 'a', 2));
             aut.delta.remove(6, 'a', 2);
-            REQUIRE(!aut.delta.contains(6, 'a', 2));
-            REQUIRE(aut.delta[6].empty());
+            CHECK(!aut.delta.contains(6, 'a', 2));
+            CHECK(aut.delta[6].empty());
 
-            REQUIRE(aut.delta.contains(4, 'a', 8));
-            REQUIRE(aut.delta.contains(4, 'c', 8));
-            REQUIRE(aut.delta.contains(4, 'a', 6));
-            REQUIRE(aut.delta.contains(4, 'b', 6));
-            REQUIRE(aut.delta[4].size() == 3);
+            CHECK(aut.delta.contains(4, 'a', 8));
+            CHECK(aut.delta.contains(4, 'c', 8));
+            CHECK(aut.delta.contains(4, 'a', 6));
+            CHECK(aut.delta.contains(4, 'b', 6));
+            CHECK(aut.delta[4].size() == 3);
             aut.delta.remove(4, 'a', 6);
-            REQUIRE(!aut.delta.contains(4, 'a', 6));
-            REQUIRE(aut.delta.contains(4, 'b', 6));
-            REQUIRE(aut.delta[4].size() == 3);
+            CHECK(!aut.delta.contains(4, 'a', 6));
+            CHECK(aut.delta.contains(4, 'b', 6));
+            CHECK(aut.delta[4].size() == 3);
 
             aut.delta.remove(4, 'a', 8);
-            REQUIRE(!aut.delta.contains(4, 'a', 8));
-            REQUIRE(aut.delta.contains(4, 'c', 8));
-            REQUIRE(aut.delta[4].size() == 2);
+            CHECK(!aut.delta.contains(4, 'a', 8));
+            CHECK(aut.delta.contains(4, 'c', 8));
+            CHECK(aut.delta[4].size() == 2);
 
             aut.delta.remove(4, 'c', 8);
-            REQUIRE(!aut.delta.contains(4, 'a', 8));
-            REQUIRE(!aut.delta.contains(4, 'c', 8));
-            REQUIRE(aut.delta[4].size() == 1);
+            CHECK(!aut.delta.contains(4, 'a', 8));
+            CHECK(!aut.delta.contains(4, 'c', 8));
+            CHECK(aut.delta[4].size() == 1);
         }
     }
 }
@@ -3630,7 +3441,7 @@ TEST_CASE("mata::nft::get_useful_states_tarjan") {
 }
 
 TEST_CASE("mata::nft::Nft::get_words()") {
-    Nft nft {Nft::with_levels(3)};
+    Nft nft{ Nft::with_levels(3) };
     std::set<Word> words_expected{};
 
     const auto CHECK_SHARED = [&]() {
@@ -3642,14 +3453,12 @@ TEST_CASE("mata::nft::Nft::get_words()") {
         }
 
         const size_t word_length_max = std::ranges::max_element(
-                words_expected,
-                [](const Word& a, const Word& b) { return a.size() < b.size(); }
-                )->size();
+            words_expected,
+            [](const Word& a, const Word& b) { return a.size() < b.size(); }
+        )->size();
         const auto words_result{ nft.get_words(word_length_max) };
         CHECK(words_result.size() == words_expected.size());
-        for (const Word& word: words_expected) {
-            CHECK(words_result.contains(word));
-        }
+        for (const Word& word : words_expected) { CHECK(words_result.contains(word)); }
     };
 
     SECTION("empty") {
@@ -3659,7 +3468,7 @@ TEST_CASE("mata::nft::Nft::get_words()") {
     }
 
     SECTION("empty word") {
-        nft = Nft{1, {0}, {0} };
+        nft = Nft{ 1, { 0 }, { 0 } };
         words_expected = { {} };
         CHECK_SHARED();
     }
@@ -3732,7 +3541,7 @@ TEST_CASE("mata::nft::Nft::get_words()") {
         nft.delta.add(2, 2, 3);
         nft.delta.add(3, 0, 1);
 
-        words_expected = { { 0, 1, 2 }, { 0, 1, 2, 0, 1, 2}, { 0, 1, 2, 0, 1, 2, 0, 1, 2} };
+        words_expected = { { 0, 1, 2 }, { 0, 1, 2, 0, 1, 2 }, { 0, 1, 2, 0, 1, 2, 0, 1, 2 } };
         CHECK_SHARED();
     }
 
@@ -3747,8 +3556,10 @@ TEST_CASE("mata::nft::Nft::get_words()") {
         nft.delta.add(4, 1, 5);
         nft.delta.add(5, 4, 6);
 
-        words_expected = { { 0, EPSILON, EPSILON, 3, 3, 3 }, { 0, 1, 2, 3, 3, 3 },
-                           { 0, EPSILON, EPSILON, 0, 1, 4 }, { 0, 1, 2, 0, 1, 4 } };
+        words_expected = {
+            { 0, EPSILON, EPSILON, 3, 3, 3 }, { 0, 1, 2, 3, 3, 3 },
+            { 0, EPSILON, EPSILON, 0, 1, 4 }, { 0, 1, 2, 0, 1, 4 }
+        };
         CHECK_SHARED();
     }
 }
@@ -5732,4 +5543,16 @@ TEST_CASE("mata::nft::Nft::apply()") {
         CHECK(nft.apply(nfa).levels.num_of_levels == 4);
         CHECK(nft.apply(nfa, 3, false).levels.num_of_levels == 5);
     }
+}
+
+TEST_CASE("mata::nft::symbols_match") {
+    CHECK(symbols_match('a', 'a'));
+    CHECK(not symbols_match('a', 'b'));
+    CHECK(symbols_match(EPSILON, EPSILON));
+    CHECK(not symbols_match('a', EPSILON));
+    CHECK(not symbols_match(EPSILON, 'b'));
+    CHECK(symbols_match(DONT_CARE, 'b'));
+    CHECK(symbols_match('b', DONT_CARE));
+    CHECK(not symbols_match(DONT_CARE, EPSILON));
+    CHECK(not symbols_match(EPSILON, DONT_CARE));
 }


### PR DESCRIPTION
This pull request implements complementation for NFTs, fixes `nft::get_words()` and adds utility functions for working with levels:
- Added the `next_level_after` method to the `Levels` class, providing a standardised way to compute the next level for a given state.
- Introduced the `map_levels_to` utility function for mapping levels to state sets.