### PR TITLE
treewide: +feat Use std::shared_ptr for alphabets in NFAs/NFTs

### DIFF
--- a/bindings/python/libmata/alphabets.pxd
+++ b/bindings/python/libmata/alphabets.pxd
@@ -2,6 +2,7 @@ from libc.stdint cimport uintptr_t
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.unordered_map cimport unordered_map as umap
+from libcpp.memory cimport shared_ptr
 from libmata.utils cimport COrdVector
 
 
@@ -33,5 +34,5 @@ cdef extern from "mata/alphabet.hh" namespace "mata":
 
 
 cdef class Alphabet:
-    cdef CAlphabet* as_base(self)
+    cdef shared_ptr[CAlphabet] as_base(self)
     cdef get_symbols(self)

--- a/bindings/python/libmata/alphabets.pyx
+++ b/bindings/python/libmata/alphabets.pyx
@@ -1,5 +1,6 @@
 cimport libmata.alphabets as alph
 
+from libcpp.memory cimport shared_ptr, make_shared, static_pointer_cast
 from libmata.alphabets cimport CAlphabet, CIntAlphabet, COnTheFlyAlphabet
 from libmata.nfa.nfa cimport State
 
@@ -10,7 +11,7 @@ cdef class Alphabet:
 
         pass
 
-    cdef CAlphabet* as_base(self):
+    cdef shared_ptr[CAlphabet] as_base(self):
         pass
 
     def translate_symbol(self, str symbol):
@@ -29,10 +30,10 @@ cdef class Alphabet:
 cdef class OnTheFlyAlphabet(Alphabet):
     """OnTheFlyAlphabet represents alphabet that is not known before hand and is constructed on-the-fly."""
 
-    cdef COnTheFlyAlphabet *thisptr
+    cdef shared_ptr[COnTheFlyAlphabet] thisptr
 
     def __cinit__(self, State initial_symbol = 0):
-        self.thisptr = new COnTheFlyAlphabet(initial_symbol)
+        self.thisptr = make_shared[COnTheFlyAlphabet](initial_symbol)
 
     @classmethod
     def from_symbol_map(cls, symbol_map: dict[str, int]) -> OnTheFlyAlphabet:
@@ -59,7 +60,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
         cdef COnTheFlyAlphabet.StringToSymbolMap c_symbol_map
         for symbol, value in symbol_map.items():
             c_symbol_map[symbol.encode('utf-8')] = value
-        self.thisptr.add_symbols_from(<COnTheFlyAlphabet.StringToSymbolMap>c_symbol_map)
+        self.thisptr.get().add_symbols_from(<COnTheFlyAlphabet.StringToSymbolMap>c_symbol_map)
 
     def add_symbols_for_names(self, symbol_names: list[str]) -> None:
         """Add symbols for symbol names to the current alphabet.
@@ -69,17 +70,14 @@ cdef class OnTheFlyAlphabet(Alphabet):
         cdef vector[string] c_symbol_names
         for symbol_name in symbol_names:
             c_symbol_names.push_back(symbol_name.encode('utf-8'))
-        self.thisptr.add_symbols_from(c_symbol_names)
-
-    def __dealloc__(self):
-        del self.thisptr
+        self.thisptr.get().add_symbols_from(c_symbol_names)
 
     def get_symbol_map(self) -> dict[str, int]:
         """Get map mapping strings to symbols.
 
         :return: Map of strings to symbols.
         """
-        cdef umap[string, Symbol] c_symbol_map = self.thisptr.get_symbol_map()
+        cdef umap[string, Symbol] c_symbol_map = self.thisptr.get().get_symbol_map()
         symbol_map = {}
         for symbol, value in c_symbol_map:
             symbol_map[symbol.decode('utf-8')] = value
@@ -91,7 +89,7 @@ cdef class OnTheFlyAlphabet(Alphabet):
         :param str symbol: translated symbol
         :return: order of the symbol as was seen during the construction
         """
-        return self.thisptr.translate_symb(symbol.encode('utf-8'))
+        return self.thisptr.get().translate_symb(symbol.encode('utf-8'))
 
     def reverse_translate_symbol(self, Symbol symbol) -> str:
         """Translate internal symbol value to the original symbol name.
@@ -100,34 +98,31 @@ cdef class OnTheFlyAlphabet(Alphabet):
         :param Symbol symbol: Internal symbol value to be translated.
         :return str: Original symbol string name.
         """
-        return self.thisptr.reverse_translate_symbol(symbol).decode('utf-8')
+        return self.thisptr.get().reverse_translate_symbol(symbol).decode('utf-8')
 
     cpdef get_alphabet_symbols(self):
         """Returns a set of supported symbols.
 
         :return: Set of supported symbols.
         """
-        cdef COrdVector[Symbol] symbols = self.thisptr.get_alphabet_symbols()
+        cdef COrdVector[Symbol] symbols = self.thisptr.get().get_alphabet_symbols()
         return {s for s in symbols}
 
-    cdef CAlphabet* as_base(self):
+    cdef shared_ptr[CAlphabet] as_base(self):
         """Retypes the alphabet to its base class
 
-        :return: alphabet as CAlphabet*
+        :return: alphabet as shared_ptr[CAlphabet]
         """
-        return <CAlphabet*> self.thisptr
+        return static_pointer_cast[CAlphabet, COnTheFlyAlphabet](self.thisptr)
 
 
 cdef class IntAlphabet(Alphabet):
     """IntAlphabet represents integer alphabet that directly maps integer string to their values."""
 
-    cdef CIntAlphabet *thisptr
+    cdef shared_ptr[CIntAlphabet] thisptr
 
     def __cinit__(self):
-        self.thisptr = new CIntAlphabet()
-
-    def __dealloc__(self):
-        del self.thisptr
+        self.thisptr = make_shared[CIntAlphabet]()
 
     def translate_symbol(self, str symbol):
         """Translates symbol to the position of the seen values
@@ -135,7 +130,7 @@ cdef class IntAlphabet(Alphabet):
         :param str symbol: translated symbol
         :return: order of the symbol as was seen during the construction
         """
-        return self.thisptr.translate_symb(symbol.encode('utf-8'))
+        return self.thisptr.get().translate_symb(symbol.encode('utf-8'))
 
     def reverse_translate_symbol(self, Symbol symbol) -> str:
         """Translate internal symbol value to the original symbol name.
@@ -143,11 +138,11 @@ cdef class IntAlphabet(Alphabet):
         :param Symbol symbol: Internal symbol value to be translated.
         :return str: Original symbol string name.
         """
-        return self.thisptr.reverse_translate_symbol(symbol).decode('utf-8')
+        return self.thisptr.get().reverse_translate_symbol(symbol).decode('utf-8')
 
-    cdef CAlphabet* as_base(self):
+    cdef shared_ptr[CAlphabet] as_base(self):
         """Retypes the alphabet to its base class
 
-        :return: alphabet as CAlphabet*
+        :return: alphabet as shared_ptr[CAlphabet]
         """
