### PR TITLE
github: +refactor Append `-cpp` to C++ tests actions in GHA

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/workflows/actions/compile
         with:
           build-log-output-file: "warnings-new"
-  run-tests:
+  run-tests-cpp:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -254,7 +254,7 @@ jobs:
           fi
   code-coverage:
     runs-on: ubuntu-latest
-    needs: run-tests
+    needs: run-tests-cpp
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-devel.yml
+++ b/.github/workflows/release-devel.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/workflows/actions/docs
         with:
           os: ${{ matrix.os }}
-  run-tests:
+  run-tests-cpp:
     if: github.event.pull_request.merged == true
     runs-on: ${{ matrix.os }}
     strategy:
@@ -76,7 +76,7 @@ jobs:
       - name: Test the Python bindings
         uses: ./.github/workflows/actions/test-python
   release-dev:
-    needs: [build-docs, run-tests, run-tests-python]
+    needs: [build-docs, run-tests-cpp, run-tests-python]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/workflows/actions/docs
         with:
           os: ${{ matrix.os }}
-  run-tests:
+  run-tests-cpp:
     if: github.event.pull_request.merged == true
     runs-on: ${{ matrix.os }}
     strategy:
@@ -77,7 +77,7 @@ jobs:
       - name: Test the Python bindings
         uses: ./.github/workflows/actions/test-python
   release:
-    needs: [build-docs, run-tests, run-tests-python]
+    needs: [build-docs, run-tests-cpp, run-tests-python]
     runs-on: ubuntu-latest
     outputs:
       new-tag: ${{ steps.bump.outputs.new-tag }}


### PR DESCRIPTION
This helps distinguish the C++ tests from the Python binding tests.