### PR TITLE
perf(strings): Disable reducing the trimmed NFTs

### DIFF
--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -380,8 +380,9 @@ public:
      *
      * @param[in] is_staying Boolean vector indicating which states are staying in the Delta.
      * @param[in] renaming Vector of states to rename the remaining state posts to.
+     * @return Self with defragmented delta.
      */
-    void defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
+    Delta& defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
     friend Delta defragment(const Delta& delta, const BoolVector& is_staying, const std::vector<State>& renaming);
 
     template <typename... Args>

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -372,7 +372,17 @@ public:
      */
     StatePost& mutable_state_post(State source);
 
+    /**
+     * @brief Defragment the Delta.
+     *
+     * This function removes all state posts which are not in @p is_staying and renames the remaining state posts
+     * according to @p renaming.
+     *
+     * @param[in] is_staying Boolean vector indicating which states are staying in the Delta.
+     * @param[in] renaming Vector of states to rename the remaining state posts to.
+     */
     void defragment(const BoolVector& is_staying, const std::vector<State>& renaming);
+    friend Delta defragment(const Delta& delta, const BoolVector& is_staying, const std::vector<State>& renaming);
 
     template <typename... Args>
     StatePost& emplace_back(Args&&... args) {
@@ -562,9 +572,23 @@ public:
      * @brief Get the maximum non-epsilon used symbol.
      */
     Symbol get_max_symbol() const;
+
 protected:
     std::vector<StatePost> state_posts_;
 }; // class Delta.
+
+/**
+ * @brief Defragment the Delta.
+ *
+ * This function removes all state posts which are not in @p is_staying and renames the remaining state posts
+ * according to @p renaming.
+ *
+ * @param[in] delta Delta to defragment.
+ * @param[in] is_staying Boolean vector indicating which states are staying in the Delta.
+ * @param[in] renaming Vector of states to rename the remaining state posts to.
+ * @return The defragmented Delta.
+ */
+Delta defragment(const Delta& delta, const BoolVector& is_staying, const std::vector<State>& renaming);
 
 /**
  * @brief Iterator over transitions represented as @c Transition instances.

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -494,6 +494,22 @@ public:
     std::vector<Transition> get_transitions_between(State state_from, State state_to) const;
 
     /**
+     * @brief Resize the delta to fit the given @p states.
+     * @tparam States A variadic parameter pack of states to resize the delta for.
+     * @param states States to resize the delta for.
+     */
+    template<typename... States> requires utils::AllOfType<State, States...>
+    Delta& resize_for_states(States... states) {
+        if constexpr (sizeof...(states) > 0) {
+            if (const State max_state{ std::max({ static_cast<State>(states)... }) }; max_state >= num_of_states()) {
+                reserve_on_insert(state_posts_, max_state);
+                state_posts_.resize(max_state + 1);
+            }
+        }
+        return *this;
+    }
+
+    /**
      * Get the set of states that are successors of the given @p state.
      * @param[in] state State from which successors are checked.
      * @return Set of states that are successors of the given @p state.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -1062,6 +1062,19 @@ utils::OrdVector<Symbol> get_symbols_to_work_with(const nfa::Nfa& nfa, const Alp
  */
 std::optional<Word> get_word_from_lang_difference(const Nfa &nfa_included, const Nfa &nfa_excluded);
 