-        return <CAlphabet*> self.thisptr
+        return static_pointer_cast[CAlphabet, CIntAlphabet](self.thisptr)

--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -132,12 +132,12 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
         CSparseSet[State] final
         CDelta delta
         umap[string, void*] attributes
-        CAlphabet* alphabet
+        shared_ptr[CAlphabet] alphabet
 
         # Constructor
         CNfa() except +
         CNfa(unsigned long) except +
-        CNfa(unsigned long, CSparseSet[State], CSparseSet[State], CAlphabet*)
+        CNfa(unsigned long, CSparseSet[State], CSparseSet[State], shared_ptr[CAlphabet])
         CNfa(const CNfa&)
 
         # Public Functions

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -196,7 +196,7 @@ cdef class Nfa:
         :param int state_number: number of states in automaton
         :param alph.Alphabet alphabet: alphabet corresponding to the automaton
         """
-        cdef CAlphabet* c_alphabet = NULL
+        cdef shared_ptr[CAlphabet] c_alphabet
         cdef CSparseSet[State] empty_default_sparse_set
         if alphabet:
             c_alphabet = alphabet.as_base()
@@ -577,7 +577,7 @@ cdef class Nfa:
         :return: true if the automaton is complete.
         """
         if alphabet:
-            return self.thisptr.get().is_complete(alphabet.as_base())
+            return self.thisptr.get().is_complete(alphabet.as_base().get())
         else:
             return self.thisptr.get().is_complete()
 
@@ -608,8 +608,8 @@ cdef class Nfa:
         result += "final_states: {}\n".format([s for s in self.thisptr.get().final])
         result += "transitions:\n"
         for trans in self.iterate():
-            symbol = trans.symbol if self.thisptr.get().alphabet == NULL \
-                else self.thisptr.get().alphabet.reverse_translate_symbol(trans.symbol)
+            symbol = trans.symbol if self.thisptr.get().alphabet.get() == NULL \
+                else self.thisptr.get().alphabet.get().reverse_translate_symbol(trans.symbol)
             result += f"{trans.source}-[{symbol}]\u2192{trans.target}\n"
         return result
 
@@ -823,7 +823,7 @@ cdef class Nfa:
         """
         if not self.thisptr.get().is_state(sink_state):
             self.thisptr.get().add_state(self.thisptr.get().num_of_states())
-        self.thisptr.get().make_complete(alphabet.as_base(), make_optional[State](sink_state))
+        self.thisptr.get().make_complete(alphabet.as_base().get(), make_optional[State](sink_state))
 
     def get_symbols(self):
         """Return a set of symbols used on the transitions in NFA.
