### PR TITLE
fix(nft): Differentiate between setting num_of_levels in Levels in operator=() and set() functions

### DIFF
--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -100,8 +100,29 @@ public:
     Levels(Levels&& other) = default;
     Levels& operator=(const Levels& other) = default;
     Levels& operator=(Levels&& other) = default;
+    /**
+     * @brief Assign levels from @p other to @c this.
+     *
+     * After assignment, @c num_of_levels is set to the minimal number of levels that can accommodate all levels in @p other.
+     *
+     * @param[in] other Levels to be assigned.
+     */
     Levels& operator=(std::initializer_list<value_type> other);
+    /**
+     * @brief Assign levels from @p levels to @c this.
+     *
+     * After assignment, @c num_of_levels is set to the minimal number of levels that can accommodate all levels in @p levels.
+     *
+     * @param[in] levels Levels to be assigned.
+     */
     Levels& operator=(const std::vector<Level>& levels);
+    /**
+     * @brief Assign levels from @p levels to @c this.
+     *
+     * After assignment, @c num_of_levels is set to the minimal number of levels that can accommodate all levels in @p levels.
+     *
+     * @param[in] levels Levels to be assigned.
+     */
     Levels& operator=(std::vector<Level>&& levels);
 
     using
@@ -160,8 +181,32 @@ public:
     bool operator==(const Levels& other) const = default;
     bool operator==(const std::vector<Level>& other) const { return static_cast<const std::vector<Level>&>(*this) == other; }
 
+    /**
+     * @brief Set level of @p state to @p level.
+     *
+     * If @p state is out of range, resize @c this to accommodate it.
+     *
+     * @c num_of_levels is not changed, in contrast to the behaviour of @c Levels::operator=.
+     *
+     * @param[in] state State whose level is to be set.
+     * @param[in] level Level to be set for @p state.
+     */
     Levels& set(State state, Level level = DEFAULT_LEVEL);
+    /**
+     * @brief Set levels of @c this to @p levels.
+     *
+     * @c num_of_levels is not changed, in contrast to the behaviour of @c Levels::operator=.
+     *
+     * @param[in] levels Vector of levels to be set.
+     */
     Levels& set(const std::vector<Level>& levels);
+    /**
+     * @brief Set levels of @c this to @p levels.
+     *
+     * @c num_of_levels is not changed, in contrast to the behaviour of @c Levels::operator=.
+     *
+     * @param[in] levels Vector of levels to be set.
+     */
     Levels& set(std::vector<Level>&& levels);
 
     /**

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -70,14 +70,16 @@ Levels& Levels::set(const State state, const Level level) {
 }
 
 Levels& Levels::set(const std::vector<Level>& levels) {
-    assert(check_levels_in_range_() && "Levels::set: level is out of range of the set number of levels.");
     assign(levels.begin(), levels.end());
+    assert(check_levels_in_range_() && "Levels::set: level is out of range of the set number of levels.");
     return *this;
 }
 
 Levels& Levels::set(std::vector<Level>&& levels) {
+    const auto num_of_levels_orig{ num_of_levels };
+    *this = std::move(levels);
+    num_of_levels = num_of_levels_orig;
     assert(check_levels_in_range_() && "Levels::set: level is out of range of the set number of levels.");
-    assign(std::make_move_iterator(levels.begin()), std::make_move_iterator(levels.end()));
     return *this;
 }
 
@@ -498,9 +500,9 @@ Nft& Nft::operator=(const Nfa& other) noexcept {
     return *this;
 }
 
-Nft& Nft::operator=(mata::nfa::Nfa&& other) noexcept {
+Nft& Nft::operator=(Nfa&& other) noexcept {
     if (this != &other) {
-        mata::nfa::Nfa::operator=(other);
+        Nfa::operator=(std::move(other));
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
         levels.num_of_levels = 1;
     }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -1978,6 +1978,16 @@ TEST_CASE("mata::nft::Levels") {
         states.erase(4);
         CHECK(levels.get_minimal_next_level_of(states) == 0);
     }
+
+    SECTION("operator=(std::vector<Level>) and set(std::vector<Level>) behaviour") {
+        levels = { 1, 0, 1 };
+        levels.num_of_levels = 12;
+        levels.set(std::vector<Level>{ 5, 6, 7 });
+        CHECK(levels.num_of_levels == 12);
+        levels = std::vector<Level>{ 2, 2, 1 };
+        CHECK(levels.num_of_levels == 3);
+        CHECK(levels == std::vector<Level>{ 2, 2, 1 });
+    }
 }
 
 TEST_CASE("mata::nft::Nft::invert_levels()") {


### PR DESCRIPTION
This PR highlights the difference between `Levels::set()` and `Levels::operator=()` when assigning `std::vector<Level>`.