### PR TITLE
nft: +refactor +fix Do not append levels twice, reuse NFA union

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -82,12 +82,12 @@
 #include <vector>
 
 #include "delta.hh"
-#include "types.hh"
 #include "mata/alphabet.hh"
 #include "mata/parser/inter-aut.hh"
 #include "mata/utils/ord-vector.hh"
 #include "mata/utils/sparse-set.hh"
 #include "mata/utils/utils.hh"
+#include "types.hh"
 
 namespace mata::nfa {
 
@@ -338,11 +338,11 @@ public:
     Nfa& concatenate(const Nfa& aut);
 
     /**
-     * @brief In-place nondeterministic union with @p aut.
+     * @brief In-place nondeterministic union of @c this with @p nfa.
      *
      * Does not add epsilon transitions, just unites initial and final states.
      */
-    Nfa& unite_nondet_with(const Nfa &aut);
+    Nfa& unite_nondet_with(const Nfa& nfa);
 
     /**
      * Unify transitions to create a directed graph with at most a single transition between two states.
@@ -800,7 +800,7 @@ OnTheFlyAlphabet create_alphabet(const std::vector<const Nfa*>& nfas);
  * Does not add epsilon transitions, just unites initial and final states.
  * @return Non-deterministic union of @p lhs and @p rhs.
  */
-Nfa union_nondet(const Nfa &lhs, const Nfa &rhs);
+Nfa union_nondet(const Nfa& lhs, const Nfa& rhs);
 
 /**
  * @brief Compute union of two complete deterministic NFAs. Perserves determinism.
@@ -809,7 +809,7 @@ Nfa union_nondet(const Nfa &lhs, const Nfa &rhs);
  * @param lhs First complete deterministic automaton.
  * @param rhs Second complete deterministic automaton.
  */
-Nfa union_det_complete(const Nfa &lhs, const Nfa &rhs);
+Nfa union_det_complete(const Nfa& lhs, const Nfa& rhs);
 
 /**
  * @brief Compute product of two NFAs with OR condition on the final states.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -100,11 +100,11 @@
 #include <vector>
 
 #include "delta.hh"
-#include "types.hh"
 #include "mata/alphabet.hh"
 #include "mata/utils/ord-vector.hh"
 #include "mata/utils/sparse-set.hh"
 #include "mata/utils/utils.hh"
+#include "types.hh"
 
 #include "mata/nfa/nfa.hh"
 
@@ -116,6 +116,7 @@ namespace mata::nft {
 class Nft: public nfa::Nfa {
 private:
     using super = nfa::Nfa;
+
 public:
     /**
      * @brief Vector of levels giving each state a level in range from 0 to @c levels.num_of_levels - 1.
@@ -496,9 +497,14 @@ public:
     Nft& concatenate(const Nft& aut);
 
     /**
-     * @brief In-place union
+     * @brief In-place nondeterministic union of @c this with @p nft.
+     *
+     * Does not add epsilon transitions, just unites initial and final states.
+     *
+     * @param[in] nft The NFT to unite with @c this.
+     * @return @c this after uniting with @p nft.
      */
-    Nft& unite_nondet_with(const Nft &aut);
+    Nft& unite_nondet_with(const Nft& nft);
 
      /**
       * @brief Get NFT where transitions of @c this are replaced with transitions over one symbol @p abstract_symbol
@@ -903,6 +909,12 @@ public:
 
     using super::is_complete;
     using super::is_deterministic;
+
+protected:
+    /**
+     * @brief Assert that the number of levels in @c this and @p nft match.
+     */
+    void assert_num_of_levels_match_(const Nft& nft) const;
 }; // class Nft.
 
 // Allow variadic number of arguments of the same type.

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -10,17 +10,17 @@
 #include <queue>
 #include <string>
 
-#include "mata/nfa/nfa.hh"
 #include <mata/simlib/explicit_lts.hh>
 #include "mata/alphabet.hh"
 #include "mata/nfa/algorithms.hh"
+#include "mata/nfa/nfa.hh"
 #include "mata/utils/sparse-set.hh"
 
 using namespace mata::utils;
 using namespace mata::nfa;
+using mata::BoolVector;
 using mata::Symbol;
 using mata::Word;
-using mata::BoolVector;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 
@@ -846,35 +846,38 @@ Nfa& Nfa::complement_deterministic(const OrdVector<Symbol>& symbols, const std::
     return *this;
 }
 
