### PR TITLE
Bug fix: update levels in `Nft::unite_nondet_with`

### DIFF
--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -973,6 +973,9 @@ Nft& Nft::unite_nondet_with(const Nft& aut) {
     this->initial.reserve(n + aut_states);
     for (const State& aut_ini : aut_initial_copy) { this->initial.insert(upd_fnc(aut_ini)); }
 
+    // update levels
+    this->levels.append(aut.levels);
+
     return *this;
 }
 


### PR DESCRIPTION
Currently, the `Nft::unite_nondet_with` function in `src/nft/operations.cc` copies the levels of the LHS transducer, but does not update them with the RHS levels. This leads to unexpected segfaults when trying to get the level of some state in the result which is part of the RHS nft.