@@ -1121,7 +1121,7 @@ def is_included_with_cex(Nfa lhs, Nfa rhs, alph.Alphabet alphabet = None, params
     run = Run()
     cdef CAlphabet* c_alphabet = NULL
     if alphabet:
-        c_alphabet = alphabet.as_base()
+        c_alphabet = alphabet.as_base().get()
     params = params or {'algorithm': 'antichains'}
     result = mata_nfa.c_is_included(
         dereference(lhs.thisptr.get()),
@@ -1146,7 +1146,7 @@ def is_included(Nfa lhs, Nfa rhs, alph.Alphabet alphabet = None, params = None):
     """
     cdef CAlphabet* c_alphabet = NULL
     if alphabet:
-        c_alphabet = alphabet.as_base()
+        c_alphabet = alphabet.as_base().get()
     params = params or {'algorithm': 'antichains'}
     result = mata_nfa.c_is_included(
         dereference(lhs.thisptr.get()),
@@ -1173,7 +1173,7 @@ def equivalence_check(Nfa lhs, Nfa rhs, alph.Alphabet alphabet = None, params = 
     params = params or {'algorithm': 'antichains'}
     cdef CAlphabet * c_alphabet = NULL
     if alphabet:
-        c_alphabet = alphabet.as_base()
+        c_alphabet = alphabet.as_base().get()
         return mata_nfa.c_are_equivalent(
             dereference(lhs.thisptr.get()),
             dereference(rhs.thisptr.get()),
@@ -1215,7 +1215,7 @@ def encode_word(alph.Alphabet alphabet, word):
     :param word: list of strings representing an encoded word.
     :return: Encoded word.
     """
-    cdef CAlphabet* c_alphabet = alphabet.as_base()
+    cdef CAlphabet* c_alphabet = alphabet.as_base().get()
     result = mata_nfa.c_encode_word(
         c_alphabet,
         [s.encode('utf-8') for s in word]

--- a/bindings/python/libmata/parser.pyx
+++ b/bindings/python/libmata/parser.pyx
@@ -40,7 +40,7 @@ def from_mata(src: str | list[str], alph.Alphabet alphabet):
     cdef parser.CMintermization mintermization
 
     if alphabet:
-        c_alphabet = alphabet.as_base()
+        c_alphabet = alphabet.as_base().get()
 
     # either load single automata
     if isinstance(src, str):

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -5,6 +5,7 @@
 #define MATA_ALPHABET_HH
 
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -457,7 +458,8 @@ public:
  *                  argument is ignored.
  *  - @c MultiLevel — distinct per-level alphabets. The level argument is required and indexes @c alphabets.
  *
- * Pointers to the underlying @c Alphabet objects are non-owning; the caller is responsible for their lifetime.
+ * The underlying @c Alphabet objects are held via @c std::shared_ptr and can be shared between multiple
+ *  @c AlphabetLevels instances (and other automata).
  */
 class AlphabetLevels {
 public:
@@ -474,12 +476,12 @@ public:
      *  direct read/write access in line with the rest of the codebase (`Nft::levels`, `Nfa::delta`/`initial`/etc.).
      *  Read-only access through @c for_level (or @c operator[]) when range/null validation is desired.
      */
-    std::vector<Alphabet*> alphabets{};
+    std::vector<std::shared_ptr<Alphabet>> alphabets{};
 
     /// Operating mode. Defaults to @c MultiLevel.
     Mode mode{ Mode::MultiLevel };
 
-    explicit AlphabetLevels(std::vector<Alphabet*> alphabets = {}, Mode mode = Mode::MultiLevel)
+    explicit AlphabetLevels(std::vector<std::shared_ptr<Alphabet>> alphabets = {}, Mode mode = Mode::MultiLevel)
         : alphabets{ std::move(alphabets) }, mode{ mode } {}
 
     /**
@@ -487,7 +489,7 @@ public:
      *
      * Stores a single-element vector and sets @c mode to @c Global.
      */
-    explicit AlphabetLevels(Alphabet* alphabet) : alphabets{ alphabet }, mode{ Mode::Global } {}
+    explicit AlphabetLevels(std::shared_ptr<Alphabet> alphabet) : alphabets{ std::move(alphabet) }, mode{ Mode::Global } {}
 
     /**
      * @brief Translate a symbol name using the alphabet for the given level.

--- a/include/mata/nfa/builder.hh
+++ b/include/mata/nfa/builder.hh
@@ -30,7 +30,7 @@ Nfa create_single_word_nfa(const std::vector<Symbol>& word);
  *  translations for all of the word symbols. If left empty, a new alphabet with only the symbols of the word will be
  *  created.
  */
-Nfa create_single_word_nfa(const std::vector<std::string>& word, Alphabet* alphabet = nullptr);
+Nfa create_single_word_nfa(const std::vector<std::string>& word, std::shared_ptr<Alphabet> alphabet = nullptr);
 
 /**
  * Create automaton accepting only epsilon string.
@@ -43,7 +43,7 @@ Nfa create_empty_string_nfa();
  * @param[in] alphabet Alphabet to construct sigma star automaton with. When alphabet is left empty, the default empty
  *  alphabet is used, creating an automaton accepting only the empty string.
  */
-Nfa create_sigma_star_nfa(Alphabet* alphabet = new OnTheFlyAlphabet{});
+Nfa create_sigma_star_nfa(std::shared_ptr<Alphabet> alphabet = std::make_shared<OnTheFlyAlphabet>());
 
 /**
  * Creates Tabakov-Vardi random NFA.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -105,7 +105,7 @@ public:
     utils::SparseSet<State> initial{};
     utils::SparseSet<State> final{};
 
-    Alphabet* alphabet = nullptr; ///< The alphabet which can be shared between multiple automata.
+    std::shared_ptr<Alphabet> alphabet = nullptr; ///< The alphabet which can be shared between multiple automata.
     /// Key value store for additional attributes for the NFA. Keys are attribute names as strings and the value types
     ///  are up to the user.
     /// For example, we can set up attributes such as "state_dict" for state dictionary attribute mapping states to their
@@ -117,8 +117,8 @@ public:
 
 public:
     explicit Nfa(Delta delta = {}, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr)
-        : delta(std::move(delta)), initial(std::move(initial_states)), final(std::move(final_states)), alphabet(alphabet) {}
+                 utils::SparseSet<State> final_states = {}, std::shared_ptr<Alphabet> alphabet = nullptr)
+        : delta(std::move(delta)), initial(std::move(initial_states)), final(std::move(final_states)), alphabet(std::move(alphabet)) {}
 
     /**
      * @brief Construct a new explicit NFA with num_of_states states and optionally set initial and final states.
@@ -129,8 +129,8 @@ public:
      * @param[in] alphabet Pointer to the alphabet used by the NFA.
      */
     explicit Nfa(const size_t num_of_states, utils::SparseSet<State> initial_states = {},
-                 utils::SparseSet<State> final_states = {}, Alphabet* alphabet = nullptr)
-        : delta(num_of_states), initial(std::move(initial_states)), final(std::move(final_states)), alphabet(alphabet) {}
+                 utils::SparseSet<State> final_states = {}, std::shared_ptr<Alphabet> alphabet = nullptr)
+        : delta(num_of_states), initial(std::move(initial_states)), final(std::move(final_states)), alphabet(std::move(alphabet)) {}
 
     /**
      * @brief Construct a new explicit NFA from other NFA.
@@ -139,7 +139,7 @@ public:
 
     Nfa(Nfa&& other) noexcept
         : delta{ std::move(other.delta) }, initial{ std::move(other.initial) }, final{ std::move(other.final) },
-          alphabet{ other.alphabet }, attributes{ std::move(other.attributes) } { other.alphabet = nullptr; }
+          alphabet{ std::move(other.alphabet) }, attributes{ std::move(other.attributes) } {}
 
     Nfa& operator=(const Nfa& other) = default;
     Nfa& operator=(Nfa&& other) noexcept;

--- a/include/mata/nft/builder.hh
+++ b/include/mata/nft/builder.hh
@@ -34,7 +34,7 @@ Nft create_single_word_nft(const Word& word);
  *  translations for all the word symbols. If left empty, a new alphabet with only the symbols of the word will be
  *  created.
  */
-Nft create_single_word_nft(const WordName& word, Alphabet* alphabet = nullptr);
+Nft create_single_word_nft(const WordName& word, std::shared_ptr<Alphabet> alphabet = nullptr);
 
 /**
  * Create automaton accepting only epsilon string.
@@ -55,7 +55,7 @@ Nft create_sigma_star_nft(size_t num_of_levels = DEFAULT_NUM_OF_LEVELS);
  *  alphabet is used, creating an automaton accepting only the empty string.
  * @param[in] num_of_levels Number of levels in the created NFT.
  */
-Nft create_sigma_star_nft(const Alphabet* alphabet = new OnTheFlyAlphabet{}, size_t num_of_levels = DEFAULT_NUM_OF_LEVELS);
+Nft create_sigma_star_nft(std::shared_ptr<Alphabet> alphabet = std::make_shared<OnTheFlyAlphabet>(), size_t num_of_levels = DEFAULT_NUM_OF_LEVELS);
 
 /** Loads an automaton from Parsed object */
 // TODO this function should the same thing as the one taking IntermediateAut or be deleted
@@ -73,9 +73,9 @@ void construct(
  * 
  * The constructed @c Nft has its @c alphabets member set to @p alphabets and its inherited @c alphabet member left as @c nullptr.
  */
-Nft construct(const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr);
+Nft construct(const IntermediateAut& inter_aut, std::shared_ptr<AlphabetLevels> alphabets, NameStateMap* state_map = nullptr);
 void construct(
-    Nft* result, const IntermediateAut& inter_aut, AlphabetLevels* alphabets, NameStateMap* state_map = nullptr
+    Nft* result, const IntermediateAut& inter_aut, std::shared_ptr<AlphabetLevels> alphabets, NameStateMap* state_map = nullptr
 );
 
 template<class ParsedObject>

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -134,7 +134,7 @@ public:
      * NFT operations always go through this member; the inherited @c Nfa::alphabet field is kept as @c nullptr and ignored,
      * anticipating the planned class split where NFT no longer derives from NFA.
      */
-    AlphabetLevels* alphabets{ nullptr };
+    std::shared_ptr<AlphabetLevels> alphabets{ nullptr };
 
     /// Key value store for additional attributes for the NFT. Keys are attribute names as strings and the value types
     ///  are up to the user.
@@ -147,10 +147,10 @@ public:
     explicit Nft(
             Delta delta = {}, utils::SparseSet<State> initial_states = {},
             utils::SparseSet<State> final_states = {}, Levels levels = {},
-            AlphabetLevels* alphabets = nullptr)
+            std::shared_ptr<AlphabetLevels> alphabets = nullptr)
         : Nfa{ std::move(delta), std::move(initial_states), std::move(final_states), nullptr },
           levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states(), DEFAULT_LEVEL } : std::move(levels) },
-          alphabets{ alphabets } {}
+          alphabets{ std::move(alphabets) } {}
 
     /**
      * @brief Construct a new explicit NFT with num_of_states states and optionally set initial and final states.
@@ -163,33 +163,33 @@ public:
      */
     explicit Nft(const size_t num_of_states, utils::SparseSet<State> initial_states = {},
                  utils::SparseSet<State> final_states = {}, Levels levels = {},
-                 AlphabetLevels* alphabets = nullptr)
+                 std::shared_ptr<AlphabetLevels> alphabets = nullptr)
         : Nfa{ num_of_states, std::move(initial_states), std::move(final_states), nullptr },
           levels{ levels.empty() ? Levels{ levels.num_of_levels, num_of_states, DEFAULT_LEVEL } : std::move(levels) },
