### PR TITLE
Python: lazy imports and extras

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -11,13 +11,13 @@ build-dist:
 	python setup.py sdist
 
 install:
-	pip install --force-reinstall './[all,dev]'
+	pip install --force-reinstall -e './[all,dev]'
 
 test:
 	python -m pytest --durations=5 --cov=./ --cov-report term-missing:skip-covered tests/
 
 init:
-	pip install './[all,dev]'
+	pip install -e './[all,dev]'
 
 build-install: build-ext install
 

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -11,14 +11,13 @@ build-dist:
 	python setup.py sdist
 
 install:
-	python setup.py build_ext -fi
-	python setup.py install --force
+	pip install --force-reinstall './[all,dev]'
 
 test:
 	python -m pytest --durations=5 --cov=./ --cov-report term-missing:skip-covered tests/
 
 init:
-	pip install ./
+	pip install './[all,dev]'
 
 build-install: build-ext install
 

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -8,7 +8,11 @@ build-ext-force:
 	python setup.py build_ext -fi -j$(jobs)
 
 build-dist:
-	python setup.py sdist
+	pip install --quiet build
+	# `-P` prevents Python from putting cwd at the start of sys.path; the
+	# setuptools-created `build/` directory in this folder otherwise shadows
+	# the pip-installed `build` package.
+	python -P -m build --sdist
 
 install:
 	pip install --force-reinstall -e './[all,dev]'
@@ -21,8 +25,7 @@ init:
 
 build-install: build-ext install
 
-pypi-release:
-	python setup.py sdist
+pypi-release: build-dist
 
 clean:
 	find . -type d \( -name "__pycache__" -o -name "*.egg-info" \) -exec rm -rf {} +

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -1,7 +1,5 @@
 import shlex
 import subprocess
-import pandas
-import networkx as nx
 
 from libc.stdint cimport uint8_t
 from libcpp cimport bool
@@ -660,7 +658,7 @@ cdef class Nfa:
             del output_stream
         return result.decode(encoding)
 
-    def to_dataframe(self) -> pandas.DataFrame:
+    def to_dataframe(self) -> "pandas.DataFrame":
         """Transforms the automaton to DataFrame format.
 
         Transforms the automaton into pandas.DataFrame format,
@@ -670,13 +668,14 @@ cdef class Nfa:
 
         :return: automaton represented as a pandas dataframe
         """
+        import pandas
         columns = ['source', 'symbol', 'target']
         data = [
             [trans.source, trans.symbol, trans.target] for trans in self.iterate()
         ]
         return pandas.DataFrame(data, columns=columns)
 
-    def to_networkx_graph(self) -> nx.Graph:
+    def to_networkx_graph(self) -> "networkx.Graph":
         """Transforms the automaton into networkx.Graph
 
         Transforms the automaton into networkx.Graph format,
@@ -687,6 +686,7 @@ cdef class Nfa:
 
         :return:
         """
+        import networkx as nx
         G = nx.DiGraph()
         for trans in self.iterate():
             G.add_edge(trans.source, trans.target, symbol=trans.symbol)

--- a/bindings/python/libmata/plotting.pyx
+++ b/bindings/python/libmata/plotting.pyx
@@ -1,9 +1,4 @@
-import networkx as nx
-import graphviz
-import IPython
 import sys
-
-from IPython.display import display, HTML
 
 cimport libmata.alphabets as alph
 cimport libmata.nfa.nfa as mata_nfa
