### PR TITLE
ci: Remove unused step in CI action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -219,15 +219,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: actions/checkout@v4
-      - name: Import bot's GPG key for signing commits
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
       - uses: ./.github/workflows/actions/setup
       - name: Check formatting using treefmt through Nix
         run: |


### PR DESCRIPTION
This PR removes now unused step importing GPG keys for CI actions.