### PR TITLE
feat: add support for per-level alphabet in NFT

### DIFF
--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -548,9 +548,11 @@ public:
      * @throws std::runtime_error If @p level is missing in @c MultiLevel mode, out of range, or the entry is null.
      */
     const Alphabet& for_level(std::optional<Level> level = std::nullopt) const;
+    Alphabet& for_level(std::optional<Level> level = std::nullopt);
 
     /// Alias for @c for_level.
     const Alphabet& operator[](std::optional<Level> level) const { return for_level(level); }
+    Alphabet& operator[](std::optional<Level> level) { return for_level(level); }
 };
 
 /**

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -5,6 +5,7 @@
 #define MATA_ALPHABET_HH
 
 #include <limits>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -15,6 +16,7 @@
 namespace mata {
 
 using Symbol = unsigned;
+using Level = unsigned;
 using Word = std::vector<Symbol>;
 using WordName = std::vector<std::string>;
 
@@ -24,24 +26,13 @@ using WordName = std::vector<std::string>;
 class Alphabet {
 public:
     /**
-     * @brief Translate a string into a symbol.
+     * @brief Translate a string into a symbol, optionally on a specific level.
      *
      * @param[in] symb Symbol name to translate.
+     * @param[in] level Optional level on which the translation should happen.
      * @return Translated symbol value.
      */
-    virtual Symbol translate_symb(const std::string &symb) = 0;
-
-    /**
-     * @brief Translate a string into a symbol on a specific level.
-     *
-     * @param[in] symb Symbol name to translate.
-     * @param[in] level Level on which the translation should happen.
-     * @return Translated symbol value.
-     */
-    virtual Symbol translate_symb(const std::string &symb, size_t level) {
-        (void)level;
-        return translate_symb(symb);
-    }
+    virtual Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) = 0;
 
     /**
      * Translate sequence of symbol names to sequence of their respective values.
@@ -52,71 +43,44 @@ public:
     }
 
     /**
-     * @brief Translate internal @p symbol representation back to its original string name.
+     * @brief Translate internal @p symbol representation back to its original string name,
+     *  optionally on a specific level.
      *
      * Throws an exception when the @p symbol is missing in the alphabet.
      * @param[in] symbol Symbol to translate.
+     * @param[in] level Optional level on which the reverse translation should happen.
      * @return @p symbol original name.
      */
-    virtual std::string reverse_translate_symbol(Symbol symbol) const = 0;
-
-    /**
-     * @brief Translate internal @p symbol representation back to its original string name on a specific level.
-     *
-     * @param[in] symbol Symbol to translate.
-     * @param[in] level Level on which the reverse translation should happen.
-     * @return @p symbol original name.
-     */
-    virtual std::string reverse_translate_symbol(Symbol symbol, size_t level) const {
-        (void)level;
-        return reverse_translate_symbol(symbol);
-    }
+    virtual std::string reverse_translate_symbol(
+        Symbol symbol, std::optional<Level> level = std::nullopt) const = 0;
 
     /// also translates strings to symbols
     Symbol operator[](const std::string &symb) { return this->translate_symb(symb); }
 
     /**
-     * @brief Get a set of all symbols in the alphabet.
+     * @brief Get a set of all symbols in the alphabet, optionally on a specific level.
      *
      * The result does not have to equal the list of symbols in the automaton using this alphabet.
+     * @param[in] level Optional level on which the symbols should be retrieved.
      */
-    virtual utils::OrdVector<Symbol> get_alphabet_symbols() const { throw std::runtime_error("Unimplemented"); }
-
-    /**
-     * @brief Get a set of all symbols in the alphabet on a specific level.
-     *
-     * @param[in] level Level on which the symbols should be retrieved.
-     * @return Set of symbols known to the alphabet on the given level.
-     */
-    virtual utils::OrdVector<Symbol> get_alphabet_symbols(size_t level) const {
+    virtual utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const {
         (void)level;
-        using AlphabetSymbolsFn = utils::OrdVector<Symbol> (Alphabet::*)() const;
-        return (this->*static_cast<AlphabetSymbolsFn>(&Alphabet::get_alphabet_symbols))();
-    }
-
-    /**
-     * @brief Get complement of a set of symbols with respect to the alphabet.
-     *
-     * @param[in] symbols Symbols whose complement should be computed.
-     * @return Complement of @p symbols.
-     */
-    virtual utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const {
-        (void)symbols;
         throw std::runtime_error("Unimplemented");
     }
 
     /**
-     * @brief Get complement of a set of symbols with respect to the alphabet on a specific level.
+     * @brief Get complement of a set of symbols with respect to the alphabet,
+     *  optionally on a specific level.
      *
      * @param[in] symbols Symbols whose complement should be computed.
-     * @param[in] level Level on which the complement should be computed.
+     * @param[in] level Optional level on which the complement should be computed.
      * @return Complement of @p symbols.
      */
     virtual utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, size_t level) const {
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const {
+        (void)symbols;
         (void)level;
-        using ComplementFn = utils::OrdVector<Symbol> (Alphabet::*)(const utils::OrdVector<Symbol>&) const;
-        return (this->*static_cast<ComplementFn>(&Alphabet::get_complement))(symbols);
+        throw std::runtime_error("Unimplemented");
     }
 
     virtual ~Alphabet() = default;
@@ -144,36 +108,21 @@ public:
     bool operator==(const Alphabet &) const = delete;
 
     /**
-     * @brief Check whether the alphabet has any symbols.
+     * @brief Check whether the alphabet has any symbols, optionally on a specific level.
      *
+     * @param[in] level Optional level on which emptiness should be checked.
      * @return True if the alphabet is empty, false otherwise.
      */
-    virtual bool empty() const = 0;
+    virtual bool empty(std::optional<Level> level = std::nullopt) const = 0;
 
     /**
-     * @brief Check whether the alphabet has any symbols on a specific level.
+     * @brief Clear symbols from the alphabet, optionally on a specific level.
      *
-     * @param[in] level Level on which emptiness should be checked.
-     * @return True if the alphabet is empty, false otherwise.
+     * @param[in] level Optional level on which the alphabet should be cleared.
      */
-    virtual bool empty(size_t level) const {
+    virtual void clear(std::optional<Level> level = std::nullopt) {
         (void)level;
-        return empty();
-    }
-
-    /**
-     * @brief Clear symbols from the alphabet.
-     */
-    virtual void clear() { throw std::runtime_error("Unimplemented"); }
-
-    /**
-     * @brief Clear symbols from the alphabet on a specific level.
-     *
-     * @param[in] level Level on which the alphabet should be cleared.
-     */
-    virtual void clear(size_t level) {
-        (void)level;
-        clear();
+        throw std::runtime_error("Unimplemented");
     }
 
 protected:
@@ -190,24 +139,24 @@ protected:
 */
 class IntAlphabet : public Alphabet {
 public:
-    using Alphabet::clear;
-    using Alphabet::empty;
-    using Alphabet::get_alphabet_symbols;
-    using Alphabet::get_complement;
-    using Alphabet::reverse_translate_symbol;
-    using Alphabet::translate_symb;
-
     IntAlphabet() : alphabet_instance_(IntAlphabetSingleton::get()) {}
-    Symbol translate_symb(const std::string &symb) override;
+    Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) override;
 
-    std::string reverse_translate_symbol(const Symbol symbol) const override { return std::to_string(symbol); }
+    std::string reverse_translate_symbol(
+        const Symbol symbol, std::optional<Level> level = std::nullopt) const override {
+        (void)level;
+        return std::to_string(symbol);
+    }
 
-    utils::OrdVector<Symbol> get_alphabet_symbols() const override {
+    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override {
+        (void)level;
         throw std::runtime_error("Nonsensical use of get_alphabet_symbols() on IntAlphabet.");
     }
 
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
+    utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override {
         (void)symbols;
+        (void)level;
         throw std::runtime_error("Nonsensical use of get_complement() on IntAlphabet.");
     }
 
@@ -215,9 +164,12 @@ public:
 
     IntAlphabet& operator=(const IntAlphabet& int_alphabet) = delete;
 
-    bool empty() const override { return false; }
+    bool empty(std::optional<Level> level = std::nullopt) const override { (void)level; return false; }
 
-    void clear() override { throw std::runtime_error("Nonsensical use of clear() on IntAlphabet."); }
+    void clear(std::optional<Level> level = std::nullopt) override {
+        (void)level;
+        throw std::runtime_error("Nonsensical use of clear() on IntAlphabet.");
+    }
 
 protected:
     const void* address() const override { return &alphabet_instance_; }
@@ -270,22 +222,23 @@ private:
  */
 class EnumAlphabet : public Alphabet {
 public:
-    using Alphabet::clear;
-    using Alphabet::empty;
-    using Alphabet::get_alphabet_symbols;
-    using Alphabet::get_complement;
-    using Alphabet::reverse_translate_symbol;
-    using Alphabet::translate_symb;
-
     explicit EnumAlphabet() = default;
     EnumAlphabet(const EnumAlphabet& alphabet) = default;
     explicit EnumAlphabet(const EnumAlphabet* const alphabet): EnumAlphabet(*alphabet) {}
     EnumAlphabet(EnumAlphabet&& rhs) = default;
 
-    utils::OrdVector<Symbol> get_alphabet_symbols() const override { return symbols_; }
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override { return symbols_.difference(symbols); }
+    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override {
+        (void)level;
+        return symbols_;
+    }
+    utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override {
+        (void)level;
+        return symbols_.difference(symbols);
+    }
 
-    std::string reverse_translate_symbol(Symbol symbol) const override;
+    std::string reverse_translate_symbol(
+        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
 
     EnumAlphabet& operator=(const EnumAlphabet& rhs) = default;
     EnumAlphabet& operator=(EnumAlphabet&& rhs) = default;
@@ -311,7 +264,7 @@ public:
     }
     EnumAlphabet(const std::initializer_list<std::string> l) : EnumAlphabet(l.begin(), l.end()) {}
 
-    Symbol translate_symb(const std::string& str) override;
+    Symbol translate_symb(const std::string& str, std::optional<Level> level = std::nullopt) override;
     Word translate_word(const WordName& word_name) const override;
 
     /**
@@ -378,9 +331,16 @@ public:
         symbols_.erase(first, last);
     }
 
-    bool empty() const override { return symbols_.empty(); }
+    bool empty(std::optional<Level> level = std::nullopt) const override {
+        (void)level;
+        return symbols_.empty();
+    }
 
-    void clear() override { symbols_.clear(); next_symbol_value_ = 0; }
+    void clear(std::optional<Level> level = std::nullopt) override {
+        (void)level;
+        symbols_.clear();
+        next_symbol_value_ = 0;
+    }
 }; // class EnumAlphabet.
 
 /**
@@ -389,13 +349,6 @@ public:
  */
 class OnTheFlyAlphabet : public Alphabet {
 public:
-    using Alphabet::clear;
-    using Alphabet::empty;
-    using Alphabet::get_alphabet_symbols;
-    using Alphabet::get_complement;
-    using Alphabet::reverse_translate_symbol;
-    using Alphabet::translate_symb;
-
     using StringToSymbolMap = std::unordered_map<std::string, Symbol>;
 
     /// Result of the insertion of a new symbol.
@@ -426,10 +379,12 @@ public:
         }
     }
 
-    utils::OrdVector<Symbol> get_alphabet_symbols() const override;
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override;
+    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override;
+    utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override;
 
-    std::string reverse_translate_symbol(Symbol symbol) const override;
+    std::string reverse_translate_symbol(
+        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
 
 public:
     OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs) = default;
@@ -451,7 +406,7 @@ public:
      */
     void add_symbols_from(const StringToSymbolMap& new_symbol_map);
 
-    Symbol translate_symb(const std::string& str) override;
+    Symbol translate_symb(const std::string& str, std::optional<Level> level = std::nullopt) override;
 
     Word translate_word(const WordName& word_name) const override;
 
@@ -505,7 +460,10 @@ public:
      */
     const StringToSymbolMap& get_symbol_map() const { return symbol_map_; }
 
-    bool empty() const override { return symbol_map_.empty(); }
+    bool empty(std::optional<Level> level = std::nullopt) const override {
+        (void)level;
+        return symbol_map_.empty();
+    }
 
 private:
     StringToSymbolMap symbol_map_{}; ///< Map of string transition symbols to symbol values.
@@ -547,7 +505,11 @@ public:
         symbol_map_.erase(first, last);
     }
 
-    void clear() override { symbol_map_.clear(); next_symbol_value_ = 0; }
+    void clear(std::optional<Level> level = std::nullopt) override {
+        (void)level;
+        symbol_map_.clear();
+        next_symbol_value_ = 0;
+    }
 }; // class OnTheFlyAlphabet.
 
 class LevelAlphabet : public Alphabet {
@@ -555,116 +517,62 @@ public:
     explicit LevelAlphabet(std::vector<Alphabet*> alphabets = {}) : alphabets_{ std::move(alphabets) } {}
 
     /**
-     * @brief Translate a symbol name using the alphabet selected without a specific level.
-     *
-     * @param[in] symb Symbol name to translate.
-     * @return Translated symbol value.
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    Symbol translate_symb(const std::string& symb) override {
-        (void)symb;
-        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
-    }
-
-    /**
      * @brief Translate a symbol name using the alphabet for the given level.
      *
      * @param[in] symb Symbol name to translate.
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
      * @return Translated symbol value.
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    Symbol translate_symb(const std::string& symb, size_t level) override;
-
-    /**
-     * @brief Translate a symbol value back to its name using the alphabet selected without a specific level.
-     *
-     * @param[in] symbol Symbol value to translate.
-     * @return Original symbol name.
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    std::string reverse_translate_symbol(Symbol symbol) const override {
-        (void)symbol;
-        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
-    }
+    Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) override;
 
     /**
      * @brief Translate a symbol value back to its name using the alphabet for the given level.
      *
      * @param[in] symbol Symbol value to translate.
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
      * @return Original symbol name.
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    std::string reverse_translate_symbol(Symbol symbol, size_t level) const override;
-
-    /**
-     * @brief Get the union of symbols from all underlying alphabets.
-     *
-     * @return Set of symbols known to the level alphabet.
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    utils::OrdVector<Symbol> get_alphabet_symbols() const override {
-        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
-    }
+    std::string reverse_translate_symbol(
+        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
 
     /**
      * @brief Get the symbols known to the alphabet on the given level.
      *
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
      * @return Set of symbols known to the selected alphabet.
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    utils::OrdVector<Symbol> get_alphabet_symbols(size_t level) const override;
-
-    /**
-     * @brief Get the complement of @p symbols with respect to the alphabet selected for the given level.
-     *
-     * @param[in] symbols Symbols whose complement should be computed.
-     * @return Complement of @p symbols with respect to the alphabet selected for the given @p level.
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
-        (void)symbols;
-        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
-    }
+    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override;
 
     /**
      * @brief Get the complement of @p symbols with respect to the alphabet for the given level.
      *
      * @param[in] symbols Symbols whose complement should be computed.
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
      * @return Complement of @p symbols with respect to the selected alphabet.
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
     utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, size_t level) const override;
-
-    /**
-     * @brief Check whether the alphabet selected without a specific level is empty.
-     *
-     * @return True if the selected alphabet is empty, false otherwise.
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    bool empty() const override { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override;
 
     /**
      * @brief Check whether the alphabet for the given level is empty.
      *
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
      * @return True if the selected alphabet is empty, false otherwise.
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    bool empty(size_t level) const override;
-
-    /**
-     * @brief Clear the alphabet selected without a specific level.
-     *
-     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
-     */
-    void clear() override { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
+    bool empty(std::optional<Level> level = std::nullopt) const override;
 
     /**
      * @brief Clear the alphabet for the given level.
      *
-     * @param[in] level Level selecting the underlying alphabet.
+     * @param[in] level Level selecting the underlying alphabet (required).
+     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    void clear(size_t level) override;
+    void clear(std::optional<Level> level = std::nullopt) override;
 
     /**
      * @brief Get the alphabet assigned to a specific level.
@@ -672,7 +580,7 @@ public:
      * @param[in] level Level whose alphabet should be returned.
      * @return Alphabet assigned to @p level, or @c nullptr if the level is out of range.
      */
-    const Alphabet* alphabet_of_level(size_t level) const;
+    const Alphabet* alphabet_of_level(Level level) const;
 
     const std::vector<Alphabet*>& alphabets() const { return alphabets_; }
 
@@ -682,9 +590,9 @@ private:
      *
      * @param[in] level Level selecting the underlying alphabet.
      * @return Resolved alphabet reference.
-     * @throws std::runtime_error If the level is invalid.
+     * @throws std::runtime_error If the level is @c std::nullopt or out of range.
      */
-    const Alphabet& resolve_alphabet(size_t level) const;
+    const Alphabet& resolve_alphabet(std::optional<Level> level) const;
 
     std::vector<Alphabet*> alphabets_{};
 };

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "utils/ord-vector.hh"
 #include "utils/utils.hh"
@@ -22,8 +23,25 @@ using WordName = std::vector<std::string>;
   */
 class Alphabet {
 public:
-    /// translates a string into a symbol
+    /**
+     * @brief Translate a string into a symbol.
+     *
+     * @param[in] symb Symbol name to translate.
+     * @return Translated symbol value.
+     */
     virtual Symbol translate_symb(const std::string &symb) = 0;
+
+    /**
+     * @brief Translate a string into a symbol on a specific level.
+     *
+     * @param[in] symb Symbol name to translate.
+     * @param[in] level Level on which the translation should happen.
+     * @return Translated symbol value.
+     */
+    virtual Symbol translate_symb(const std::string &symb, size_t level) {
+        (void)level;
+        return translate_symb(symb);
+    }
 
     /**
      * Translate sequence of symbol names to sequence of their respective values.
@@ -42,6 +60,18 @@ public:
      */
     virtual std::string reverse_translate_symbol(Symbol symbol) const = 0;
 
+    /**
+     * @brief Translate internal @p symbol representation back to its original string name on a specific level.
+     *
+     * @param[in] symbol Symbol to translate.
+     * @param[in] level Level on which the reverse translation should happen.
+     * @return @p symbol original name.
+     */
+    virtual std::string reverse_translate_symbol(Symbol symbol, size_t level) const {
+        (void)level;
+        return reverse_translate_symbol(symbol);
+    }
+
     /// also translates strings to symbols
     Symbol operator[](const std::string &symb) { return this->translate_symb(symb); }
 
@@ -52,11 +82,42 @@ public:
      */
     virtual utils::OrdVector<Symbol> get_alphabet_symbols() const { throw std::runtime_error("Unimplemented"); }
 
-    /// complement of a set of symbols wrt the alphabet
-    virtual utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const { // {{{
-        (void) symbols;
+    /**
+     * @brief Get a set of all symbols in the alphabet on a specific level.
+     *
+     * @param[in] level Level on which the symbols should be retrieved.
+     * @return Set of symbols known to the alphabet on the given level.
+     */
+    virtual utils::OrdVector<Symbol> get_alphabet_symbols(size_t level) const {
+        (void)level;
+        using AlphabetSymbolsFn = utils::OrdVector<Symbol> (Alphabet::*)() const;
+        return (this->*static_cast<AlphabetSymbolsFn>(&Alphabet::get_alphabet_symbols))();
+    }
+
+    /**
+     * @brief Get complement of a set of symbols with respect to the alphabet.
+     *
+     * @param[in] symbols Symbols whose complement should be computed.
+     * @return Complement of @p symbols.
+     */
+    virtual utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const {
+        (void)symbols;
         throw std::runtime_error("Unimplemented");
-    } // }}}
+    }
+
+    /**
+     * @brief Get complement of a set of symbols with respect to the alphabet on a specific level.
+     *
+     * @param[in] symbols Symbols whose complement should be computed.
+     * @param[in] level Level on which the complement should be computed.
+     * @return Complement of @p symbols.
+     */
+    virtual utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, size_t level) const {
+        (void)level;
+        using ComplementFn = utils::OrdVector<Symbol> (Alphabet::*)(const utils::OrdVector<Symbol>&) const;
+        return (this->*static_cast<ComplementFn>(&Alphabet::get_complement))(symbols);
+    }
 
     virtual ~Alphabet() = default;
 
@@ -83,11 +144,37 @@ public:
     bool operator==(const Alphabet &) const = delete;
 
     /**
-     * Checks whether the alphabet has any symbols.
+     * @brief Check whether the alphabet has any symbols.
+     *
+     * @return True if the alphabet is empty, false otherwise.
      */
     virtual bool empty() const = 0;
 
+    /**
+     * @brief Check whether the alphabet has any symbols on a specific level.
+     *
+     * @param[in] level Level on which emptiness should be checked.
+     * @return True if the alphabet is empty, false otherwise.
+     */
+    virtual bool empty(size_t level) const {
+        (void)level;
+        return empty();
+    }
+
+    /**
+     * @brief Clear symbols from the alphabet.
+     */
     virtual void clear() { throw std::runtime_error("Unimplemented"); }
+
+    /**
+     * @brief Clear symbols from the alphabet on a specific level.
+     *
+     * @param[in] level Level on which the alphabet should be cleared.
+     */
+    virtual void clear(size_t level) {
+        (void)level;
+        clear();
+    }
 
 protected:
     virtual const void* address() const { return this; }
@@ -103,8 +190,14 @@ protected:
 */
 class IntAlphabet : public Alphabet {
 public:
-    IntAlphabet() : alphabet_instance_(IntAlphabetSingleton::get()) {}
+    using Alphabet::clear;
+    using Alphabet::empty;
+    using Alphabet::get_alphabet_symbols;
+    using Alphabet::get_complement;
+    using Alphabet::reverse_translate_symbol;
+    using Alphabet::translate_symb;
 
+    IntAlphabet() : alphabet_instance_(IntAlphabetSingleton::get()) {}
     Symbol translate_symb(const std::string &symb) override;
 
     std::string reverse_translate_symbol(const Symbol symbol) const override { return std::to_string(symbol); }
@@ -114,7 +207,7 @@ public:
     }
 
     utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
-        (void) symbols;
+        (void)symbols;
         throw std::runtime_error("Nonsensical use of get_complement() on IntAlphabet.");
     }
 
@@ -177,15 +270,20 @@ private:
  */
 class EnumAlphabet : public Alphabet {
 public:
+    using Alphabet::clear;
+    using Alphabet::empty;
+    using Alphabet::get_alphabet_symbols;
+    using Alphabet::get_complement;
+    using Alphabet::reverse_translate_symbol;
+    using Alphabet::translate_symb;
+
     explicit EnumAlphabet() = default;
     EnumAlphabet(const EnumAlphabet& alphabet) = default;
     explicit EnumAlphabet(const EnumAlphabet* const alphabet): EnumAlphabet(*alphabet) {}
     EnumAlphabet(EnumAlphabet&& rhs) = default;
 
     utils::OrdVector<Symbol> get_alphabet_symbols() const override { return symbols_; }
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
-        return symbols_.difference(symbols);
-    }
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override { return symbols_.difference(symbols); }
 
     std::string reverse_translate_symbol(Symbol symbol) const override;
 
@@ -245,8 +343,6 @@ public:
      */
     size_t get_number_of_symbols() const { return symbols_.size(); }
 
-    bool empty() const override { return symbols_.empty(); }
-
 private:
     mata::utils::OrdVector<Symbol> symbols_{}; ///< Map of string transition symbols to symbol values.
     Symbol next_symbol_value_{ 0 }; ///< Next value to be used for a newly added symbol.
@@ -282,6 +378,8 @@ public:
         symbols_.erase(first, last);
     }
 