-          alphabets{ alphabets } {}
+          alphabets{ std::move(alphabets) } {}
 
     static Nft with_levels(
             Levels levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
-        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), alphabets };
+            utils::SparseSet<State> final_states = {}, std::shared_ptr<AlphabetLevels> alphabets = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), std::move(levels), std::move(alphabets) };
     }
 
     static Nft with_levels(
             Levels levels, Delta delta, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
-        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), alphabets };
+            utils::SparseSet<State> final_states = {}, std::shared_ptr<AlphabetLevels> alphabets = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), std::move(levels), std::move(alphabets) };
     }
 
     static Nft with_levels(
             const size_t num_of_levels, const size_t num_of_states = 0, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
-        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabets };
+            utils::SparseSet<State> final_states = {}, std::shared_ptr<AlphabetLevels> alphabets = nullptr) {
+        return Nft{ num_of_states, std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, std::move(alphabets) };
     }
 
     static Nft with_levels(
             const size_t num_of_levels, Delta delta, utils::SparseSet<State> initial_states = {},
-            utils::SparseSet<State> final_states = {}, AlphabetLevels* alphabets = nullptr) {
-        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, alphabets };
+            utils::SparseSet<State> final_states = {}, std::shared_ptr<AlphabetLevels> alphabets = nullptr) {
+        return Nft{ std::move(delta), std::move(initial_states), std::move(final_states), Levels{ num_of_levels }, std::move(alphabets) };
     }
 
     Nft(const Nft& other) = default;

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -225,7 +225,7 @@ mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
 bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
     if (mode == Mode::MultiLevel && !level.has_value()) {
         // MultiLevel + nullopt: empty iff every underlying alphabet is empty.
-        for (const Alphabet* alphabet : alphabets) {
+        for (const auto& alphabet : alphabets) {
             if (alphabet != nullptr && !alphabet->empty()) { return false; }
         }
         return true;
@@ -236,7 +236,7 @@ bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
 void AlphabetLevels::clear(const std::optional<mata::Level> level) {
     if (mode == Mode::MultiLevel && !level.has_value()) {
         // MultiLevel + nullopt: clear every underlying alphabet.
-        for (Alphabet* alphabet : alphabets) {
+        for (const auto& alphabet : alphabets) {
             if (alphabet != nullptr) { alphabet->clear(); }
         }
         return;

--- a/src/nfa/builder.cc
+++ b/src/nfa/builder.cc
@@ -181,9 +181,9 @@ Nfa builder::create_single_word_nfa(const std::vector<Symbol>& word) {
     return nfa;
 }
 
-Nfa builder::create_single_word_nfa(const std::vector<std::string>& word, Alphabet *alphabet) {
+Nfa builder::create_single_word_nfa(const std::vector<std::string>& word, std::shared_ptr<Alphabet> alphabet) {
     if (!alphabet) {
-        alphabet = new OnTheFlyAlphabet{ word };
+        alphabet = std::make_shared<OnTheFlyAlphabet>(word);
     }
     const size_t word_size{ word.size() };
     Nfa nfa{ word_size + 1, { 0 }, { word_size }, alphabet };
@@ -198,7 +198,7 @@ Nfa builder::create_empty_string_nfa() {
     return Nfa{ 1, { 0 }, { 0 } };
 }
 
-Nfa builder::create_sigma_star_nfa(Alphabet* alphabet) {
+Nfa builder::create_sigma_star_nfa(std::shared_ptr<Alphabet> alphabet) {
     Nfa nfa{ 1, { 0 }, { 0 }, alphabet };
     for (const Symbol& symbol : alphabet->get_alphabet_symbols()) {
         nfa.delta.add(0, symbol, 0);
@@ -219,7 +219,7 @@ Nfa builder::create_random_nfa_tabakov_vardi(const size_t num_of_states, const s
         throw std::runtime_error("Final state density must be in range (0, 1]");
     }
 
-    Nfa nfa{ num_of_states, { 0 }, { 0 }, new OnTheFlyAlphabet{} };
+    Nfa nfa{ num_of_states, { 0 }, { 0 }, std::make_shared<OnTheFlyAlphabet>() };
 
     // Initialize the random number generator
     const unsigned int seed_value{ seed.value_or(std::random_device{}()) };  // Seed for the random number engine

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -761,9 +761,8 @@ Nfa& Nfa::operator=(Nfa&& other) noexcept {
         delta = std::move(other.delta);
         initial = std::move(other.initial);
         final = std::move(other.final);
-        alphabet = other.alphabet;
+        alphabet = std::move(other.alphabet);
         attributes = std::move(other.attributes);
-        other.alphabet = nullptr;
     }
     return *this;
 }

--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -216,7 +216,7 @@ void builder::construct(
     *result = construct(inter_aut, alphabet, state_map);
 }
 
-Nft builder::construct(const mata::IntermediateAut& inter_aut, mata::AlphabetLevels* alphabets, NameStateMap* state_map) {
+Nft builder::construct(const mata::IntermediateAut& inter_aut, std::shared_ptr<mata::AlphabetLevels> alphabets, NameStateMap* state_map) {
     assert(nullptr != alphabets);
 
     if (!inter_aut.is_nft()) {
@@ -282,7 +282,7 @@ Nft builder::construct(const mata::IntermediateAut& inter_aut, mata::AlphabetLev
 void builder::construct(
         mata::nft::Nft *result,
         const mata::IntermediateAut &inter_aut,
-        mata::AlphabetLevels *alphabets,
+        std::shared_ptr<mata::AlphabetLevels> alphabets,
         mata::nft::builder::NameStateMap *state_map
 ) {
     *result = construct(inter_aut, alphabets, state_map);
@@ -292,7 +292,7 @@ Nft builder::create_single_word_nft(const std::vector<Symbol>& word) {
     return Nft(mata::nfa::builder::create_single_word_nfa(word));
 }
 
-Nft builder::create_single_word_nft(const std::vector<std::string>& word, mata::Alphabet *alphabet) {
+Nft builder::create_single_word_nft(const std::vector<std::string>& word, std::shared_ptr<mata::Alphabet> alphabet) {
     return Nft(mata::nfa::builder::create_single_word_nfa(word, alphabet));
 }
 
@@ -308,7 +308,7 @@ Nft builder::create_sigma_star_nft(const size_t num_of_levels) {
     return nft;
 }
 
-Nft builder::create_sigma_star_nft(const mata::Alphabet* alphabet, const size_t num_of_levels) {
+Nft builder::create_sigma_star_nft(std::shared_ptr<mata::Alphabet> alphabet, const size_t num_of_levels) {
     Nft nft{ Nft::with_levels({num_of_levels, { 0 } }, 1, { 0 }, { 0 }) };
     nft.insert_identity(0, alphabet->get_alphabet_symbols().to_vector());
     return nft;

--- a/tests/applications/strings/replace.cc
+++ b/tests/applications/strings/replace.cc
@@ -31,8 +31,8 @@ TEST_CASE("nft::create_identity()") {
     nft.initial = { 0 };
     nft.final = { 0 };
     SECTION("small identity nft") {
-        EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        nft.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0, 1, 2, 3 });
+        nft.alphabet = alphabet;
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 0, 2);
         nft.delta.add(2, 0, 0);
@@ -46,7 +46,7 @@ TEST_CASE("nft::create_identity()") {
         nft.delta.add(7, 3, 8);
         nft.delta.add(8, 3, 0);
         nft.levels.num_of_levels = 3;
-        nft.levels.resize(nft.levels.num_of_levels * (alphabet.get_number_of_symbols() - 1));
+        nft.levels.resize(nft.levels.num_of_levels * (alphabet->get_number_of_symbols() - 1));
         nft.levels[0] = 0;
         nft.levels[1] = 1;
         nft.levels[2] = 2;
@@ -56,38 +56,38 @@ TEST_CASE("nft::create_identity()") {
         nft.levels[6] = 2;
         nft.levels[7] = 1;
         nft.levels[8] = 2;
-        Nft nft_identity{ create_identity(&alphabet, 3) };
+        Nft nft_identity{ create_identity(alphabet.get(), 3) };
         CHECK(nft::are_equivalent(nft_identity, nft));
     }
 
     SECTION("identity nft no symbols") {
-        EnumAlphabet alphabet{};
-        nft.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>();
+        nft.alphabet = alphabet;
         nft.levels.num_of_levels = 3;
         nft.levels.resize(1);
         nft.levels[0] = 0;
-        Nft nft_identity{ create_identity(&alphabet, 3) };
+        Nft nft_identity{ create_identity(alphabet.get(), 3) };
         CHECK(nft::are_equivalent(nft_identity, nft));
     }
 
     SECTION("identity nft one symbol") {
-        EnumAlphabet alphabet{ 0 };
-        nft.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0 });
+        nft.alphabet = alphabet;
         nft.levels.num_of_levels = 2;
         nft.levels.resize(2);
         nft.levels[0] = 0;
         nft.levels[1] = 1;
         nft.delta.add(0, 0, 1);
         nft.delta.add(1, 0, 0);
-        Nft nft_identity{ create_identity(&alphabet, 2) };
+        Nft nft_identity{ create_identity(alphabet.get(), 2) };
         CHECK(nft::are_equivalent(nft_identity, nft));
-        nft_identity = create_identity(&alphabet);
+        nft_identity = create_identity(alphabet.get());
         CHECK(nft::are_equivalent(nft_identity, nft));
     }
 
     SECTION("small identity nft one level") {
-        EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        nft.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0, 1, 2, 3 });
+        nft.alphabet = alphabet;
         nft.delta.add(0, 0, 0);
         nft.delta.add(0, 1, 0);
         nft.delta.add(0, 2, 0);
@@ -95,7 +95,7 @@ TEST_CASE("nft::create_identity()") {
         nft.levels.num_of_levels = 1;
         nft.levels.resize(1);
         nft.levels[0] = 0;
-        Nft nft_identity{ create_identity(&alphabet, 1) };
+        Nft nft_identity{ create_identity(alphabet.get(), 1) };
         CHECK(nft::are_equivalent(nft_identity, nft));
     }
 }
@@ -105,8 +105,8 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
     expected.initial = { 0 };
     expected.final = { 0 };
     SECTION("small identity nft") {
-        EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        expected.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0, 1, 2, 3 });
+        expected.alphabet = alphabet;
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 0, 0);
         expected.delta.add(0, 1, 2);
@@ -122,7 +122,7 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.levels[2] = 1;
         expected.levels[3] = 1;
         expected.levels[4] = 1;
-        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, 3) };
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(alphabet.get(), 1, 3) };
         CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
     }
 
@@ -132,21 +132,21 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
     }
 
     SECTION("identity nft one symbol") {
-        EnumAlphabet alphabet{ 0 };
-        expected.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0 });
+        expected.alphabet = alphabet;
         expected.levels.num_of_levels = 2;
         expected.levels.resize(2);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 1, 0);
-        Nft nft_identity{ create_identity_with_single_symbol_replace(&alphabet, 0, 1) };
+        Nft nft_identity{ create_identity_with_single_symbol_replace(alphabet.get(), 0, 1) };
         CHECK(nft::are_equivalent(nft_identity, expected));
     }
 
     SECTION("small identity expected longer replace") {
-        EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        expected.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0, 1, 2, 3 });
+        expected.alphabet = alphabet;
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 0, 0);
         expected.delta.add(0, 1, 2);
@@ -170,13 +170,13 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.levels[6] = 1;
         expected.levels[7] = 0;
         expected.levels[8] = 1;
-        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{ 5, 6, 7 }) };
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(alphabet.get(), 1, Word{ 5, 6, 7 }) };
         CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
     }
 
     SECTION("small identity expected replace symbol with empty string") {
-        EnumAlphabet alphabet{ 0, 1, 2, 3 };
-        expected.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0, 1, 2, 3 });
+        expected.alphabet = alphabet;
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 0, 0);
         expected.delta.add(0, 1, 2);