@@ -83,6 +78,8 @@ def plot_using_graphviz(
     :param alph.Alphabet alphabet: alphabet for reverse translation of symbols
     :return: automaton in graphviz
     """
+    import graphviz
+    import networkx as nx
     # Configuration
     base_configuration = store()['node_style']
     edge_configuration = store()['edge_style']
@@ -175,6 +172,7 @@ def display_inline(*args, per_row=None, show=None):
     If the `per_row` argument is given, at most `per_row` arguments are
     displayed on each row, each one taking 1/per_row of the line width.
     """
+    from IPython.display import display, HTML
     width = res = ''
     if per_row:
         width = 'width:{}%;'.format(100//per_row)

--- a/bindings/python/libmata/utils.pyx
+++ b/bindings/python/libmata/utils.pyx
@@ -1,5 +1,3 @@
-import tabulate
-
 from cython.operator import dereference
 
 from libmata.utils cimport CBinaryRelation
@@ -154,4 +152,5 @@ cdef class BinaryRelation:
         return projection
 
     def __str__(self):
+        import tabulate
         return str(tabulate.tabulate(self.to_matrix()))

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -14,20 +14,23 @@ authors = [
   { name = "Juraj Síč", email = "sicjuraj@fit.vutbr.cz" },
   { name = "Tomáš Vojnar", email = "vojnar@fit.vutbr.cz" },
 ]
-dependencies = [
-  "coverage>=6.4.1",
-  "cython>=0.29.32",
+# Core libmata has no runtime Python dependencies. Optional integrations
+# (pandas/networkx export, graphviz/IPython plotting) are imported lazily
+# inside the methods that use them; install the relevant extra to enable
+# them, e.g. `pip install libmata[plotting]`.
+dependencies = []
+
+[project.optional-dependencies]
+pandas = ["pandas>=1.3.5"]
+plotting = [
   "graphviz>=0.20.1",
-  "ipykernel>=7.1.0",
-  "ipython>=7.9.0",
   "networkx>=2.6.3",
-  "pandas>=1.3.5",
-  "papermill>=2.6.0",
-  "pytest>=3.6.4",
-  "pytest-cov>=3.0.0",
-  "seaborn>=0.13.2",
+  "ipython>=7.9.0",
   "tabulate>=0.8.10",
 ]
+all = ["libmata[pandas,plotting]"]
+dev = ["pytest>=3.6.4", "pytest-cov>=3.0.0", "coverage>=6.4.1"]
+notebooks = ["ipykernel>=7.1.0", "papermill>=2.6.0", "seaborn>=0.13.2"]
 
 [project.urls]
 Homepage = "https://github.com/VeriFIT/mata"

--- a/uv.lock
+++ b/uv.lock
@@ -318,32 +318,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cython"
-version = "3.2.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/3b/ebd94c8b85f8e41b5015a9ed94ee3df866024d480d05cd08b774684fb81d/cython-3.2.5.tar.gz", hash = "sha256:3dd42e4cf36ad15f265bdfec2337cc00c688c8eb6d374ffd13bb19437c27bba1", size = 3286381, upload-time = "2026-05-23T19:34:08.439Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/30/f648409de61fd74ae63090071061145059664cc9b9ff8578197601a3beb6/cython-3.2.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6e5d7a60835345a8bd29d3aa57070880cc3ce017ea0ade7b9f771ce4bf539b1f", size = 2968935, upload-time = "2026-05-23T19:34:49Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/1b/95f07b5c0f1996e8e23b30d7aaadf5ecb9fb14d730c48af0963a359fdc25/cython-3.2.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b564f67b01bffa2521f475794b49f2787709cec1f91d5935a38eba37f2b359", size = 3223037, upload-time = "2026-05-23T19:34:51.634Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/29/ac650cf7eb449619b16d13bc452cac254f3a1843ca0d66dc462993bd4b23/cython-3.2.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81220817ff954eddf4512a5b82089094a2f523eb1dc4ad555efd6f07b009b4", size = 3382276, upload-time = "2026-05-23T19:34:53.858Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/0f/b3ce218dd833313e9d90c38bdc285f592e50e8e9bb981b49126cd2082141/cython-3.2.5-cp313-cp313-win_amd64.whl", hash = "sha256:3795237ab49753647e329181b140c424e8aa97543074f171f8d2c45e5014a06e", size = 2757027, upload-time = "2026-05-23T19:34:55.803Z" },
-    { url = "https://files.pythonhosted.org/packages/82/78/668ef887621f68255feddd482dbcdcf5788b6c91227dd35bd17f128f827b/cython-3.2.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a636c8b7824f3cb587eb2fdde59d8f4a14d433565508081cc290198e37567910", size = 2981525, upload-time = "2026-05-23T19:34:58.445Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/26/3b0adcbab1ab97db0fbcfd6ba30e375bf2ae1ee0389279dadcc277a061a3/cython-3.2.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69cd71b90d4e0f142fd15b2353982c3f9171fc5e613001f16bcb366ffb29004b", size = 3257788, upload-time = "2026-05-23T19:35:00.764Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/57/4b3e78cbacff3800468632c08e2c48b0b58f0d72f20595ddc1d0c8c3442c/cython-3.2.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3864da4ca2ebe4660d8f672f2143b02840bf3045655222f6090486171c84298f", size = 3390671, upload-time = "2026-05-23T19:35:02.659Z" },
-    { url = "https://files.pythonhosted.org/packages/69/22/6d93cc72ec6a840b185dc0c21a0465a79ce0e992d3863168d43170c96276/cython-3.2.5-cp314-cp314-win_amd64.whl", hash = "sha256:605c447188aecf2941709f53a2ce44862be256e54601c01b38ab710d83db8047", size = 2794115, upload-time = "2026-05-23T19:35:04.883Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/de/e3e0cf5704fe569d54b8cd5dc316c9fbf08b1b74728732f86e90168b7a3f/cython-3.2.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:224149d18d980e6ea5001b70fc7ce096c1891d59035dfa9cc5ede50f55804913", size = 2879054, upload-time = "2026-05-23T19:35:18.265Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d1/0a6a8caa35c4c57a1f1866b1141c2d00c6af67f73edbe34b2baec6919ccf/cython-3.2.5-cp39-abi3-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:992a50e90d01813333752f374a4405863113059ec67102ab8d6a431a171ee328", size = 3210422, upload-time = "2026-05-23T19:35:20.641Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b8/2523398ec96bb0c9bf69ada625a2256a581940b09fe11fcd0029f26ef4ad/cython-3.2.5-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8d7b81e6a52a84a02993f01aa5873786ba1dd593c892d93d5fe9866da0bad297", size = 2863809, upload-time = "2026-05-23T19:35:22.416Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/3d/6b2f316d97bdb02283d79934e50da5cedfec65a536cdd3d69cc3a93486f9/cython-3.2.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:34d21aeb08477c9173e8be7a566b19e880a7c8109ec6bb47a4b20cb680141114", size = 2992518, upload-time = "2026-05-23T19:35:24.737Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2c/c9238db1eba208e226d363c00c8b74bf531a6b40c75df2334baa85e142bf/cython-3.2.5-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c4c79e697db55f082a2d3ba97702e71881d5bb1f56f0a80fa338e69101e4c59b", size = 2886221, upload-time = "2026-05-23T19:35:26.64Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/15/229cc5c2ed92bb8b43c73a3d31c2b4eaf498409300c34a06d93147f7a42b/cython-3.2.5-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:39acb30eba78ba6d995d5cf3d97d57d450663d93aac6f8b93753d2b89d768c60", size = 3226990, upload-time = "2026-05-23T19:35:28.979Z" },
-    { url = "https://files.pythonhosted.org/packages/56/31/9c0024f2c772fc303f8cae2a204bcad2fedfaf921ba71cf13a878639432d/cython-3.2.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:382122de8d6b6024fc374fabc3a2b14ba5860ed981c25055ed14fe44278b9dc7", size = 3111004, upload-time = "2026-05-23T19:35:30.957Z" },
-    { url = "https://files.pythonhosted.org/packages/82/71/8b528247e42ee63cbe1c1d53805d30b28663fa782c88da4a9b69a1a412dd/cython-3.2.5-cp39-abi3-win32.whl", hash = "sha256:0bc29c7f870b09efdb1f583fbec9592b33af81a7ce273b89c8f5163d7572d5c1", size = 2440395, upload-time = "2026-05-23T19:35:33.082Z" },
-    { url = "https://files.pythonhosted.org/packages/50/4d/81c91d3279d156ee2c9ead7ed9eaa862e498066d759e92fb83d0d842c5a7/cython-3.2.5-cp39-abi3-win_arm64.whl", hash = "sha256:85b2944c3eddfc230f9082720195a2e9f869908e5a8b3185be1be832755ee7fc", size = 2446963, upload-time = "2026-05-23T19:35:35.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5c/9cd909e6a8bb178e4e0f9a2a9227c8201a2be38abe45ada4a4c3e9154277/cython-3.2.5-py3-none-any.whl", hash = "sha256:dc1c8cebb7df5bce37f5f8dc1e5bf04313272a5973d50a55c0ec76c83812911b", size = 1257622, upload-time = "2026-05-23T19:34:05.163Z" },
-]
-
-[[package]]
 name = "debugpy"
 version = "1.8.21"
 source = { registry = "https://pypi.org/simple" }
@@ -653,36 +627,51 @@ wheels = [
 [[package]]
 name = "libmata"
 source = { editable = "bindings/python" }
-dependencies = [
-    { name = "coverage" },
-    { name = "cython" },
+
+[package.optional-dependencies]
+all = [
     { name = "graphviz" },
-    { name = "ipykernel" },
     { name = "ipython" },
     { name = "networkx" },
     { name = "pandas" },
-    { name = "papermill" },
+    { name = "tabulate" },
+]
+dev = [
+    { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-cov" },
+]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "papermill" },
     { name = "seaborn" },
+]
+pandas = [
+    { name = "pandas" },
+]
+plotting = [
+    { name = "graphviz" },
+    { name = "ipython" },
+    { name = "networkx" },
     { name = "tabulate" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "coverage", specifier = ">=6.4.1" },
-    { name = "cython", specifier = ">=0.29.32" },
-    { name = "graphviz", specifier = ">=0.20.1" },
-    { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "ipython", specifier = ">=7.9.0" },
-    { name = "networkx", specifier = ">=2.6.3" },
-    { name = "pandas", specifier = ">=1.3.5" },
-    { name = "papermill", specifier = ">=2.6.0" },
-    { name = "pytest", specifier = ">=3.6.4" },
-    { name = "pytest-cov", specifier = ">=3.0.0" },
-    { name = "seaborn", specifier = ">=0.13.2" },
-    { name = "tabulate", specifier = ">=0.8.10" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = ">=6.4.1" },
+    { name = "graphviz", marker = "extra == 'plotting'", specifier = ">=0.20.1" },
+    { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">=7.1.0" },
+    { name = "ipython", marker = "extra == 'plotting'", specifier = ">=7.9.0" },
+    { name = "libmata", extras = ["pandas", "plotting"], marker = "extra == 'all'" },
+    { name = "networkx", marker = "extra == 'plotting'", specifier = ">=2.6.3" },
+    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.3.5" },
+    { name = "papermill", marker = "extra == 'notebooks'", specifier = ">=2.6.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=3.6.4" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "seaborn", marker = "extra == 'notebooks'", specifier = ">=0.13.2" },
+    { name = "tabulate", marker = "extra == 'plotting'", specifier = ">=0.8.10" },
 ]
+provides-extras = ["pandas", "plotting", "all", "dev", "notebooks"]
 
 [[package]]
 name = "mata-tests-integration"


### PR DESCRIPTION
Make the module footprint of the Python library minimal by default, use optional dependencies for non-core utilities.