### PR TITLE
github: fix: Merge origin/master to devel

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Merge master into devel
         run: |
           git checkout devel
-          git merge master --no-edit
+          git merge origin/master --no-edit
           git push origin devel
   deploy-docs:
     needs: release


### PR DESCRIPTION
This PR fixes merging `master` into `devel` because during the merge, we were on a detached HEAD, so `master` was not a known branch name.