+    bool empty() const override { return symbols_.empty(); }
+
     void clear() override { symbols_.clear(); next_symbol_value_ = 0; }
 }; // class EnumAlphabet.
 
@@ -291,6 +389,13 @@ public:
  */
 class OnTheFlyAlphabet : public Alphabet {
 public:
+    using Alphabet::clear;
+    using Alphabet::empty;
+    using Alphabet::get_alphabet_symbols;
+    using Alphabet::get_complement;
+    using Alphabet::reverse_translate_symbol;
+    using Alphabet::translate_symb;
+
     using StringToSymbolMap = std::unordered_map<std::string, Symbol>;
 
     /// Result of the insertion of a new symbol.
@@ -444,6 +549,145 @@ public:
 
     void clear() override { symbol_map_.clear(); next_symbol_value_ = 0; }
 }; // class OnTheFlyAlphabet.
+
+class LevelAlphabet : public Alphabet {
+public:
+    explicit LevelAlphabet(std::vector<Alphabet*> alphabets = {}) : alphabets_{ std::move(alphabets) } {}
+
+    /**
+     * @brief Translate a symbol name using the alphabet selected without a specific level.
+     *
+     * @param[in] symb Symbol name to translate.
+     * @return Translated symbol value.
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    Symbol translate_symb(const std::string& symb) override {
+        (void)symb;
+        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
+    }
+
+    /**
+     * @brief Translate a symbol name using the alphabet for the given level.
+     *
+     * @param[in] symb Symbol name to translate.
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return Translated symbol value.
+     */
+    Symbol translate_symb(const std::string& symb, size_t level) override;
+
+    /**
+     * @brief Translate a symbol value back to its name using the alphabet selected without a specific level.
+     *
+     * @param[in] symbol Symbol value to translate.
+     * @return Original symbol name.
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    std::string reverse_translate_symbol(Symbol symbol) const override {
+        (void)symbol;
+        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
+    }
+
+    /**
+     * @brief Translate a symbol value back to its name using the alphabet for the given level.
+     *
+     * @param[in] symbol Symbol value to translate.
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return Original symbol name.
+     */
+    std::string reverse_translate_symbol(Symbol symbol, size_t level) const override;
+
+    /**
+     * @brief Get the union of symbols from all underlying alphabets.
+     *
+     * @return Set of symbols known to the level alphabet.
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    utils::OrdVector<Symbol> get_alphabet_symbols() const override {
+        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
+    }
+
+    /**
+     * @brief Get the symbols known to the alphabet on the given level.
+     *
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return Set of symbols known to the selected alphabet.
+     */
+    utils::OrdVector<Symbol> get_alphabet_symbols(size_t level) const override;
+
+    /**
+     * @brief Get the complement of @p symbols with respect to the alphabet selected for the given level.
+     *
+     * @param[in] symbols Symbols whose complement should be computed.
+     * @return Complement of @p symbols with respect to the alphabet selected for the given @p level.
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
+        (void)symbols;
+        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
+    }
+
+    /**
+     * @brief Get the complement of @p symbols with respect to the alphabet for the given level.
+     *
+     * @param[in] symbols Symbols whose complement should be computed.
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return Complement of @p symbols with respect to the selected alphabet.
+     */
+    utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, size_t level) const override;
+
+    /**
+     * @brief Check whether the alphabet selected without a specific level is empty.
+     *
+     * @return True if the selected alphabet is empty, false otherwise.
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    bool empty() const override { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
+
+    /**
+     * @brief Check whether the alphabet for the given level is empty.
+     *
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return True if the selected alphabet is empty, false otherwise.
+     */
+    bool empty(size_t level) const override;
+
+    /**
+     * @brief Clear the alphabet selected without a specific level.
+     *
+     * @throws std::runtime_error Always, because LevelAlphabet requires an explicit level.
+     */
+    void clear() override { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
+
+    /**
+     * @brief Clear the alphabet for the given level.
+     *
+     * @param[in] level Level selecting the underlying alphabet.
+     */
+    void clear(size_t level) override;
+
+    /**
+     * @brief Get the alphabet assigned to a specific level.
+     *
+     * @param[in] level Level whose alphabet should be returned.
+     * @return Alphabet assigned to @p level, or @c nullptr if the level is out of range.
+     */
+    const Alphabet* alphabet_of_level(size_t level) const;
+
+    const std::vector<Alphabet*>& alphabets() const { return alphabets_; }
+
+private:
+    /**
+     * @brief Resolve the alphabet to use for the given level.
+     *
+     * @param[in] level Level selecting the underlying alphabet.
+     * @return Resolved alphabet reference.
+     * @throws std::runtime_error If the level is invalid.
+     */
+    const Alphabet& resolve_alphabet(size_t level) const;
+
+    std::vector<Alphabet*> alphabets_{};
+};
 
 /**
  * @brief Encode a word using UTF-8 encoding.

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -517,11 +517,20 @@ public:
 
     /**
      * @brief Check whether the alphabet for the given level is empty.
+     *
+     * In @c Global mode, always checks @c alphabets[0] (level argument is ignored).
+     * In @c MultiLevel mode, checks @c alphabets[level] when @p level has a value, or returns @c true iff every
+     *  underlying alphabet is empty when @p level is @c std::nullopt.
      */
     bool empty(std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Clear the alphabet for the given level.
+     *
+     * In @c Global mode, always clears @c alphabets[0] (level argument is ignored, calling @c clear repeatedly is
+     *  idempotent on the same alphabet).
+     * In @c MultiLevel mode, clears @c alphabets[level] when @p level has a value, or clears every underlying
+     *  alphabet when @p level is @c std::nullopt.
      */
     void clear(std::optional<Level> level = std::nullopt);
 

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -5,7 +5,6 @@
 #define MATA_ALPHABET_HH
 
 #include <limits>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,14 +24,8 @@ using WordName = std::vector<std::string>;
   */
 class Alphabet {
 public:
-    /**
-     * @brief Translate a string into a symbol, optionally on a specific level.
-     *
-     * @param[in] symb Symbol name to translate.
-     * @param[in] level Optional level on which the translation should happen.
-     * @return Translated symbol value.
-     */
-    virtual Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) = 0;
+    /// translates a string into a symbol
+    virtual Symbol translate_symb(const std::string &symb) = 0;
 
     /**
      * Translate sequence of symbol names to sequence of their respective values.
@@ -43,45 +36,29 @@ public:
     }
 
     /**
-     * @brief Translate internal @p symbol representation back to its original string name,
-     *  optionally on a specific level.
+     * @brief Translate internal @p symbol representation back to its original string name.
      *
      * Throws an exception when the @p symbol is missing in the alphabet.
      * @param[in] symbol Symbol to translate.
-     * @param[in] level Optional level on which the reverse translation should happen.
      * @return @p symbol original name.
      */
-    virtual std::string reverse_translate_symbol(
-        Symbol symbol, std::optional<Level> level = std::nullopt) const = 0;
+    virtual std::string reverse_translate_symbol(Symbol symbol) const = 0;
 
     /// also translates strings to symbols
     Symbol operator[](const std::string &symb) { return this->translate_symb(symb); }
 
     /**
-     * @brief Get a set of all symbols in the alphabet, optionally on a specific level.
+     * @brief Get a set of all symbols in the alphabet.
      *
      * The result does not have to equal the list of symbols in the automaton using this alphabet.
-     * @param[in] level Optional level on which the symbols should be retrieved.
      */
-    virtual utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const {
-        (void)level;
-        throw std::runtime_error("Unimplemented");
-    }
+    virtual utils::OrdVector<Symbol> get_alphabet_symbols() const { throw std::runtime_error("Unimplemented"); }
 
-    /**
-     * @brief Get complement of a set of symbols with respect to the alphabet,
-     *  optionally on a specific level.
-     *
-     * @param[in] symbols Symbols whose complement should be computed.
-     * @param[in] level Optional level on which the complement should be computed.
-     * @return Complement of @p symbols.
-     */
-    virtual utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const {
-        (void)symbols;
-        (void)level;
+    /// complement of a set of symbols wrt the alphabet
+    virtual utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const { // {{{
+        (void) symbols;
         throw std::runtime_error("Unimplemented");
-    }
+    } // }}}
 
     virtual ~Alphabet() = default;
 
@@ -108,22 +85,11 @@ public:
     bool operator==(const Alphabet &) const = delete;
 
     /**
-     * @brief Check whether the alphabet has any symbols, optionally on a specific level.
-     *
-     * @param[in] level Optional level on which emptiness should be checked.
-     * @return True if the alphabet is empty, false otherwise.
+     * Checks whether the alphabet has any symbols.
      */
-    virtual bool empty(std::optional<Level> level = std::nullopt) const = 0;
+    virtual bool empty() const = 0;
 
-    /**
-     * @brief Clear symbols from the alphabet, optionally on a specific level.
-     *
-     * @param[in] level Optional level on which the alphabet should be cleared.
-     */
-    virtual void clear(std::optional<Level> level = std::nullopt) {
-        (void)level;
-        throw std::runtime_error("Unimplemented");
-    }
+    virtual void clear() { throw std::runtime_error("Unimplemented"); }
 
 protected:
     virtual const void* address() const { return this; }
@@ -140,23 +106,17 @@ protected:
 class IntAlphabet : public Alphabet {
 public:
     IntAlphabet() : alphabet_instance_(IntAlphabetSingleton::get()) {}
-    Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) override;
 
-    std::string reverse_translate_symbol(
-        const Symbol symbol, std::optional<Level> level = std::nullopt) const override {
-        (void)level;
-        return std::to_string(symbol);
-    }
+    Symbol translate_symb(const std::string &symb) override;
 
-    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override {
-        (void)level;
+    std::string reverse_translate_symbol(const Symbol symbol) const override { return std::to_string(symbol); }
+
+    utils::OrdVector<Symbol> get_alphabet_symbols() const override {
         throw std::runtime_error("Nonsensical use of get_alphabet_symbols() on IntAlphabet.");
     }
 
-    utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override {
-        (void)symbols;
-        (void)level;
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
+        (void) symbols;
         throw std::runtime_error("Nonsensical use of get_complement() on IntAlphabet.");
     }
 
@@ -164,12 +124,9 @@ public:
 
     IntAlphabet& operator=(const IntAlphabet& int_alphabet) = delete;
 
-    bool empty(std::optional<Level> level = std::nullopt) const override { (void)level; return false; }
+    bool empty() const override { return false; }
 
-    void clear(std::optional<Level> level = std::nullopt) override {
-        (void)level;
-        throw std::runtime_error("Nonsensical use of clear() on IntAlphabet.");
-    }
+    void clear() override { throw std::runtime_error("Nonsensical use of clear() on IntAlphabet."); }
 
 protected:
     const void* address() const override { return &alphabet_instance_; }
@@ -227,18 +184,12 @@ public:
     explicit EnumAlphabet(const EnumAlphabet* const alphabet): EnumAlphabet(*alphabet) {}
     EnumAlphabet(EnumAlphabet&& rhs) = default;
 
-    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override {
-        (void)level;
-        return symbols_;
-    }
-    utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override {
-        (void)level;
+    utils::OrdVector<Symbol> get_alphabet_symbols() const override { return symbols_; }
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {
         return symbols_.difference(symbols);
     }
 
-    std::string reverse_translate_symbol(
-        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
+    std::string reverse_translate_symbol(Symbol symbol) const override;
 
     EnumAlphabet& operator=(const EnumAlphabet& rhs) = default;
     EnumAlphabet& operator=(EnumAlphabet&& rhs) = default;
@@ -264,7 +215,7 @@ public:
     }
     EnumAlphabet(const std::initializer_list<std::string> l) : EnumAlphabet(l.begin(), l.end()) {}
 
-    Symbol translate_symb(const std::string& str, std::optional<Level> level = std::nullopt) override;
+    Symbol translate_symb(const std::string& str) override;
     Word translate_word(const WordName& word_name) const override;
 
     /**
@@ -295,6 +246,8 @@ public:
      * @return The number of symbols.
      */
     size_t get_number_of_symbols() const { return symbols_.size(); }
+
+    bool empty() const override { return symbols_.empty(); }
 
 private:
     mata::utils::OrdVector<Symbol> symbols_{}; ///< Map of string transition symbols to symbol values.
@@ -331,16 +284,7 @@ public:
         symbols_.erase(first, last);
     }
 
-    bool empty(std::optional<Level> level = std::nullopt) const override {
-        (void)level;
-        return symbols_.empty();
-    }
-
-    void clear(std::optional<Level> level = std::nullopt) override {
-        (void)level;
-        symbols_.clear();
-        next_symbol_value_ = 0;
-    }
+    void clear() override { symbols_.clear(); next_symbol_value_ = 0; }
 }; // class EnumAlphabet.
 
 /**
@@ -379,12 +323,10 @@ public:
         }
     }
 
-    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override;
-    utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override;
+    utils::OrdVector<Symbol> get_alphabet_symbols() const override;
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override;
 
-    std::string reverse_translate_symbol(
-        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
+    std::string reverse_translate_symbol(Symbol symbol) const override;
 
 public:
     OnTheFlyAlphabet& operator=(const OnTheFlyAlphabet& rhs) = default;
@@ -406,7 +348,7 @@ public:
      */
     void add_symbols_from(const StringToSymbolMap& new_symbol_map);
 
-    Symbol translate_symb(const std::string& str, std::optional<Level> level = std::nullopt) override;
+    Symbol translate_symb(const std::string& str) override;
 
     Word translate_word(const WordName& word_name) const override;
 
@@ -460,10 +402,7 @@ public:
      */
     const StringToSymbolMap& get_symbol_map() const { return symbol_map_; }
 
-    bool empty(std::optional<Level> level = std::nullopt) const override {
-        (void)level;
-        return symbol_map_.empty();
-    }
+    bool empty() const override { return symbol_map_.empty(); }
 
 private:
     StringToSymbolMap symbol_map_{}; ///< Map of string transition symbols to symbol values.
@@ -505,107 +444,73 @@ public:
         symbol_map_.erase(first, last);
     }
 