-Nfa& Nfa::unite_nondet_with(const mata::nfa::Nfa& aut) {
-    const size_t num_of_states{ this->num_of_states() };
-    const size_t aut_num_of_states{ aut.num_of_states() };
-    const size_t new_num_of_states{ num_of_states + aut_num_of_states };
-
-    if (this == &aut) {
+Nfa& Nfa::unite_nondet_with(const mata::nfa::Nfa& nfa) {
+    if (this == &nfa) {
+        return *this;
+    }
+    if (final.empty() || initial.empty()) {
+        *this = nfa;
+        return *this;
+    }
+    if (nfa.final.empty() || nfa.initial.empty()) {
         return *this;
     }
 
-    if (final.empty() || initial.empty()) { *this = aut; return *this; }
-    if (aut.final.empty() || aut.initial.empty()) { return *this; }
+    const size_t num_of_states_this{this->num_of_states()};
+    const size_t num_of_states_aut{nfa.num_of_states()};
+    const size_t num_of_states_result{num_of_states_this + num_of_states_aut};
 
-    this->delta.reserve(new_num_of_states);
+    this->delta.reserve(num_of_states_result);
     // Allocate space for initial and final states from 'this' which might be missing in Delta.
-    this->delta.allocate(num_of_states);
+    // This ensures that the next state appended to Delta will have the correct index for the first state of 'aut'.
+    this->delta.allocate(num_of_states_this);
 
-    auto renumber_states = [&](const State st) {
-        return st + num_of_states;
-    };
-    this->delta.append(aut.delta.renumber_targets(renumber_states));
+    auto renumber_states{[&](const State state) { return num_of_states_this + state; }};
+    this->delta.append(nfa.delta.renumber_targets(renumber_states));
 
     // Set accepting states.
-    this->final.reserve(new_num_of_states);
-    for(const State& aut_fin: aut.final) {
+    this->final.reserve(num_of_states_result);
+    for (const State& aut_fin : nfa.final) {
         this->final.insert(renumber_states(aut_fin));
     }
     // Set initial states.
-    this->initial.reserve(new_num_of_states);
-    for(const State& aut_ini: aut.initial) {
+    this->initial.reserve(num_of_states_result);
+    for (const State& aut_ini : nfa.initial) {
         this->initial.insert(renumber_states(aut_ini));
     }
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -4,24 +4,22 @@
 
 #include <algorithm>
 #include <cassert>
-#include <format>
 #include <fstream>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <utility>
-#include <queue>
 
-#include "mata/nft/nft.hh"
 #include "mata/nfa/builder.hh"
+#include "mata/nft/nft.hh"
 #include "mata/utils/sparse-set.hh"
 
 
 using namespace mata::utils;
 using namespace mata::nft;
+using mata::BoolVector;
 using mata::Symbol;
 using mata::Word;
-using mata::BoolVector;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -3,18 +3,16 @@
  */
 
 #include <algorithm>
+#include <format>
 #include <iterator>
-#include <list>
 #include <ranges>
 
-#include <mata/simlib/explicit_lts.hh>
 #include "mata/nft/algorithms.hh"
-#include "mata/nft/builder.hh"
 #include "mata/nft/delta.hh"
 #include "mata/nft/nft.hh"
+#include "mata/simlib/explicit_lts.hh"
+#include "mata/utils/assert.hh"
 #include "mata/utils/sparse-set.hh"
-
-using std::tie;
 
 using namespace mata::utils;
 using namespace mata::nft;
@@ -951,34 +949,26 @@ Nft mata::nft::minimize(
 #endif
 
 Nft mata::nft::union_nondet(const Nft& lhs, const Nft& rhs) {
-    Nft union_nft{ lhs };
+    Nft union_nft{lhs};
     return union_nft.unite_nondet_with(rhs);
 }
 
-Nft& Nft::unite_nondet_with(const Nft& aut) {
-    const size_t n = this->num_of_states();
-    auto upd_fnc = [&](const State st) { return st + n; };
+void Nft::assert_num_of_levels_match_(const Nft& nft) const {
+    MATA_ASSERT(
+            this->levels.num_of_levels == nft.levels.num_of_levels,
+            "Cannot perform this operation on two NFTs with different number of levels: this={} and nft={}.",
+            this->levels.num_of_levels, nft.levels.num_of_levels);
+    (void) nft; // Suppress unused parameter warning in release builds.
+}
 
-    // copy the information about aut to save the case when this is the same object as aut.
-    const size_t aut_states = aut.num_of_states();
-    SparseSet<mata::nft::State> aut_final_copy = aut.final;
-    SparseSet<mata::nft::State> aut_initial_copy = aut.initial;
+Nft& Nft::unite_nondet_with(const Nft& nft) {
+    assert_num_of_levels_match_(nft);
 
-    this->delta.allocate(n);
-    this->delta.append(aut.delta.renumber_targets(upd_fnc));
+    super::unite_nondet_with(nft);
 
-    // set accepting states
-    this->final.reserve(n + aut_states);
-    for (const State& aut_fin : aut_final_copy) { this->final.insert(upd_fnc(aut_fin)); }
-    // set initial states
-    this->initial.reserve(n + aut_states);
-    for (const State& aut_ini : aut_initial_copy) { this->initial.insert(upd_fnc(aut_ini)); }
-    // combine levels
-    this->levels.num_of_levels = std::max(this->levels.num_of_levels, aut.levels.num_of_levels);
-    this->levels.append(aut.levels);
-
-    // update levels
-    this->levels.append(aut.levels);
+    // Combine the levels of both NFTs.
+    this->levels.num_of_levels = std::max(this->levels.num_of_levels, nft.levels.num_of_levels);
+    this->levels.append(nft.levels);
 
     return *this;
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -3,6 +3,8 @@
  */
 
 #include <algorithm>
+#include <limits>
+#include <optional>
 #include <ranges>
 #include <unordered_set>
 
@@ -2736,33 +2738,80 @@ TEST_CASE("mata::nft::union_nondet() minimal") {
 }
 
 TEST_CASE("mata::nft::unite_nondet_with()") {
-    Run one{ { 1, 1 }, {} };
-    Run zero{ { 0, 0 }, {} };
 
-    Nft lhs(2);
-    lhs.initial.insert(0);
-    lhs.delta.add(0, 0, 1);
-    lhs.final.insert(1);
-    CHECK(!lhs.is_in_lang(one));
-    CHECK(lhs.is_in_lang(zero));
+    Nft lhs{};
+    Nft rhs{};
+    Nft result{};
 
-    Nft rhs(2);
-    rhs.initial.insert(0);
-    rhs.delta.add(0, 1, 1);
-    rhs.final.insert(1);
-    CHECK(rhs.is_in_lang(one));
-    CHECK(!rhs.is_in_lang(zero));
+    const auto CHECK_SHARED = [&](size_t max_word_length = std::numeric_limits<size_t>::max()) {
+        // The result preserves all originally accepted words from input automata.
+        for (const auto& word : lhs.get_words(max_word_length)) {
+            CHECK(result.is_in_lang(word));
+        }
+        for (const auto& word : rhs.get_words(max_word_length)) {
+            CHECK(result.is_in_lang(word));
+        }
 
-    SECTION("failing minimal scenario") {
-        Nft result = lhs.unite_nondet_with(rhs);
-        CHECK(result.is_in_lang(one));
-        CHECK(result.is_in_lang(zero));
+        // Result accepts no other words than those accepted by the input automata.
+        for (const auto& word : result.get_words(max_word_length)) {
+            CHECK((lhs.is_in_lang(word) || rhs.is_in_lang(word)));
+        }
+    };
+
+    SECTION("empty automata") {
+        lhs.unite_nondet_with(rhs);
+        CHECK_SHARED();
     }
 
-    SECTION("same automata") {
-        size_t lhs_states = lhs.num_of_states();
-        Nft result = lhs.unite_nondet_with(lhs);
-        CHECK(result.num_of_states() == lhs_states * 2);
+    SECTION("simple NFTs") {
+        lhs.initial.insert(0);
+        lhs.final.insert(1);
+        lhs.insert_word(0, {'a', 'b', 'c', 'd'}, 1);
+        rhs.insert_word(0, {'e', 'f', 'g', 'h'}, 1);
+
+        result = lhs;
+        result.unite_nondet_with(rhs);
+        CHECK_SHARED();
+    }
+
+    SECTION("NFTs with multiple initial/final states") {
+        lhs.levels.num_of_levels = 3;
+        lhs.initial.insert(0);
+        lhs.initial.insert(1);
+        lhs.final.insert(2);
+        lhs.final.insert(3);
+        lhs.insert_word(0, {'a', 'b', 'c'}, 2);
+        lhs.insert_word(1, {'d', 'e', 'f'}, 3);
+
+        rhs.levels.num_of_levels = 3;
+        rhs.initial.insert(0);
+        rhs.initial.insert(1);
+        rhs.final.insert(2);
+        rhs.final.insert(3);
+        rhs.insert_word(0, {'g', 'h', 'i'}, 2);
+        rhs.insert_word(1, {'j', 'k', 'l'}, 3);
+
+        result = lhs;
+        result.unite_nondet_with(rhs);
+        CHECK_SHARED();
+    }
+
+    SECTION("NFTs with loops") {
+        lhs.levels.num_of_levels = 3;
+        lhs.initial.insert(0);
+        lhs.final.insert(1);
+        lhs.insert_word(0, {'a', 'b', 'c'}, 1);
+        lhs.insert_word(1, {'d', 'e', 'f'}, 1);
+
+        rhs.levels.num_of_levels = 3;
+        rhs.initial.insert(0);
+        rhs.final.insert(1);
+        rhs.insert_word(0, {'g', 'h', 'i'}, 1);
+        rhs.insert_word(1, {'j', 'k', 'l'}, 1);
+
+        result = lhs;
+        result.unite_nondet_with(rhs);
+        CHECK_SHARED(15);
     }
 }
 


### PR DESCRIPTION
This PR makes NFT union reuse the NFA union and fixes an issue where the vector of levels is appended to the union result NFT twice. 