@@ -192,20 +192,20 @@ TEST_CASE("nft::create_identity_with_single_symbol_replace()") {
         expected.levels[2] = 1;
         expected.levels[3] = 1;
         expected.levels[4] = 1;
-        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(&alphabet, 1, Word{}) };
+        Nft nft_identity_with_replace{ create_identity_with_single_symbol_replace(alphabet.get(), 1, Word{}) };
         CHECK(nft::are_equivalent(nft_identity_with_replace, expected));
     }
 
     SECTION("identity expected one symbol with word replace") {
-        EnumAlphabet alphabet{ 0 };
-        expected.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 0 });
+        expected.alphabet = alphabet;
         expected.levels.num_of_levels = 2;
         expected.levels.resize(2);
         expected.levels[0] = 0;
         expected.levels[1] = 1;
         expected.delta.add(0, 0, 1);
         expected.delta.add(1, 0, 0);
-        Nft nft_identity{ create_identity_with_single_symbol_replace(&alphabet, 0, Word{ 0 }) };
+        Nft nft_identity{ create_identity_with_single_symbol_replace(alphabet.get(), 0, Word{ 0 }) };
         CHECK(nft::are_equivalent(nft_identity, expected));
     }
 

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -541,7 +541,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
     Nfa aut{};
     std::optional<mata::Word> result;
     std::unordered_map<StateSet, State> subset_map;