-    void clear(std::optional<Level> level = std::nullopt) override {
-        (void)level;
-        symbol_map_.clear();
-        next_symbol_value_ = 0;
-    }
+    void clear() override { symbol_map_.clear(); next_symbol_value_ = 0; }
 }; // class OnTheFlyAlphabet.
 
-class LevelAlphabet : public Alphabet {
+/**
+ * @brief Per-level alphabets for transducer-like automata.
+ *
+ * Standalone (does NOT inherit from @c Alphabet) wrapper holding a vector of @c Alphabet*, one per level.
+ * If the vector contains a single element, the same alphabet is used for every level (shared-alphabet form).
+ *
+ * Pointers to the underlying @c Alphabet objects are non-owning; the caller is responsible for their lifetime.
+ */
+class AlphabetLevels {
 public:
-    explicit LevelAlphabet(std::vector<Alphabet*> alphabets = {}) : alphabets_{ std::move(alphabets) } {}
+    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}) : alphabets_{ std::move(alphabets) } {}
+
+    /**
+     * @brief Convenience constructor: use the same @p alphabet for every level.
+     *
+     * Stores a single-element vector. @c get_alphabet_for_level returns this alphabet for any requested level.
+     */
+    explicit AlphabetLevels(Alphabet* alphabet) : alphabets_{ alphabet } {}
 
     /**
      * @brief Translate a symbol name using the alphabet for the given level.
-     *
-     * @param[in] symb Symbol name to translate.
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @return Translated symbol value.
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt) override;
+    Symbol translate_symb(const std::string& symb, Level level);
 
     /**
      * @brief Translate a symbol value back to its name using the alphabet for the given level.
-     *
-     * @param[in] symbol Symbol value to translate.
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @return Original symbol name.
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    std::string reverse_translate_symbol(
-        Symbol symbol, std::optional<Level> level = std::nullopt) const override;
+    std::string reverse_translate_symbol(Symbol symbol, Level level) const;
 
     /**
      * @brief Get the symbols known to the alphabet on the given level.
-     *
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @return Set of symbols known to the selected alphabet.
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const override;
+    utils::OrdVector<Symbol> get_alphabet_symbols(Level level) const;
 
     /**
      * @brief Get the complement of @p symbols with respect to the alphabet for the given level.
-     *
-     * @param[in] symbols Symbols whose complement should be computed.
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @return Complement of @p symbols with respect to the selected alphabet.
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    utils::OrdVector<Symbol> get_complement(
-        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const override;
+    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols, Level level) const;
 
     /**
      * @brief Check whether the alphabet for the given level is empty.
-     *
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @return True if the selected alphabet is empty, false otherwise.
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    bool empty(std::optional<Level> level = std::nullopt) const override;
+    bool empty(Level level) const;
 
     /**
      * @brief Clear the alphabet for the given level.
-     *
-     * @param[in] level Level selecting the underlying alphabet (required).
-     * @throws std::runtime_error If @p level is @c std::nullopt or out of range.
      */
-    void clear(std::optional<Level> level = std::nullopt) override;
+    void clear(Level level);
 
     /**
      * @brief Get the alphabet assigned to a specific level.
      *
+     * If the internal vector has a single element, it is used regardless of @p level (shared-alphabet form).
+     * Otherwise, @p level must be a valid index and the corresponding entry must be non-null.
+     *
      * @param[in] level Level whose alphabet should be returned.
-     * @return Alphabet assigned to @p level, or @c nullptr if the level is out of range.
+     * @return Alphabet assigned to @p level.
+     * @throws std::runtime_error If @p level is out of range or the entry is null.
      */
-    const Alphabet* alphabet_of_level(Level level) const;
+    const Alphabet& alphabet_of_level(Level level) const;
 
     const std::vector<Alphabet*>& alphabets() const { return alphabets_; }
 
 private:
-    /**
-     * @brief Get the alphabet to use for the given level.
-     *
-     * @param[in] level Level selecting the underlying alphabet.
-     * @return Alphabet reference for @p level.
-     * @throws std::runtime_error If the level is out of range.
-     */
-    const Alphabet& get_alphabet_for_level(Level level) const;
-
-    /**
-     * @brief Unwrap an optional level, throwing if it is @c std::nullopt.
-     *
-     * @param[in] level Optional level supplied through the @c Alphabet interface.
-     * @return Unwrapped level value.
-     * @throws std::runtime_error If @p level is @c std::nullopt.
-     */
-    static Level require_level(std::optional<Level> level) {
-        if (!level) { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
-        return *level;
-    }
-
     std::vector<Alphabet*> alphabets_{};
 };
 

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -523,8 +523,10 @@ public:
      * @return Alphabet assigned to @p level.
      * @throws std::runtime_error If @p level is out of range or the entry is null.
      */
-    const Alphabet& alphabet_of_level(Level level) const;
+    const Alphabet& for_level(Level level) const;
 
+    /// Alias for @c for_level.
+    const Alphabet& operator[](Level level) const { return for_level(level); }
 };
 
 /**

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -457,14 +457,23 @@ public:
  */
 class AlphabetLevels {
 public:
-    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}) : alphabets_{ std::move(alphabets) } {}
+    /**
+     * @brief Per-level alphabets.
+     *
+     * One @c Alphabet* per level, or a single-element vector to share one alphabet across all levels. Public to allow
+     *  direct read/write access in line with the rest of the codebase (`Nft::levels`, `Nfa::delta`/`initial`/etc.).
+     *  Read-only access through @c alphabet_of_level when range/null validation is desired.
+     */
+    std::vector<Alphabet*> alphabets{};
+
+    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}) : alphabets{ std::move(alphabets) } {}
 
     /**
      * @brief Convenience constructor: use the same @p alphabet for every level.
      *
-     * Stores a single-element vector. @c get_alphabet_for_level returns this alphabet for any requested level.
+     * Stores a single-element vector. @c alphabet_of_level returns this alphabet for any requested level.
      */
-    explicit AlphabetLevels(Alphabet* alphabet) : alphabets_{ alphabet } {}
+    explicit AlphabetLevels(Alphabet* alphabet) : alphabets{ alphabet } {}
 
     /**
      * @brief Translate a symbol name using the alphabet for the given level.
@@ -499,6 +508,8 @@ public:
     /**
      * @brief Get the alphabet assigned to a specific level.
      *
+     * This is like a validated accessor for the internal vector of @c Alphabet*.
+     *
      * If the internal vector has a single element, it is used regardless of @p level (shared-alphabet form).
      * Otherwise, @p level must be a valid index and the corresponding entry must be non-null.
      *
@@ -508,10 +519,6 @@ public:
      */
     const Alphabet& alphabet_of_level(Level level) const;
 
-    const std::vector<Alphabet*>& alphabets() const { return alphabets_; }
-
-private:
-    std::vector<Alphabet*> alphabets_{};
 };
 
 /**

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -5,6 +5,7 @@
 #define MATA_ALPHABET_HH
 
 #include <limits>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -497,13 +498,18 @@ public:
 
     /**
      * @brief Check whether the alphabet for the given level is empty.
+     *
+     * When @p level is @c std::nullopt, returns @c true iff every underlying alphabet is empty (or there are no
+     *  underlying alphabets at all).
      */
-    bool empty(Level level) const;
+    bool empty(std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Clear the alphabet for the given level.
+     *
+     * When @p level is @c std::nullopt, clears every underlying alphabet.
      */
-    void clear(Level level);
+    void clear(std::optional<Level> level = std::nullopt);
 
     /**
      * @brief Get the alphabet assigned to a specific level.

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -452,81 +452,96 @@ public:
  * @brief Per-level alphabets for transducer-like automata.
  *
  * Standalone (does NOT inherit from @c Alphabet) wrapper holding a vector of @c Alphabet*, one per level.
- * If the vector contains a single element, the same alphabet is used for every level (shared-alphabet form).
+ * Operates in one of two modes (see @c Mode):
+ *  - @c Global   — a single shared alphabet (typically stored in @c alphabets[0]) applies to every level. The level
+ *                  argument is ignored.
+ *  - @c MultiLevel — distinct per-level alphabets. The level argument is required and indexes @c alphabets.
  *
  * Pointers to the underlying @c Alphabet objects are non-owning; the caller is responsible for their lifetime.
  */
 class AlphabetLevels {
 public:
+    /// Operating mode of the @c AlphabetLevels instance.
+    enum class Mode {
+        Global,      ///< @c alphabets[0] is used for every level; level argument is ignored.
+        MultiLevel,  ///< Each level uses its own alphabet from @c alphabets[level]; level argument is required.
+    };
+
     /**
      * @brief Per-level alphabets.
      *
-     * One @c Alphabet* per level, or a single-element vector to share one alphabet across all levels. Public to allow
+     * In @c Global mode, only @c alphabets[0] is used. In @c MultiLevel mode, indexed by level. Public to allow
      *  direct read/write access in line with the rest of the codebase (`Nft::levels`, `Nfa::delta`/`initial`/etc.).
-     *  Read-only access through @c alphabet_of_level when range/null validation is desired.
+     *  Read-only access through @c for_level (or @c operator[]) when range/null validation is desired.
      */
     std::vector<Alphabet*> alphabets{};
 
-    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}) : alphabets{ std::move(alphabets) } {}
+    /// Operating mode. Defaults to @c MultiLevel.
+    Mode mode{ Mode::MultiLevel };
+
+    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}, Mode mode = Mode::MultiLevel)
+        : alphabets{ std::move(alphabets) }, mode{ mode } {}
 
     /**
-     * @brief Convenience constructor: use the same @p alphabet for every level.
+     * @brief Convenience constructor: use the same @p alphabet for every level (Global mode).
      *
-     * Stores a single-element vector. @c alphabet_of_level returns this alphabet for any requested level.
+     * Stores a single-element vector and sets @c mode to @c Global.
      */
-    explicit AlphabetLevels(Alphabet* alphabet) : alphabets{ alphabet } {}
+    explicit AlphabetLevels(Alphabet* alphabet) : alphabets{ alphabet }, mode{ Mode::Global } {}
 
     /**
      * @brief Translate a symbol name using the alphabet for the given level.
+     *
+     * When @p level is @c std::nullopt and the instance is in @c Global mode, the shared alphabet is used.
+     * In @c MultiLevel mode @p level must have a value.
      */
-    Symbol translate_symb(const std::string& symb, Level level);
+    Symbol translate_symb(const std::string& symb, std::optional<Level> level = std::nullopt);
 
     /**
      * @brief Translate a symbol value back to its name using the alphabet for the given level.
+     *
+     * Same level-resolution semantics as @c translate_symb.
      */
-    std::string reverse_translate_symbol(Symbol symbol, Level level) const;
+    std::string reverse_translate_symbol(Symbol symbol, std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Get the symbols known to the alphabet on the given level.
      */
-    utils::OrdVector<Symbol> get_alphabet_symbols(Level level) const;
+    utils::OrdVector<Symbol> get_alphabet_symbols(std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Get the complement of @p symbols with respect to the alphabet for the given level.
      */
-    utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols, Level level) const;
+    utils::OrdVector<Symbol> get_complement(
+        const utils::OrdVector<Symbol>& symbols, std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Check whether the alphabet for the given level is empty.
-     *
-     * When @p level is @c std::nullopt, returns @c true iff every underlying alphabet is empty (or there are no
-     *  underlying alphabets at all).
      */
     bool empty(std::optional<Level> level = std::nullopt) const;
 
     /**
      * @brief Clear the alphabet for the given level.
-     *
-     * When @p level is @c std::nullopt, clears every underlying alphabet.
      */
     void clear(std::optional<Level> level = std::nullopt);
 
     /**
      * @brief Get the alphabet assigned to a specific level.
      *
-     * This is like a validated accessor for the internal vector of @c Alphabet*.
+     * Validated accessor for the internal vector of @c Alphabet*.
      *
-     * If the internal vector has a single element, it is used regardless of @p level (shared-alphabet form).
-     * Otherwise, @p level must be a valid index and the corresponding entry must be non-null.
+     * - In @c Global mode, @c alphabets[0] is returned regardless of @p level.
+     * - In @c MultiLevel mode, @p level must have a value and be a valid index; the corresponding entry must be
+     *   non-null.
      *
-     * @param[in] level Level whose alphabet should be returned.
+     * @param[in] level Level whose alphabet should be returned (required in @c MultiLevel mode).
      * @return Alphabet assigned to @p level.
-     * @throws std::runtime_error If @p level is out of range or the entry is null.
+     * @throws std::runtime_error If @p level is missing in @c MultiLevel mode, out of range, or the entry is null.
      */
-    const Alphabet& for_level(Level level) const;
+    const Alphabet& for_level(std::optional<Level> level = std::nullopt) const;
 
     /// Alias for @c for_level.
-    const Alphabet& operator[](Level level) const { return for_level(level); }
+    const Alphabet& operator[](std::optional<Level> level) const { return for_level(level); }
 };
 
 /**

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -586,13 +586,25 @@ public:
 
 private:
     /**
-     * @brief Resolve the alphabet to use for the given level.
+     * @brief Get the alphabet to use for the given level.
      *
      * @param[in] level Level selecting the underlying alphabet.
-     * @return Resolved alphabet reference.
-     * @throws std::runtime_error If the level is @c std::nullopt or out of range.
+     * @return Alphabet reference for @p level.
+     * @throws std::runtime_error If the level is out of range.
      */
-    const Alphabet& resolve_alphabet(std::optional<Level> level) const;
+    const Alphabet& get_alphabet_for_level(Level level) const;
+
+    /**
+     * @brief Unwrap an optional level, throwing if it is @c std::nullopt.
+     *
+     * @param[in] level Optional level supplied through the @c Alphabet interface.
+     * @return Unwrapped level value.
+     * @throws std::runtime_error If @p level is @c std::nullopt.
+     */
+    static Level require_level(std::optional<Level> level) {
+        if (!level) { throw std::runtime_error("LevelAlphabet operation requires an explicit level."); }
+        return *level;
+    }
 
     std::vector<Alphabet*> alphabets_{};
 };

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -68,8 +68,11 @@ void construct(
     Nft* result, const IntermediateAut& inter_aut, Alphabet* alphabet, NameStateMap* state_map = nullptr
 );
 
