### PR TITLE
fix(github): Move section descriptions into comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,9 +9,13 @@ assignees: ""
 
 ## Description
 
-<!-- Thanks for your report! Please describe your problem or request here.
-For questions, use https://github.com/idursun/jjui/discussions/new instead.
-Feel free to remove any of the sections below if they don't seem useful. -->
+<!--
+Thank you for your report.
+Each bug report helps the project immensely.
+Please describe your report here.
+For questions or general discussions, use https://github.com/VeriFIT/mata/discussions/new instead.
+Feel free to remove any of the sections below if they don't seem useful.
+-->
 
 ## Steps to Reproduce the Problem
 
@@ -26,4 +30,5 @@ Feel free to remove any of the sections below if they don't seem useful. -->
 ## Specifications
 
 - Platform:
-- Version:
+- Mata version:
+- Compiler:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,10 @@ labels: ""
 assignees: ""
 ---
 
+<!--
+Suggested questions to consider. Fill out the template or modify it as needed.
+-->
+
 ## Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/implementation_proposal.md
+++ b/.github/ISSUE_TEMPLATE/implementation_proposal.md
@@ -7,6 +7,7 @@ labels: ""
 assignees: ""
 ---
 
+<!--
 If you have already started working on this, use `WIP` (Work In Progress) instead of `IP` (Implementation Proposal).
 
 Feel free to change, adapt, or remove any of the following sections as it makes sense to you.
@@ -15,55 +16,69 @@ Nothing you write here is set in stone. The purpose of this issue is to help mai
 
 Discussion can be moved once you have a PR to iterate on specific implementation details.
 
-**What are you planning to implement?**
+Lastly, be sure to read CONTRIBUTING.md at least once.
 
+Thank you for helping improve Mata.
+-->
+
+## What are you planning to implement?
+
+<!--
 Provide a clear and concise description of the feature or fix you want to implement.
-
 Include any relevant context, such as links to issues or discussions related to this change.
+-->
 
-**Proposed Approach**
+## Proposed approach
 
+<!--
 Briefly describe your planned feature approach:
 
 - How will this feature work? For example, describe how the user would interact with Mata using this new feature.
-
 - How will this integrate with or impact existing features?
+-->
 
-**Implementation Details**
+## Implementation details
 
+<!--
 Does it help to have a checklist to track implementation progress?
+-->
 
-- [ ] Step 1: Description
-- [ ] Step 2: Description
-- [ ] Step 3: Description
+- [ ] <!-- Description -->
 
-**Testing Strategy**
+## Testing strategy
 
+<!--
 How do you plan to test this implementation?
 
 - Unit tests needed
 - Integration tests
 - Manual testing approach
+-->
 
-**Alternatives Considered**
+## Considered alternative, if any
 
+<!--
 What other implementation approaches have you considered? Why did you choose this particular approach?
+-->
 
-**Breaking Changes**
+## Breaking changes
 
+<!--
 Would this implementation introduce any breaking changes? If so, describe them and any migration strategy.
+-->
 
-**Questions for Discussion**
+## Questions for discussion
+
+<!--
 What specific aspects of this implementation would you like feedback on?
 
 Are there any areas where you're unsure about the approach?
 
 Do you need any kind of direction or help regarding how or where to find code related to this change?
+-->
 
-**Additional Context**
+## Additional context
 
+<!--
 Add any other context, mockups, or references that would help reviewers understand your proposal.
-
-Lastly, be sure to read CONTRIBUTING.md at least once.
-
-Thank you for helping improve Mata.
+-->


### PR DESCRIPTION
This PR moves section descriptions into comments to make issue creation easier.