### PR TITLE
Optimize repeated concatenation

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -875,7 +875,17 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs,
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
                 StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
-Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exp);
+/**
+ * @brief Compute NFA by concatenating @p nfa_to_concatenate with itself @p exponent times.
+ *
+ * Uses exponentiation by squaring for efficiency. The result accepts the language L^exponent,
+ * where L is the language of the input automaton.
+ *
+ * @param[in] nfa_to_concatenate NFA to concatenate with itself.
+ * @param[in] exponent The exponent (number of times to concatenate).
+ * @return NFA accepting the exponent-power of the input language.
+ */
+Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exponent);
 
 /**
  * @brief Compute automaton accepting complement of @p aut.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -876,16 +876,16 @@ Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
                 StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
 /**
- * @brief Compute NFA by concatenating @p nfa_to_concatenate with itself @p exponent times.
+ * @brief Compute NFA by concatenating @p nfa_to_concatenate with itself @p power times.
  *
- * Uses exponentiation by squaring for efficiency. The result accepts the language L^exponent,
+ * Uses exponentiation by squaring for efficiency. The result accepts the language L^power,
  * where L is the language of the input automaton.
  *
  * @param[in] nfa_to_concatenate NFA to concatenate with itself.
- * @param[in] exponent The exponent (number of times to concatenate).
- * @return NFA accepting the exponent-power of the input language.
+ * @param[in] power The nth power (number of times to concatenate).
+ * @return NFA accepting the nth power of the input language.
  */
-Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exponent);
+Nfa concatenate_nth_power(Nfa nfa_to_concatenate, unsigned power);
 
 /**
  * @brief Compute automaton accepting complement of @p aut.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -875,6 +875,8 @@ Nfa intersection(const Nfa& lhs, const Nfa& rhs,
 Nfa concatenate(const Nfa& lhs, const Nfa& rhs, bool use_epsilon = false,
                 StateRenaming* lhs_state_renaming = nullptr, StateRenaming* rhs_state_renaming = nullptr);
 
+Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exp);
+
 /**
  * @brief Compute automaton accepting complement of @p aut.
  *

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -133,9 +133,9 @@ Nfa algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     return result;
 } // concatenate_eps().
 
-Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exponent) {
-    // If exponent is 0, return the NFA that accepts only the empty string
-    if (exponent == 0) {
+Nfa concatenate_nth_power(Nfa nfa_to_concatenate, unsigned power) {
+    // If power is 0, return the NFA that accepts only the empty string.
+    if (power == 0) {
         return builder::create_empty_string_nfa();
     }
 
@@ -145,20 +145,20 @@ Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exponent) {
     // `base` is the current power of the original NFA.
     Nfa base = std::move(nfa_to_concatenate);
 
-    // Exponentiation by squaring (binary exponentiation) using in-place concatenation.
+    // Exponentiation by squaring (binary exponentiation)
     // For each binary digit (LSB first): if the bit is 1, multiply `result` by `base`.
     // Then square `base` for the next bit.
-    while (exponent > 0) {
+    while (power > 0) {
         // If current least-significant bit is set, append `base` to `result`.
-        if (exponent & 1u) {
+        if (power & 1u) {
             result.concatenate(base);
         }
 
         // Shift to the next bit.
-        exponent >>= 1;
+        power >>= 1;
 
         // If there are still bits to process, square `base` (i.e. base = base * base).
-        if (exponent) {
+        if (power) {
             base.concatenate(base);
         }
     }

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -133,9 +133,9 @@ Nfa algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     return result;
 } // concatenate_eps().
 
-Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exp) {
+Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exponent) {
     // If exponent is 0, return the NFA that accepts only the empty string
-    if (exp == 0) {
+    if (exponent == 0) {
         return builder::create_empty_string_nfa();
     }
 
@@ -148,17 +148,17 @@ Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exp) {
     // Exponentiation by squaring (binary exponentiation) using in-place concatenation.
     // For each binary digit (LSB first): if the bit is 1, multiply `result` by `base`.
     // Then square `base` for the next bit.
-    while (exp > 0) {
+    while (exponent > 0) {
         // If current least-significant bit is set, append `base` to `result`.
-        if (exp & 1u) {
+        if (exponent & 1u) {
             result.concatenate(base);
         }
 
         // Shift to the next bit.
-        exp >>= 1;
+        exponent >>= 1;
 
         // If there are still bits to process, square `base` (i.e. base = base * base).
-        if (exp) {
+        if (exponent) {
             base.concatenate(base);
         }
     }

--- a/src/nfa/concatenation.cc
+++ b/src/nfa/concatenation.cc
@@ -2,10 +2,11 @@
  * @brief Concatenation of NFAs.
  */
 
+#include <ranges>
+
 #include "mata/nfa/algorithms.hh"
 #include "mata/nfa/nfa.hh"