-/** Loads an automaton from an IntermediateAut using per-level alphabets. The constructed @c Nft has its @c alphabets
- * member set to @p alphabets and its inherited @c alphabet member left as @c nullptr. */
+/** 
+ * @brief Loads an automaton from an IntermediateAut using per-level alphabets.
+ * 
+ * The constructed @c Nft has its @c alphabets member set to @p alphabets and its inherited @c alphabet member left as @c nullptr.
+ */
 Nft construct(const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr);
 void construct(
     Nft* result, const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -68,6 +68,13 @@ void construct(
     Nft* result, const IntermediateAut& inter_aut, Alphabet* alphabet, NameStateMap* state_map = nullptr
 );
 
+/** Loads an automaton from an IntermediateAut using per-level alphabets. The constructed @c Nft has its @c alphabets
+ * member set to @p alphabets and its inherited @c alphabet member left as @c nullptr. */
+Nft construct(const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr);
+void construct(
+    Nft* result, const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr
+);
+
 template<class ParsedObject>
 Nft construct(const ParsedObject& parsed, Alphabet* alphabet = nullptr,
               NameStateMap* state_map = nullptr) {

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -126,16 +126,6 @@ public:
      */
     Levels levels{};
 
-    /**
-     * @brief Optional per-level alphabets.
-     *
-     * When empty, the NFT falls back to the shared @ref alphabet inherited from @ref nfa::Nfa.
-     * When non-empty, the vector is indexed by NFT level. If all entries are the same pointer,
-     * the inherited shared @ref alphabet is kept in sync with that pointer; otherwise it is set
-     * to @c nullptr because no single shared alphabet describes the whole NFT.
-     */
-    std::vector<Alphabet*> level_alphabets{};
-
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
     /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
@@ -144,41 +134,12 @@ public:
     // TODO: When there is a need for state dictionary, consider creating default library implementation of state
     //  dictionary in the attributes.
 
-public:
-    /**
-     * Create a repeated vector of @p num_of_levels entries of the same @p alphabet pointer for the level alphabets.
-     *
-     * @param num_of_levels The number of levels for which to create the vector.
-     */
-    static std::vector<Alphabet*> repeated_level_alphabets(const size_t num_of_levels, Alphabet* alphabet);
-
-    /**
-     * Check if all entries in @p level_alphabets are the same pointer and return that pointer if so, or return nullptr
-     *
-     * @param level_alphabets The vector of level alphabets to check for being all the same pointer.
-     */
-    static Alphabet* shared_alphabet_or_null(const std::vector<Alphabet*>& level_alphabets);
-
     explicit Nft(
             Delta delta = {}, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Levels levels = {},
             Alphabet* alphabet = nullptr)
         : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
-          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
-
-    explicit Nft(
-            Delta delta, utils::SparseSet<State> initial_states, utils::SparseSet<State> final_states, Levels levels,
-            std::vector<Alphabet*> level_alphabets)
-        : Nfa{
-                  std::move(delta), std::move(initial_states), std::move(final_states),
-                  shared_alphabet_or_null(level_alphabets) },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
-          level_alphabets{ std::move(level_alphabets) } {
-        if (!this->level_alphabets.empty()) {
-            assert(this->level_alphabets.size() == this->levels.num_of_levels);
-        }
-    }
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) } {}
 
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
@@ -193,32 +154,12 @@ public:
                  utils::SparseSet<State> final_states = {}, Levels levels = {},
                  Alphabet* alphabet = nullptr)
         : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
-          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
-
-    explicit Nft(
-            const size_t num_of_states, utils::SparseSet<State> initial_states, utils::SparseSet<State> final_states,
-            Levels levels, std::vector<Alphabet*> level_alphabets)
-        : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), shared_alphabet_or_null(level_alphabets) },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
-          level_alphabets{ std::move(level_alphabets) } {
-        if (!this->level_alphabets.empty()) {
-            assert(this->level_alphabets.size() == this->levels.num_of_levels);
-        }
-    }
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) } {}
 
     static Nft with_levels(
             Levels levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
         return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
-    }
-
-    static Nft with_levels(
-            Levels levels, const size_t num_of_states, utils::SparseSet<State> initial_states,
-            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
-        return Nft{
-                num_of_states, std::move(initial_states), std::move(final_states), std::move(levels),
-                std::move(level_alphabets) };
     }
 
     static Nft with_levels(
@@ -228,25 +169,9 @@ public:
     }
 
     static Nft with_levels(
-            Levels levels, Delta delta, utils::SparseSet<State> initial_states,
-            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
-        return Nft{
-                std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels),
-                std::move(level_alphabets) };
-    }
-
-    static Nft with_levels(
             const size_t num_of_levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
         return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
-    }
-
-    static Nft with_levels(
-            const size_t num_of_levels, const size_t num_of_states, utils::SparseSet<State> initial_states,
-            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
-        return Nft{
-                num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels },
-                std::move(level_alphabets) };
     }
 
     static Nft with_levels(
@@ -255,27 +180,13 @@ public:
         return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
     }
 
-    static Nft with_levels(
-            const size_t num_of_levels, Delta delta, utils::SparseSet<State> initial_states,
-            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
-        return Nft{
-                std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels },
-                std::move(level_alphabets) };
-    }
-
     /**
      * @brief Construct a new explicit NFT from other NFT.
      */
     Nft(const Nft& other) = default;
 
     Nft(Nft&& other) noexcept
-        : levels{ std::move(other.levels) }, level_alphabets{ std::move(other.level_alphabets) } {
-          delta = std::move(other.delta);
-          initial = std::move(other.initial);
-          final = std::move(other.final);
-          attributes = std::move(other.attributes);
-          alphabet = other.alphabet;
-          other.alphabet = nullptr;
+        : Nfa{ std::move(other) }, levels{ std::move(other.levels) } {
     }
 
     Nft& operator=(const Nft& other) = default;
@@ -293,8 +204,7 @@ public:
      * @param default_level Default level for the states. (default: 0)
      */
     explicit Nft(const mata::nfa::Nfa& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
-        : mata::nfa::Nfa(other), levels{ num_of_levels, num_of_states(), default_level },
-          level_alphabets{ repeated_level_alphabets(num_of_levels, alphabet) } {}
+        : mata::nfa::Nfa(other), levels{ num_of_levels, num_of_states(), default_level } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -308,8 +218,7 @@ public:
      * @param default_level Default level for the states. (default: 0)
      */
     explicit Nft(Nfa&& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
-        : Nfa(std::move(other)), levels{ num_of_levels, num_of_states(), default_level },
-          level_alphabets{ repeated_level_alphabets(num_of_levels, alphabet) } {}
+        : Nfa(std::move(other)), levels{ num_of_levels, num_of_states(), default_level } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -322,8 +231,7 @@ public:
      * @param levels Levels for the states of the NFA @c other.
      */
     explicit Nft(const Nfa& other, Levels levels)
-        : Nfa(other), levels{ std::move(levels) },
-          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
+        : Nfa(other), levels{ std::move(levels) } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -336,27 +244,7 @@ public:
      * @param levels Levels for the states of the NFA @c other.
      */
     explicit Nft(Nfa&& other, Levels levels)
-        : Nfa{ std::move(other) }, levels{ std::move(levels) },
-          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
-
-    /**
-     * @brief Get the alphabet of the NFT for a given level.
-     * If the level has a specific alphabet in @c level_alphabets, return that alphabet;
-     * otherwise, return the shared @ref alphabet.
-     *
-     * @param level The level for which to get the alphabet.
-     */
-    const Alphabet* alphabet_of_level(const size_t level) const;
-
-    /**
-     * @brief Set the level alphabets for the NFT.
-     *
-     * When the vector of level alphabets is non-empty, it must have a size equal to the number of levels in the NFT.
-     * If the vector is empty, the NFT falls back to using the shared @ref alphabet for all levels.
-     *
-     * @param new_level_alphabets The new vector of level alphabets to set for the NFT.
-     */
-    void set_level_alphabets(std::vector<Alphabet*> new_level_alphabets);
+        : Nfa{ std::move(other) }, levels{ std::move(levels) } {}
 
     Nft& operator=(const Nfa& other) noexcept;
     Nft& operator=(Nfa&& other) noexcept;

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -126,6 +126,16 @@ public:
      */
     Levels levels{};
 
+    /**
+     * @brief Optional per-level alphabets.
+     *
+     * When empty, the NFT falls back to the shared @ref alphabet inherited from @ref nfa::Nfa.
+     * When non-empty, the vector is indexed by NFT level. If all entries are the same pointer,
+     * the inherited shared @ref alphabet is kept in sync with that pointer; otherwise it is set
+     * to @c nullptr because no single shared alphabet describes the whole NFT.
+     */
+    std::vector<Alphabet*> level_alphabets{};
+
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
     /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
@@ -135,12 +145,45 @@ public:
     //  dictionary in the attributes.
 
 public:
+    static std::vector<Alphabet*> repeated_level_alphabets(const size_t num_of_levels, Alphabet* alphabet) {
+        return std::vector<Alphabet*>(num_of_levels, alphabet);
+    }
+
+    static Alphabet* shared_alphabet_or_null(const std::vector<Alphabet*>& level_alphabets) {
+        if (level_alphabets.empty()) {
+            return nullptr;
+        }
+
+        const Alphabet* first = level_alphabets.front();
+        for (const Alphabet* alphabet : level_alphabets) {
+            if (alphabet != first) {
+                return nullptr;
+            }
+        }
+
+        return const_cast<Alphabet*>(first);
+    }
+
     explicit Nft(
             Delta delta = {}, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Levels levels = {},
             Alphabet* alphabet = nullptr)
         : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) } {}
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
+          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
+
+    explicit Nft(
+            Delta delta, utils::SparseSet<State> initial_states, utils::SparseSet<State> final_states, Levels levels,
+            std::vector<Alphabet*> level_alphabets)
+        : Nfa{
+                  std::move(delta), std::move(initial_states), std::move(final_states),
+                  shared_alphabet_or_null(level_alphabets) },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
+          level_alphabets{ std::move(level_alphabets) } {
+        if (!this->level_alphabets.empty()) {
+            assert(this->level_alphabets.size() == this->levels.num_of_levels);
+        }
+    }
 
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
@@ -155,12 +198,32 @@ public:
                  utils::SparseSet<State> final_states = {}, Levels levels = {},
                  Alphabet* alphabet = nullptr)
         : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) } {}
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
+          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
+
+    explicit Nft(
+            const size_t num_of_states, utils::SparseSet<State> initial_states, utils::SparseSet<State> final_states,
+            Levels levels, std::vector<Alphabet*> level_alphabets)
+        : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), shared_alphabet_or_null(level_alphabets) },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
+          level_alphabets{ std::move(level_alphabets) } {
+        if (!this->level_alphabets.empty()) {
+            assert(this->level_alphabets.size() == this->levels.num_of_levels);
+        }
+    }
 
     static Nft with_levels(
             Levels levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
         return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
+    }
+
+    static Nft with_levels(
+            Levels levels, const size_t num_of_states, utils::SparseSet<State> initial_states,
+            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
+        return Nft{
+                num_of_states, std::move(initial_states), std::move(final_states), std::move(levels),
+                std::move(level_alphabets) };
     }
 
     static Nft with_levels(
@@ -170,9 +233,25 @@ public:
     }
 
     static Nft with_levels(
+            Levels levels, Delta delta, utils::SparseSet<State> initial_states,
+            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
+        return Nft{
+                std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels),
+                std::move(level_alphabets) };
+    }
+
+    static Nft with_levels(
             const size_t num_of_levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
         return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
+    }
+
+    static Nft with_levels(
+            const size_t num_of_levels, const size_t num_of_states, utils::SparseSet<State> initial_states,
+            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
+        return Nft{
+                num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels },
+                std::move(level_alphabets) };
     }
 
     static Nft with_levels(
@@ -181,13 +260,21 @@ public:
         return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
     }
 
+    static Nft with_levels(
+            const size_t num_of_levels, Delta delta, utils::SparseSet<State> initial_states,
+            utils::SparseSet<State> final_states, std::vector<Alphabet*> level_alphabets) {
+        return Nft{
+                std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels },
+                std::move(level_alphabets) };
+    }
+
     /**
      * @brief Construct a new explicit NFT from other NFT.
      */
     Nft(const Nft& other) = default;
 
     Nft(Nft&& other) noexcept
-        : levels{ std::move(other.levels) } {
+        : levels{ std::move(other.levels) }, level_alphabets{ std::move(other.level_alphabets) } {
           delta = std::move(other.delta);
           initial = std::move(other.initial);
           final = std::move(other.final);
@@ -211,7 +298,8 @@ public:
      * @param default_level Default level for the states. (default: 0)
      */
     explicit Nft(const mata::nfa::Nfa& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
-        : mata::nfa::Nfa(other), levels{ num_of_levels, num_of_states(), default_level } {}
+        : mata::nfa::Nfa(other), levels{ num_of_levels, num_of_states(), default_level },
+          level_alphabets{ repeated_level_alphabets(num_of_levels, alphabet) } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -225,7 +313,8 @@ public:
      * @param default_level Default level for the states. (default: 0)
      */
     explicit Nft(Nfa&& other, const size_t num_of_levels = 1, const Level default_level = DEFAULT_LEVEL)
-        : Nfa(std::move(other)), levels{ num_of_levels, num_of_states(), default_level } {}
+        : Nfa(std::move(other)), levels{ num_of_levels, num_of_states(), default_level },
+          level_alphabets{ repeated_level_alphabets(num_of_levels, alphabet) } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -237,7 +326,9 @@ public:
      * @param other NFA to be converted to NFT.
      * @param levels Levels for the states of the NFA @c other.
      */
-    explicit Nft(const Nfa& other, Levels levels): Nfa(other), levels{ std::move(levels) } {}
+    explicit Nft(const Nfa& other, Levels levels)
+        : Nfa(other), levels{ std::move(levels) },
+          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
 
     /**
      * @brief Construct a new NFT with @p num_of_levels levels from NFA.
@@ -249,7 +340,24 @@ public:
      * @param other NFA to be converted to NFT.
      * @param levels Levels for the states of the NFA @c other.
      */
-    explicit Nft(Nfa&& other, Levels levels): Nfa{ std::move(other) }, levels{ std::move(levels) } {}
+    explicit Nft(Nfa&& other, Levels levels)
+        : Nfa{ std::move(other) }, levels{ std::move(levels) },
+          level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
+
+    const Alphabet* alphabet_of_level(const size_t level) const {
+        if (!level_alphabets.empty() && level < level_alphabets.size() && level_alphabets[level] != nullptr) {
+            return level_alphabets[level];
+        }
+        return alphabet;
+    }
+
+    void set_level_alphabets(std::vector<Alphabet*> new_level_alphabets) {
+        if (!new_level_alphabets.empty()) {
+            assert(new_level_alphabets.size() == levels.num_of_levels);
+        }
+        alphabet = shared_alphabet_or_null(new_level_alphabets);
+        level_alphabets = std::move(new_level_alphabets);
+    }
 
     Nft& operator=(const Nfa& other) noexcept;
     Nft& operator=(Nfa&& other) noexcept;

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -126,6 +126,14 @@ public:
      */
     Levels levels{};
 
+    /**
+     * @brief Per-level alphabets
+     *
+     * NFT operations always go through this member; the inherited @c Nfa::alphabet field is kept as @c nullptr and ignored,
+     * anticipating the planned class split where NFT no longer derives from NFA.
+     */
+    AlphabetLevels* alphabets{ nullptr };
+
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
     /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
@@ -137,9 +145,10 @@ public:
     explicit Nft(
             Delta delta = {}, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Levels levels = {},
-            Alphabet* alphabet = nullptr)
-        : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) } {}
+            AlphabetLevels* alphabets = nullptr)
+        : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), nullptr },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
+          alphabets{ alphabets } {}
 
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
@@ -148,46 +157,41 @@ public:
      * @param initial_states Initial states of the NFT.
      * @param final_states Final states of the NFT.
      * @param levels Levels of the states.
-     * @param alphabet Alphabet of the NFT.
+     * @param alphabets Per-level alphabets of the NFT (non-owning).
      */
     explicit Nft(const size_t num_of_states, utils::SparseSet<State> initial_states = {},
                  utils::SparseSet<State> final_states = {}, Levels levels = {},
-                 Alphabet* alphabet = nullptr)
-        : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), alphabet },
-          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) } {}
+                 AlphabetLevels* alphabets = nullptr)
+        : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), nullptr },
+          levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
+          alphabets{ alphabets } {}
 
     static Nft with_levels(
             Levels levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
+            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabets };
     }
 
     static Nft with_levels(
             Levels levels, Delta delta, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), alphabet };
+            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), alphabets };
     }
 
     static Nft with_levels(
             const size_t num_of_levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
+            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabets };
     }
 
     static Nft with_levels(
             const size_t num_of_levels, Delta delta, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr) {
-        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabet };
+            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabets };
     }
 
-    /**
-     * @brief Construct a new explicit NFT from other NFT.
-     */
     Nft(const Nft& other) = default;
-
-    Nft(Nft&& other) noexcept
-        : Nfa{ std::move(other) }, levels{ std::move(other.levels) } {
-    }
+    Nft(Nft&& other) noexcept = default;
 
     Nft& operator=(const Nft& other) = default;
     Nft& operator=(Nft&& other) noexcept;

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -145,24 +145,19 @@ public:
     //  dictionary in the attributes.
 
 public:
-    static std::vector<Alphabet*> repeated_level_alphabets(const size_t num_of_levels, Alphabet* alphabet) {
-        return std::vector<Alphabet*>(num_of_levels, alphabet);
-    }
+    /**
+     * Create a repeated vector of @p num_of_levels entries of the same @p alphabet pointer for the level alphabets.
+     *
+     * @param num_of_levels The number of levels for which to create the vector.
+     */
+    static std::vector<Alphabet*> repeated_level_alphabets(const size_t num_of_levels, Alphabet* alphabet);
 