-    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 'a', 'b', 'c' });
 
     SECTION("empty automaton") {
         result = aut.get_word_from_complement();
@@ -567,7 +567,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
     SECTION("simple automaton 1") {
         aut.initial = { 0 };
         aut.final = { 0 };
-        result = aut.get_word_from_complement(&alphabet);
+        result = aut.get_word_from_complement(alphabet.get());
         REQUIRE(result.has_value());
         CHECK(*result == Word{ 'a' });
     }
@@ -582,7 +582,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
     }
 
     SECTION("simple automaton 2 with epsilon") {
-        aut.alphabet = &alphabet;
+        aut.alphabet = alphabet;
         aut.initial = { 0 };
         aut.final = { 0, 1 };
         aut.delta.add(0, 'a', 1);
@@ -592,7 +592,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
     }
 
     SECTION("nfa accepting \\eps+a+b+c") {
-        aut.alphabet = &alphabet;
+        aut.alphabet = alphabet;
         aut.initial = { 0 };
         aut.final = { 0, 1 };
         aut.delta.add(0, 'a', 1);
@@ -640,7 +640,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
         aut.initial = { 1 };
         aut.final = { 1 };
         aut.delta.add(1, 'b', 1);
-        result = aut.get_word_from_complement(&alphabet);
+        result = aut.get_word_from_complement(alphabet.get());
         REQUIRE(result.has_value());
         CHECK(*result == Word{ 'a' });
     }
@@ -650,7 +650,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
         aut.final = { 1 };
         aut.delta.add(1, 'a', 1);
         aut.delta.add(1, 0, 2);
-        result = aut.get_word_from_complement(&alphabet);
+        result = aut.get_word_from_complement(alphabet.get());
         REQUIRE(result.has_value());
         CHECK(*result == Word{ 0 });
     }
@@ -659,7 +659,7 @@ TEST_CASE("mata::nfa::Nfa::get_word_from_complement()") {
         aut.initial = { 1 };
         aut.final = { 1 };
         aut.delta.add(1, 0, 2);
-        result = aut.get_word_from_complement(&alphabet);
+        result = aut.get_word_from_complement(alphabet.get());
         REQUIRE(result.has_value());
         CHECK(*result == Word{ 0 });
     }
@@ -1813,8 +1813,8 @@ TEST_CASE("mata::nfa::make_complete()")
         aut.delta.add(2, 'c', 3);
         aut.delta.add(3, 'b', 5);
         aut.delta.add(4, 'c', 8);
-        EnumAlphabet alphabet{ 'a', 'b', 'c' };
-        aut.alphabet = &alphabet;
+        auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 'a', 'b', 'c' });
+        aut.alphabet = alphabet;
 
         aut.make_complete();
         CHECK(aut.delta.contains(1, 'a', 2));
@@ -1885,26 +1885,26 @@ TEST_CASE("mata::nfa::complement()")
 
     SECTION("empty automaton, empty alphabet")
     {
-        OnTheFlyAlphabet alph{};
+        auto alph = std::make_shared<OnTheFlyAlphabet>();
 
-        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
-        Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
+        cmpl = complement(aut, *alph, { {"algorithm", "classical"} });
+        Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(alph) };
         CHECK(are_equivalent(cmpl, empty_string_nfa));
     }
 
     SECTION("empty automaton")
     {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
+        auto alph = std::make_shared<OnTheFlyAlphabet>(std::vector<std::string>{ "a", "b" });
 
-        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
+        cmpl = complement(aut, *alph, { {"algorithm", "classical"} });
 
         REQUIRE(cmpl.is_in_lang(Run{}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["b"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["b"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"], (*alph)["a"]}, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"], (*alph)["b"], (*alph)["b"], (*alph)["a"] }, {}}));
 
-        Nfa sigma_star_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
+        Nfa sigma_star_nfa{ nfa::builder::create_sigma_star_nfa(alph) };
         CHECK(are_equivalent(cmpl, sigma_star_nfa));
     }
 
@@ -1964,26 +1964,26 @@ TEST_CASE("mata::nfa::complement()")
 
     SECTION("empty automaton, empty alphabet, minimization")
     {
-        OnTheFlyAlphabet alph{};
+        auto alph = std::make_shared<OnTheFlyAlphabet>();
 
-        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
-        Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
+        cmpl = complement(aut, *alph, { {"algorithm", "classical"} });
+        Nfa empty_string_nfa{ nfa::builder::create_sigma_star_nfa(alph) };
         CHECK(are_equivalent(empty_string_nfa, cmpl));
     }
 
     SECTION("empty automaton, minimization")
     {
-        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
+        auto alph = std::make_shared<OnTheFlyAlphabet>(std::vector<std::string>{ "a", "b" });
 
-        cmpl = complement(aut, alph, { {"algorithm", "classical"} });
+        cmpl = complement(aut, *alph, { {"algorithm", "classical"} });
 
         REQUIRE(cmpl.is_in_lang(Run{}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["b"] }, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["a"]}, {}}));
