### PR TITLE
fix a build error in mingw64 environment

### DIFF
--- a/src/inter-aut.cc
+++ b/src/inter-aut.cc
@@ -410,7 +410,7 @@ size_t mata::IntermediateAut::get_number_of_disjuncts() const
             for (const auto &ch: gr->children)
                 stack.push_back(&ch);
         }
-        res += std::max(trans_disjuncts, 1ul);
+        res += std::max(trans_disjuncts, size_t{1});
     }
 
     return res;


### PR DESCRIPTION
In windows mingw64, size_t is unsigned long long, so `1ul` will introduce type mismatch