-    static Alphabet* shared_alphabet_or_null(const std::vector<Alphabet*>& level_alphabets) {
-        if (level_alphabets.empty()) {
-            return nullptr;
-        }
-
-        const Alphabet* first = level_alphabets.front();
-        for (const Alphabet* alphabet : level_alphabets) {
-            if (alphabet != first) {
-                return nullptr;
-            }
-        }
-
-        return const_cast<Alphabet*>(first);
-    }
+    /**
+     * Check if all entries in @p level_alphabets are the same pointer and return that pointer if so, or return nullptr
+     *
+     * @param level_alphabets The vector of level alphabets to check for being all the same pointer.
+     */
+    static Alphabet* shared_alphabet_or_null(const std::vector<Alphabet*>& level_alphabets);
 
     explicit Nft(
             Delta delta = {}, utils::SparseSet<State> initial_states = {},
@@ -344,20 +339,24 @@ public:
         : Nfa{ std::move(other) }, levels{ std::move(levels) },
           level_alphabets{ repeated_level_alphabets(this->levels.num_of_levels, alphabet) } {}
 
-    const Alphabet* alphabet_of_level(const size_t level) const {
-        if (!level_alphabets.empty() && level < level_alphabets.size() && level_alphabets[level] != nullptr) {
-            return level_alphabets[level];
-        }
-        return alphabet;
-    }
+    /**
+     * @brief Get the alphabet of the NFT for a given level.
+     * If the level has a specific alphabet in @c level_alphabets, return that alphabet;
+     * otherwise, return the shared @ref alphabet.
+     *
+     * @param level The level for which to get the alphabet.
+     */
+    const Alphabet* alphabet_of_level(const size_t level) const;
 
-    void set_level_alphabets(std::vector<Alphabet*> new_level_alphabets) {
-        if (!new_level_alphabets.empty()) {
-            assert(new_level_alphabets.size() == levels.num_of_levels);
-        }
-        alphabet = shared_alphabet_or_null(new_level_alphabets);
-        level_alphabets = std::move(new_level_alphabets);
-    }
+    /**
+     * @brief Set the level alphabets for the NFT.
+     *
+     * When the vector of level alphabets is non-empty, it must have a size equal to the number of levels in the NFT.
+     * If the vector is empty, the NFT falls back to using the shared @ref alphabet for all levels.
+     *
+     * @param new_level_alphabets The new vector of level alphabets to set for the NFT.
+     */
+    void set_level_alphabets(std::vector<Alphabet*> new_level_alphabets);
 
     Nft& operator=(const Nfa& other) noexcept;
     Nft& operator=(Nfa&& other) noexcept;

--- a/include/mata/nft/types.hh
+++ b/include/mata/nft/types.hh
@@ -17,7 +17,7 @@ namespace mata::nft {
 
 extern const std::string TYPE_NFT;
 
-using Level = unsigned;
+using Level = mata::Level;
 
 using State = nfa::State;
 using StateSet = nfa::StateSet;

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -223,10 +223,24 @@ mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
 }
 
 bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
+    if (mode == Mode::MultiLevel && !level.has_value()) {
+        // MultiLevel + nullopt: empty iff every underlying alphabet is empty.
+        for (const Alphabet* alphabet : alphabets) {
+            if (alphabet != nullptr && !alphabet->empty()) { return false; }
+        }
+        return true;
+    }
     return for_level(level).empty();
 }
 
 void AlphabetLevels::clear(const std::optional<mata::Level> level) {
+    if (mode == Mode::MultiLevel && !level.has_value()) {
+        // MultiLevel + nullopt: clear every underlying alphabet.
+        for (Alphabet* alphabet : alphabets) {
+            if (alphabet != nullptr) { alphabet->clear(); }
+        }
+        return;
+    }
     const_cast<Alphabet&>(for_level(level)).clear();
 }
 

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -203,52 +203,57 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
     return 0;
 }
 
-Symbol AlphabetLevels::translate_symb(const std::string& symb, const mata::Level level) {
+Symbol AlphabetLevels::translate_symb(const std::string& symb, const std::optional<mata::Level> level) {
     return const_cast<Alphabet&>(for_level(level)).translate_symb(symb);
 }
 
-std::string AlphabetLevels::reverse_translate_symbol(const Symbol symbol, const mata::Level level) const {
+std::string AlphabetLevels::reverse_translate_symbol(
+    const Symbol symbol, const std::optional<mata::Level> level) const {
     return for_level(level).reverse_translate_symbol(symbol);
 }
 
-mata::utils::OrdVector<Symbol> AlphabetLevels::get_alphabet_symbols(const mata::Level level) const {
+mata::utils::OrdVector<Symbol> AlphabetLevels::get_alphabet_symbols(
+    const std::optional<mata::Level> level) const {
     return for_level(level).get_alphabet_symbols();
 }
 
 mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
-    const mata::utils::OrdVector<Symbol>& symbols, const mata::Level level) const {
+    const mata::utils::OrdVector<Symbol>& symbols, const std::optional<mata::Level> level) const {
     return for_level(level).get_complement(symbols);
 }
 
 bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
-    if (level.has_value()) {
-        return for_level(*level).empty();
-    }
-    for (const Alphabet* alphabet : alphabets) {
-        if (alphabet != nullptr && !alphabet->empty()) { return false; }
-    }
-    return true;
+    return for_level(level).empty();
 }
 
 void AlphabetLevels::clear(const std::optional<mata::Level> level) {
-    if (level.has_value()) {
-        const_cast<Alphabet&>(for_level(*level)).clear();
-        return;
-    }
-    for (Alphabet* alphabet : alphabets) {
-        if (alphabet != nullptr) { alphabet->clear(); }
-    }
+    const_cast<Alphabet&>(for_level(level)).clear();
 }
 
-const mata::Alphabet& AlphabetLevels::for_level(const mata::Level level) const {
-    const Alphabet* alphabet{ alphabets.size() == 1
-                                  ? alphabets[0]
-                                  : (level < alphabets.size() ? alphabets[level] : nullptr) };
-    if (alphabet == nullptr) {
-        throw std::runtime_error(
-            "AlphabetLevels has no alphabet for level " + std::to_string(level) + ".");
+const mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level> level) const {
+    if (mode == Mode::Global) {
+        if (alphabets.empty() || alphabets[0] == nullptr) {
+            throw std::runtime_error("AlphabetLevels (Global) has no underlying alphabet.");
+        }
+        return *alphabets[0];
     }
-    return *alphabet;
+
+    // Mode::MultiLevel
+    if (!level.has_value()) {
+        throw std::runtime_error("AlphabetLevels (MultiLevel) requires an explicit level.");
+    }
+
+    if (*level >= alphabets.size()) {
+        throw std::runtime_error(
+            "AlphabetLevels has no alphabet for level " + std::to_string(*level) + " (out of range).");
+    }
+
+    if (alphabets[*level] == nullptr) {
+        throw std::runtime_error(
+            "AlphabetLevels has no alphabet for level " + std::to_string(*level) + " (entry is null).");
+    }
+
+    return *alphabets[*level];
 }
 
 mata::Word mata::encode_word_utf8(const mata::Word& word) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -4,6 +4,7 @@
 #include <mata/alphabet.hh>
 
 using mata::Symbol;
+using mata::LevelAlphabet;
 using mata::OnTheFlyAlphabet;
 
 mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
@@ -200,6 +201,49 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
         return 1;
     }
     return 0;
+}
+
+const mata::Alphabet& LevelAlphabet::resolve_alphabet(const size_t level) const {
+    if (alphabets_.empty()) {
+        throw std::runtime_error("LevelAlphabet has no underlying alphabets.");
+    }
+
+    if (level >= alphabets_.size()) {
+        throw std::runtime_error("Requested level " + std::to_string(level) + " is out of range.");
+    }
+    if (alphabets_[level] == nullptr) {
+        throw std::runtime_error("Requested level " + std::to_string(level) + " has no alphabet.");
+    }
+    return *alphabets_[level];
+}
+
+Symbol LevelAlphabet::translate_symb(const std::string& symb, const size_t level) {
+    return const_cast<Alphabet&>(resolve_alphabet(level)).translate_symb(symb);
+}
+
+std::string LevelAlphabet::reverse_translate_symbol(const Symbol symbol, const size_t level) const {
+    return resolve_alphabet(level).reverse_translate_symbol(symbol);
+}
+
+mata::utils::OrdVector<Symbol> LevelAlphabet::get_alphabet_symbols(const size_t level) const {
+    return resolve_alphabet(level).get_alphabet_symbols();
+}
+
+mata::utils::OrdVector<Symbol> LevelAlphabet::get_complement(
+    const mata::utils::OrdVector<Symbol>& symbols, const size_t level) const {
+    return resolve_alphabet(level).get_complement(symbols);
+}
+
+bool LevelAlphabet::empty(const size_t level) const {
+    return resolve_alphabet(level).empty();
+}
+
+void LevelAlphabet::clear(const size_t level) {
+    const_cast<Alphabet&>(resolve_alphabet(level)).clear();
+}
+
+const mata::Alphabet* LevelAlphabet::alphabet_of_level(const size_t level) const {
+    return level < alphabets_.size() ? alphabets_[level] : nullptr;
 }
 
 mata::Word mata::encode_word_utf8(const mata::Word& word) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -213,47 +213,43 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
     return 0;
 }
 
-const mata::Alphabet& LevelAlphabet::resolve_alphabet(const std::optional<mata::Level> level) const {
-    if (!level.has_value()) {
-        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
-    }
+const mata::Alphabet& LevelAlphabet::get_alphabet_for_level(const mata::Level level) const {
     if (alphabets_.empty()) {
         throw std::runtime_error("LevelAlphabet has no underlying alphabets.");
     }
-
-    if (*level >= alphabets_.size()) {
-        throw std::runtime_error("Requested level " + std::to_string(*level) + " is out of range.");
+    if (level >= alphabets_.size()) {
+        throw std::runtime_error("Requested level " + std::to_string(level) + " is out of range.");
     }
-    if (alphabets_[*level] == nullptr) {
-        throw std::runtime_error("Requested level " + std::to_string(*level) + " has no alphabet.");
+    if (alphabets_[level] == nullptr) {
+        throw std::runtime_error("Requested level " + std::to_string(level) + " has no alphabet.");
     }
-    return *alphabets_[*level];
+    return *alphabets_[level];
 }
 
 Symbol LevelAlphabet::translate_symb(const std::string& symb, const std::optional<mata::Level> level) {
-    return const_cast<Alphabet&>(resolve_alphabet(level)).translate_symb(symb);
+    return const_cast<Alphabet&>(get_alphabet_for_level(require_level(level))).translate_symb(symb);
 }
 
 std::string LevelAlphabet::reverse_translate_symbol(
     const Symbol symbol, const std::optional<mata::Level> level) const {
-    return resolve_alphabet(level).reverse_translate_symbol(symbol);
+    return get_alphabet_for_level(require_level(level)).reverse_translate_symbol(symbol);
 }
 
 mata::utils::OrdVector<Symbol> LevelAlphabet::get_alphabet_symbols(const std::optional<mata::Level> level) const {
-    return resolve_alphabet(level).get_alphabet_symbols();
+    return get_alphabet_for_level(require_level(level)).get_alphabet_symbols();
 }
 
 mata::utils::OrdVector<Symbol> LevelAlphabet::get_complement(
     const mata::utils::OrdVector<Symbol>& symbols, const std::optional<mata::Level> level) const {
-    return resolve_alphabet(level).get_complement(symbols);
+    return get_alphabet_for_level(require_level(level)).get_complement(symbols);
 }
 
 bool LevelAlphabet::empty(const std::optional<mata::Level> level) const {
-    return resolve_alphabet(level).empty();
+    return get_alphabet_for_level(require_level(level)).empty();
 }
 
 void LevelAlphabet::clear(const std::optional<mata::Level> level) {
-    const_cast<Alphabet&>(resolve_alphabet(level)).clear();
+    const_cast<Alphabet&>(get_alphabet_for_level(require_level(level))).clear();
 }
 
 const mata::Alphabet* LevelAlphabet::alphabet_of_level(const mata::Level level) const {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -204,7 +204,7 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
 }
 
 Symbol AlphabetLevels::translate_symb(const std::string& symb, const std::optional<mata::Level> level) {
-    return const_cast<Alphabet&>(for_level(level)).translate_symb(symb);
+    return for_level(level).translate_symb(symb);
 }
 
 std::string AlphabetLevels::reverse_translate_symbol(
@@ -241,7 +241,7 @@ void AlphabetLevels::clear(const std::optional<mata::Level> level) {
         }
         return;
     }
-    const_cast<Alphabet&>(for_level(level)).clear();
+    for_level(level).clear();
 }
 
 const mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level> level) const {
@@ -268,6 +268,10 @@ const mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level>
     }
 
     return *alphabets[*level];
+}
+
+mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level> level) {
+    return const_cast<Alphabet&>(std::as_const(*this).for_level(level));
 }
 
 mata::Word mata::encode_word_utf8(const mata::Word& word) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -4,11 +4,10 @@
 #include <mata/alphabet.hh>
 
 using mata::Symbol;
-using mata::LevelAlphabet;
+using mata::AlphabetLevels;
 using mata::OnTheFlyAlphabet;
 
-mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols(std::optional<mata::Level> level) const {
-    (void)level;
+mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
     utils::OrdVector<Symbol> result;
     for (const auto& symbol : symbol_map_ | std::views::values) {
         result.insert(symbol);
@@ -16,9 +15,7 @@ mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols(std::optio
     return result;
 } // OnTheFlyAlphabet::get_alphabet_symbols.
 
-mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(
-    const mata::utils::OrdVector<Symbol>& symbols, std::optional<mata::Level> level) const {
-    (void)level;
+mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const mata::utils::OrdVector<Symbol>& symbols) const {
     mata::utils::OrdVector<Symbol> symbols_alphabet{};
     symbols_alphabet.reserve(symbol_map_.size());
     for (const auto& symbol : symbol_map_ | std::views::values) {
@@ -34,9 +31,7 @@ void OnTheFlyAlphabet::add_symbols_from(const StringToSymbolMap& new_symbol_map)
     }
 }
 
-std::string mata::OnTheFlyAlphabet::reverse_translate_symbol(
-    const Symbol symbol, std::optional<mata::Level> level) const {
-    (void)level;
+std::string mata::OnTheFlyAlphabet::reverse_translate_symbol(const Symbol symbol) const {
     for (const auto& [symbol_name, symbol_val]: symbol_map_) {
         if (symbol_val == symbol) {
             return symbol_name;
@@ -51,8 +46,7 @@ void mata::OnTheFlyAlphabet::add_symbols_from(const std::vector<std::string>& sy
     }
 }
 
-Symbol mata::OnTheFlyAlphabet::translate_symb(const std::string& str, std::optional<mata::Level> level) {
-    (void)level;
+Symbol mata::OnTheFlyAlphabet::translate_symb(const std::string& str) {
     const auto [it, inserted] = symbol_map_.insert({str, next_symbol_value_});
     if (inserted) {
         return next_symbol_value_++;
@@ -112,8 +106,7 @@ std::ostream &std::operator<<(std::ostream &os, const mata::Alphabet& alphabet) 
     return os << std::to_string(alphabet);
 }
 
-Symbol mata::IntAlphabet::translate_symb(const std::string& symb, std::optional<mata::Level> level) {
-    (void)level;
+Symbol mata::IntAlphabet::translate_symb(const std::string& symb) {
     Symbol symbol;
     std::istringstream stream{ symb };
     stream >> symbol;
@@ -123,17 +116,14 @@ Symbol mata::IntAlphabet::translate_symb(const std::string& symb, std::optional<
     return symbol;
 }
 
-std::string mata::EnumAlphabet::reverse_translate_symbol(
-    const Symbol symbol, std::optional<mata::Level> level) const {
-    (void)level;
+std::string mata::EnumAlphabet::reverse_translate_symbol(const Symbol symbol) const {
     if (symbols_.find(symbol) == symbols_.end()) {
         throw std::runtime_error("Symbol '" + std::to_string(symbol) + "' is out of range of enumeration.");
     }
     return std::to_string(symbol);
 }
 
-Symbol mata::EnumAlphabet::translate_symb(const std::string& str, std::optional<mata::Level> level) {
-    (void)level;
+Symbol mata::EnumAlphabet::translate_symb(const std::string& str) {
     Symbol symbol;
     std::istringstream stream{ str };
     stream >> symbol;
@@ -213,47 +203,40 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
     return 0;
 }
 
-const mata::Alphabet& LevelAlphabet::get_alphabet_for_level(const mata::Level level) const {
-    if (alphabets_.empty()) {
-        throw std::runtime_error("LevelAlphabet has no underlying alphabets.");
+Symbol AlphabetLevels::translate_symb(const std::string& symb, const mata::Level level) {
+    return const_cast<Alphabet&>(alphabet_of_level(level)).translate_symb(symb);
+}
+
+std::string AlphabetLevels::reverse_translate_symbol(const Symbol symbol, const mata::Level level) const {
+    return alphabet_of_level(level).reverse_translate_symbol(symbol);
+}
+
+mata::utils::OrdVector<Symbol> AlphabetLevels::get_alphabet_symbols(const mata::Level level) const {
+    return alphabet_of_level(level).get_alphabet_symbols();
+}
+
+mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
+    const mata::utils::OrdVector<Symbol>& symbols, const mata::Level level) const {
+    return alphabet_of_level(level).get_complement(symbols);
+}
+
+bool AlphabetLevels::empty(const mata::Level level) const {
+    return alphabet_of_level(level).empty();
+}
+
+void AlphabetLevels::clear(const mata::Level level) {
+    const_cast<Alphabet&>(alphabet_of_level(level)).clear();
+}
+
+const mata::Alphabet& AlphabetLevels::alphabet_of_level(const mata::Level level) const {
+    const Alphabet* alphabet{ alphabets_.size() == 1
+                                  ? alphabets_[0]
+                                  : (level < alphabets_.size() ? alphabets_[level] : nullptr) };
+    if (alphabet == nullptr) {
+        throw std::runtime_error(
+            "AlphabetLevels has no alphabet for level " + std::to_string(level) + ".");
     }
-    if (level >= alphabets_.size()) {
-        throw std::runtime_error("Requested level " + std::to_string(level) + " is out of range.");
-    }
-    if (alphabets_[level] == nullptr) {
-        throw std::runtime_error("Requested level " + std::to_string(level) + " has no alphabet.");
-    }
-    return *alphabets_[level];
-}
-
-Symbol LevelAlphabet::translate_symb(const std::string& symb, const std::optional<mata::Level> level) {
-    return const_cast<Alphabet&>(get_alphabet_for_level(require_level(level))).translate_symb(symb);
-}
-
-std::string LevelAlphabet::reverse_translate_symbol(
-    const Symbol symbol, const std::optional<mata::Level> level) const {
-    return get_alphabet_for_level(require_level(level)).reverse_translate_symbol(symbol);
-}
-
-mata::utils::OrdVector<Symbol> LevelAlphabet::get_alphabet_symbols(const std::optional<mata::Level> level) const {
-    return get_alphabet_for_level(require_level(level)).get_alphabet_symbols();
-}
-
-mata::utils::OrdVector<Symbol> LevelAlphabet::get_complement(
-    const mata::utils::OrdVector<Symbol>& symbols, const std::optional<mata::Level> level) const {
-    return get_alphabet_for_level(require_level(level)).get_complement(symbols);
-}
-
-bool LevelAlphabet::empty(const std::optional<mata::Level> level) const {
-    return get_alphabet_for_level(require_level(level)).empty();
-}
-
-void LevelAlphabet::clear(const std::optional<mata::Level> level) {
-    const_cast<Alphabet&>(get_alphabet_for_level(require_level(level))).clear();
-}
-
-const mata::Alphabet* LevelAlphabet::alphabet_of_level(const mata::Level level) const {
-    return level < alphabets_.size() ? alphabets_[level] : nullptr;
+    return *alphabet;
 }
 
 mata::Word mata::encode_word_utf8(const mata::Word& word) {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -7,7 +7,8 @@ using mata::Symbol;
 using mata::LevelAlphabet;
 using mata::OnTheFlyAlphabet;
 
-mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
+mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols(std::optional<mata::Level> level) const {
+    (void)level;
     utils::OrdVector<Symbol> result;
     for (const auto& symbol : symbol_map_ | std::views::values) {
         result.insert(symbol);
@@ -15,7 +16,9 @@ mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_alphabet_symbols() const {
     return result;
 } // OnTheFlyAlphabet::get_alphabet_symbols.
 
-mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(const mata::utils::OrdVector<Symbol>& symbols) const {
+mata::utils::OrdVector<Symbol> OnTheFlyAlphabet::get_complement(
+    const mata::utils::OrdVector<Symbol>& symbols, std::optional<mata::Level> level) const {
+    (void)level;
     mata::utils::OrdVector<Symbol> symbols_alphabet{};
     symbols_alphabet.reserve(symbol_map_.size());
     for (const auto& symbol : symbol_map_ | std::views::values) {
@@ -31,7 +34,9 @@ void OnTheFlyAlphabet::add_symbols_from(const StringToSymbolMap& new_symbol_map)
     }
 }
 
-std::string mata::OnTheFlyAlphabet::reverse_translate_symbol(const Symbol symbol) const {
+std::string mata::OnTheFlyAlphabet::reverse_translate_symbol(
+    const Symbol symbol, std::optional<mata::Level> level) const {
+    (void)level;
     for (const auto& [symbol_name, symbol_val]: symbol_map_) {
         if (symbol_val == symbol) {
             return symbol_name;
@@ -46,7 +51,8 @@ void mata::OnTheFlyAlphabet::add_symbols_from(const std::vector<std::string>& sy
     }
 }
 
-Symbol mata::OnTheFlyAlphabet::translate_symb(const std::string& str) {
+Symbol mata::OnTheFlyAlphabet::translate_symb(const std::string& str, std::optional<mata::Level> level) {
+    (void)level;
     const auto [it, inserted] = symbol_map_.insert({str, next_symbol_value_});
     if (inserted) {
         return next_symbol_value_++;
@@ -106,7 +112,8 @@ std::ostream &std::operator<<(std::ostream &os, const mata::Alphabet& alphabet) 
     return os << std::to_string(alphabet);
 }
 
-Symbol mata::IntAlphabet::translate_symb(const std::string& symb) {
+Symbol mata::IntAlphabet::translate_symb(const std::string& symb, std::optional<mata::Level> level) {
+    (void)level;
     Symbol symbol;
     std::istringstream stream{ symb };
     stream >> symbol;
@@ -116,14 +123,17 @@ Symbol mata::IntAlphabet::translate_symb(const std::string& symb) {
     return symbol;
 }
 
-std::string mata::EnumAlphabet::reverse_translate_symbol(const Symbol symbol) const {
+std::string mata::EnumAlphabet::reverse_translate_symbol(
+    const Symbol symbol, std::optional<mata::Level> level) const {
+    (void)level;
     if (symbols_.find(symbol) == symbols_.end()) {
         throw std::runtime_error("Symbol '" + std::to_string(symbol) + "' is out of range of enumeration.");
     }
     return std::to_string(symbol);
 }
 
-Symbol mata::EnumAlphabet::translate_symb(const std::string& str) {
+Symbol mata::EnumAlphabet::translate_symb(const std::string& str, std::optional<mata::Level> level) {
+    (void)level;
     Symbol symbol;
     std::istringstream stream{ str };
     stream >> symbol;
@@ -203,46 +213,50 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
     return 0;
 }
 
-const mata::Alphabet& LevelAlphabet::resolve_alphabet(const size_t level) const {
+const mata::Alphabet& LevelAlphabet::resolve_alphabet(const std::optional<mata::Level> level) const {
+    if (!level.has_value()) {
+        throw std::runtime_error("LevelAlphabet operation requires an explicit level.");
+    }
     if (alphabets_.empty()) {
         throw std::runtime_error("LevelAlphabet has no underlying alphabets.");
     }
 
-    if (level >= alphabets_.size()) {
-        throw std::runtime_error("Requested level " + std::to_string(level) + " is out of range.");
+    if (*level >= alphabets_.size()) {
+        throw std::runtime_error("Requested level " + std::to_string(*level) + " is out of range.");
     }
-    if (alphabets_[level] == nullptr) {
-        throw std::runtime_error("Requested level " + std::to_string(level) + " has no alphabet.");
+    if (alphabets_[*level] == nullptr) {
+        throw std::runtime_error("Requested level " + std::to_string(*level) + " has no alphabet.");
     }
-    return *alphabets_[level];
+    return *alphabets_[*level];
 }
 
-Symbol LevelAlphabet::translate_symb(const std::string& symb, const size_t level) {
+Symbol LevelAlphabet::translate_symb(const std::string& symb, const std::optional<mata::Level> level) {
     return const_cast<Alphabet&>(resolve_alphabet(level)).translate_symb(symb);
 }
 
-std::string LevelAlphabet::reverse_translate_symbol(const Symbol symbol, const size_t level) const {
+std::string LevelAlphabet::reverse_translate_symbol(
+    const Symbol symbol, const std::optional<mata::Level> level) const {
     return resolve_alphabet(level).reverse_translate_symbol(symbol);
 }
 
-mata::utils::OrdVector<Symbol> LevelAlphabet::get_alphabet_symbols(const size_t level) const {
+mata::utils::OrdVector<Symbol> LevelAlphabet::get_alphabet_symbols(const std::optional<mata::Level> level) const {
     return resolve_alphabet(level).get_alphabet_symbols();
 }
 
 mata::utils::OrdVector<Symbol> LevelAlphabet::get_complement(
-    const mata::utils::OrdVector<Symbol>& symbols, const size_t level) const {
+    const mata::utils::OrdVector<Symbol>& symbols, const std::optional<mata::Level> level) const {
     return resolve_alphabet(level).get_complement(symbols);
 }
 
-bool LevelAlphabet::empty(const size_t level) const {
+bool LevelAlphabet::empty(const std::optional<mata::Level> level) const {
     return resolve_alphabet(level).empty();
 }
 
-void LevelAlphabet::clear(const size_t level) {
+void LevelAlphabet::clear(const std::optional<mata::Level> level) {
     const_cast<Alphabet&>(resolve_alphabet(level)).clear();
 }
 
-const mata::Alphabet* LevelAlphabet::alphabet_of_level(const size_t level) const {
+const mata::Alphabet* LevelAlphabet::alphabet_of_level(const mata::Level level) const {
     return level < alphabets_.size() ? alphabets_[level] : nullptr;
 }
 

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -220,12 +220,24 @@ mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
     return alphabet_of_level(level).get_complement(symbols);
 }
 
-bool AlphabetLevels::empty(const mata::Level level) const {
-    return alphabet_of_level(level).empty();
+bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
+    if (level.has_value()) {
+        return alphabet_of_level(*level).empty();
+    }
+    for (const Alphabet* alphabet : alphabets) {
+        if (alphabet != nullptr && !alphabet->empty()) { return false; }
+    }
+    return true;
 }
 
-void AlphabetLevels::clear(const mata::Level level) {
-    const_cast<Alphabet&>(alphabet_of_level(level)).clear();
+void AlphabetLevels::clear(const std::optional<mata::Level> level) {
+    if (level.has_value()) {
+        const_cast<Alphabet&>(alphabet_of_level(*level)).clear();
+        return;
+    }
+    for (Alphabet* alphabet : alphabets) {
+        if (alphabet != nullptr) { alphabet->clear(); }
+    }
 }
 
 const mata::Alphabet& AlphabetLevels::alphabet_of_level(const mata::Level level) const {

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -204,25 +204,25 @@ size_t mata::OnTheFlyAlphabet::erase(const std::string& symbol_name) {
 }
 
 Symbol AlphabetLevels::translate_symb(const std::string& symb, const mata::Level level) {
-    return const_cast<Alphabet&>(alphabet_of_level(level)).translate_symb(symb);
+    return const_cast<Alphabet&>(for_level(level)).translate_symb(symb);
 }
 
 std::string AlphabetLevels::reverse_translate_symbol(const Symbol symbol, const mata::Level level) const {
-    return alphabet_of_level(level).reverse_translate_symbol(symbol);
+    return for_level(level).reverse_translate_symbol(symbol);
 }
 
 mata::utils::OrdVector<Symbol> AlphabetLevels::get_alphabet_symbols(const mata::Level level) const {
-    return alphabet_of_level(level).get_alphabet_symbols();
+    return for_level(level).get_alphabet_symbols();
 }
 
 mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
     const mata::utils::OrdVector<Symbol>& symbols, const mata::Level level) const {
-    return alphabet_of_level(level).get_complement(symbols);
+    return for_level(level).get_complement(symbols);
 }
 
 bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
     if (level.has_value()) {
-        return alphabet_of_level(*level).empty();
+        return for_level(*level).empty();
     }
     for (const Alphabet* alphabet : alphabets) {
         if (alphabet != nullptr && !alphabet->empty()) { return false; }
@@ -232,7 +232,7 @@ bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
 
 void AlphabetLevels::clear(const std::optional<mata::Level> level) {
     if (level.has_value()) {
-        const_cast<Alphabet&>(alphabet_of_level(*level)).clear();
+        const_cast<Alphabet&>(for_level(*level)).clear();
         return;
     }
     for (Alphabet* alphabet : alphabets) {
@@ -240,7 +240,7 @@ void AlphabetLevels::clear(const std::optional<mata::Level> level) {
     }
 }
 
-const mata::Alphabet& AlphabetLevels::alphabet_of_level(const mata::Level level) const {
+const mata::Alphabet& AlphabetLevels::for_level(const mata::Level level) const {
     const Alphabet* alphabet{ alphabets.size() == 1
                                   ? alphabets[0]
                                   : (level < alphabets.size() ? alphabets[level] : nullptr) };

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -229,9 +229,9 @@ void AlphabetLevels::clear(const mata::Level level) {
 }
 
 const mata::Alphabet& AlphabetLevels::alphabet_of_level(const mata::Level level) const {
-    const Alphabet* alphabet{ alphabets_.size() == 1
-                                  ? alphabets_[0]
-                                  : (level < alphabets_.size() ? alphabets_[level] : nullptr) };
+    const Alphabet* alphabet{ alphabets.size() == 1
+                                  ? alphabets[0]
+                                  : (level < alphabets.size() ? alphabets[level] : nullptr) };
     if (alphabet == nullptr) {
         throw std::runtime_error(
             "AlphabetLevels has no alphabet for level " + std::to_string(level) + ".");

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -126,7 +126,7 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
         }
 
         const State source = get_state_name(body_line[0]);
-        const Symbol symbol = alphabet->translate_symb(body_line[1], aut.levels[source]);
+        const Symbol symbol = alphabet->translate_symb(body_line[1]);
         const State target = get_state_name(body_line[2]);
         aut.delta.add(source, symbol, target);
     }
@@ -178,7 +178,7 @@ Nft builder::construct(const mata::IntermediateAut& inter_aut, mata::Alphabet* a
         }
 
         const State source = get_state_name(formula_node.name);
-        const Symbol symbol = alphabet->translate_symb(formula_graph.children[0].node.name, aut.levels[source]);
+        const Symbol symbol = alphabet->translate_symb(formula_graph.children[0].node.name);
         const State target = get_state_name(formula_graph.children[1].node.name);
 
         aut.delta.add(source, symbol, target);
@@ -214,6 +214,78 @@ void builder::construct(
         mata::nft::builder::NameStateMap *state_map
 ) {
     *result = construct(inter_aut, alphabet, state_map);
+}
+
+Nft builder::construct(const mata::IntermediateAut& inter_aut, mata::AlphabetLevels* alphabets, NameStateMap* state_map) {
+    assert(nullptr != alphabets);
+
+    if (!inter_aut.is_nft()) {
+        throw std::runtime_error(std::string(__FUNCTION__) + ": expecting type \"" + TYPE_NFT + "\"");
+    }
+
+    Nft aut;
+    aut.alphabets = alphabets;
+    aut.alphabet = nullptr;
+
+    NameStateMap tmp_state_map;
+    if (nullptr == state_map) {
+        state_map = &tmp_state_map;
+    }
+
+    auto get_state_name = [&state_map, &aut](const std::string& str) {
+        if (!state_map->contains(str)) {
+            State state = aut.add_state();
+            state_map->insert({str, state});
+            return state;
+        }
+        return (*state_map)[str];
+    };
+
+    for (const auto& str : inter_aut.initial_formula.collect_node_names()) {
+        const State state = get_state_name(str);
+        aut.initial.insert(state);
+    }
+
+    for (const auto& [formula_node, formula_graph] : inter_aut.transitions) {
+        if (formula_graph.children.size() != 2) {
+            if (formula_graph.children.size() == 1) {
+                throw std::runtime_error("Epsilon transitions not supported");
+            }
+            throw std::runtime_error("Invalid transition");
+        }
+
+        const State source = get_state_name(formula_node.name);
+        const Symbol symbol = alphabets->translate_symb(
+            formula_graph.children[0].node.name, aut.levels[source]);
+        const State target = get_state_name(formula_graph.children[1].node.name);
+        aut.delta.add(source, symbol, target);
+    }
+
+    std::unordered_set<std::string> final_formula_nodes;
+    if (!(inter_aut.final_formula.node.is_constant())) {
+        final_formula_nodes = inter_aut.final_formula.collect_node_names();
+    }
+
+    if (inter_aut.final_formula.node.is_true() || inter_aut.are_final_states_conjunction_of_negation()) {
+        for (const auto& [state_name, state] : *state_map) {
+            if (!final_formula_nodes.contains(state_name)) {
+                aut.final.insert(state);
+            }
+        }
+    } else {
+        for (const auto& str : final_formula_nodes) { aut.final.insert(get_state_name(str)); }
+    }
+
+    return aut;
+}
+
+void builder::construct(
+        mata::nft::Nft *result,
+        const mata::IntermediateAut &inter_aut,
+        mata::AlphabetLevels *alphabets,
+        mata::nft::builder::NameStateMap *state_map
+) {
+    *result = construct(inter_aut, alphabets, state_map);
 }
 
 Nft builder::create_single_word_nft(const std::vector<Symbol>& word) {

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -126,7 +126,7 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
         }
 
         const State source = get_state_name(body_line[0]);
-        const Symbol symbol = alphabet->translate_symb(body_line[1]);
+        const Symbol symbol = alphabet->translate_symb(body_line[1], aut.levels[source]);
         const State target = get_state_name(body_line[2]);
         aut.delta.add(source, symbol, target);
     }
@@ -178,7 +178,7 @@ Nft builder::construct(const mata::IntermediateAut& inter_aut, mata::Alphabet* a
         }
 
         const State source = get_state_name(formula_node.name);
-        const Symbol symbol = alphabet->translate_symb(formula_graph.children[0].node.name);
+        const Symbol symbol = alphabet->translate_symb(formula_graph.children[0].node.name, aut.levels[source]);
         const State target = get_state_name(formula_graph.children[1].node.name);
 
         aut.delta.add(source, symbol, target);

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -528,9 +528,10 @@ void Nft::unwind_jumps(
 
 Nft& Nft::operator=(Nft&& other) noexcept {
     if (this != &other) {
-        Nfa::operator=(other);
+        Nfa::operator=(std::move(other));
         levels = std::move(other.levels);
         levels.num_of_levels = other.levels.num_of_levels;
+        level_alphabets = std::move(other.level_alphabets);
     }
     return *this;
 }
@@ -541,6 +542,7 @@ Nft& Nft::operator=(const Nfa& other) noexcept {
         Nfa::operator=(other);
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
         levels.num_of_levels = 1;
+        level_alphabets = Nft::repeated_level_alphabets(levels.num_of_levels, alphabet);
     }
     return *this;
 }
@@ -550,6 +552,7 @@ Nft& Nft::operator=(Nfa&& other) noexcept {
         Nfa::operator=(std::move(other));
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
         levels.num_of_levels = 1;
+        level_alphabets = Nft::repeated_level_alphabets(levels.num_of_levels, alphabet);
     }
     return *this;
 }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -208,6 +208,7 @@ void Nft::print_to_dot(
         if (decode_ascii_chars) { return to_ascii(symbol); }
         if (alphabet != nullptr) { return alphabet->reverse_translate_symbol(symbol); }
         if (this->alphabets != nullptr) { return this->alphabets->reverse_translate_symbol(symbol, level); }
+        if (this->alphabet != nullptr) { return this->alphabet->reverse_translate_symbol(symbol); }
         return std::to_string(symbol);
     };
 
@@ -369,6 +370,8 @@ void Nft::print_to_mata(std::ostream& output) const {
         std::string symbol_label;
         if (alphabets != nullptr) {
             symbol_label = alphabets->reverse_translate_symbol(trans.symbol, levels[trans.source]);
+        } else if (alphabet != nullptr) {
+            symbol_label = alphabet->reverse_translate_symbol(trans.symbol);
         } else {
             symbol_label = std::to_string(trans.symbol);
         }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -200,19 +200,18 @@ void Nft::print_to_dot(
         }
     };
 
-    auto translate_symbol = [&](const Symbol symbol, const size_t level) -> std::string {
+    auto translate_symbol = [&](const Symbol symbol, const Level level) -> std::string {
         switch (symbol) {
             case EPSILON: return "<eps>";
             default: break;
         }
-        if (decode_ascii_chars) { return to_ascii(symbol); } else if (alphabet != nullptr) {
-            return alphabet->reverse_translate_symbol(symbol, level);
-        } else if (this->alphabet != nullptr) { return this->alphabet->reverse_translate_symbol(symbol, level); } else {
-            return std::to_string(symbol);
-        }
+        if (decode_ascii_chars) { return to_ascii(symbol); }
+        if (alphabet != nullptr) { return alphabet->reverse_translate_symbol(symbol); }
+        if (this->alphabets != nullptr) { return this->alphabets->reverse_translate_symbol(symbol, level); }
+        return std::to_string(symbol);
     };
 
-    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols, const size_t level) {
+    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols, const Level level) {
         std::string result;
         for (const Symbol& symbol : symbols) { result += translate_symbol(symbol, level) + ","; }
         result.pop_back(); // Remove last comma
@@ -220,7 +219,7 @@ void Nft::print_to_dot(
     };
 
     auto vec_of_symbols_to_string_with_intervals = [&](
-        const OrdVector<Symbol>& symbols, const size_t level) {
+        const OrdVector<Symbol>& symbols, const Level level) {
         std::string result;
 
         const auto intervals{
@@ -282,7 +281,7 @@ void Nft::print_to_dot(
                 continue;
             }
 
-            const size_t source_level = source < levels.size() ? levels[source] : 0;
+            const Level source_level = source < levels.size() ? levels[source] : 0;
             std::string label = use_intervals
                                     ? vec_of_symbols_to_string_with_intervals(symbols, source_level)
                                     : vec_of_symbols_to_string(symbols, source_level);
@@ -367,13 +366,13 @@ void Nft::print_to_mata(std::ostream& output) const {
     output << "%LevelsNum " << levels.num_of_levels << std::endl;
 
     for (const Transition& trans : delta.transitions()) {
-                output << "q" << trans.source << " "
-                << ((alphabet != nullptr)
-                        ? alphabet->reverse_translate_symbol(trans.symbol, levels[trans.source])
-                        : ((this->alphabet != nullptr)
-                               ? this->alphabet->reverse_translate_symbol(trans.symbol, levels[trans.source])
-                               : std::to_string(trans.symbol)))
-                << " q" << trans.target << std::endl;
+        std::string symbol_label;
+        if (alphabets != nullptr) {
+            symbol_label = alphabets->reverse_translate_symbol(trans.symbol, levels[trans.source]);
+        } else {
+            symbol_label = std::to_string(trans.symbol);
+        }
+        output << "q" << trans.source << " " << symbol_label << " q" << trans.target << std::endl;
     }
 }
 
@@ -535,6 +534,7 @@ Nft& Nft::operator=(Nft&& other) noexcept {
         Nfa::operator=(std::move(other));
         levels = std::move(other.levels);
         levels.num_of_levels = other.levels.num_of_levels;
+        alphabets = std::exchange(other.alphabets, nullptr);
     }
     return *this;
 }

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -886,3 +886,37 @@ bool Nft::make_complete(
 
     return transition_added;
 }
+
+std::vector<mata::Alphabet*> Nft::repeated_level_alphabets(const size_t num_of_levels, mata::Alphabet* alphabet) {
+    return std::vector<Alphabet*>(num_of_levels, alphabet);
+}
+
+mata::Alphabet* Nft::shared_alphabet_or_null(const std::vector<mata::Alphabet*>& level_alphabets) {
+    if (level_alphabets.empty()) {
+        return nullptr;
+    }
+
+    const mata::Alphabet* first = level_alphabets.front();
+    for (const mata::Alphabet* alphabet : level_alphabets) {
+        if (alphabet != first) {
+            return nullptr;
+        }
+    }
+
+    return const_cast<mata::Alphabet*>(first);
+}
+
+const mata::Alphabet* Nft::alphabet_of_level(const size_t level) const {
+    if (!level_alphabets.empty() && level < level_alphabets.size() && level_alphabets[level] != nullptr) {
+        return level_alphabets[level];
+    }
+    return alphabet;
+}
+
+void Nft::set_level_alphabets(std::vector<mata::Alphabet*> new_level_alphabets) {
+    if (!new_level_alphabets.empty()) {
+        assert(new_level_alphabets.size() == levels.num_of_levels);
+    }
+    alphabet = shared_alphabet_or_null(new_level_alphabets);
+    level_alphabets = std::move(new_level_alphabets);
+}

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -200,26 +200,27 @@ void Nft::print_to_dot(
         }
     };
 
-    auto translate_symbol = [&](const Symbol symbol) -> std::string {
+    auto translate_symbol = [&](const Symbol symbol, const size_t level) -> std::string {
         switch (symbol) {
             case EPSILON: return "<eps>";
             default: break;
         }
         if (decode_ascii_chars) { return to_ascii(symbol); } else if (alphabet != nullptr) {
-            return alphabet->reverse_translate_symbol(symbol);
-        } else if (this->alphabet != nullptr) { return this->alphabet->reverse_translate_symbol(symbol); } else {
+            return alphabet->reverse_translate_symbol(symbol, level);
+        } else if (this->alphabet != nullptr) { return this->alphabet->reverse_translate_symbol(symbol, level); } else {
             return std::to_string(symbol);
         }
     };
 
-    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols) {
+    auto vec_of_symbols_to_string = [&](const OrdVector<Symbol>& symbols, const size_t level) {
         std::string result;
-        for (const Symbol& symbol : symbols) { result += translate_symbol(symbol) + ","; }
+        for (const Symbol& symbol : symbols) { result += translate_symbol(symbol, level) + ","; }
         result.pop_back(); // Remove last comma
         return result;
     };
 
-    auto vec_of_symbols_to_string_with_intervals = [&](const OrdVector<Symbol>& symbols) {
+    auto vec_of_symbols_to_string_with_intervals = [&](
+        const OrdVector<Symbol>& symbols, const size_t level) {
         std::string result;
 
         const auto intervals{
@@ -241,10 +242,12 @@ void Nft::print_to_dot(
 
         for (const auto& [symbol_from, symbol_to] : intervals) {
             if (const size_t interval_size{ symbol_to - symbol_from + 1 }; interval_size == 1) {
-                result += translate_symbol(symbol_from) + ",";
+                result += translate_symbol(symbol_from, level) + ",";
             } else if (interval_size == 2) {
-                result += translate_symbol(symbol_from) + "," + translate_symbol(symbol_to) + ",";
-            } else { result += "[" + translate_symbol(symbol_from) + "-" + translate_symbol(symbol_to) + "],"; }
+                result += translate_symbol(symbol_from, level) + "," + translate_symbol(symbol_to, level) + ",";
+            } else {
+                result += "[" + translate_symbol(symbol_from, level) + "-" + translate_symbol(symbol_to, level) + "],";
+            }
         }
 
         result.pop_back(); // Remove last comma
@@ -279,9 +282,10 @@ void Nft::print_to_dot(
                 continue;
             }
 
+            const size_t source_level = source < levels.size() ? levels[source] : 0;
             std::string label = use_intervals
-                                    ? vec_of_symbols_to_string_with_intervals(symbols)
-                                    : vec_of_symbols_to_string(symbols);
+                                    ? vec_of_symbols_to_string_with_intervals(symbols, source_level)
+                                    : vec_of_symbols_to_string(symbols, source_level);
             std::string on_hover_label = replace_all(replace_all(label, "<", "&lt;"), ">", "&gt;");
             bool is_shortened = false;
             if (max_label_length > 0 && label.length() > static_cast<size_t>(max_label_length)) {
@@ -363,11 +367,11 @@ void Nft::print_to_mata(std::ostream& output) const {
     output << "%LevelsNum " << levels.num_of_levels << std::endl;
 
     for (const Transition& trans : delta.transitions()) {
-        output << "q" << trans.source << " "
+                output << "q" << trans.source << " "
                 << ((alphabet != nullptr)
-                        ? alphabet->reverse_translate_symbol(trans.symbol)
+                        ? alphabet->reverse_translate_symbol(trans.symbol, levels[trans.source])
                         : ((this->alphabet != nullptr)
-                               ? this->alphabet->reverse_translate_symbol(trans.symbol)
+                               ? this->alphabet->reverse_translate_symbol(trans.symbol, levels[trans.source])
                                : std::to_string(trans.symbol)))
                 << " q" << trans.target << std::endl;
     }
@@ -531,7 +535,6 @@ Nft& Nft::operator=(Nft&& other) noexcept {
         Nfa::operator=(std::move(other));
         levels = std::move(other.levels);
         levels.num_of_levels = other.levels.num_of_levels;
-        level_alphabets = std::move(other.level_alphabets);
     }
     return *this;
 }
@@ -542,7 +545,6 @@ Nft& Nft::operator=(const Nfa& other) noexcept {
         Nfa::operator=(other);
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
         levels.num_of_levels = 1;
-        level_alphabets = Nft::repeated_level_alphabets(levels.num_of_levels, alphabet);
     }
     return *this;
 }
@@ -552,7 +554,6 @@ Nft& Nft::operator=(Nfa&& other) noexcept {
         Nfa::operator=(std::move(other));
         levels = Levels(num_of_states(), DEFAULT_LEVEL);
         levels.num_of_levels = 1;
-        level_alphabets = Nft::repeated_level_alphabets(levels.num_of_levels, alphabet);
     }
     return *this;
 }
@@ -885,38 +886,4 @@ bool Nft::make_complete(
     }
 
     return transition_added;
-}
-
-std::vector<mata::Alphabet*> Nft::repeated_level_alphabets(const size_t num_of_levels, mata::Alphabet* alphabet) {
-    return std::vector<Alphabet*>(num_of_levels, alphabet);
-}
-
-mata::Alphabet* Nft::shared_alphabet_or_null(const std::vector<mata::Alphabet*>& level_alphabets) {
-    if (level_alphabets.empty()) {
-        return nullptr;
-    }
-
-    const mata::Alphabet* first = level_alphabets.front();
-    for (const mata::Alphabet* alphabet : level_alphabets) {
-        if (alphabet != first) {
-            return nullptr;
-        }
-    }
-
-    return const_cast<mata::Alphabet*>(first);
-}
-
-const mata::Alphabet* Nft::alphabet_of_level(const size_t level) const {
-    if (!level_alphabets.empty() && level < level_alphabets.size() && level_alphabets[level] != nullptr) {
-        return level_alphabets[level];
-    }
-    return alphabet;
-}
-
-void Nft::set_level_alphabets(std::vector<mata::Alphabet*> new_level_alphabets) {
-    if (!new_level_alphabets.empty()) {
-        assert(new_level_alphabets.size() == levels.num_of_levels);
-    }
-    alphabet = shared_alphabet_or_null(new_level_alphabets);
-    level_alphabets = std::move(new_level_alphabets);
 }

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -338,7 +338,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     }
 
     // Construct the automaton with projected levels.
-    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.alphabet) };
+    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.alphabets) };
     for (State src_state{ 0 }; src_state < num_of_states_in_delta; src_state++) { // For every state.
         for (const State cls_state : closure[src_state]) { // For every state in its epsilon closure.
             if (nft.final[cls_state] && can_be_final(src_state)) result.final.insert(src_state);
@@ -449,7 +449,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 
     // Construct an empty automaton with updated levels.
     Nft result(
-        Nft::with_levels(Levels{ new_levels_mask.size(), new_state_levels }, nft.num_of_states(), nft.initial, nft.final, nft.alphabet)
+        Nft::with_levels(Levels{ new_levels_mask.size(), new_state_levels }, nft.num_of_states(), nft.initial, nft.final, nft.alphabets)
     );
 
     // Function to create a transition between source and target states.
@@ -716,7 +716,7 @@ Nft nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
     // Create new automaton
     Nft aut_inv = Nft::with_levels(
         { aut.levels.num_of_levels, num_of_zero_states, DEFAULT_LEVEL },
-        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.alphabet
+        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.alphabets
     );
 
     // Creates new states with inverted levels for each inner state in the path.
@@ -1036,7 +1036,7 @@ Nft mata::nft::reduce(const Nft& aut, StateRenaming* state_renaming, const Param
 
 Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset_map) {
     Nft result{ Nft::with_levels(nft.levels.num_of_levels) };
-    result.alphabet = nft.alphabet;
+    result.alphabets = nft.alphabets;
     if (nft.initial.empty()) { return result; }
 
     // Assuming all sets targets are non-empty.

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -338,7 +338,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     }
 
     // Construct the automaton with projected levels.
-    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.level_alphabets) };
+    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.alphabet) };
     for (State src_state{ 0 }; src_state < num_of_states_in_delta; src_state++) { // For every state.
         for (const State cls_state : closure[src_state]) { // For every state in its epsilon closure.
             if (nft.final[cls_state] && can_be_final(src_state)) result.final.insert(src_state);
@@ -449,10 +449,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 
     // Construct an empty automaton with updated levels.
     Nft result(
-        Nft::with_levels(
-            Levels{ new_levels_mask.size(), new_state_levels },
-            nft.num_of_states(), nft.initial, nft.final, nft.level_alphabets
-        )
+        Nft::with_levels(Levels{ new_levels_mask.size(), new_state_levels }, nft.num_of_states(), nft.initial, nft.final, nft.alphabet)
     );
 
     // Function to create a transition between source and target states.
@@ -719,7 +716,7 @@ Nft nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
     // Create new automaton
     Nft aut_inv = Nft::with_levels(
         { aut.levels.num_of_levels, num_of_zero_states, DEFAULT_LEVEL },
-        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.level_alphabets
+        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.alphabet
     );
 
     // Creates new states with inverted levels for each inner state in the path.
@@ -1039,7 +1036,7 @@ Nft mata::nft::reduce(const Nft& aut, StateRenaming* state_renaming, const Param
 
 Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset_map) {
     Nft result{ Nft::with_levels(nft.levels.num_of_levels) };
-    result.set_level_alphabets(nft.level_alphabets);
+    result.alphabet = nft.alphabet;
     if (nft.initial.empty()) { return result; }
 
     // Assuming all sets targets are non-empty.

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -338,7 +338,7 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
     }
 
     // Construct the automaton with projected levels.
-    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.alphabet) };
+    Nft result{ Nft::with_levels(nft.levels, Delta{}, nft.initial, nft.final, nft.level_alphabets) };
     for (State src_state{ 0 }; src_state < num_of_states_in_delta; src_state++) { // For every state.
         for (const State cls_state : closure[src_state]) { // For every state in its epsilon closure.
             if (nft.final[cls_state] && can_be_final(src_state)) result.final.insert(src_state);
@@ -451,7 +451,7 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
     Nft result(
         Nft::with_levels(
             Levels{ new_levels_mask.size(), new_state_levels },
-            nft.num_of_states(), nft.initial, nft.final, nft.alphabet
+            nft.num_of_states(), nft.initial, nft.final, nft.level_alphabets
         )
     );
 
@@ -719,7 +719,7 @@ Nft nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
     // Create new automaton
     Nft aut_inv = Nft::with_levels(
         { aut.levels.num_of_levels, num_of_zero_states, DEFAULT_LEVEL },
-        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.alphabet
+        num_of_zero_states, std::move(new_initial), std::move(new_final), aut.level_alphabets
     );
 
     // Creates new states with inverted levels for each inner state in the path.
@@ -1039,7 +1039,7 @@ Nft mata::nft::reduce(const Nft& aut, StateRenaming* state_renaming, const Param
 
 Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset_map) {
     Nft result{ Nft::with_levels(nft.levels.num_of_levels) };
-    result.alphabet = nft.alphabet;
+    result.set_level_alphabets(nft.level_alphabets);
     if (nft.initial.empty()) { return result; }
 
     // Assuming all sets targets are non-empty.

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -59,8 +59,8 @@ TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correc
 
         CHECK(nft.alphabet == nullptr);
         REQUIRE(nft.alphabets == &shared_alphabets);
-        CHECK(&nft.alphabets->alphabet_of_level(0) == &shared_alphabet);
-        CHECK(&nft.alphabets->alphabet_of_level(7) == &shared_alphabet);
+        CHECK(&nft.alphabets->for_level(0) == &shared_alphabet);
+        CHECK(&nft.alphabets->for_level(7) == &shared_alphabet);
     }
 
     SECTION("per-level alphabets are stored in the alphabets member") {
@@ -68,8 +68,8 @@ TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correc
 
         REQUIRE(nft.alphabets == &split_alphabets);
         CHECK(nft.alphabet == nullptr);
-        CHECK(&nft.alphabets->alphabet_of_level(0) == &input_alphabet);
-        CHECK(&nft.alphabets->alphabet_of_level(1) == &output_alphabet);
+        CHECK(&nft.alphabets->for_level(0) == &input_alphabet);
+        CHECK(&nft.alphabets->for_level(1) == &output_alphabet);
     }
 
     SECTION("level-aware translation routes to the right underlying alphabet") {
@@ -114,8 +114,8 @@ TEST_CASE("mata::AlphabetLevels single-element form treats every level uniformly
     IntAlphabet base{};
     AlphabetLevels uniform{ &base };
 
-    CHECK(&uniform.alphabet_of_level(0) == &base);
-    CHECK(&uniform.alphabet_of_level(7) == &base);
+    CHECK(&uniform.for_level(0) == &base);
+    CHECK(&uniform.for_level(7) == &base);
     CHECK(uniform.translate_symb("3", 0) == 3);
     CHECK(uniform.translate_symb("3", 5) == 3);
     CHECK(uniform.reverse_translate_symbol(3, 5) == "3");
@@ -135,8 +135,8 @@ TEST_CASE("mata::nft::determinize preserves the per-level alphabets pointer") {
 
     REQUIRE(determinized.alphabets == &alphabets);
     REQUIRE(determinized.alphabet == nullptr);
-    CHECK(&determinized.alphabets->alphabet_of_level(0) == &input_alphabet);
-    CHECK(&determinized.alphabets->alphabet_of_level(1) == &output_alphabet);
+    CHECK(&determinized.alphabets->for_level(0) == &input_alphabet);
+    CHECK(&determinized.alphabets->for_level(1) == &output_alphabet);
 }
 
 TEST_CASE("mata::nft::size()") {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -47,53 +47,49 @@ TEST_CASE("mata::nft::Nft()") {
     CHECK(nft.levels == std::vector<Level>{ 0, 3, 1 });
 }
 
-TEST_CASE("mata::nft::Nft level alphabets are initialized and updated correctly") {
+TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correctly") {
     IntAlphabet shared_alphabet{};
     IntAlphabet input_alphabet{};
     IntAlphabet output_alphabet{};
-    LevelAlphabet repeated_level_alphabet{ std::vector<Alphabet*>{ &shared_alphabet, &shared_alphabet } };
-    LevelAlphabet split_level_alphabet{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+    AlphabetLevels split_alphabets{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
 
-    SECTION("shared alphabet stays a plain alphabet pointer") {
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &shared_alphabet };
+    SECTION("a shared alphabet is wrapped via AlphabetLevels(Alphabet*) by the caller") {
+        AlphabetLevels shared_alphabets{ &shared_alphabet };
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &shared_alphabets };
 
-        REQUIRE(nft.alphabet == &shared_alphabet);
-        CHECK(nft.alphabet->translate_symb("7", 0) == 7);
-        CHECK(nft.alphabet->translate_symb("7", 1) == 7);
+        CHECK(nft.alphabet == nullptr);
+        REQUIRE(nft.alphabets == &shared_alphabets);
+        CHECK(&nft.alphabets->alphabet_of_level(0) == &shared_alphabet);
+        CHECK(&nft.alphabets->alphabet_of_level(7) == &shared_alphabet);
     }
 
-    SECTION("per-level alphabets are represented by a LevelAlphabet") {
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_level_alphabet };
+    SECTION("per-level alphabets are stored in the alphabets member") {
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_alphabets };
 
-        auto* level_alphabet = dynamic_cast<LevelAlphabet*>(nft.alphabet);
-        REQUIRE(level_alphabet != nullptr);
-        CHECK(level_alphabet->alphabet_of_level(0) == &input_alphabet);
-        CHECK(level_alphabet->alphabet_of_level(1) == &output_alphabet);
+        REQUIRE(nft.alphabets == &split_alphabets);
+        CHECK(nft.alphabet == nullptr);
+        CHECK(&nft.alphabets->alphabet_of_level(0) == &input_alphabet);
+        CHECK(&nft.alphabets->alphabet_of_level(1) == &output_alphabet);
     }
 
-    SECTION("level-aware translation requires the correct level") {
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_level_alphabet };
+    SECTION("level-aware translation routes to the right underlying alphabet") {
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_alphabets };
 
-        CHECK_NOTHROW(nft.alphabet->translate_symb("1", 0));
-        CHECK_NOTHROW(nft.alphabet->translate_symb("1", 1));
-        CHECK_THROWS(nft.alphabet->translate_symb("1"));
-        CHECK_THROWS(nft.alphabet->reverse_translate_symbol(1));
-        CHECK(nft.alphabet->reverse_translate_symbol(1, 0) == "1");
-        CHECK(nft.alphabet->reverse_translate_symbol(1, 1) == "1");
-        CHECK_THROWS(repeated_level_alphabet.translate_symb("2"));
+        CHECK_NOTHROW(nft.alphabets->translate_symb("1", 0));
+        CHECK_NOTHROW(nft.alphabets->translate_symb("1", 1));
+        CHECK(nft.alphabets->reverse_translate_symbol(1, 0) == "1");
+        CHECK(nft.alphabets->reverse_translate_symbol(1, 1) == "1");
     }
 
     SECTION("level-aware complement uses the selected level") {
         EnumAlphabet input_symbols{ 1, 2, 3 };
         EnumAlphabet output_symbols{ 2, 4 };
-        LevelAlphabet complement_alphabet{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+        AlphabetLevels complement_alphabets{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
 
-        CHECK(complement_alphabet.get_alphabet_symbols(0) == OrdVector<Symbol>{ 1, 2, 3 });
-        CHECK(complement_alphabet.get_alphabet_symbols(1) == OrdVector<Symbol>{ 2, 4 });
-        CHECK_THROWS(complement_alphabet.get_alphabet_symbols());
-        CHECK(complement_alphabet.get_complement({ 2 }, 0) == OrdVector<Symbol>{ 1, 3 });
-        CHECK(complement_alphabet.get_complement({ 2 }, 1) == OrdVector<Symbol>{ 4 });
-        CHECK_THROWS(complement_alphabet.get_complement({ 2 }));
+        CHECK(complement_alphabets.get_alphabet_symbols(0) == OrdVector<Symbol>{ 1, 2, 3 });
+        CHECK(complement_alphabets.get_alphabet_symbols(1) == OrdVector<Symbol>{ 2, 4 });
+        CHECK(complement_alphabets.get_complement({ 2 }, 0) == OrdVector<Symbol>{ 1, 3 });
+        CHECK(complement_alphabets.get_complement({ 2 }, 1) == OrdVector<Symbol>{ 4 });
     }
 
     SECTION("level-aware empty and clear use the selected level") {
@@ -101,38 +97,46 @@ TEST_CASE("mata::nft::Nft level alphabets are initialized and updated correctly"
         OnTheFlyAlphabet output_symbols{};
         input_symbols.add_new_symbol("a");
         output_symbols.add_new_symbol("b");
-        LevelAlphabet mutable_level_alphabet{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+        AlphabetLevels mutable_alphabets{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
 
-        CHECK_FALSE(mutable_level_alphabet.empty(0));
-        CHECK_FALSE(mutable_level_alphabet.empty(1));
-        CHECK_THROWS(mutable_level_alphabet.empty());
+        CHECK_FALSE(mutable_alphabets.empty(0));
+        CHECK_FALSE(mutable_alphabets.empty(1));
 
-        mutable_level_alphabet.clear(0);
+        mutable_alphabets.clear(0);
         CHECK(input_symbols.empty());
         CHECK_FALSE(output_symbols.empty());
-        CHECK(mutable_level_alphabet.empty(0));
-        CHECK_FALSE(mutable_level_alphabet.empty(1));
-        CHECK_THROWS(mutable_level_alphabet.clear());
+        CHECK(mutable_alphabets.empty(0));
+        CHECK_FALSE(mutable_alphabets.empty(1));
     }
 }
 
-TEST_CASE("mata::nft::determinize preserves level alphabets") {
+TEST_CASE("mata::AlphabetLevels single-element form treats every level uniformly") {
+    IntAlphabet base{};
+    AlphabetLevels uniform{ &base };
+
+    CHECK(&uniform.alphabet_of_level(0) == &base);
+    CHECK(&uniform.alphabet_of_level(7) == &base);
+    CHECK(uniform.translate_symb("3", 0) == 3);
+    CHECK(uniform.translate_symb("3", 5) == 3);
+    CHECK(uniform.reverse_translate_symbol(3, 5) == "3");
+}
+
+TEST_CASE("mata::nft::determinize preserves the per-level alphabets pointer") {
     IntAlphabet input_alphabet{};
     IntAlphabet output_alphabet{};
 
-    LevelAlphabet level_alphabet{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+    AlphabetLevels alphabets{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
 
-    Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &level_alphabet };
+    Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &alphabets };
     nft.delta.add(0, 1, 1);
     nft.delta.add(1, 2, 2);
 
     Nft determinized = determinize(nft);
 
-    REQUIRE(determinized.alphabet == &level_alphabet);
-    auto* determinized_level_alphabet = dynamic_cast<LevelAlphabet*>(determinized.alphabet);
-    REQUIRE(determinized_level_alphabet != nullptr);
-    CHECK(determinized_level_alphabet->alphabet_of_level(0) == &input_alphabet);
-    CHECK(determinized_level_alphabet->alphabet_of_level(1) == &output_alphabet);
+    REQUIRE(determinized.alphabets == &alphabets);
+    REQUIRE(determinized.alphabet == nullptr);
+    CHECK(&determinized.alphabets->alphabet_of_level(0) == &input_alphabet);
+    CHECK(&determinized.alphabets->alphabet_of_level(1) == &output_alphabet);
 }
 
 TEST_CASE("mata::nft::size()") {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -47,6 +47,94 @@ TEST_CASE("mata::nft::Nft()") {
     CHECK(nft.levels == std::vector<Level>{ 0, 3, 1 });
 }
 
+TEST_CASE("mata::nft::Nft level alphabets are initialized and updated correctly") {
+    IntAlphabet shared_alphabet{};
+    IntAlphabet input_alphabet{};
+    IntAlphabet output_alphabet{};
+    LevelAlphabet repeated_level_alphabet{ std::vector<Alphabet*>{ &shared_alphabet, &shared_alphabet } };
+    LevelAlphabet split_level_alphabet{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+
+    SECTION("shared alphabet stays a plain alphabet pointer") {
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &shared_alphabet };
+
+        REQUIRE(nft.alphabet == &shared_alphabet);
+        CHECK(nft.alphabet->translate_symb("7", 0) == 7);
+        CHECK(nft.alphabet->translate_symb("7", 1) == 7);
+    }
+
+    SECTION("per-level alphabets are represented by a LevelAlphabet") {
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_level_alphabet };
+
+        auto* level_alphabet = dynamic_cast<LevelAlphabet*>(nft.alphabet);
+        REQUIRE(level_alphabet != nullptr);
+        CHECK(level_alphabet->alphabet_of_level(0) == &input_alphabet);
+        CHECK(level_alphabet->alphabet_of_level(1) == &output_alphabet);
+    }
+
+    SECTION("level-aware translation requires the correct level") {
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_level_alphabet };
+
+        CHECK_NOTHROW(nft.alphabet->translate_symb("1", 0));
+        CHECK_NOTHROW(nft.alphabet->translate_symb("1", 1));
+        CHECK_THROWS(nft.alphabet->translate_symb("1"));
+        CHECK_THROWS(nft.alphabet->reverse_translate_symbol(1));
+        CHECK(nft.alphabet->reverse_translate_symbol(1, 0) == "1");
+        CHECK(nft.alphabet->reverse_translate_symbol(1, 1) == "1");
+        CHECK_THROWS(repeated_level_alphabet.translate_symb("2"));
+    }
+
+    SECTION("level-aware complement uses the selected level") {
+        EnumAlphabet input_symbols{ 1, 2, 3 };
+        EnumAlphabet output_symbols{ 2, 4 };
+        LevelAlphabet complement_alphabet{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+
+        CHECK(complement_alphabet.get_alphabet_symbols(0) == OrdVector<Symbol>{ 1, 2, 3 });
+        CHECK(complement_alphabet.get_alphabet_symbols(1) == OrdVector<Symbol>{ 2, 4 });
+        CHECK_THROWS(complement_alphabet.get_alphabet_symbols());
+        CHECK(complement_alphabet.get_complement({ 2 }, 0) == OrdVector<Symbol>{ 1, 3 });
+        CHECK(complement_alphabet.get_complement({ 2 }, 1) == OrdVector<Symbol>{ 4 });
+        CHECK_THROWS(complement_alphabet.get_complement({ 2 }));
+    }
+
+    SECTION("level-aware empty and clear use the selected level") {
+        OnTheFlyAlphabet input_symbols{};
+        OnTheFlyAlphabet output_symbols{};
+        input_symbols.add_new_symbol("a");
+        output_symbols.add_new_symbol("b");
+        LevelAlphabet mutable_level_alphabet{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+
+        CHECK_FALSE(mutable_level_alphabet.empty(0));
+        CHECK_FALSE(mutable_level_alphabet.empty(1));
+        CHECK_THROWS(mutable_level_alphabet.empty());
+
+        mutable_level_alphabet.clear(0);
+        CHECK(input_symbols.empty());
+        CHECK_FALSE(output_symbols.empty());
+        CHECK(mutable_level_alphabet.empty(0));
+        CHECK_FALSE(mutable_level_alphabet.empty(1));
+        CHECK_THROWS(mutable_level_alphabet.clear());
+    }
+}
+
+TEST_CASE("mata::nft::determinize preserves level alphabets") {
+    IntAlphabet input_alphabet{};
+    IntAlphabet output_alphabet{};
+
+    LevelAlphabet level_alphabet{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+
+    Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &level_alphabet };
+    nft.delta.add(0, 1, 1);
+    nft.delta.add(1, 2, 2);
+
+    Nft determinized = determinize(nft);
+
+    REQUIRE(determinized.alphabet == &level_alphabet);
+    auto* determinized_level_alphabet = dynamic_cast<LevelAlphabet*>(determinized.alphabet);
+    REQUIRE(determinized_level_alphabet != nullptr);
+    CHECK(determinized_level_alphabet->alphabet_of_level(0) == &input_alphabet);
+    CHECK(determinized_level_alphabet->alphabet_of_level(1) == &output_alphabet);
+}
+
 TEST_CASE("mata::nft::size()") {
     Nft nft{};
     CHECK(nft.num_of_states() == 0);


### PR DESCRIPTION
This PR adds support for per-level alphabets in `mata::nft::Nft`.

The main addition is:

- `std::vector<Alphabet*> level_alphabets`

with the following semantics:

- in case the vector is empty, `Nft` can fallback to use the inherited `nfa::Nfa::alphabet`
- if different levels use different alphabets, `Nft::alphabet` is set to `nullptr`, and the per-level alphabets are stored in `level_alphabets`
- When all levels share the same alphabet, Nft can still expose a shared alphabet through the inherited Nfa::Nfa field. (not sure if this is necessary)

The PR also adds two helper functions:

- `alphabet_of_level` returns the alphabet for a given level and falls back to the inherited `Nfa` alphabet when no level-specific alphabet is available
- `set_level_alphabets` to assign or update alphabets

This PR does not yet introduce any changes to NFT operations or to the `.mata` format for NFTs. The `.mata` format part likely deserves a separate discussion.