### PR TITLE
alphabet: +feat Operations to modify and share the alphabets

### DIFF
--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -170,12 +170,12 @@ class IntAlphabet : public Alphabet {
  *  of @c EnumAlphabet and the functions give the expected results.
  *
  *  Example:
- *  ```cpp
- *  Alphabet alph{ EnumAlphabet{ 0, 4, 6, 8, 9 } };
- *  CHECK(alph.translate_symb("6") == 6);
- *  CHECK_THROWS(alph.translate_symb("5")); // Throws an exception about an unknown symbol.
- *  CHECK(alph.get_complement({ utils::OrdVector<Symbol>{ 0, 6, 9 } }) == utils::OrdVector<Symbol>{ 4, 8 });
- *  ```
+ *  @code
+ *  Alphabet alphabet{ EnumAlphabet{ 0, 4, 6, 8, 9 } };
+ *  CHECK(alphabet.translate_symb("6") == 6);
+ *  CHECK_THROWS(alphabet.translate_symb("5")); // Throws an exception about an unknown symbol.
+ *  CHECK(alphabet.get_complement({ utils::OrdVector<Symbol>{ 0, 6, 9 } }) == utils::OrdVector<Symbol>{ 4, 8 });
+ *  @endcode
  */
 class EnumAlphabet : public Alphabet {
   public:
@@ -183,6 +183,7 @@ class EnumAlphabet : public Alphabet {
 	EnumAlphabet(const EnumAlphabet& alphabet) = default;
 	explicit EnumAlphabet(const EnumAlphabet* const alphabet) : EnumAlphabet(*alphabet) {}
 	EnumAlphabet(EnumAlphabet&& rhs) = default;
+	EnumAlphabet(utils::OrdVector<Symbol> symbols) : symbols_(std::move(symbols)) {}
 
 	utils::OrdVector<Symbol> get_alphabet_symbols() const override { return symbols_; }
 	utils::OrdVector<Symbol> get_complement(const utils::OrdVector<Symbol>& symbols) const override {

--- a/include/mata/alphabet.hh
+++ b/include/mata/alphabet.hh
@@ -458,7 +458,8 @@ class OnTheFlyAlphabet : public Alphabet {
 /**
  * @brief Per-level alphabets for transducer-like automata.
  *
- * Standalone (does NOT inherit from @c Alphabet) wrapper holding a vector of @c Alphabet*, one per level.
+ * Standalone (does NOT inherit from @c Alphabet) wrapper holding a vector of @c std::shared_ptr<Alphabet>, one per
+ * level.
  * Operates in one of two modes (see @c Mode):
  *  - @c Global   — a single shared alphabet (typically stored in @c alphabets[0]) applies to every level. The level
  *                  argument is ignored.
@@ -475,28 +476,107 @@ class AlphabetLevels {
 		MultiLevel, ///< Each level uses its own alphabet from @c alphabets[level]; level argument is required.
 	};
 
-	/**
-	 * @brief Per-level alphabets.
-	 *
-	 * In @c Global mode, only @c alphabets[0] is used. In @c MultiLevel mode, indexed by level. Public to allow
-	 *  direct read/write access in line with the rest of the codebase (`Nft::levels`, `Nfa::delta`/`initial`/etc.).
-	 *  Read-only access through @c for_level (or @c operator[]) when range/null validation is desired.
-	 */
-	std::vector<std::shared_ptr<Alphabet>> alphabets{};
-
-	/// Operating mode. Defaults to @c MultiLevel.
-	Mode mode{Mode::MultiLevel};
-
 	explicit AlphabetLevels(std::vector<std::shared_ptr<Alphabet>> alphabets = {}, Mode mode = Mode::MultiLevel)
-		: alphabets{std::move(alphabets)},
-		  mode{mode} {}
+		: alphabets_{std::move(alphabets)},
+		  mode_{mode} {
+		check_can_grow_to_(alphabets_.size());
+	}
 
 	/**
-	 * @brief Convenience constructor: use the same @p alphabet for every level (Global mode).
+	 * @brief Use the same @p alphabet for every level (Global mode).
 	 *
 	 * Stores a single-element vector and sets @c mode to @c Global.
 	 */
-	explicit AlphabetLevels(std::shared_ptr<Alphabet> alphabet) : alphabets{std::move(alphabet)}, mode{Mode::Global} {}
+	explicit AlphabetLevels(std::shared_ptr<Alphabet> alphabet)
+		: alphabets_{std::move(alphabet)},
+		  mode_{Mode::Global} {}
+
+	/**
+	 * @brief Construct in @c Global mode, using @p alphabet as the single shared alphabet for every level.
+	 *
+	 * @see set_global_mode(std::shared_ptr<Alphabet>)
+	 */
+	static AlphabetLevels global_mode(std::shared_ptr<Alphabet> alphabet) {
+		return AlphabetLevels{std::move(alphabet)};
+	}
+
+	/**
+	 * @brief Construct in @c MultiLevel mode, using @p alphabets indexed by level.
+	 *
+	 * @see set_multi_level_mode()
+	 */
+	static AlphabetLevels multi_level_mode(std::vector<std::shared_ptr<Alphabet>> alphabets = {}) {
+		return AlphabetLevels{std::move(alphabets), Mode::MultiLevel};
+	}
+
+	AlphabetLevels(const AlphabetLevels& other) = default;
+	AlphabetLevels(AlphabetLevels&& other) noexcept = default;
+	AlphabetLevels& operator=(const AlphabetLevels& other) = default;
+	AlphabetLevels& operator=(AlphabetLevels&& other) noexcept = default;
+
+	/**
+	 * @brief Equality of two @c AlphabetLevels instances.
+	 *
+	 * Memberwise comparison of @c mode and the stored alphabet slots.
+	 * Slots are @c std::shared_ptr<Alphabet> and are compared by the pointee's identity (i.e., whether both slots point
+	 *  to the same underlying @c Alphabet object), not by the alphabets' contents, since @c Alphabet does not support
+	 *  value equality.
+	 */
+	bool operator==(const AlphabetLevels& other) const = default;
+
+	/// Current operating mode.
+	Mode mode() const noexcept { return mode_; }
+
+	/**
+	 * @brief Switch to @c Global mode, keeping only the alphabet at @p level_for_kept_alphabet as the single
+	 *  shared alphabet.
+	 *
+	 * Any other stored alphabets are dropped from @c AlphabetLevels (the @c Alphabet objects themselves survive
+	 *  if still referenced elsewhere, since they are held via @c shared_ptr). Unlike @c for_level, this never
+	 *  throws due to a missing alphabet: switching an empty instance to @c Global just leaves it empty.
+	 *
+	 * @param[in] level_for_kept_alphabet Level whose alphabet to keep. Ignored when no alphabet is currently
+	 *  stored.
+	 * @throws std::out_of_range If @p level_for_kept_alphabet is out of range and at least one alphabet is
+	 *  stored.
+	 */
+	void set_global_mode(Level level_for_kept_alphabet = 0) {
+		if (!alphabets_.empty()) { alphabets_ = {alphabets_.at(level_for_kept_alphabet)}; }
+		mode_ = Mode::Global;
+	}
+
+	/**
+	 * @brief Switch to @c Global mode, using @p alphabet as the new single shared alphabet.
+	 *
+	 * Replaces any previously stored alphabets regardless of how many there were. @c AlphabetLevels takes shared
+	 *  ownership of @p alphabet (via @c std::shared_ptr); it may still be shared with other owners.
+	 *
+	 * @param[in] alphabet The alphabet to use for every level.
+	 */
+	void set_global_mode(std::shared_ptr<Alphabet> alphabet) {
+		alphabets_ = {std::move(alphabet)};
+		mode_ = Mode::Global;
+	}
+
+	/**
+	 * @brief Switch to @c MultiLevel mode.
+	 *
+	 * Always safe: @c MultiLevel places no constraint on the number of stored alphabets. Existing alphabets are
+	 *  kept as-is, now indexed by level (e.g., a single alphabet from @c Global mode becomes level 0's alphabet).
+	 */
+	void set_multi_level_mode() noexcept { mode_ = Mode::MultiLevel; }
+
+	/**
+	 * @brief Switch to @c MultiLevel mode, using @p alphabets as the new per-level alphabets.
+	 *
+	 * Replaces any previously stored alphabets regardless of how many there were.
+	 *
+	 * @param[in] alphabets The alphabets to use, indexed by level.
+	 */
+	void set_multi_level_mode(std::vector<std::shared_ptr<Alphabet>> alphabets) noexcept {
+		alphabets_ = std::move(alphabets);
+		mode_ = Mode::MultiLevel;
+	}
 
 	/**
 	 * @brief Translate a symbol name using the alphabet for the given level.
@@ -559,9 +639,108 @@ class AlphabetLevels {
 	const Alphabet& for_level(std::optional<Level> level = std::nullopt) const;
 	Alphabet& for_level(std::optional<Level> level = std::nullopt);
 
-	/// Alias for @c for_level.
+	/**
+	 * @brief Alias for @c for_level.
+	 *
+	 * @see @c for_level.
+	 */
 	const Alphabet& operator[](std::optional<Level> level) const { return for_level(level); }
+	/**
+	 * @brief Alias for @c for_level.
+	 *
+	 * @see @c for_level.
+	 */
 	Alphabet& operator[](std::optional<Level> level) { return for_level(level); }
+
+	/**
+	 * @name Raw slot access (mode-agnostic).
+	 *
+	 * Bounds-checked access to a raw slot by its index in the underlying vector, ignoring @c mode. Unlike
+	 *  @c for_level, a null entry is returned as-is instead of throwing; only an out-of-range @p index throws.
+	 *  @see std::vector::at.
+	 */
+	///@{
+	const std::shared_ptr<Alphabet>& at(size_t index) const { return alphabets_.at(index); }
+	std::shared_ptr<Alphabet>& at(size_t index) { return alphabets_.at(index); }
+	///@}
+
+	/// Number of alphabet slots currently stored. @see std::vector::size.
+	size_t size() const noexcept { return alphabets_.size(); }
+
+	std::vector<std::shared_ptr<Alphabet>>::const_iterator begin() const noexcept { return alphabets_.begin(); }
+	std::vector<std::shared_ptr<Alphabet>>::const_iterator end() const noexcept { return alphabets_.end(); }
+	std::vector<std::shared_ptr<Alphabet>>::iterator begin() noexcept { return alphabets_.begin(); }
+	std::vector<std::shared_ptr<Alphabet>>::iterator end() noexcept { return alphabets_.end(); }
+
+	/// Append an alphabet as the new last level. @see std::vector::push_back.
+	void push_back(std::shared_ptr<Alphabet> alphabet) {
+		check_can_grow_to_(alphabets_.size() + 1);
+		alphabets_.push_back(std::move(alphabet));
+	}
+
+	/// Insert an alphabet before @p pos, shifting subsequent levels up. @see std::vector::insert.
+	std::vector<std::shared_ptr<Alphabet>>::iterator
+		insert(std::vector<std::shared_ptr<Alphabet>>::const_iterator pos, std::shared_ptr<Alphabet> alphabet) {
+		check_can_grow_to_(alphabets_.size() + 1);
+		return alphabets_.insert(pos, std::move(alphabet));
+	}
+
+	/// Remove the last level's alphabet. @see std::vector::pop_back.
+	void pop_back() { alphabets_.pop_back(); }
+
+	/// Reserve storage for at least @p new_cap levels. @see std::vector::reserve.
+	void reserve(size_t new_cap) { alphabets_.reserve(new_cap); }
+
+	/// Resize the number of levels, value-initializing (null) any newly added slots. @see std::vector::resize.
+	void resize(size_t count) {
+		check_can_grow_to_(count);
+		alphabets_.resize(count);
+	}
+
+	/// Remove the alphabet at @p pos. @see std::vector::erase.
+	std::vector<std::shared_ptr<Alphabet>>::iterator erase(std::vector<std::shared_ptr<Alphabet>>::const_iterator pos) {
+		return alphabets_.erase(pos);
+	}
+
+	/// Remove alphabets in the range [@p first, @p last). @see std::vector::erase.
+	std::vector<std::shared_ptr<Alphabet>>::iterator erase(
+		std::vector<std::shared_ptr<Alphabet>>::const_iterator first,
+		std::vector<std::shared_ptr<Alphabet>>::const_iterator last
+	) {
+		return alphabets_.erase(first, last);
+	}
+
+  public:
+	/**
+	 * @brief Per-level alphabets.
+	 *
+	 * In @c Global mode, only @c alphabets[0] is used. In @c MultiLevel mode, indexed by level. Private so that the
+	 *  @c Global invariant (exactly one alphabet) can be enforced by the build-up methods below; use @c for_level
+	 *  (or @c operator[]) for validated read/write access, @c at for raw slot access, or the vector-like methods to
+	 *  build up a @c MultiLevel instance.
+	 * @warning Modifying directly may break the class invariants.
+	 */
+	std::vector<std::shared_ptr<Alphabet>> alphabets_{};
+
+	/**
+	 * @brief Operating mode. Defaults to @c MultiLevel.
+	 *
+	 * Private so switching to @c Global can be rejected while more than one alphabet is stored (see @c
+	 * set_global_mode).
+	 * @warning Modifying directly may break the class invariants.
+	 */
+	Mode mode_{Mode::MultiLevel};
+
+  private:
+	/// Throw if growing to @p new_size would violate the @c Global invariant of holding a single alphabet.
+	void check_can_grow_to_(size_t new_size) const {
+		if (mode_ == Mode::Global && new_size > 1) {
+			throw std::runtime_error(
+				"AlphabetLevels (Global) can only hold a single alphabet; use set_global_mode()/for_level()/"
+				"operator[] to replace it."
+			);
+		}
+	}
 };
 
 /**

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -577,6 +577,27 @@ class Nfa {
 	void fill_alphabet(mata::OnTheFlyAlphabet& alphabet_to_fill) const;
 
 	/**
+	 * @brief Resolve which alphabet to use for the current operation.
+	 *
+	 * Priority order:
+	 *  -# @p alphabet, when non-null;
+	 *  -# @c this->alphabet, when non-null;
+	 *  -# an alphabet built on the fly from the symbols used on the NFA's transitions (see @c Delta::get_used_symbols).
+	 *
+	 * @param[in] alphabet Explicit alphabet to use, taking precedence over @c this->alphabet when non-null.
+	 * @return The resolved alphabet.
+	 */
+	std::shared_ptr<const Alphabet> resolve_alphabet(const Alphabet* alphabet = nullptr) const;
+
+	/**
+	 * @brief Get the set of symbols to work with for the current operation.
+	 *
+	 * @param[in] alphabet Explicit alphabet to use, taking precedence over @c this->alphabet when non-null.
+	 * @return Symbols of the alphabet resolved via @c resolve_alphabet(alphabet).
+	 */
+	utils::OrdVector<Symbol> get_symbols_to_work_with(const Alphabet* alphabet = nullptr) const;
+
+	/**
 	 * @brief Check whether the language of the automaton is universal.
 	 *
 	 * @param alphabet Alphabet to use for checking the universality.
@@ -1161,6 +1182,10 @@ Run encode_word(const Alphabet* alphabet, const std::vector<std::string>& input)
 
 /**
  * Get the set of symbols to work with during operations.
+ *
+ * Resolves the alphabet to use via @c Nfa::resolve_alphabet(shared_alphabet) and returns its symbols. Prefer calling
+ *  @c nfa.get_symbols_to_work_with(shared_alphabet) directly when a reference to @p nfa is already at hand.
+ *
  * @param nfa NFA to get symbols from.
  * @param[in] shared_alphabet Optional alphabet shared between NFAs passed as an argument to a function.
  */

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -470,13 +470,14 @@ class Nft : public nfa::Nfa {
 	 * @param state The state where the identity transition will be inserted. @p state serves as both the source and
 	 *  target state.
 	 * @param alphabet The alphabet with symbols used for the identity transition. Identity will be created for each
-	 * symbol in the @p alphabet.
+	 *  symbol in the alphabet resolved via @c get_symbols_to_work_with(alphabet, levels[state]) (see
+	 *  @c resolve_alphabet for the resolution order).
 	 * @param jump_mode Specifies if the symbol on a jump transition (a transition with a length greater than 1)
 	 * is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a
 	 * sequence of @c DONT_CARE symbols.
 	 * @return Self with inserted identity.
 	 */
-	Nft& insert_identity(State state, const Alphabet* alphabet, JumpMode jump_mode = JumpMode::RepeatSymbol);
+	Nft& insert_identity(State state, const Alphabet* alphabet = nullptr, JumpMode jump_mode = JumpMode::RepeatSymbol);
 
 	/**
 	 * Inserts an identity transition into the NFT.
@@ -1249,8 +1250,13 @@ class Nft : public nfa::Nfa {
 	 *  transitions from given `state`) to `sink_states[next_level_after(level)]` where `level == this->levels[state]`.
 	 * If NFT does not contain any states, this function does nothing.
 	 *
-	 * @param[in] alphabet Alphabet to use for computing "missing" symbols. If @c nullptr, use @c this->alphabet when
-	 *  defined, otherwise use @c this->delta.get_used_symbols().
+	 * The same symbols are used to complete every level (see @c resolve_alphabet); there is currently no support for
+	 *  completing different levels to different per-level symbol sets in this overload.
+	 *
+	 * @param[in] alphabet Alphabet to use for computing "missing" symbols, resolved via @c resolve_alphabet(alphabet).
+	 *  @warning If @p alphabet is @c nullptr and @c this->alphabets is set in @c AlphabetLevels::Mode::MultiLevel,
+	 *   resolution throws, since there is no single alphabet to use for every level; pass an explicit @p alphabet in
+	 *   that case.
 	 * @param[in] sink_states The level-indexed vector of sink states, one per level, already existing in the NFT, into
 	 *  which new transitions are added. If @c std::nullopt, add new sink states.
 	 * @return @c true if a new transition was added to the NFA, @c false otherwise.
@@ -1279,6 +1285,35 @@ class Nft : public nfa::Nfa {
 		const utils::OrdVector<Symbol>& symbols, const std::optional<std::vector<State>>& sink_states = std::nullopt
 	);
 
+	/**
+	 * @brief Resolve which alphabet to use for the current operation on @p level.
+	 *
+	 * Priority order:
+	 *  -# @p alphabet, when non-null;
+	 *  -# @c this->alphabets, when non-null, resolved for @p level (see @c AlphabetLevels::for_level for the
+	 *     semantics of @p level, including @c std::nullopt);
+	 *  -# @c this->alphabet (inherited from @c Nfa; expected to always be @c nullptr for NFTs), when non-null;
+	 *  -# an alphabet built on the fly from the symbols used on the NFT's transitions (see @c Delta::get_used_symbols).
+	 *
+	 * @param[in] alphabet Explicit alphabet to use, taking precedence over @c this->alphabets/@c this->alphabet
+	 *  when non-null.
+	 * @param[in] level Level to resolve the alphabet for when falling back to @c this->alphabets.
+	 * @return The resolved alphabet.
+	 */
+	std::shared_ptr<const Alphabet>
+		resolve_alphabet(const Alphabet* alphabet = nullptr, std::optional<Level> level = std::nullopt) const;
+
+	/**
+	 * @brief Get the set of symbols to work with for the current operation on @p level.
+	 *
+	 * @param[in] alphabet Explicit alphabet to use, taking precedence over @c this->alphabets/@c this->alphabet
+	 *  when non-null.
+	 * @param[in] level Level to resolve the alphabet for when falling back to @c this->alphabets.
+	 * @return Symbols of the alphabet resolved via @c resolve_alphabet(alphabet, level).
+	 */
+	utils::OrdVector<Symbol>
+		get_symbols_to_work_with(const Alphabet* alphabet = nullptr, std::optional<Level> level = std::nullopt) const;
+
 	using super::is_complete;
 	using super::is_deterministic;
 
@@ -1299,6 +1334,21 @@ template <bool...> struct BoolPack {};
 template <typename... Ts> using conjunction = std::is_same<BoolPack<true, Ts::value...>, BoolPack<Ts::value..., true>>;
 /// Check that all types in a sequence of parameters @p Ts are of type @p T.
 template <typename T, typename... Ts> using AreAllOfType = conjunction<std::is_same<Ts, T>...>::type;
+
+/**
+ * Get the set of symbols to work with during operations, for a given @p level.
+ *
+ * Resolves the alphabet to use via @c Nft::resolve_alphabet(shared_alphabet, level) and returns its symbols. Prefer
+ *  calling @c nft.get_symbols_to_work_with(shared_alphabet, level) directly when a reference to @p nft is already at
+ *  hand.
+ *
+ * @param nft NFT to get symbols from.
+ * @param[in] shared_alphabet Optional alphabet shared between NFTs passed as an argument to a function.
+ * @param[in] level Level to resolve the alphabet for when falling back to @c nft.alphabets.
+ */
+utils::OrdVector<Symbol> get_symbols_to_work_with(
+	const Nft& nft, const Alphabet* shared_alphabet = nullptr, std::optional<Level> level = std::nullopt
+);
 
 /**
  * @brief Compute non-deterministic union.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -1442,6 +1442,32 @@ Nft compose(
 );
 
 /**
+ * @brief Compose the per-level alphabets for NFTs to be composed.
+ *
+ * Carries through the alphabet for each output level from whichever side (@p lhs / @p rhs) that level came from,
+ *  in the same block order used to align levels for composition (non-synchronization levels from @p lhs, then
+ *  from @p rhs, then the synchronization level itself, repeated per synchronization block, with a trailing block
+ *  of remaining non-synchronization levels after the last synchronization level).
+ *
+ * The synchronization levels of @p lhs and @p rhs are expected to already share the same alphabet instance
+ *  (the caller's responsibility); when both are non-null this is checked with an assert.
+ *
+ * @param[in] lhs First transducer whose alphabets to compose.
+ * @param[in] rhs Second transducer whose alphabets to compose.
+ * @param[in] lhs_sync_levels Ordered vector of synchronization levels of the @p lhs.
+ * @param[in] rhs_sync_levels Ordered vector of synchronization levels of the @p rhs.
+ * @param[in] project_out_sync_levels Whether we want to project out the synchronization levels.
+ * @return @c nullptr if either @p lhs.alphabets or @p rhs.alphabets is @c nullptr.
+ */
+std::shared_ptr<mata::AlphabetLevels> compose_alphabets(
+	const Nft& lhs,
+	const Nft& rhs,
+	const utils::OrdVector<Level>& lhs_sync_levels,
+	const utils::OrdVector<Level>& rhs_sync_levels,
+	bool project_out_sync_levels = true
+);
+
+/**
  * @brief Composes two NFTs with a single synchronization level.
  *
  * The levels of the resulting NFT are in the following order:

--- a/src/alphabet.cc
+++ b/src/alphabet.cc
@@ -205,9 +205,9 @@ mata::utils::OrdVector<Symbol> AlphabetLevels::get_complement(
 }
 
 bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
-	if (mode == Mode::MultiLevel && !level.has_value()) {
+	if (mode_ == Mode::MultiLevel && !level.has_value()) {
 		// MultiLevel + nullopt: empty iff every underlying alphabet is empty.
-		for (const auto& alphabet : alphabets) {
+		for (const auto& alphabet : alphabets_) {
 			if (alphabet != nullptr && !alphabet->empty()) { return false; }
 		}
 		return true;
@@ -216,9 +216,9 @@ bool AlphabetLevels::empty(const std::optional<mata::Level> level) const {
 }
 
 void AlphabetLevels::clear(const std::optional<mata::Level> level) {
-	if (mode == Mode::MultiLevel && !level.has_value()) {
+	if (mode_ == Mode::MultiLevel && !level.has_value()) {
 		// MultiLevel + nullopt: clear every underlying alphabet.
-		for (const auto& alphabet : alphabets) {
+		for (const auto& alphabet : alphabets_) {
 			if (alphabet != nullptr) { alphabet->clear(); }
 		}
 		return;
@@ -227,29 +227,31 @@ void AlphabetLevels::clear(const std::optional<mata::Level> level) {
 }
 
 const mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level> level) const {
-	if (mode == Mode::Global) {
-		if (alphabets.empty() || alphabets[0] == nullptr) {
+	// Handle Mode::Global.
+	if (mode_ == Mode::Global) {
+		if (alphabets_.empty() || alphabets_[0] == nullptr) {
 			throw std::runtime_error("AlphabetLevels (Global) has no underlying alphabet.");
 		}
-		return *alphabets[0];
+		return *alphabets_[0];
 	}
 
-	// Mode::MultiLevel
-	if (!level.has_value()) { throw std::runtime_error("AlphabetLevels (MultiLevel) requires an explicit level."); }
+	// Handle Mode::MultiLevel.
 
-	if (*level >= alphabets.size()) {
+	if (not level.has_value()) { throw std::runtime_error("AlphabetLevels (MultiLevel) requires an explicit level."); }
+
+	if (*level >= alphabets_.size()) {
 		throw std::runtime_error(
 			"AlphabetLevels has no alphabet for level " + std::to_string(*level) + " (out of range)."
 		);
 	}
 
-	if (alphabets[*level] == nullptr) {
+	if (alphabets_[*level] == nullptr) {
 		throw std::runtime_error(
 			"AlphabetLevels has no alphabet for level " + std::to_string(*level) + " (entry is null)."
 		);
 	}
 
-	return *alphabets[*level];
+	return *alphabets_[*level];
 }
 
 mata::Alphabet& AlphabetLevels::for_level(const std::optional<mata::Level> level) {

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1250,7 +1250,12 @@ void mata::nfa::Nfa::fill_alphabet(OnTheFlyAlphabet& alphabet_to_fill) const {
 }
 
 std::shared_ptr<const mata::Alphabet> mata::nfa::Nfa::resolve_alphabet(const Alphabet* const alphabet) const {
-	if (alphabet != nullptr) { return std::shared_ptr<const Alphabet>(alphabet); }
+	if (alphabet != nullptr) {
+		// Non-owning: `alphabet` is borrowed from the caller (e.g., a stack-local object), so wrap it with a
+		//  no-op deleter instead of an owning shared_ptr, which would erroneously delete it once this shared_ptr's
+		//  refcount reaches zero.
+		return std::shared_ptr<const Alphabet>(alphabet, [](const Alphabet*) {});
+	}
 	if (this->alphabet != nullptr) { return this->alphabet; }
 	return {std::make_shared<mata::EnumAlphabet>(EnumAlphabet{delta.get_used_symbols()})};
 }

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -211,7 +211,7 @@ std::ostream& std::operator<<(std::ostream& os, const mata::nfa::Transition& tra
 }
 
 bool mata::nfa::Nfa::make_complete(const Alphabet* const alphabet, const std::optional<State> sink_state) {
-	return make_complete(get_symbols_to_work_with(*this, alphabet), sink_state);
+	return make_complete(get_symbols_to_work_with(alphabet), sink_state);
 }
 
 bool mata::nfa::Nfa::make_complete(const OrdVector<Symbol>& symbols, const std::optional<State> sink_state) {
@@ -488,9 +488,7 @@ bool mata::nfa::Nfa::is_deterministic() const {
 	return true;
 }
 
-bool Nfa::is_complete(const Alphabet* const alphabet) const {
-	return is_complete(get_symbols_to_work_with(*this, alphabet));
-}
+bool Nfa::is_complete(const Alphabet* const alphabet) const { return is_complete(get_symbols_to_work_with(alphabet)); }
 
 bool mata::nfa::Nfa::is_complete(const OrdVector<Symbol>& symbols) const {
 	// TODO: make a general function for traversal over reachable states that can be shared by other functions?
@@ -1251,6 +1249,16 @@ void mata::nfa::Nfa::fill_alphabet(OnTheFlyAlphabet& alphabet_to_fill) const {
 	}
 }
 
+std::shared_ptr<const mata::Alphabet> mata::nfa::Nfa::resolve_alphabet(const Alphabet* const alphabet) const {
+	if (alphabet != nullptr) { return std::shared_ptr<const Alphabet>(alphabet); }
+	if (this->alphabet != nullptr) { return this->alphabet; }
+	return {std::make_shared<mata::EnumAlphabet>(EnumAlphabet{delta.get_used_symbols()})};
+}
+
+OrdVector<Symbol> mata::nfa::Nfa::get_symbols_to_work_with(const Alphabet* const alphabet) const {
+	return mata::nfa::get_symbols_to_work_with(*this, alphabet);
+}
+
 mata::OnTheFlyAlphabet mata::nfa::create_alphabet(const std::vector<std::reference_wrapper<const Nfa>>& nfas) {
 	mata::OnTheFlyAlphabet alphabet{};
 	for (const auto& nfa : nfas) { nfa.get().fill_alphabet(alphabet); }
@@ -1314,13 +1322,7 @@ std::set<mata::Word> mata::nfa::Nfa::get_words(const size_t max_length) const {
 }
 
 OrdVector<Symbol> mata::nfa::get_symbols_to_work_with(const Nfa& nfa, const mata::Alphabet* const shared_alphabet) {
-	if (shared_alphabet != nullptr) {
-		return shared_alphabet->get_alphabet_symbols();
-	} else if (nfa.alphabet != nullptr) {
-		return nfa.alphabet->get_alphabet_symbols();
-	} else {
-		return nfa.delta.get_used_symbols();
-	}
+	return nfa.resolve_alphabet(shared_alphabet)->get_alphabet_symbols();
 }
 
 std::optional<mata::Word> Nfa::get_word(const std::optional<Symbol> first_epsilon) const {
@@ -1489,7 +1491,7 @@ std::optional<mata::Word> Nfa::get_word_from_complement(const Alphabet* alphabet
 	using Iterator = mata::utils::OrdVector<SymbolPost>::const_iterator;
 	SynchronizedExistentialSymbolPostIterator synchronized_iterator{};
 
-	const utils::OrdVector<Symbol> symbols{get_symbols_to_work_with(*this, alphabet)};
+	const utils::OrdVector<Symbol> symbols{get_symbols_to_work_with(alphabet)};
 	const auto symbols_end{symbols.end()};
 	bool continue_complementation{true};
 	while (continue_complementation && !worklist.empty()) {

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -196,9 +196,62 @@ class SynchronizationProperties {
 		}));
 	}
 };
+
 } // namespace
 
 namespace mata::nft {
+
+std::shared_ptr<mata::AlphabetLevels> compose_alphabets(
+	const Nft& lhs,
+	const Nft& rhs,
+	const OrdVector<Level>& lhs_sync_levels,
+	const OrdVector<Level>& rhs_sync_levels,
+	const bool project_out_sync_levels
+) {
+	if (lhs.alphabets == nullptr || rhs.alphabets == nullptr) { return nullptr; }
+
+	// Raw slot for a level, honoring Global (single shared alphabet) vs MultiLevel (per-level) mode.
+	auto slot_for_level = [](const mata::AlphabetLevels& alphabets,
+							 const Level level) -> std::shared_ptr<mata::Alphabet> {
+		return alphabets.mode() == mata::AlphabetLevels::Mode::Global ? alphabets.at(0) : alphabets.at(level);
+	};
+
+	std::vector<std::shared_ptr<mata::Alphabet>> composed_alphabets;
+	composed_alphabets.reserve(lhs.levels.num_of_levels + rhs.levels.num_of_levels);
+
+	const size_t num_of_sync_levels = lhs_sync_levels.size();
+	auto lhs_sync_it = lhs_sync_levels.cbegin();
+	auto rhs_sync_it = rhs_sync_levels.cbegin();
+	Level lhs_lvl{0};
+	Level rhs_lvl{0};
+	for (size_t i{0}; i < num_of_sync_levels; ++i) {
+		for (; lhs_lvl < *lhs_sync_it; ++lhs_lvl) {
+			composed_alphabets.push_back(slot_for_level(*lhs.alphabets, lhs_lvl));
+		}
+		for (; rhs_lvl < *rhs_sync_it; ++rhs_lvl) {
+			composed_alphabets.push_back(slot_for_level(*rhs.alphabets, rhs_lvl));
+		}
+		if (!project_out_sync_levels) {
+			assert(
+				slot_for_level(*lhs.alphabets, *lhs_sync_it) == slot_for_level(*rhs.alphabets, *rhs_sync_it) &&
+				"lhs and rhs must share the same alphabet instance on their synchronization levels"
+			);
+			composed_alphabets.push_back(slot_for_level(*lhs.alphabets, *lhs_sync_it));
+		}
+		++lhs_lvl;
+		++rhs_lvl; // Skip over the synchronization level itself (already handled above).
+		++lhs_sync_it;
+		++rhs_sync_it;
+	}
+	for (; lhs_lvl < lhs.levels.num_of_levels; ++lhs_lvl) {
+		composed_alphabets.push_back(slot_for_level(*lhs.alphabets, lhs_lvl));
+	}
+	for (; rhs_lvl < rhs.levels.num_of_levels; ++rhs_lvl) {
+		composed_alphabets.push_back(slot_for_level(*rhs.alphabets, rhs_lvl));
+	}
+
+	return std::make_shared<mata::AlphabetLevels>(std::move(composed_alphabets));
+}
 
 // Dispatch function for composition modes.
 Nft compose(
@@ -1024,6 +1077,10 @@ Nft algorithms::compose_fast_no_jump(
 	// TODO: Make trim on demand.
 	if (project_out_sync_levels) { result.trim(); }
 
+	result.alphabets = compose_alphabets(
+		lhs, rhs, OrdVector<Level>{lhs_sync_level}, OrdVector<Level>{rhs_sync_level}, project_out_sync_levels
+	);
+
 	return result;
 }
 
@@ -1136,6 +1193,9 @@ Nft algorithms::compose_general(
 
 	Nft result{intersection(lhs_synced, rhs_synced, nullptr, jump_mode, lhs_first_aux_state, rhs_first_aux_state)};
 	if (project_out_sync_levels) { result = project_out(result, sync_levels_to_project_out, jump_mode); }
+
+	result.alphabets = compose_alphabets(lhs, rhs, lhs_sync_levels, rhs_sync_levels, project_out_sync_levels);
+
 	return result;
 }
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "mata/alphabet.hh"
 #include "mata/nfa/builder.hh"
 #include "mata/nft/nft.hh"
 #include "mata/utils/assert.hh"
@@ -1097,7 +1098,9 @@ Nft& Nft::insert_identity(const State state, const std::vector<Symbol>& symbols,
 }
 
 Nft& Nft::insert_identity(const State state, const Alphabet* alphabet, const JumpMode jump_mode) {
-	for (const Symbol symbol : alphabet->get_alphabet_symbols()) { insert_identity(state, symbol, jump_mode); }
+	for (const Symbol symbol : get_symbols_to_work_with(alphabet, levels[state])) {
+		insert_identity(state, symbol, jump_mode);
+	}
 	return *this;
 }
 
@@ -1113,6 +1116,23 @@ Nft& Nft::insert_identity(const State state, const Symbol symbol, const JumpMode
 	insert_word(state, Word(levels.num_of_levels, symbol), state);
 	//    }
 	return *this;
+}
+
+std::shared_ptr<const mata::Alphabet>
+	Nft::resolve_alphabet(const Alphabet* const alphabet, const std::optional<Level> level) const {
+	if (alphabet != nullptr) {
+		return std::shared_ptr<const Alphabet>(alphabet, [](const Alphabet*) {});
+	}
+	if (this->alphabets != nullptr) {
+		return std::shared_ptr<const Alphabet>(this->alphabets, &this->alphabets->for_level(level));
+	}
+	if (this->alphabet != nullptr) { return this->alphabet; }
+	return {std::make_shared<mata::EnumAlphabet>(EnumAlphabet{delta.get_used_symbols()})};
+}
+
+OrdVector<Symbol>
+	Nft::get_symbols_to_work_with(const Alphabet* const alphabet, const std::optional<Level> level) const {
+	return mata::nft::get_symbols_to_work_with(*this, alphabet, level);
 }
 
 bool Nft::contains_jump_transitions() const {
@@ -1163,7 +1183,7 @@ Nft Nft::apply(
 }
 
 bool Nft::make_complete(const Alphabet* const alphabet, const std::optional<std::vector<State>>& sink_states) {
-	return make_complete(get_symbols_to_work_with(*this, alphabet), sink_states);
+	return make_complete(get_symbols_to_work_with(alphabet), sink_states);
 }
 
 bool Nft::make_complete(const OrdVector<Symbol>& symbols, const std::optional<std::vector<State>>& sink_states) {

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1196,6 +1196,12 @@ Nft mata::nft::minimize(const Nft& aut, const ParameterMap& params) {
 }
 #endif
 
+OrdVector<Symbol> mata::nft::get_symbols_to_work_with(
+	const Nft& nft, const Alphabet* const shared_alphabet, const std::optional<Level> level
+) {
+	return nft.resolve_alphabet(shared_alphabet, level)->get_alphabet_symbols();
+}
+
 Nft mata::nft::union_nondet(const Nft& lhs, const Nft& rhs) {
 	Nft union_nft{lhs};
 	return union_nft.unite_nondet_with(rhs);

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -564,6 +564,16 @@ Nft mata::nft::project_out(const Nft& nft, const utils::OrdVector<Level>& levels
 	for (State s{0}; s < result.levels.size(); s++) { result.levels[s] = new_levels[result.levels[s]]; }
 	result.levels.num_of_levels = static_cast<Level>(result.levels.num_of_levels - levels_to_project.size());
 
+	// Repare per-level alphabets: drop the entries of the projected-out levels, keeping the rest indexed by their
+	//  new level numbers. In Global mode result.alphabets (== nft.alphabets) is already correct as-is.
+	if (nft.alphabets != nullptr && nft.alphabets->mode() == AlphabetLevels::Mode::MultiLevel) {
+		auto new_alphabets = std::make_shared<AlphabetLevels>(*nft.alphabets);
+		for (auto it = levels_to_proj_v.rbegin(); it != levels_to_proj_v.rend(); ++it) {
+			new_alphabets->erase(new_alphabets->begin() + *it);
+		}
+		result.alphabets = std::move(new_alphabets);
+	}
+
 	return result;
 }
 
@@ -641,6 +651,19 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 			Levels{new_levels_mask.size(), new_state_levels}, nft.num_of_states(), nft.initial, nft.final, nft.alphabets
 		)
 	);
+
+	// Repare per-level alphabets: insert a null slot for each newly-inserted level, keeping existing entries at
+	//  their shifted indices (matching updated_levels above). In Global mode result.alphabets (== nft.alphabets) is
+	//  already correct as-is.
+	if (nft.alphabets != nullptr && nft.alphabets->mode() == AlphabetLevels::Mode::MultiLevel) {
+		auto new_alphabets = std::make_shared<AlphabetLevels>(*nft.alphabets);
+		for (size_t i{0}; i < new_levels_mask.size(); i++) {
+			if (new_levels_mask[i]) {
+				new_alphabets->insert(new_alphabets->begin() + static_cast<std::ptrdiff_t>(i), nullptr);
+			}
+		}
+		result.alphabets = std::move(new_alphabets);
+	}
 
 	// Function to create a transition between source and target states.
 	// The transition symbol is determined based on the parameters:

--- a/tests/nft/nft-composition.cc
+++ b/tests/nft/nft-composition.cc
@@ -2948,3 +2948,86 @@ TEST_CASE("mata::nft::compose_fast_no_jump()") {
         CHECK(are_equivalent(composed_normal, composed_fast_no_jump));
     }
 }
+
+TEST_CASE("mata::nft::compose() keeps per-level alphabets in sync") {
+    auto lhs_alphabet = std::make_shared<mata::IntAlphabet>();
+    auto sync_alphabet = std::make_shared<mata::IntAlphabet>();
+    auto rhs_alphabet = std::make_shared<mata::IntAlphabet>();
+
+    // lhs: level 0 uses lhs_alphabet, level 1 (the synchronization level) uses sync_alphabet.
+    Nft lhs{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
+    lhs.delta.add(0, 'a', 1);
+    lhs.delta.add(1, 99, 2);
+    lhs.alphabets = std::make_shared<mata::AlphabetLevels>(
+        mata::AlphabetLevels{ std::vector<std::shared_ptr<mata::Alphabet>>{ lhs_alphabet, sync_alphabet } });
+
+    // rhs: level 0 (the synchronization level) uses the SAME sync_alphabet instance, level 1 uses rhs_alphabet.
+    Nft rhs{ Nft::with_levels({ 2, { 0, 1, 0 } }, 3, { 0 }, { 2 }) };
+    rhs.delta.add(0, 99, 1);
+    rhs.delta.add(1, 'b', 2);
+    rhs.alphabets = std::make_shared<mata::AlphabetLevels>(
+        mata::AlphabetLevels{ std::vector<std::shared_ptr<mata::Alphabet>>{ sync_alphabet, rhs_alphabet } });
+
+    SECTION("project_out_sync_levels == true drops the (shared) synchronization level's alphabet") {
+        for (const Nft& result : {
+                 algorithms::compose_fast_no_jump(lhs, rhs, 1, 0, true),
+                 algorithms::compose_general(lhs, rhs, { 1 }, { 0 }, true),
+                 compose(lhs, rhs, 1, 0, true) }) {
+            REQUIRE(result.alphabets != nullptr);
+            REQUIRE(result.alphabets->size() == 2);
+            CHECK(&result.alphabets->for_level(0) == lhs_alphabet.get());
+            CHECK(&result.alphabets->for_level(1) == rhs_alphabet.get());
+        }
+    }
+
+    SECTION("project_out_sync_levels == false keeps the synchronization level's alphabet") {
+        for (const Nft& result : {
+                 algorithms::compose_fast_no_jump(lhs, rhs, 1, 0, false),
+                 algorithms::compose_general(lhs, rhs, { 1 }, { 0 }, false),
+                 compose(lhs, rhs, 1, 0, false) }) {
+            REQUIRE(result.alphabets != nullptr);
+            REQUIRE(result.alphabets->size() == 3);
+            CHECK(&result.alphabets->for_level(0) == lhs_alphabet.get());
+            CHECK(&result.alphabets->for_level(1) == sync_alphabet.get());
+            CHECK(&result.alphabets->for_level(2) == rhs_alphabet.get());
+        }
+    }
+
+    SECTION("missing alphabets on either side yield a null result") {
+        Nft rhs_without_alphabets{ rhs };
+        rhs_without_alphabets.alphabets = nullptr;
+        const Nft result{ compose(lhs, rhs_without_alphabets, 1, 0, true) };
+        CHECK(result.alphabets == nullptr);
+    }
+
+    SECTION("kept levels share the exact Alphabet instance, not a copy of it") {
+        const Nft result{ compose(lhs, rhs, 1, 0, true) };
+        REQUIRE(result.alphabets != nullptr);
+        // Same shared_ptr as in lhs/rhs: the refcount is now shared across lhs, rhs, and result.
+        CHECK(lhs_alphabet.use_count() == 3); // local lhs_alphabet + lhs.alphabets' slot + result.alphabets' slot.
+        CHECK(rhs_alphabet.use_count() == 3); // local rhs_alphabet + rhs.alphabets' slot + result.alphabets' slot.
+        // local sync_alphabet + lhs.alphabets' slot + rhs.alphabets' slot; unaffected by being dropped from result.
+        CHECK(sync_alphabet.use_count() == 3);
+        // The AlphabetLevels *container* is legitimately a new object (a different level layout than either input),
+        //  but that's orthogonal to the underlying Alphabet instances being shared.
+        CHECK(result.alphabets != lhs.alphabets);
+        CHECK(result.alphabets != rhs.alphabets);
+    }
+
+    SECTION("mutating a shared alphabet through one automaton is visible through the other") {
+        auto mutable_alphabet = std::make_shared<mata::OnTheFlyAlphabet>();
+        Nft lhs_mut{ lhs };
+        lhs_mut.alphabets = std::make_shared<mata::AlphabetLevels>(
+            mata::AlphabetLevels{ std::vector<std::shared_ptr<mata::Alphabet>>{ mutable_alphabet, sync_alphabet } });
+
+        const Nft result{ compose(lhs_mut, rhs, 1, 0, true) };
+        REQUIRE(result.alphabets != nullptr);
+        CHECK(&result.alphabets->for_level(0) == mutable_alphabet.get());
+
+        REQUIRE(mutable_alphabet->empty());
+        mutable_alphabet->add_new_symbol("x");
+        // Same instance: a mutation via the original NFT's alphabet is visible through the composed result's too.
+        CHECK_FALSE(result.alphabets->empty(0));
+        CHECK_FALSE(mutable_alphabet->empty());
+    }
+}

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -124,6 +124,55 @@ TEST_CASE("mata::AlphabetLevels single-element form treats every level uniformly
     CHECK(uniform.reverse_translate_symbol(3, 5) == "3");
 }
 
+TEST_CASE("mata::AlphabetLevels::erase()") {
+    auto a0 = std::make_shared<IntAlphabet>();
+    auto a1 = std::make_shared<IntAlphabet>();
+    auto a2 = std::make_shared<IntAlphabet>();
+
+    SECTION("erase a single position") {
+        AlphabetLevels alphabets{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2 } };
+        alphabets.erase(alphabets.begin() + 1);
+        REQUIRE(alphabets.size() == 2);
+        CHECK(&alphabets.for_level(0) == a0.get());
+        CHECK(&alphabets.for_level(1) == a2.get());
+    }
+
+    SECTION("erase a range") {
+        AlphabetLevels alphabets{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2 } };
+        alphabets.erase(alphabets.begin(), alphabets.begin() + 2);
+        REQUIRE(alphabets.size() == 1);
+        CHECK(&alphabets.for_level(0) == a2.get());
+    }
+
+    SECTION("erasing the only alphabet in Global mode empties it") {
+        AlphabetLevels alphabets{ a0 };
+        REQUIRE(alphabets.mode() == AlphabetLevels::Mode::Global);
+        alphabets.erase(alphabets.begin());
+        CHECK(alphabets.size() == 0);
+    }
+}
+
+TEST_CASE("mata::nft::Nft copying/plumbing shares the AlphabetLevels container, not just its alphabets") {
+    auto a0 = std::make_shared<IntAlphabet>();
+    auto a1 = std::make_shared<IntAlphabet>();
+    auto alphabets = std::make_shared<AlphabetLevels>(
+        AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1 } });
+    Nft nft{ 2, { 0 }, { 1 }, Levels{ 2, { 0, 1 } }, alphabets };
+
+    SECTION("copy construction shares the exact same AlphabetLevels instance") {
+        Nft copy{ nft };
+        // Not just equivalent contents: the very same shared_ptr, since nothing about the level structure changed.
+        CHECK(copy.alphabets == nft.alphabets);
+        CHECK(alphabets.use_count() == 3); // local `alphabets` + nft.alphabets + copy.alphabets.
+    }
+
+    SECTION("copy assignment shares the exact same AlphabetLevels instance") {
+        Nft copy;
+        copy = nft;
+        CHECK(copy.alphabets == nft.alphabets);
+    }
+}
+
 TEST_CASE("mata::nft::determinize preserves the per-level alphabets pointer") {
     auto input_alphabet = std::make_shared<IntAlphabet>();
     auto output_alphabet = std::make_shared<IntAlphabet>();
@@ -4463,6 +4512,125 @@ TEST_CASE("mata::nft::project_to()") {
         expected.delta.add(6, 9, 7);
         expected.delta.add(7, 11, 0);
         CHECK(nft::are_equivalent(projection, expected));
+    }
+}
+
+TEST_CASE("mata::nft::project_out() and mata::nft::project_to() keep per-level alphabets in sync") {
+    auto a0 = std::make_shared<IntAlphabet>();
+    auto a1 = std::make_shared<IntAlphabet>();
+    auto a2 = std::make_shared<IntAlphabet>();
+    auto a3 = std::make_shared<IntAlphabet>();
+    auto alphabets = std::make_shared<AlphabetLevels>(
+        AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2, a3 } });
+
+    Delta delta;
+    delta.add(0, 0, 1);
+    delta.add(1, 1, 2);
+    delta.add(2, 2, 3);
+    delta.add(3, 3, 4);
+    Nft nft(Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, delta, { 0 }, { 4 }, alphabets));
+
+    SECTION("projecting out a middle level shifts the remaining alphabets") {
+        Nft proj = project_out(nft, OrdVector<Level>{ 1 }, JumpMode::AppendDontCares);
+        REQUIRE(proj.alphabets != nullptr);
+        REQUIRE(proj.alphabets->size() == 3);
+        CHECK(&proj.alphabets->for_level(0) == a0.get());
+        CHECK(&proj.alphabets->for_level(1) == a2.get());
+        CHECK(&proj.alphabets->for_level(2) == a3.get());
+        // The original alphabets object must stay untouched (no aliasing corruption via the shared_ptr).
+        REQUIRE(nft.alphabets->size() == 4);
+        CHECK(&nft.alphabets->for_level(1) == a1.get());
+        // The AlphabetLevels *container* is legitimately a new object (its contents differ from nft.alphabets'),
+        //  but each surviving level's underlying Alphabet instance is still the exact same shared one.
+        CHECK(proj.alphabets != nft.alphabets);
+        CHECK(a0.use_count() == 3); // local a0 + nft.alphabets' slot + proj.alphabets' slot.
+        CHECK(a1.use_count() == 2); // local a1 + nft.alphabets' slot only (dropped from proj).
+    }
+
+    SECTION("projecting out non-contiguous levels") {
+        Nft proj = project_out(nft, OrdVector<Level>{ 0, 2 }, JumpMode::AppendDontCares);
+        REQUIRE(proj.alphabets != nullptr);
+        REQUIRE(proj.alphabets->size() == 2);
+        CHECK(&proj.alphabets->for_level(0) == a1.get());
+        CHECK(&proj.alphabets->for_level(1) == a3.get());
+    }
+
+    SECTION("project_to keeps the alphabets of the retained levels") {
+        Nft proj = project_to(nft, OrdVector<Level>{ 1, 3 });
+        REQUIRE(proj.alphabets != nullptr);
+        REQUIRE(proj.alphabets->size() == 2);
+        CHECK(&proj.alphabets->for_level(0) == a1.get());
+        CHECK(&proj.alphabets->for_level(1) == a3.get());
+    }
+
+    SECTION("Global mode alphabets pass through unchanged") {
+        auto shared_alphabet = std::make_shared<IntAlphabet>();
+        auto global_alphabets = std::make_shared<AlphabetLevels>(AlphabetLevels{ shared_alphabet });
+        Nft global_nft(Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, delta, { 0 }, { 4 }, global_alphabets));
+
+        Nft proj = project_out(global_nft, OrdVector<Level>{ 1 }, JumpMode::AppendDontCares);
+        REQUIRE(proj.alphabets != nullptr);
+        CHECK(proj.alphabets->mode() == AlphabetLevels::Mode::Global);
+        CHECK(&proj.alphabets->for_level(0) == shared_alphabet.get());
+        // Global mode is level-count-agnostic, so nothing needed to change: the AlphabetLevels *container* itself
+        //  is shared with global_nft, not just its underlying alphabet.
+        CHECK(proj.alphabets == global_nft.alphabets);
+    }
+}
+
+TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels() keep per-level alphabets in sync") {
+    auto a0 = std::make_shared<IntAlphabet>();
+    auto a1 = std::make_shared<IntAlphabet>();
+    auto a2 = std::make_shared<IntAlphabet>();
+    auto alphabets = std::make_shared<AlphabetLevels>(
+        AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2 } });
+
+    Delta delta;
+    delta.add(0, 0, 1);
+    delta.add(1, 1, 2);
+    delta.add(2, 2, 3);
+    Nft nft(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }, alphabets));
+
+    SECTION("insert_level inserts a null slot at the new level, shifting the rest") {
+        Nft output_nft = insert_level(nft, 1, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        REQUIRE(output_nft.alphabets->size() == 4);
+        CHECK(&output_nft.alphabets->for_level(0) == a0.get());
+        CHECK(output_nft.alphabets->at(1) == nullptr);
+        CHECK(&output_nft.alphabets->for_level(2) == a1.get());
+        CHECK(&output_nft.alphabets->for_level(3) == a2.get());
+        // The original alphabets object must stay untouched (no aliasing corruption via the shared_ptr).
+        REQUIRE(nft.alphabets->size() == 3);
+        // The AlphabetLevels *container* is legitimately a new object, but each level's underlying Alphabet
+        //  instance is still the exact same shared one.
+        CHECK(output_nft.alphabets != nft.alphabets);
+        CHECK(a0.use_count() == 3); // local a0 + nft.alphabets' slot + output_nft.alphabets' slot.
+    }
+
+    SECTION("insert_levels inserts null slots at every new position") {
+        Nft output_nft = insert_levels(nft, { 0, 0, 1, 1, 0, 1 }, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        REQUIRE(output_nft.alphabets->size() == 6);
+        CHECK(&output_nft.alphabets->for_level(0) == a0.get());
+        CHECK(&output_nft.alphabets->for_level(1) == a1.get());
+        CHECK(output_nft.alphabets->at(2) == nullptr);
+        CHECK(output_nft.alphabets->at(3) == nullptr);
+        CHECK(&output_nft.alphabets->for_level(4) == a2.get());
+        CHECK(output_nft.alphabets->at(5) == nullptr);
+    }
+
+    SECTION("Global mode alphabets pass through unchanged") {
+        auto shared_alphabet = std::make_shared<IntAlphabet>();
+        auto global_alphabets = std::make_shared<AlphabetLevels>(AlphabetLevels{ shared_alphabet });
+        Nft global_nft(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }, global_alphabets));
+
+        Nft output_nft = insert_level(global_nft, 1, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        CHECK(output_nft.alphabets->mode() == AlphabetLevels::Mode::Global);
+        CHECK(&output_nft.alphabets->for_level(0) == shared_alphabet.get());
+        // Global mode is level-count-agnostic, so nothing needed to change: the AlphabetLevels *container* itself
+        //  is shared with global_nft, not just its underlying alphabet.
+        CHECK(output_nft.alphabets == global_nft.alphabets);
     }
 }
 


### PR DESCRIPTION
Adds operations that allow modifying the underlying alphabet container; and enables sharing alphabets through operations on the automata/transducers.

Resolves #684 and #685.