### PR TITLE
cmake: +feat Use file sets to define include headers

### DIFF
--- a/3rdparty/cudd/CMakeLists.txt
+++ b/3rdparty/cudd/CMakeLists.txt
@@ -142,6 +142,14 @@ target_include_directories(cudd_headers
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
+target_sources(cudd_headers
+    INTERFACE
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+        FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/mata/cudd/cudd.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/mata/cudd/cuddObj.hh
+)
 target_link_libraries(cudd PUBLIC cudd_headers)
 
 target_include_directories(cudd

--- a/3rdparty/simlib/CMakeLists.txt
+++ b/3rdparty/simlib/CMakeLists.txt
@@ -8,4 +8,11 @@ target_include_directories(simlib_headers
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
+file(GLOB_RECURSE SIMLIB_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh")
+target_sources(simlib_headers
+    INTERFACE
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+        FILES ${SIMLIB_HEADERS}
+)
 target_link_libraries(simlib PUBLIC simlib_headers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15.0)
+cmake_minimum_required (VERSION 3.23.0)
 project (
 	libMATA
 	#VERSION ???? TODO: set the version automatically during merging
@@ -139,14 +139,7 @@ install (
 	TARGETS libmata cudd_headers simlib_headers
 	EXPORT mataTargets
 	ARCHIVE DESTINATION lib
-)
-# TODO: should headers be installed in some nicer way? there is something called FILE_SET in cmake, but I do not feel it will make it better
-install(
-	DIRECTORY
-		${PROJECT_SOURCE_DIR}/include/
-		${PROJECT_SOURCE_DIR}/3rdparty/cudd/include/ # TODO remove this after we remove PUBLIC dependency on CUDD
-		${PROJECT_SOURCE_DIR}/3rdparty/simlib/include/ # TODO remove this after we remove PUBLIC dependency on simlib
-	DESTINATION include
+	FILE_SET HEADERS DESTINATION include
 )
 install(
 	EXPORT mataTargets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,15 +3,24 @@ configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/config.cc.in" "${CMAKE_CURRENT_BINA
 
 # create glob all source files with .cc and .hh extensions
 file (GLOB_RECURSE MATA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cc")
+file (GLOB_RECURSE MATA_HEADERS "${PROJECT_SOURCE_DIR}/include/*.hh")
 
 # add_library(libmata SHARED
 add_library (libmata STATIC
 	${MATA_SOURCES}
 	"${CMAKE_CURRENT_BINARY_DIR}/config.cc"
-	# we add files from the libraries here, so we create one static library libmata.a with everything and so that we can export only libmata
+	# we add files from the libraries here, so we create one static library libmata.a with everything and so that we can
+	# export only libmata
 	$<TARGET_OBJECTS:cudd>
 	$<TARGET_OBJECTS:simlib>
 	$<TARGET_OBJECTS:re2>
+)
+
+target_sources (libmata
+	PUBLIC
+		FILE_SET HEADERS
+		BASE_DIRS ${PROJECT_SOURCE_DIR}/include
+		FILES ${MATA_HEADERS}
 )
 
 # libmata needs at least c++20
@@ -25,9 +34,11 @@ set_target_properties (libmata PROPERTIES
 find_package(Threads REQUIRED)
 target_link_libraries(libmata PRIVATE Threads::Threads)
 
+# TODO remove cudd_headers after we remove PUBLIC dependency on CUDD
+# TODO remove this simlib_headers we remove PUBLIC dependency on simlib
 target_link_libraries(libmata PUBLIC cudd_headers simlib_headers)
 
-target_include_directories (libmata 
+target_include_directories (libmata
 	PUBLIC
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 		$<INSTALL_INTERFACE:include>


### PR DESCRIPTION
Defines file sets in `CMakeLists.txt` for headers to prevent copying invalid files, such as macOS `.DS_Store`, when installing Mata.

Fixes #339.