### PR TITLE
+chore Add `.clangd`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/clangd.json
+CompileFlags:
+  CompilationDatabase: ./build/
+  Add: ["--include-directory=./include/"]
+# Diagnostics:
+#   MissingIncludes: Strict
+#   UnusedIncludes: Strict


### PR DESCRIPTION
Adds `.clangd` which configures where to look for `compile_commands.json`.