-
-using namespace mata::nfa;
+#include "mata/nfa/builder.hh"
 
 namespace mata::nfa {
 
@@ -131,4 +132,38 @@ Nfa algorithms::concatenate_eps(const Nfa& lhs, const Nfa& rhs, const Symbol& ep
     if (rhs_state_renaming != nullptr) { *rhs_state_renaming = rhs_states_renaming; }
     return result;
 } // concatenate_eps().
+
+Nfa concatenate_exponent(Nfa nfa_to_concatenate, unsigned exp) {
+    // If exponent is 0, return the NFA that accepts only the empty string
+    if (exp == 0) {
+        return builder::create_empty_string_nfa();
+    }
+
+    // `result` holds the accumulating product (starts as identity — empty-string NFA)
+    Nfa result = builder::create_empty_string_nfa();
+
+    // `base` is the current power of the original NFA.
+    Nfa base = std::move(nfa_to_concatenate);
+
+    // Exponentiation by squaring (binary exponentiation) using in-place concatenation.
+    // For each binary digit (LSB first): if the bit is 1, multiply `result` by `base`.
+    // Then square `base` for the next bit.
+    while (exp > 0) {
+        // If current least-significant bit is set, append `base` to `result`.
+        if (exp & 1u) {
+            result.concatenate(base);
+        }
+
+        // Shift to the next bit.
+        exp >>= 1;
+
+        // If there are still bits to process, square `base` (i.e. base = base * base).
+        if (exp) {
+            base.concatenate(base);
+        }
+    }
+
+    return result;
+}
+
 } // Namespace mata::nfa.

--- a/tests/nfa/nfa-concatenation.cc
+++ b/tests/nfa/nfa-concatenation.cc
@@ -1079,7 +1079,7 @@ TEST_CASE("Concat_inplace performance", "[.profiling]") {
     }
 }
 
-TEST_CASE("mata::nfa::concatenate_exponent()") {
+TEST_CASE("mata::nfa::concatenate_nth_power()") {
     SECTION("Exponent 0 returns empty-string automaton") {
         Nfa aut{};
         aut.add_state(1);
@@ -1087,7 +1087,7 @@ TEST_CASE("mata::nfa::concatenate_exponent()") {
         aut.final.insert(1);
         aut.delta.add(0, 'a', 1);
 
-        CHECK(are_equivalent(concatenate_exponent(aut, 0), builder::create_empty_string_nfa()));
+        CHECK(are_equivalent(concatenate_nth_power(aut, 0), builder::create_empty_string_nfa()));
     }
 
     SECTION("Exponent 1 returns the same language") {
@@ -1097,7 +1097,7 @@ TEST_CASE("mata::nfa::concatenate_exponent()") {
         aut.final.insert(1);
         aut.delta.add(0, 'a', 1);
 
-        CHECK(are_equivalent(concatenate_exponent(aut, 1), aut));
+        CHECK(are_equivalent(concatenate_nth_power(aut, 1), aut));
     }
 
     SECTION("Exponent 2 matches normal concatenate") {
@@ -1111,7 +1111,7 @@ TEST_CASE("mata::nfa::concatenate_exponent()") {
         Nfa expected = aut;
         expected.concatenate(aut);
 
-        CHECK(are_equivalent(concatenate_exponent(aut, 2), expected));
+        CHECK(are_equivalent(concatenate_nth_power(aut, 2), expected));
     }
 
     SECTION("Exponent 4 matches repeated normal concatenate") {
@@ -1126,6 +1126,6 @@ TEST_CASE("mata::nfa::concatenate_exponent()") {
         expected.concatenate(aut);
         expected.concatenate(aut);
 
-        CHECK(are_equivalent(concatenate_exponent(aut, 4), expected));
+        CHECK(are_equivalent(concatenate_nth_power(aut, 4), expected));
     }
 }

--- a/tests/nfa/nfa-concatenation.cc
+++ b/tests/nfa/nfa-concatenation.cc
@@ -1078,3 +1078,54 @@ TEST_CASE("Concat_inplace performance", "[.profiling]") {
         base.concatenate(concat);
     }
 }
+
+TEST_CASE("mata::nfa::concatenate_exponent()") {
+    SECTION("Exponent 0 returns empty-string automaton") {
+        Nfa aut{};
+        aut.add_state(1);
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.delta.add(0, 'a', 1);
+
+        CHECK(are_equivalent(concatenate_exponent(aut, 0), builder::create_empty_string_nfa()));
+    }
+
+    SECTION("Exponent 1 returns the same language") {
+        Nfa aut{};
+        aut.add_state(1);
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.delta.add(0, 'a', 1);
+
+        CHECK(are_equivalent(concatenate_exponent(aut, 1), aut));
+    }
+
+    SECTION("Exponent 2 matches normal concatenate") {
+        Nfa aut{};
+        aut.add_state(2);
+        aut.initial.insert(0);
+        aut.final.insert(2);
+        aut.delta.add(0, 'a', 1);
+        aut.delta.add(1, 'b', 2);
+
+        Nfa expected = aut;
+        expected.concatenate(aut);
+
+        CHECK(are_equivalent(concatenate_exponent(aut, 2), expected));
+    }
+
+    SECTION("Exponent 4 matches repeated normal concatenate") {
+        Nfa aut{};
+        aut.add_state(1);
+        aut.initial.insert(0);
+        aut.final.insert(1);
+        aut.delta.add(0, 'c', 1);
+
+        Nfa expected = aut;
+        expected.concatenate(aut);
+        expected.concatenate(aut);
+        expected.concatenate(aut);
+
+        CHECK(are_equivalent(concatenate_exponent(aut, 4), expected));
+    }
+}


### PR DESCRIPTION
This PR adds function `concatenate_exponent` that takes input NFA and concatenates it multiple times. It uses exponentiation by squaring.