### PR TITLE
Add support for exporting mata as a package

### DIFF
--- a/3rdparty/cudd/CMakeLists.txt
+++ b/3rdparty/cudd/CMakeLists.txt
@@ -136,11 +136,21 @@ add_library(cudd OBJECT
 
 target_compile_features(cudd PUBLIC cxx_std_20)
 
-target_include_directories(cudd PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/cudd/"
-                                        "${CMAKE_CURRENT_SOURCE_DIR}/st/"
-                                        "${CMAKE_CURRENT_SOURCE_DIR}/mtr/"
-                                        "${CMAKE_CURRENT_SOURCE_DIR}/epd/"
-                                        "${CMAKE_CURRENT_SOURCE_DIR}/util/"
-                                        "${CMAKE_CURRENT_SOURCE_DIR}/cplusplus/"
-                                        "${CMAKE_CURRENT_BINARY_DIR}/")
-target_include_directories(cudd PUBLIC  "${CMAKE_CURRENT_SOURCE_DIR}/include/") # for cudd_config.h
+add_library(cudd_headers INTERFACE)
+target_include_directories(cudd_headers
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(cudd PUBLIC cudd_headers)
+
+target_include_directories(cudd
+    PRIVATE 
+        "${CMAKE_CURRENT_SOURCE_DIR}/cudd/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/st/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/mtr/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/epd/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/util/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cplusplus/"
+        "${CMAKE_CURRENT_BINARY_DIR}/"
+)

--- a/3rdparty/simlib/CMakeLists.txt
+++ b/3rdparty/simlib/CMakeLists.txt
@@ -2,4 +2,10 @@ add_library(simlib OBJECT src/explicit_lts_sim.cc)
 
 target_compile_features(simlib PUBLIC cxx_std_20)
 
-target_include_directories(simlib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+add_library(simlib_headers INTERFACE)
+target_include_directories(simlib_headers
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(simlib PUBLIC simlib_headers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,17 +138,30 @@ endif ()
 
 
 ##### INSTALLING AND UNINSTALLING #####
-install (TARGETS libmata
-	ARCHIVE DESTINATION lib)
+install (TARGETS libmata cudd_headers simlib_headers
+    EXPORT mataTargets
+	ARCHIVE DESTINATION lib
+)
 # TODO: should headers be installed in some nicer way? there is something called FILE_SET in cmake, but I do not feel it will make it better
-get_target_property (LIBMATA_PUBLIC_INCLUDES libmata INTERFACE_INCLUDE_DIRECTORIES)
-install (DIRECTORY "${LIBMATA_PUBLIC_INCLUDES}" TYPE INCLUDE)
-# TODO remove this after we remove PUBLIC dependency on CUDD
-get_target_property (CUDD_PUBLIC_INCLUDES cudd INTERFACE_INCLUDE_DIRECTORIES)
-install (DIRECTORY "${CUDD_PUBLIC_INCLUDES}" TYPE INCLUDE)
-# TODO remove this after we remove PUBLIC dependency on simlib
-get_target_property (SIMLIB_PUBLIC_INCLUDES simlib INTERFACE_INCLUDE_DIRECTORIES)
-install (DIRECTORY "${SIMLIB_PUBLIC_INCLUDES}" TYPE INCLUDE)
+install(
+    DIRECTORY
+        ${PROJECT_SOURCE_DIR}/include/
+        ${PROJECT_SOURCE_DIR}/3rdparty/cudd/include/ # TODO remove this after we remove PUBLIC dependency on CUDD
+        ${PROJECT_SOURCE_DIR}/3rdparty/simlib/include/ # TODO remove this after we remove PUBLIC dependency on simlib
+    DESTINATION include
+)
+install(EXPORT mataTargets
+    # NAMESPACE mata:: # for modern cmake, commented out because I am not sure what could break with it
+    DESTINATION lib/cmake/mata
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/mataConfig.cmake.in       # your template
+    "${CMAKE_CURRENT_BINARY_DIR}/mataConfig.cmake"  # output
+    INSTALL_DESTINATION lib/cmake/mata
+)
+
 
 # Uninstall target from https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
 # Add it only if we are building mata as the main project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 option (MATA_WERROR "Warnings should be handled as errors" OFF)
 option (MATA_ENABLE_COVERAGE "Build with coverage compiler flags" OFF)
 
-# For the case of WASM build we need to add -pthread option
-if (EMSCRIPTEN)
-	add_compile_options (-pthread)
-endif ()
-
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 	# Store compile commands into 'build/compile_commands.json', which are needed, beside others, for linters.
@@ -161,6 +156,8 @@ configure_package_config_file(
     "${CMAKE_CURRENT_BINARY_DIR}/mataConfig.cmake"  # output
     INSTALL_DESTINATION lib/cmake/mata
 )
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mataConfig.cmake"
+        DESTINATION lib/cmake/mata)
 
 
 # Uninstall target from https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake

--- a/README.md
+++ b/README.md
@@ -202,11 +202,22 @@ cmake_minimum_required (VERSION 3.15.0)
 project (mata-example)
 set (CMAKE_CXX_STANDARD 20)
 
-find_library(LIBMATA mata REQUIRED)
+# find either installed mata, or if it not installed fetch the latest version and build it
+include (FetchContent)
+find_package(mata QUIET)
+if(NOT mata_FOUND)
+	FetchContent_Declare(
+        mata
+        GIT_REPOSITORY https://github.com/VeriFIT/mata
+        GIT_TAG        devel # can be also commit hash or tag
+    )
+
+    FetchContent_MakeAvailable(mata)
+endif()
 
 add_executable(mata-example
     mata-example.cc)
-target_link_libraries(mata-example PUBLIC ${LIBMATA})
+target_link_libraries(mata-example PUBLIC libmata)
 ```
 
 ### Using the Python binding

--- a/cmake/mataConfig.cmake.in
+++ b/cmake/mataConfig.cmake.in
@@ -2,3 +2,4 @@
 
 # Include the exported targets
 include("${CMAKE_CURRENT_LIST_DIR}/mataTargets.cmake")
+find_package(Threads REQUIRED)

--- a/cmake/mataConfig.cmake.in
+++ b/cmake/mataConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+# Include the exported targets
+include("${CMAKE_CURRENT_LIST_DIR}/mataTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,10 @@ file (GLOB_RECURSE MATA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
 add_library (libmata STATIC
 	${MATA_SOURCES}
 	"${CMAKE_CURRENT_BINARY_DIR}/config.cc"
+	# we add files from the libraries here, so we create one static library libmata.a with everything and so that we can export only libmata
+	$<TARGET_OBJECTS:cudd>
+	$<TARGET_OBJECTS:simlib>
+	$<TARGET_OBJECTS:re2>
 )
 
 # libmata needs at least c++20
@@ -17,15 +21,23 @@ set_target_properties (libmata PROPERTIES
 	OUTPUT_NAME mata
 )
 
-target_include_directories (libmata PUBLIC "${PROJECT_SOURCE_DIR}/include/")
+# Just to be safe, RE2 might need it, for WASM it is also needed
+find_package(Threads REQUIRED)
+target_link_libraries(libmata PRIVATE Threads::Threads)
 
-# For the case of WASM build we need to link with pthread
-if (EMSCRIPTEN)
-	target_link_libraries (libmata PRIVATE pthread)
-endif ()
+target_link_libraries(libmata PUBLIC cudd_headers simlib_headers)
 
-target_link_libraries (libmata PUBLIC cudd simlib)
-target_link_libraries (libmata PRIVATE re2)
+target_include_directories (libmata 
+	PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+
+	# we need to add include files from the libraries
+	PRIVATE
+		$<TARGET_PROPERTY:cudd,INTERFACE_INCLUDE_DIRECTORIES>
+		$<TARGET_PROPERTY:simlib,INTERFACE_INCLUDE_DIRECTORIES>
+		$<TARGET_PROPERTY:re2,INTERFACE_INCLUDE_DIRECTORIES>
+)
 
 # Add common compile warnings.
 target_compile_options (libmata PRIVATE "$<$<CONFIG:DEBUG>:${MATA_COMMON_WARNINGS}>")


### PR DESCRIPTION
This PR makes mata a CMake package, so it can be found by `find_package(mata)` or fetched by `FetchContent_Declare` and `FetchContent_MakeAvailable`. See update readme for an example.