-        REQUIRE(cmpl.is_in_lang(Run{{ alph["a"], alph["b"], alph["b"], alph["a"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["b"] }, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"], (*alph)["a"]}, {}}));
+        REQUIRE(cmpl.is_in_lang(Run{{ (*alph)["a"], (*alph)["b"], (*alph)["b"], (*alph)["a"] }, {}}));
 
-        Nfa sigma_star_nfa{ nfa::builder::create_sigma_star_nfa(&alph) };
+        Nfa sigma_star_nfa{ nfa::builder::create_sigma_star_nfa(alph) };
         CHECK(are_equivalent(sigma_star_nfa, cmpl));
     }
 
@@ -4268,8 +4268,8 @@ TEST_CASE("mata::nfa:: create simple automata") {
     CHECK(nfa.is_in_lang(Word{}));
     CHECK(get_word_lengths(nfa) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
 
-    OnTheFlyAlphabet alphabet{ { "a", 0 }, { "b", 1 }, { "c", 2 } };
-    nfa = builder::create_sigma_star_nfa(&alphabet);
+    auto alphabet = std::make_shared<OnTheFlyAlphabet>(OnTheFlyAlphabet{ { "a", 0 }, { "b", 1 }, { "c", 2 } });
+    nfa = builder::create_sigma_star_nfa(alphabet);
     CHECK(nfa.is_in_lang(Word{}));
     CHECK(nfa.is_in_lang(Word{ 0 }));
     CHECK(nfa.is_in_lang(Word{ 1 }));

--- a/tests/nft/complement.cc
+++ b/tests/nft/complement.cc
@@ -19,11 +19,11 @@ using namespace mata::utils;
 using namespace mata;
 
 TEST_CASE("mata::nft::complement()") {
-    EnumAlphabet alphabet{ 'a', 'b', 'c' };
+    auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 'a', 'b', 'c' });
     Nft nft{ Nft::with_levels(3, 10) };
-    nft.alphabet = &alphabet;
+    nft.alphabet = alphabet;
     Nft nft_complemented{ Nft::with_levels(3) };
-    nft_complemented.alphabet = &alphabet;
+    nft_complemented.alphabet = alphabet;
 
     const auto CHECK_SHARED = [&] {
         CHECK(intersection(nft, nft_complemented).is_lang_empty());
@@ -60,8 +60,8 @@ TEST_CASE("mata::nft::complement()") {
     };
 
     SECTION("empty automaton, empty alphabet") {
-        alphabet.clear();
-        nft_complemented = complement(nft, alphabet);
+        alphabet->clear();
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 
@@ -72,7 +72,7 @@ TEST_CASE("mata::nft::complement()") {
         nft.delta.add(0, 'a', 1);
         nft.delta.add(1, 'b', 2);
 
-        nft_complemented = complement(nft, alphabet);
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 
@@ -86,7 +86,7 @@ TEST_CASE("mata::nft::complement()") {
         nft.delta.add(2, 'a', 3);
         nft.delta.add(3, 'b', 4);
 
-        nft_complemented = complement(nft, alphabet);
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 
@@ -100,7 +100,7 @@ TEST_CASE("mata::nft::complement()") {
         nft.delta.add(3, 'b', 4);
         nft.delta.add(4, 'a', 5);
 
-        nft_complemented = complement(nft, alphabet);
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 
@@ -117,7 +117,7 @@ TEST_CASE("mata::nft::complement()") {
         nft.delta.add(3, 'b', 4);
         nft.delta.add(4, 'a', 5);
 
-        nft_complemented = complement(nft, alphabet);
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 
@@ -135,7 +135,7 @@ TEST_CASE("mata::nft::complement()") {
         nft.delta.add(3, 'b', 4);
         nft.delta.add(4, 'a', 5);
 
-        nft_complemented = complement(nft, alphabet);
+        nft_complemented = complement(nft, *alphabet);
         CHECK_SHARED();
     }
 }

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -50,32 +50,33 @@ TEST_CASE("mata::nft::Nft()") {
 }
 
 TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correctly") {
-    IntAlphabet shared_alphabet{};
-    IntAlphabet input_alphabet{};
-    IntAlphabet output_alphabet{};
-    AlphabetLevels split_alphabets{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+    auto shared_alphabet = std::make_shared<IntAlphabet>();
+    auto input_alphabet = std::make_shared<IntAlphabet>();
+    auto output_alphabet = std::make_shared<IntAlphabet>();
+    auto split_alphabets = std::make_shared<AlphabetLevels>(
+        AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ input_alphabet, output_alphabet } });
 
     SECTION("a shared alphabet is wrapped via AlphabetLevels(Alphabet*) by the caller") {
-        AlphabetLevels shared_alphabets{ &shared_alphabet };
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &shared_alphabets };
+        auto shared_alphabets = std::make_shared<AlphabetLevels>(AlphabetLevels{ shared_alphabet });
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, shared_alphabets };
 
         CHECK(nft.alphabet == nullptr);
-        REQUIRE(nft.alphabets == &shared_alphabets);
-        CHECK(&nft.alphabets->for_level(0) == &shared_alphabet);
-        CHECK(&nft.alphabets->for_level(7) == &shared_alphabet);
+        REQUIRE(nft.alphabets == shared_alphabets);
+        CHECK(&nft.alphabets->for_level(0) == shared_alphabet.get());
+        CHECK(&nft.alphabets->for_level(7) == shared_alphabet.get());
     }
 
     SECTION("per-level alphabets are stored in the alphabets member") {
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_alphabets };
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, split_alphabets };
 
-        REQUIRE(nft.alphabets == &split_alphabets);
+        REQUIRE(nft.alphabets == split_alphabets);
         CHECK(nft.alphabet == nullptr);
-        CHECK(&nft.alphabets->for_level(0) == &input_alphabet);
-        CHECK(&nft.alphabets->for_level(1) == &output_alphabet);
+        CHECK(&nft.alphabets->for_level(0) == input_alphabet.get());
+        CHECK(&nft.alphabets->for_level(1) == output_alphabet.get());
     }
 
     SECTION("level-aware translation routes to the right underlying alphabet") {
-        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &split_alphabets };
+        Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, split_alphabets };
 
         CHECK_NOTHROW(nft.alphabets->translate_symb("1", 0));
         CHECK_NOTHROW(nft.alphabets->translate_symb("1", 1));
@@ -84,9 +85,9 @@ TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correc
     }
 
     SECTION("level-aware complement uses the selected level") {
-        EnumAlphabet input_symbols{ 1, 2, 3 };
-        EnumAlphabet output_symbols{ 2, 4 };
-        AlphabetLevels complement_alphabets{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+        auto input_symbols = std::make_shared<EnumAlphabet>(EnumAlphabet{ 1, 2, 3 });
+        auto output_symbols = std::make_shared<EnumAlphabet>(EnumAlphabet{ 2, 4 });
+        AlphabetLevels complement_alphabets{ std::vector<std::shared_ptr<Alphabet>>{ input_symbols, output_symbols } };
 
         CHECK(complement_alphabets.get_alphabet_symbols(0) == OrdVector<Symbol>{ 1, 2, 3 });
         CHECK(complement_alphabets.get_alphabet_symbols(1) == OrdVector<Symbol>{ 2, 4 });
@@ -95,50 +96,51 @@ TEST_CASE("mata::nft::Nft per-level alphabets are initialized and updated correc
     }
 
     SECTION("level-aware empty and clear use the selected level") {
-        OnTheFlyAlphabet input_symbols{};
-        OnTheFlyAlphabet output_symbols{};
-        input_symbols.add_new_symbol("a");
-        output_symbols.add_new_symbol("b");
-        AlphabetLevels mutable_alphabets{ std::vector<Alphabet*>{ &input_symbols, &output_symbols } };
+        auto input_symbols = std::make_shared<OnTheFlyAlphabet>();
+        auto output_symbols = std::make_shared<OnTheFlyAlphabet>();
+        input_symbols->add_new_symbol("a");
+        output_symbols->add_new_symbol("b");
+        AlphabetLevels mutable_alphabets{ std::vector<std::shared_ptr<Alphabet>>{ input_symbols, output_symbols } };
 
         CHECK_FALSE(mutable_alphabets.empty(0));
         CHECK_FALSE(mutable_alphabets.empty(1));
 
         mutable_alphabets.clear(0);
-        CHECK(input_symbols.empty());
-        CHECK_FALSE(output_symbols.empty());
+        CHECK(input_symbols->empty());
+        CHECK_FALSE(output_symbols->empty());
         CHECK(mutable_alphabets.empty(0));
         CHECK_FALSE(mutable_alphabets.empty(1));
     }
 }
 
 TEST_CASE("mata::AlphabetLevels single-element form treats every level uniformly") {
-    IntAlphabet base{};
-    AlphabetLevels uniform{ &base };
+    auto base = std::make_shared<IntAlphabet>();
+    AlphabetLevels uniform{ base };
 
-    CHECK(&uniform.for_level(0) == &base);
-    CHECK(&uniform.for_level(7) == &base);
+    CHECK(&uniform.for_level(0) == base.get());
+    CHECK(&uniform.for_level(7) == base.get());
     CHECK(uniform.translate_symb("3", 0) == 3);
     CHECK(uniform.translate_symb("3", 5) == 3);
     CHECK(uniform.reverse_translate_symbol(3, 5) == "3");
 }
 
 TEST_CASE("mata::nft::determinize preserves the per-level alphabets pointer") {
-    IntAlphabet input_alphabet{};
-    IntAlphabet output_alphabet{};
+    auto input_alphabet = std::make_shared<IntAlphabet>();
+    auto output_alphabet = std::make_shared<IntAlphabet>();
 
-    AlphabetLevels alphabets{ std::vector<Alphabet*>{ &input_alphabet, &output_alphabet } };
+    auto alphabets = std::make_shared<AlphabetLevels>(
+        AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ input_alphabet, output_alphabet } });
 
-    Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, &alphabets };
+    Nft nft{ 3, { 0 }, { 2 }, Levels{ 2, { 0, 1, 0 } }, alphabets };
     nft.delta.add(0, 1, 1);
     nft.delta.add(1, 2, 2);
 
     Nft determinized = determinize(nft);
 
-    REQUIRE(determinized.alphabets == &alphabets);
+    REQUIRE(determinized.alphabets == alphabets);
     REQUIRE(determinized.alphabet == nullptr);
-    CHECK(&determinized.alphabets->for_level(0) == &input_alphabet);
-    CHECK(&determinized.alphabets->for_level(1) == &output_alphabet);
+    CHECK(&determinized.alphabets->for_level(0) == input_alphabet.get());
+    CHECK(&determinized.alphabets->for_level(1) == output_alphabet.get());
 }
 
 TEST_CASE("mata::nft::size()") {
@@ -1007,10 +1009,10 @@ TEST_CASE("mata::nft::construct() from IntermediateAut correct calls") { // {{{
 TEST_CASE("mata::nft::make_complete()") {
     Nft nft{ Nft::with_levels(3) };
     Nft result{ Nft::with_levels(3) };
-    EnumAlphabet alphabet{ 'a', 'b', 'c' };
-    nft.alphabet = &alphabet;
-    result.alphabet = &alphabet;
-    auto alphabet_symbols = [&] { return alphabet.get_alphabet_symbols(); };
+    auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 'a', 'b', 'c' });
+    nft.alphabet = alphabet;
+    result.alphabet = alphabet;
+    auto alphabet_symbols = [&] { return alphabet->get_alphabet_symbols(); };
     OrdVector<Symbol> symbols{ alphabet_symbols() };
 
     std::optional<std::vector<State>> sinks{ std::nullopt };
@@ -1032,7 +1034,7 @@ TEST_CASE("mata::nft::make_complete()") {
 
 
         // Check sinks if any were provided.
-        // CHECK(not result.make_complete(&alphabet, std::vector<State>{ sinks }));
+        // CHECK(not result.make_complete(alphabet.get(), std::vector<State>{ sinks }));
         for (auto sinks_val{ sinks.value_or(std::vector<State>{}) }; const State sink : sinks_val) {
             for (const auto symbol : alphabet_symbols()) {
                 CHECK(result.delta.contains(sink, symbol, ((sink + 1) % sinks_val.size()) + *sinks_val.begin()));
@@ -1041,9 +1043,9 @@ TEST_CASE("mata::nft::make_complete()") {
     };
 
     SECTION("empty automaton, empty alphabet") {
-        alphabet.clear();
+        alphabet->clear();
         result = nft;
-        result.make_complete(&alphabet, sinks);
+        result.make_complete(alphabet.get(), sinks);
         CHECK_SHARED();
     }
 
@@ -1055,7 +1057,7 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(1, 'b', 2);
 
         result = nft;
-        result.make_complete(&alphabet);
+        result.make_complete(alphabet.get());
         CHECK_SHARED();
     }
 
@@ -1070,7 +1072,7 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(3, 'b', 4);
 
         result = nft;
-        result.make_complete(&alphabet);
+        result.make_complete(alphabet.get());
         CHECK_SHARED();
     }
 
@@ -1085,7 +1087,7 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(4, 'a', 5);
 
         result = nft;
-        result.make_complete(&alphabet);
+        result.make_complete(alphabet.get());
         CHECK_SHARED();
     }
 
@@ -1103,7 +1105,7 @@ TEST_CASE("mata::nft::make_complete()") {
         nft.delta.add(4, 'a', 5);
 
         result = nft;
-        result.make_complete(&alphabet);
+        result.make_complete(alphabet.get());
         CHECK_SHARED();
     }
 
@@ -1124,7 +1126,7 @@ TEST_CASE("mata::nft::make_complete()") {
         sinks = { 6, 7, 8 };
 
         result = nft;
-        result.make_complete(&alphabet, sinks);
+        result.make_complete(alphabet.get(), sinks);
         CHECK_SHARED();
     }
 }
