### PR TITLE
Issue #613 - fix

### DIFF
--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1274,7 +1274,7 @@ bool Nft::is_in_lang_by_levels(const std::vector<Word>& level_words, const bool 
                     if (level == 0 && level_target == 0) {
                         for (Level level_loop{ level }; level_loop < levels.num_of_levels; ++level_loop) {
                             if (next_words_its[level_loop] == track_words_ends[level_loop] ||
-                                not symbols_match(*word_symbol_it, *next_words_its[level_loop])) {
+                                not symbols_match(symbol_post_it->symbol, *next_words_its[level_loop])) {
                                 jump_failed = true;
                                 break;
                             }
@@ -1284,7 +1284,7 @@ bool Nft::is_in_lang_by_levels(const std::vector<Word>& level_words, const bool 
                         for (Level level_loop{ level }; level_loop != level_target;
                              level_loop = levels.next_level_after(level_loop)) {
                             if (next_words_its[level_loop] == track_words_ends[level_loop] ||
-                                not symbols_match(*word_symbol_it, *next_words_its[level_loop])) {
+                                not symbols_match(symbol_post_it->symbol, *next_words_its[level_loop])) {
                                 jump_failed = true;
                                 break;
                             }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3326,6 +3326,30 @@ TEST_CASE("mata::nft:: create simple automata") {
     CHECK(!nft.is_in_lang({ 3 }));
 }
 
+TEST_CASE("ISSUE #613 - mata::nft::nft::is_in_lang()") {
+    SECTION("DONT_CARE jump") {
+        Nft nft{ builder::create_sigma_star_nft(2) };
+        CHECK(nft.is_in_lang({ 'a', 'b' }));
+        CHECK(nft.is_in_lang({ 'a', 'a' }));
+        CHECK(nft.is_in_lang({ 'b', 'a' }));
+
+        Nft nft3{ builder::create_sigma_star_nft(3) };
+        CHECK(nft3.is_in_lang({ 'a', 'b', 'c' }));
+    }
+
+    SECTION("DONT_CARE in the word") {
+        Nft nft{ Nft::with_levels({ 2, { 0 } }, 1, { 0 }, { 0 }) };
+        nft.delta.add(0, 'x', 0);
+
+        CHECK(nft.is_in_lang({ 'x', 'x' }));
+        CHECK(nft.is_in_lang({ DONT_CARE, 'x' }));
+        CHECK(nft.is_in_lang({ 'x', DONT_CARE }));
+        CHECK(!nft.is_in_lang({ DONT_CARE, 'b' }));
+        CHECK(!nft.is_in_lang({ 'b', DONT_CARE }));
+    }
+}
+
+
 TEST_CASE("mata::nft::print_to_mata()") {
     Nft aut_big{ Nft::with_levels(2, 9) };
     aut_big.initial = { 1, 2 };


### PR DESCRIPTION
This PR fixes and closes #613.

There was no issue with `create_sigma_star_nft`, contrary to what the issue suggested. The problem was in the implementation of `is_in_lang_by_levels`, which is called by `is_in_lang`.

In the case of a jump transition, the method did not use the symbol of that transition. Instead, it incorrectly used the first symbol of the input word. As a result, words such as `{'a', 'a'}` correctly passed a `DONT_CARE` jump transition, but words such as `{'a', 'b'}` were incorrectly rejected.

Moreover, this bug allowed any word beginning with `DONT_CARE` to be accepted by any jump transition, which is incorrect. For example, the word `{DONT_CARE, 'b'}` was accepted by a jump transition over the repeated symbol `'a'` because every comparison was made against the first symbol of the word (`DONT_CARE`) instead of the symbol on the transition.