### PR TITLE
fix(github): Move issues section descriptions into comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,20 +13,30 @@ Suggested questions to consider. Fill out the template or modify it as needed.
 
 ## Is your feature request related to a problem? Please describe.
 
+<!--
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
 
 ## Describe the solution you'd like
 
+<!--
 A clear and concise description of what you want to happen.
+-->
 
 ## Describe alternatives you have considered
 
+<!--
 A clear and concise description of any alternative solutions or features you have considered.
+-->
 
 ## Why current features fail to cover this request
 
+<!--
 A clear and concise description of why current features cannot solve the problem.
+-->
 
 ## Additional context
 
+<!--
 Add any other context or screenshots about the feature request here.
+-->


### PR DESCRIPTION
This PR fixes the FR issue template by moving section descriptions into comments for easier issue creation.