@@ -2514,8 +2516,8 @@ TEST_CASE("mata::nft::Nft::is_deterministic()") { // {{{
 
 TEST_CASE("mata::nft::Nft::is_in_lang[_prefix][_by_levels]()") {
     Nft nft{ Nft::with_levels(3) };
-    EnumAlphabet alphabet{ 'a', 'b', 'c', 'd', 'e' };
-    nft.alphabet = &alphabet;
+    auto alphabet = std::make_shared<EnumAlphabet>(EnumAlphabet{ 'a', 'b', 'c', 'd', 'e' });
+    nft.alphabet = alphabet;
 
     SECTION("empty automaton") {
         CHECK(nft.is_lang_empty());
@@ -3516,8 +3518,8 @@ TEST_CASE("mata::nft:: create simple automata") {
     CHECK(nft.is_in_lang(Word{}));
     CHECK(get_word_lengths(nft) == std::set<std::pair<int, int>>{ std::make_pair(0, 0) });
 
-    OnTheFlyAlphabet alphabet{ { "a", 0 }, { "b", 1 }, { "c", 2 } };
-    nft = builder::create_sigma_star_nft(&alphabet, 1);
+    auto alphabet = std::make_shared<OnTheFlyAlphabet>(OnTheFlyAlphabet{ { "a", 0 }, { "b", 1 }, { "c", 2 } });
+    nft = builder::create_sigma_star_nft(alphabet, 1);
     CHECK(nft.is_in_lang(Word{}));
     CHECK(nft.is_in_lang({ 0 }));
     CHECK(nft.is_in_lang({ 1 }));


### PR DESCRIPTION
Replaces `Alphabet*` with `std::share_ptr<Alphabet>` in the `alphabet` members of NFAs, NFTs. Functions still often take just an `Alphabet*` since they do not take ownership of the alphabet.  This follows the commonly used conventions, too: `std::shared_ptr` should be used only when the object takes ownership of the pointed-to object.

Fixes #685 by introducing shared alphabets owned by the NFAs/NFTs, thus resolving the dangling pointer issue.