+/**
+ * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.
+ *
+ * Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
+ * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
+ * the starting point of a path ending in a final state).
+ *
+ * @param nfa NFA to trim.
+ * @param[out] state_renaming Mapping of trimmed states to new states.
+ * @return @c this after trimming.
+ */
+Nfa trim(const Nfa& nfa, StateRenaming* state_renaming = nullptr, std::optional<std::reference_wrapper<const utils::SparseSet<State>>> initial_states = std::nullopt, std::optional<std::reference_wrapper<const utils::SparseSet<State>>> final_states = std::nullopt);
+
 } // namespace mata::nfa.
 
 namespace std {

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -248,7 +248,8 @@ public:
      *
      * @return BoolVector Bool vector whose `i`-th value is true iff the state `i` is useful.
      */
-    BoolVector get_useful_states() const;
+    // BoolVector get_useful_states() const;
+    BoolVector get_useful_states(std::optional<std::reference_wrapper<const utils::SparseSet<State>>> initial_states = std::nullopt, std::optional<std::reference_wrapper<const utils::SparseSet<State>>> final_states = std::nullopt) const;
 
     /**
      * @brief Structure for storing callback functions (event handlers) utilizing
@@ -268,9 +269,9 @@ public:
     /**
      * @brief Tarjan's SCC discover algorithm.
      *
-     * @param callback Callbacks class to instantiate callbacks for the Tarjan's algorithm.
+     * @param callback Callback class to instantiate callbacks for the Tarjan's algorithm.
      */
-    void tarjan_scc_discover(const TarjanDiscoverCallback& callback) const;
+    void tarjan_scc_discover(const TarjanDiscoverCallback& callback, std::optional<std::reference_wrapper<const utils::SparseSet<State>>> initial_states = std::nullopt) const;
 
     /**
      * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -145,11 +145,12 @@ public:
     // but useful in NFA where temporarily breaking the sortedness invariant allows for a faster algorithm (e.g. revert)
     reference push_back(Key&& t) { return emplace_back(std::move(t)); }
 
-    virtual inline void reserve(size_t size) { vec_.reserve(size); }
-    virtual inline void resize(size_t size) { vec_.resize(size); }
+    virtual void reserve(size_t size) { vec_.reserve(size); }
+    virtual void resize(size_t size) { vec_.resize(size); }
 
-    virtual inline iterator erase(const_iterator pos) { return vec_.erase(pos); }
-    virtual inline iterator erase(const_iterator first, const_iterator last) { return vec_.erase(first, last); }
+    virtual iterator erase(const_iterator pos) { return vec_.erase(pos); }
+    virtual iterator erase(const_iterator first, const_iterator last) { return vec_.erase(first, last); }
+    virtual size_type erase_if(std::function<bool(const value_type&)> should_erase) { return std::erase_if(vec_, should_erase); }
 
     virtual std::pair<iterator, bool> insert(const Key& x) {
         assert(is_sorted());
@@ -391,6 +392,7 @@ public:
     }
 
     const std::vector<Key>& to_vector() const { return vec_; }
+    std::vector<Key>& to_vector_mut() const { return vec_; }
 
     bool is_subset_of(const OrdVector& bigger) const {
         return std::includes(bigger.cbegin(), bigger.cend(), this->cbegin(), this->cend());

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -184,6 +184,10 @@ inline size_t hash_combine(size_t lhs, const T& rhs)
 } // hash_combine }}}
 
 
+// Concept to check if all types in a parameter pack are the same as a specified type U
+template<typename U, typename... Ts>
+concept AllOfType = (std::same_as<U, Ts> && ...);
+
 /**
  * @brief  Hashes a range
  *

--- a/src/applications/strings/noodlification.cc
+++ b/src/applications/strings/noodlification.cc
@@ -102,13 +102,9 @@ std::vector<seg_nfa::Noodle> seg_nfa::noodlify(const SegNfa& aut, const Symbol e
     const auto& segments{ segmentation.get_untrimmed_segments() };
 
     if (segments.size() == 1) {
-        std::shared_ptr<Nfa> segment = std::make_shared<Nfa>(segments[0]);
-        segment->trim();
-        if (segment->num_of_states() > 0 || include_empty) {
-            return {{ segment }};
-        } else {
-            return {};
-        }
+        if (auto segment{ std::make_shared<Nfa>(trim(segments[0])) }; segment->num_of_states() > 0 || include_empty) {
+            return { { segment } };
+        } else { return {}; }
     }
 
     State unused_state = aut.num_of_states(); // get some State not used in aut
@@ -185,33 +181,40 @@ void seg_nfa::segs_one_initial_final(
     for (auto iter = segments.begin(); iter != segments.end(); ++iter) {
         if (iter == segments.begin()) { // first segment will always have all initial states in noodles
             for (const State final_state: iter->final) {
-                Nfa segment_one_final = *iter;
-                segment_one_final.final = {final_state };
-                segment_one_final = reduce(segment_one_final.trim());
-
-                if (segment_one_final.num_of_states() > 0 || include_empty) {
-                    out[std::make_pair(unused_state, final_state)] = std::make_shared<Nfa>(segment_one_final);
-                }
+                // Nfa segment_one_final = *iter;
+                // segment_one_final.final = {final_state };
+                // segment_one_final = reduce(segment_one_final.trim());
+                if (Nfa segment_one_final = reduce(trim(*iter, nullptr,
+                                                    std::nullopt,
+                                                     std::make_optional(utils::SparseSet<State>{final_state})));
+                    segment_one_final.num_of_states() > 0 || include_empty) {
+                    out[std::make_pair(unused_state, final_state)] = std::make_shared<Nfa>(std::move(segment_one_final));
+                    }
             }
         } else if (iter + 1 == segments.end()) { // last segment will always have all final states in noodles
             for (const State init_state: iter->initial) {
-                Nfa segment_one_init = *iter;
-                segment_one_init.initial = {init_state };
-                segment_one_init = reduce(segment_one_init.trim());
-
-                if (segment_one_init.num_of_states() > 0 || include_empty) {
-                    out[std::make_pair(init_state, unused_state)] = std::make_shared<Nfa>(segment_one_init);
+                // Nfa segment_one_init = *iter;
+                // segment_one_init.initial = {init_state };
+                // segment_one_init = reduce(segment_one_init.trim());
+                if (Nfa segment_one_init = reduce(trim(*iter, nullptr,
+                                              std::make_optional(utils::SparseSet<State>{init_state}),
+                                              std::nullopt));
+                    segment_one_init.num_of_states() > 0 || include_empty) {
+                    out[std::make_pair(init_state, unused_state)] = std::make_shared<Nfa>(std::move(segment_one_init));
                 }
             }
         } else { // the segments in-between
             for (const State init_state: iter->initial) {
                 for (const State final_state: iter->final) {
-                    Nfa segment_one_init_final = *iter;
-                    segment_one_init_final.initial = {init_state };
-                    segment_one_init_final.final = {final_state };
-                    segment_one_init_final = reduce(segment_one_init_final.trim());
-                    if (segment_one_init_final.num_of_states() > 0 || include_empty) {
-                        out[std::make_pair(init_state, final_state)] = std::make_shared<Nfa>(segment_one_init_final);
+                    // Nfa segment_one_init_final = *iter;
+                    // segment_one_init_final.initial = {init_state };
+                    // segment_one_init_final.final = {final_state };
+                    // segment_one_init_final = reduce(segment_one_init_final.trim());
+                    if (Nfa segment_one_init_final = reduce(trim(*iter, nullptr,
+                                                         std::make_optional(utils::SparseSet<State>{init_state}),
+                                                         std::make_optional(utils::SparseSet<State>{final_state})));
+                        segment_one_init_final.num_of_states() > 0 || include_empty) {
+                        out[std::make_pair(init_state, final_state)] = std::make_shared<Nfa>(std::move(segment_one_init_final));
                     }
                 }
             }
@@ -230,11 +233,8 @@ std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_mult_eps(const
     VisitedEpsilonsCounterVector def_eps_vector = process_eps_map(def_eps_map);
 
     if (segments.size() == 1) {
-        std::shared_ptr<Nfa> segment = std::make_shared<Nfa>(segments[0]);
-        segment->trim();
-        if (segment->num_of_states() > 0 || include_empty) {
-            return {{ {segment, def_eps_vector} } };
-        } else {
+        if (auto segment{ std::make_shared<Nfa>(trim(segments[0])) };
+            segment->num_of_states() > 0 || include_empty) { return { { { segment, def_eps_vector } } }; } else {
             return {};
         }
     }

--- a/src/applications/strings/noodlification.cc
+++ b/src/applications/strings/noodlification.cc
@@ -222,7 +222,8 @@ void seg_nfa::segs_one_initial_final(
     }
 }
 
-std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_mult_eps(const SegNfa& aut, const std::set<Symbol>& epsilons, bool include_empty) {
+std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_mult_eps(
+    const SegNfa& aut, const std::set<Symbol>& epsilons, bool include_empty) {
     Segmentation segmentation{ aut, epsilons };
     const auto& segments{ segmentation.get_untrimmed_segments() };
 
@@ -234,9 +235,8 @@ std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_mult_eps(const
 
     if (segments.size() == 1) {
         if (auto segment{ std::make_shared<Nfa>(trim(segments[0])) };
-            segment->num_of_states() > 0 || include_empty) { return { { { segment, def_eps_vector } } }; } else {
-            return {};
-        }
+            segment->num_of_states() > 0 || include_empty) { return { { { segment, def_eps_vector } } }; }
+        return {};
     }
 
     State unused_state = aut.num_of_states(); // get some State not used in aut
@@ -289,13 +289,13 @@ std::vector<seg_nfa::NoodleWithEpsilonsCounter> seg_nfa::noodlify_mult_eps(const
 
             for(const State& fn : fins) {
                 auto seg_iter = segments_one_initial_final.find({ tr.target, fn});
-                if(seg_iter == segments_one_initial_final.end())
-                    continue;
+                if (seg_iter == segments_one_initial_final.end()) { continue; }
 
                 SegItem new_item = item; // deep copy
                 new_item.seg_id++;
                 // do not include segments with trivial epsilon language
-                if(seg_iter->second->final.size() != 1 || seg_iter->second->delta.num_of_transitions() > 0) { // L(seg_iter) != {epsilon}
+                if (seg_iter->second->final.size() != 1 || seg_iter->second->delta.num_of_transitions() > 0) {
+                    // L(seg_iter) != {epsilon}
                     new_item.noodle.emplace_back(seg_iter->second, process_eps_map(visited_eps[tr.target]));
                 }
                 new_item.fin = fn;

--- a/src/applications/strings/noodlification.cc
+++ b/src/applications/strings/noodlification.cc
@@ -184,9 +184,15 @@ void seg_nfa::segs_one_initial_final(
                 // Nfa segment_one_final = *iter;
                 // segment_one_final.final = {final_state };
                 // segment_one_final = reduce(segment_one_final.trim());
-                if (Nfa segment_one_final = reduce(trim(*iter, nullptr,
-                                                    std::nullopt,
-                                                     std::make_optional(utils::SparseSet<State>{final_state})));
+                if (Nfa segment_one_final =
+                            // reduce(
+                                trim(
+                                    *iter, nullptr,
+                                    std::nullopt,
+                                    std::make_optional(utils::SparseSet<State>{ final_state })
+                                )
+                            // )
+                            ;
                     segment_one_final.num_of_states() > 0 || include_empty) {
                     out[std::make_pair(unused_state, final_state)] = std::make_shared<Nfa>(std::move(segment_one_final));
                     }
@@ -196,9 +202,15 @@ void seg_nfa::segs_one_initial_final(
                 // Nfa segment_one_init = *iter;
                 // segment_one_init.initial = {init_state };
                 // segment_one_init = reduce(segment_one_init.trim());
-                if (Nfa segment_one_init = reduce(trim(*iter, nullptr,
-                                              std::make_optional(utils::SparseSet<State>{init_state}),
-                                              std::nullopt));
+                if (Nfa segment_one_init =
+                            // reduce(
+                            trim(
+                                *iter, nullptr,
+                                std::make_optional(utils::SparseSet<State>{ init_state }),
+                                std::nullopt
+                            )
+                    // )
+                    ;
                     segment_one_init.num_of_states() > 0 || include_empty) {
                     out[std::make_pair(init_state, unused_state)] = std::make_shared<Nfa>(std::move(segment_one_init));
                 }

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -366,39 +366,24 @@ Delta mata::nfa::defragment(const Delta &delta, const BoolVector &is_staying, co
     return delta_defragmented;
 }
 
-void Delta::defragment(const BoolVector& is_staying, const std::vector<State>& renaming) {
-    //TODO: this function seems to be unreadable, should be refactored, maybe into several functions with a clear functionality?
-
-    //first, indexes of post are filtered (places of to be removed states are taken by states on their right)
-    size_t move_index{ 0 };
-    std::erase_if(state_posts_,
-         [&](StatePost&) -> bool {
-             size_t prev{ move_index };
-             ++move_index;
-             return !is_staying[prev];
-         }
-    );
-
-    //this iterates through every post and every move, filters and renames states,
-    //and then removes moves that became empty.
-    for (State q=0,size=state_posts_.size(); q < size; ++q) {
-        StatePost & p = mutable_state_post(q);
-        for (auto move = p.begin(); move < p.end(); ++move) {
-            move->targets.erase(
-                    std::remove_if(move->targets.begin(), move->targets.end(), [&](State q) -> bool {
-                        return !is_staying[q];
-                    }),
-                    move->targets.end()
-            );
-            move->targets.rename(renaming);
+Delta& Delta::defragment(const BoolVector& is_staying, const std::vector<State>& renaming) {
+    size_t source_new{ 0 };
+    for (size_t source_orig{ 0 }, num_of_states{ this->num_of_states() }; source_orig < num_of_states; ++source_orig) {
+        if (!is_staying[source_orig]) { continue; } // Skip source states not staying.
+        StatePost& state_post = state_posts_[source_orig];
+        for (auto state_post_it{ state_post.begin() }; state_post_it != state_post.end();) {
+            StateSet& targets{ state_post_it->targets };
+            targets.erase_if([&is_staying](const State& target) { return !is_staying[target]; });
+            targets.rename(renaming);
+            if (targets.empty()) { state_post_it = state_post.erase(state_post_it); } else { ++state_post_it; }
         }
-        p.erase(
-                std::remove_if(p.begin(), p.end(), [&](SymbolPost& move) -> bool {
-                    return move.targets.empty();
-                }),
-                p.end()
-        );
+        // Move the filtered state post to the new position, if needed.
+        if (source_new != source_orig) { state_posts_[source_new] = std::move(state_post); }
+        ++source_new;
     }
+    // Resize to remove filtered-out state posts.
+    state_posts_.resize(source_new);
+    return *this;
 }
 
 bool Delta::operator==(const Delta& other) const {

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -116,10 +116,7 @@ std::vector<Transition> Delta::get_transitions_between(const State state_from, c
 }
 
 void Delta::add(const State source, Symbol symbol, const State target) {
-    if (const State max_state{ std::max(source, target) }; max_state >= state_posts_.size()) {
-        reserve_on_insert(state_posts_, max_state);
-        state_posts_.resize(max_state + 1);
-    }
+    resize_for_states(source, target);
 
     if (StatePost& state_transitions{ state_posts_[source] }; state_transitions.empty()) {
         state_transitions.insert({ symbol, target });
@@ -140,11 +137,7 @@ void Delta::add(const State source, Symbol symbol, const State target) {
 
 void Delta::add(const State source, const Symbol symbol, const StateSet& targets) {
     if(targets.empty()) { return; }
-
-    if (const State max_state{ std::max(source, targets.back()) }; max_state >= state_posts_.size()) {
-        reserve_on_insert(state_posts_, max_state + 1);
-        state_posts_.resize(max_state + 1);
-    }
+    resize_for_states(source, targets.back());
 
     if (StatePost& state_transitions{ state_posts_[source] }; state_transitions.empty()) {
         state_transitions.insert({ symbol, targets });

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -11,15 +11,13 @@
 #include "mata/nfa/types.hh"
 #include "mata/utils/sparse-set.hh"
 
-
 #include <algorithm>
 #include <functional>
 #include <iterator>
 #include <list>
 #include <queue>
-#include <utility>
 #include <ranges>
-
+#include <utility>
 
 using namespace mata::utils;
 using namespace mata::nfa;

--- a/src/nfa/delta.cc
+++ b/src/nfa/delta.cc
@@ -6,17 +6,20 @@
  *  well as iterating over transitions.
  */
 
+#include "mata/nfa/delta.hh"
+#include "mata/nfa/nfa.hh"
 #include "mata/nfa/types.hh"
 #include "mata/utils/sparse-set.hh"
-#include "mata/nfa/nfa.hh"
-#include "mata/nfa/delta.hh"
 
 
 #include <algorithm>
-#include <list>
+#include <functional>
 #include <iterator>
 #include <list>
 #include <queue>
+#include <utility>
+#include <ranges>
+
 
 using namespace mata::utils;
 using namespace mata::nfa;
@@ -334,6 +337,33 @@ StatePost& Delta::mutable_state_post(const State q) {
     }
 
     return state_posts_[q];
+}
+
+Delta mata::nfa::defragment(const Delta &delta, const BoolVector &is_staying, const std::vector<State> &renaming) {
+    auto filter_rename_symbol_post = [&](const SymbolPost& symbol_post) {
+        SymbolPost new_symbol_post{ symbol_post.symbol };
+        for (const State& target : symbol_post.targets) {
+            if (!is_staying[target]) { continue; }
+            new_symbol_post.push_back(renaming[target]);
+        }
+        return new_symbol_post;
+    };
+    auto filter_rename_state_post = [&](const StatePost& state_post, const std::function<SymbolPost(const SymbolPost&)>& transform_symbol_post) {
+        StatePost result{};
+        for (const SymbolPost& symbol_post : state_post) {
+            SymbolPost new_symbol_post = transform_symbol_post(symbol_post);
+            if (new_symbol_post.empty()) { continue; }
+            result.push_back(std::move(new_symbol_post));
+        }
+        return result;
+    };
+
+    Delta delta_defragmented{};
+    for (State source{ 0 }; source < delta.num_of_states(); ++source) {
+        if (!is_staying[source]) { continue; }
+        delta_defragmented.emplace_back(filter_rename_state_post(delta[source], filter_rename_symbol_post));
+    }
+    return delta_defragmented;
 }
 
 void Delta::defragment(const BoolVector& is_staying, const std::vector<State>& renaming) {

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -231,13 +231,15 @@ namespace {
  *    in @p tarjan_stack as it contains states that can reach this closed SCC.
  *
  */
-void Nfa::tarjan_scc_discover(const TarjanDiscoverCallback& callback) const {
+void Nfa::tarjan_scc_discover(
+    const TarjanDiscoverCallback& callback,
+    const std::optional<std::reference_wrapper<const SparseSet<State>>> initial_states) const {
     std::vector<TarjanNodeData> node_info(this->num_of_states());
     std::vector<State> program_stack;
     std::vector<State> tarjan_stack;
     unsigned long index_cnt = 0;
 
-    for(const State& q0 : initial) {
+    for(const State& q0 : (initial_states.value_or(this->initial)).get()) {
         program_stack.push_back(q0);
     }
 
@@ -311,13 +313,16 @@ void Nfa::tarjan_scc_discover(const TarjanDiscoverCallback& callback) const {
     }
 }
 
-BoolVector Nfa::get_useful_states() const {
+BoolVector Nfa::get_useful_states(const std::optional<std::reference_wrapper<const SparseSet<State>>> initial_states, const std::optional<std::reference_wrapper<const SparseSet<State>>> final_states) const {
     BoolVector useful(this->num_of_states(), false);
     bool final_scc = false;
 
+    const SparseSet<State>& used_initial_states{ initial_states.value_or(initial) };
+    const SparseSet<State>& used_final_states{ final_states.value_or(this->final) };
+
     TarjanDiscoverCallback callback {};
-    callback.state_discover = [&](State state) -> bool {
-        if(this->final.contains(state)) {
+    callback.state_discover = [&](const State state) -> bool {
+        if(used_final_states.contains(state)) {
             useful[state] = true;
         }
         return false;
@@ -336,18 +341,18 @@ BoolVector Nfa::get_useful_states() const {
         final_scc = false;
         return false;
     };
-    callback.scc_state_discover = [&](State state) {
+    callback.scc_state_discover = [&](const State state) {
         if(useful[state]) {
             final_scc = true;
         }
     };
-    callback.succ_state_discover = [&](State act_state, State next_state) {
+    callback.succ_state_discover = [&](const State act_state, const State next_state) {
         if(useful[next_state]) {
             useful[act_state] = true;
         }
     };
 
-    tarjan_scc_discover(callback);
+    tarjan_scc_discover(callback, used_initial_states);
     return useful;
 }
 

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -136,7 +136,7 @@ Nfa& Nfa::trim(StateRenaming* state_renaming) {
     useful_states.clear();
     useful_states = useful_states();
 #else
-    BoolVector useful_states{ get_useful_states() };
+    const BoolVector useful_states{ get_useful_states() };
 #endif
     const size_t useful_states_size{ useful_states.size() };
     std::vector<State> renaming(useful_states_size);
@@ -149,10 +149,10 @@ Nfa& Nfa::trim(StateRenaming* state_renaming) {
 
     delta.defragment(useful_states, renaming);
 
-    auto is_state_useful = [&](State q){return q < useful_states_size && useful_states[q];};
+    auto is_state_useful = [&](const State q){return q < useful_states_size && useful_states[q];};
     initial.filter(is_state_useful);
     final.filter(is_state_useful);
-    auto rename_state = [&](State q){return renaming[q];};
+    auto rename_state = [&](const State q){return renaming[q];};
     initial.rename(rename_state);
     final.rename(rename_state);
     initial.truncate();
@@ -167,6 +167,58 @@ Nfa& Nfa::trim(StateRenaming* state_renaming) {
         }
     }
     return *this;
+}
+
+
+Nfa mata::nfa::trim(const Nfa &nfa, StateRenaming *state_renaming,
+                       std::optional<std::reference_wrapper<const SparseSet<State>> > initial_states,
+                       std::optional<std::reference_wrapper<const SparseSet<State>> > final_states) {
+    if (!initial_states) { initial_states = nfa.initial; }
+    if (!final_states) { final_states = nfa.final; }
+
+    // Compute useful states using Tarjan's algorithm.
+    // The result is a bool vector where true means the state is useful.
+#ifdef _STATIC_STRUCTURES_
+    BoolVector useful_states{ nfa.get_useful_states(initial_states, final_states) };
+    useful_states.clear();
+    useful_states = nfa.get_useful_states(initial_states, final_states);
+#else
+    const BoolVector useful_states{ nfa.get_useful_states(initial_states, final_states) };
+#endif
+    Nfa nfa_trimmed{};
+
+    const size_t useful_states_size{ useful_states.size() };
+    std::vector<State> renaming(useful_states_size);
+    for (State new_state{ 0 }, orig_state{ 0 }; orig_state < useful_states_size; ++orig_state) {
+        if (useful_states[orig_state]) {
+            renaming[orig_state] = new_state;
+            ++new_state;
+        }
+    }
+
+    nfa_trimmed.delta = defragment(nfa.delta, useful_states, renaming);
+
+    nfa_trimmed.initial = initial_states.value_or(nfa.initial);
+    nfa_trimmed.final = final_states.value_or(nfa.final);
+
+    auto is_state_useful = [&](const State q){return q < useful_states.size() && useful_states[q];};
+    nfa_trimmed.initial.filter(is_state_useful);
+    nfa_trimmed.final.filter(is_state_useful);
+    auto rename_state = [&](const State q){return renaming[q];};
+    nfa_trimmed.initial.rename(rename_state);
+    nfa_trimmed.final.rename(rename_state);
+    nfa_trimmed.initial.truncate();
+    nfa_trimmed.final.truncate();
+    if (state_renaming != nullptr) {
+        state_renaming->clear();
+        state_renaming->reserve(useful_states_size);
+        for (State q{ 0 }; q < useful_states_size; ++q) {
+            if (useful_states[q]) {
+                (*state_renaming)[q] = renaming[q];
+            }
+        }
+    }
+    return nfa_trimmed;
 }
 
 namespace {
@@ -187,7 +239,7 @@ namespace {
 
         TarjanNodeData() = default;
 
-        TarjanNodeData(State q, const Delta& delta, unsigned long index)
+        TarjanNodeData(const State q, const Delta& delta, const unsigned long index)
             : index(index), lowlink(index), initilized(true), on_stack(true) {
             const StatePost::Moves moves{ delta[q].moves() };
             current_move = moves.begin();
@@ -360,7 +412,7 @@ bool Nfa::is_lang_empty_scc() const {
     bool accepting_state = false;
 
     TarjanDiscoverCallback callback {};
-    callback.state_discover = [&](State state) -> bool {
+    callback.state_discover = [&](const State state) -> bool {
         if(this->final.contains(state)) {
             accepting_state = true;
             return true;

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1,4 +1,5 @@
-/* nfa.cc -- operations for NFA
+/** @file
+ * @brief Operations on NFAs.
  */
 
 #include <algorithm>

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1328,26 +1328,32 @@ std::optional<mata::Word> Nfa::get_word(const std::optional<Symbol> first_epsilo
         }
 
         // Try to recursively walk through the NFA transitions from the current @p initial_state until a final state is
-        //  encountered or all states reachable from @p initial_state are searched without finding any final state.
+        //  encountered, or all states reachable from @p initial_state are searched without finding any final state.
         while (!worklist.empty()) {
             // Using references to iterators to be able to increment the top-most element in the worklist in place.
-            auto& [state_post_it, state_post_end, targets_it]{ worklist.back() };
-            if (state_post_it != state_post_end) {
+            if (auto &[state_post_it, state_post_end, targets_it]{worklist.back()}; state_post_it != state_post_end) {
                 if (targets_it != state_post_it->targets.cend()) {
-                    if (searched[*targets_it]) { ++targets_it; continue; }
-                    if (final.contains(*targets_it)) { final_found = true; break; }
+                    if (searched[*targets_it]) {
+                        ++targets_it;
+                        continue;
+                    }
+                    if (final.contains(*targets_it)) {
+                        final_found = true;
+                        break;
+                    }
                     searched[*targets_it] = true;
-                    const StatePost& state_post{ delta[*targets_it] };
-                    if (!state_post.empty()) {
-                        auto new_state_post_it{ state_post.cbegin() };
-                        auto new_targets_it{ new_state_post_it->cbegin() };
+                    if (const StatePost &state_post{delta[*targets_it]}; !state_post.empty()) {
+                        auto new_state_post_it{state_post.cbegin()};
+                        auto new_targets_it{new_state_post_it->cbegin()};
                         worklist.emplace_back(new_state_post_it, state_post.cend(), new_targets_it);
                     } else { ++targets_it; }
-                } else { // targets_it == state_post_it->targets.cend().
+                } else {
+                    // targets_it == state_post_it->targets.cend().
                     ++state_post_it;
                     if (state_post_it != state_post_end) { targets_it = state_post_it->cbegin(); }
                 }
-            } else { // state_post_it == state_post_end.
+            } else {
+                // state_post_it == state_post_end.
                 worklist.pop_back();
                 if (!worklist.empty()) {
                     auto& [_prev_state_post_it, _prev_state_post_end, prev_targets_it]{ worklist.back() };
@@ -1361,8 +1367,10 @@ std::optional<mata::Word> Nfa::get_word(const std::optional<Symbol> first_epsilo
     if (!final_found) { return std::nullopt; }
     Word word;
     word.reserve(worklist.size());
-    for (const auto& [symbol_post_it, symbol_post_end, _targets_it]: worklist) {
-        if (!first_epsilon.has_value() || symbol_post_it->symbol < first_epsilon) { word.push_back(symbol_post_it->symbol); }
+    for (const auto &[symbol_post_it, symbol_post_end, _targets_it]: worklist) {
+        if (!first_epsilon.has_value() || symbol_post_it->symbol < first_epsilon) {
+            word.push_back(symbol_post_it->symbol);
+        }
     }
     return word;
 }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -400,6 +400,7 @@ Nft Nft::get_one_letter_aut(const std::set<Level>& levels_to_keep, const Symbol 
 
 void Nft::get_one_letter_aut(Nft& result) const { result = get_one_letter_aut(); }
 
+// TODO(nft): Implement for NFTs.
 StateSet Nft::post(const StateSet& states, const Symbol symbol, const EpsilonClosureOpt epsilon_closure_opt) const {
     StateSet res{};
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -25,7 +25,7 @@ using mata::BoolVector;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 
-constexpr std::string mata::nft::TYPE_NFT = "NFT";
+const std::string mata::nft::TYPE_NFT = "NFT";
 
 Levels::Levels(const size_t num_of_levels, const size_t count, const Level value)
     : super(count, value), num_of_levels{ num_of_levels } {

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -4520,24 +4520,25 @@ TEST_CASE("mata::nfa::Nfa::get_word()") {
         CHECK(aut.get_word() == Word{ 'b', 'c' });
     }
 
-    SECTION("Complex automaton with self loops, epsilons, and nonterminating states, one separate final") {
-        Nfa aut{};
-        aut.initial = { 0, 6 };
-        aut.final = { 7 };
-        aut.delta.add(6, 'd', 7);
-        aut.delta.add(0, 'a', 0);
-        aut.delta.add(0, 'b', 1);
-        aut.delta.add(1, 'b', 1);
-        aut.delta.add(0, 'b', 2);
-        aut.delta.add(2, EPSILON, 3);
-        aut.delta.add(2, EPSILON, 1);
-        aut.delta.add(2, 'a', 0);
-        aut.delta.add(2, 'a', 2);
-        aut.delta.add(3, 'a', 5);
-        aut.delta.add(3, 'c', 4);
-        aut.delta.add(4, 'a', 4);
-        CHECK(aut.get_word() == Word{ 'd' });
-    }
+    // FIXME: Causes a nondeterministic segmentation fault in the get_word() function.
+    // SECTION("Complex automaton with self loops, epsilons, and nonterminating states, one separate final") {
+    //     Nfa aut{};
+    //     aut.initial = { 0, 6 };
+    //     aut.final = { 7 };
+    //     aut.delta.add(6, 'd', 7);
+    //     aut.delta.add(0, 'a', 0);
+    //     aut.delta.add(0, 'b', 1);
+    //     aut.delta.add(1, 'b', 1);
+    //     aut.delta.add(0, 'b', 2);
+    //     aut.delta.add(2, EPSILON, 3);
+    //     aut.delta.add(2, EPSILON, 1);
+    //     aut.delta.add(2, 'a', 0);
+    //     aut.delta.add(2, 'a', 2);
+    //     aut.delta.add(3, 'a', 5);
+    //     aut.delta.add(3, 'c', 4);
+    //     aut.delta.add(4, 'a', 4);
+    //     CHECK(aut.get_word() == Word{ 'd' });
+    // }
 
     SECTION("Break after finding the first final without iterating over other initial states") {
         Nfa aut{};

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -3904,19 +3904,17 @@ TEST_CASE("mata::nfa::get_useful_states() for profiling", "[.profiling],[useful_
     }
 }
 
-TEST_CASE("mata::nfa::trim() trivial") {
-    Nfa aut{1};
-    aut.initial.insert(0);
-    aut.final.insert(0);
-    aut.trim();
-}
-
-TEST_CASE("mata::nfa::trim()")
-{
+TEST_CASE("mata::nfa::Nfa::trim()") {
     Nfa orig_aut{20};
     FILL_WITH_AUT_A(orig_aut);
     orig_aut.delta.remove(1, 'a', 10);
 
+    SECTION("trivial") {
+        Nfa aut{1};
+        aut.initial.insert(0);
+        aut.final.insert(0);
+        aut.trim();
+    }
 
     SECTION("Without state map") {
         Nfa aut{orig_aut};
@@ -3960,8 +3958,59 @@ TEST_CASE("mata::nfa::trim()")
     }
 }
 
-TEST_CASE("mata::nfa::Nfa::delta.empty()")
-{
+TEST_CASE("mata::nfa::trim()") {
+    Nfa orig_aut{20};
+    FILL_WITH_AUT_A(orig_aut);
+    orig_aut.delta.remove(1, 'a', 10);
+
+    SECTION("trivial") {
+        Nfa aut{1};
+        aut.initial.insert(0);
+        aut.final.insert(0);
+        aut.trim();
+    }
+
+    SECTION("Without state map") {
+        Nfa aut{ orig_aut };
+        Nfa trimmed_aut{ trim(orig_aut) };
+        CHECK(trimmed_aut.initial.size() == orig_aut.initial.size());
+        CHECK(trimmed_aut.final.size() == orig_aut.final.size());
+        CHECK(trimmed_aut.num_of_states() == 4);
+        for (const Word &word: get_shortest_words(orig_aut)) {
+            CHECK(trimmed_aut.is_in_lang(Run{word,{}}));
+        }
+
+        trimmed_aut.final.erase(2); // '2' is the new final state in the earlier trimmed automaton.
+        trimmed_aut = trim(trimmed_aut);
+        CHECK(trimmed_aut.delta.empty());
+        CHECK(trimmed_aut.num_of_states() == 0);
+    }
+
+    SECTION("With state map") {
+        Nfa aut{orig_aut};
+        StateRenaming state_map{};
+        aut = trim(aut, &state_map);
+        CHECK(aut.initial.size() == orig_aut.initial.size());
+        CHECK(aut.final.size() == orig_aut.final.size());
+        CHECK(aut.num_of_states() == 4);
+        for (const Word &word: get_shortest_words(orig_aut)) {
+            CHECK(aut.is_in_lang(Run{word,{}}));
+        }
+        REQUIRE(state_map.size() == 4);
+        CHECK(state_map.at(1) == 0);
+        CHECK(state_map.at(3) == 1);
+        CHECK(state_map.at(7) == 3);
+        CHECK(state_map.at(5) == 2);
+
+        aut.final.erase(2); // '2' is the new final state in the earlier trimmed automaton.
+        aut = trim(aut, &state_map);
+        CHECK(aut.delta.empty());
+        CHECK(aut.num_of_states() == 0);
+        CHECK(state_map.empty());
+    }
+}
+
+TEST_CASE("mata::nfa::Nfa::delta.empty()") {
     Nfa aut{};
 
     SECTION("Empty automaton")

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -4569,25 +4569,25 @@ TEST_CASE("mata::nfa::Nfa::get_word()") {
         CHECK(aut.get_word() == Word{ 'b', 'c' });
     }
 
-    // FIXME: Causes a nondeterministic segmentation fault in the get_word() function.
-    // SECTION("Complex automaton with self loops, epsilons, and nonterminating states, one separate final") {
-    //     Nfa aut{};
-    //     aut.initial = { 0, 6 };
-    //     aut.final = { 7 };
-    //     aut.delta.add(6, 'd', 7);
-    //     aut.delta.add(0, 'a', 0);
-    //     aut.delta.add(0, 'b', 1);
-    //     aut.delta.add(1, 'b', 1);
-    //     aut.delta.add(0, 'b', 2);
-    //     aut.delta.add(2, EPSILON, 3);
-    //     aut.delta.add(2, EPSILON, 1);
-    //     aut.delta.add(2, 'a', 0);
-    //     aut.delta.add(2, 'a', 2);
-    //     aut.delta.add(3, 'a', 5);
-    //     aut.delta.add(3, 'c', 4);
-    //     aut.delta.add(4, 'a', 4);
-    //     CHECK(aut.get_word() == Word{ 'd' });
-    // }
+    // FIXME: 1 Causes a nondeterministic segmentation fault in the get_word() function.
+    SECTION("Complex automaton with self loops, epsilons, and nonterminating states, one separate final") {
+        Nfa aut{};
+        aut.initial = { 0, 6 };
+        aut.final = { 7 };
+        aut.delta.add(6, 'd', 7);
+        aut.delta.add(0, 'a', 0);
+        aut.delta.add(0, 'b', 1);
+        aut.delta.add(1, 'b', 1);
+        aut.delta.add(0, 'b', 2);
+        aut.delta.add(2, EPSILON, 3);
+        aut.delta.add(2, EPSILON, 1);
+        aut.delta.add(2, 'a', 0);
+        aut.delta.add(2, 'a', 2);
+        aut.delta.add(3, 'a', 5);
+        aut.delta.add(3, 'c', 4);
+        aut.delta.add(4, 'a', 4);
+        CHECK(aut.get_word() == Word{ 'd' });
+    }
 
     SECTION("Break after finding the first final without iterating over other initial states") {
         Nfa aut{};
@@ -4600,6 +4600,7 @@ TEST_CASE("mata::nfa::Nfa::get_word()") {
         CHECK(aut.get_word() == Word{ 'a', 'c' });
    }
 
+    // FIXME: 2 Causes a nondeterministic segmentation fault in the get_word() function.
     SECTION("Complex automaton with self loops, epsilons, and nonterminating states, no reachable final") {
         Nfa aut{};
         aut.initial = { 0 };


### PR DESCRIPTION
This PR disables calling `reduce()` on the trimmed NFTs created during segmentation in noodlification.