### PR TITLE
 nft: +feat Fill AlphabetLevels on insertion in insert_level(s)

### DIFF
--- a/bindings/python/libmata/nft/nft.pxd
+++ b/bindings/python/libmata/nft/nft.pxd
@@ -202,8 +202,12 @@ cdef extern from "mata/nft/nft.hh" namespace "mata::nft":
     cdef CNft c_remove_epsilon "mata::nft::remove_epsilon" (CNft&, Symbol) except +
     cdef CNft c_project_out "mata::nft::project_out" (CNft&, COrdVector[Level]&, CJumpMode) except +
     cdef CNft c_project_to "mata::nft::project_to" (CNft&, COrdVector[Level]&, CJumpMode) except +
-    cdef CNft c_insert_levels "mata::nft::insert_levels" (CNft&, CBoolVector&, CJumpMode) except +
-    cdef CNft c_insert_level "mata::nft::insert_level" (CNft&, Level, CJumpMode) except +
+    cdef CNft c_insert_levels "mata::nft::insert_levels" (
+        CNft&, CBoolVector&, vector[shared_ptr[CAlphabet]]&, CJumpMode
+    ) except +
+    cdef CNft c_insert_level "mata::nft::insert_level" (
+        CNft&, Level, shared_ptr[CAlphabet], CJumpMode
+    ) except +
     cdef CRun c_encode_word "mata::nft::encode_word" (CAlphabet*, vector[string]) except +
     cdef bool c_symbols_match "mata::nft::symbols_match" (Symbol, Symbol)
     cdef bool c_has_epsilon_cycle "mata::nft::has_epsilon_cycle" (CNft&)

--- a/bindings/python/libmata/nft/nft.pyi
+++ b/bindings/python/libmata/nft/nft.pyi
@@ -3,25 +3,25 @@ from typing import Iterable, Self
 
 import libmata.alphabets as alph
 import libmata.nfa.nfa as mata_nfa
-from libmata.alphabets import Symbol, Level
-from libmata.nfa.nfa import Run, Transition, State, StateSet, StateRenaming
+from libmata.alphabets import Level, Symbol
+from libmata.nfa.nfa import Run, State, StateRenaming, StateSet, Transition
 from libmata.utils import BinaryRelation
 
 DEFAULT_NUM_OF_LEVELS: int
 
-def epsilon() -> Symbol:
-    ...
-def dont_care() -> Symbol:
-    ...
+def epsilon() -> Symbol: ...
+def dont_care() -> Symbol: ...
 
 class JumpMode(IntEnum):
     """Specifies how a jump transition (a transition with a length greater than 1) is interpreted."""
+
     RepeatSymbol = 0
     AppendDontCares = 1
     NoJump = 2
 
 class CompositionMode(IntEnum):
     """Mode of composition to use for `compose()`."""
+
     General = 0
     FastNoJump = 1
     Auto = 2
@@ -34,24 +34,16 @@ class Levels:
         levels: Self | list[Level] | None = None,
         count: int | None = None,
         value: Level = 0,
-    ) -> None:
-        ...
+    ) -> None: ...
     @property
-    def num_of_levels(self) -> int:
-        ...
+    def num_of_levels(self) -> int: ...
     @num_of_levels.setter
-    def num_of_levels(self, value: int) -> None:
-        ...
-    def __len__(self) -> int:
-        ...
-    def __getitem__(self, state: State) -> Level:
-        ...
-    def __setitem__(self, state: State, level: Level) -> None:
-        ...
-    def __iter__(self):
-        ...
-    def __eq__(self, other: object) -> bool:
-        ...
+    def num_of_levels(self, value: int) -> None: ...
+    def __len__(self) -> int: ...
+    def __getitem__(self, state: State) -> Level: ...
+    def __setitem__(self, state: State, level: Level) -> None: ...
+    def __iter__(self): ...
+    def __eq__(self, other: object) -> bool: ...
     def append(self, other: Self) -> None:
         """Append `other`'s levels to the end of `self`."""
         ...
@@ -89,16 +81,25 @@ class Levels:
 
 class Nft:
     """Wrapper over NFT (non-deterministic finite transducer)."""
-    def __init__(self, state_number: int = 0, num_of_levels: int = DEFAULT_NUM_OF_LEVELS, label=None) -> None:
-        ...
+    def __init__(
+        self,
+        state_number: int = 0,
+        num_of_levels: int = DEFAULT_NUM_OF_LEVELS,
+        label=None,
+    ) -> None: ...
     @classmethod
     def with_levels(
-        cls, levels: int | Levels, num_of_states: int = 0, alphabets: alph.AlphabetLevels | None = None
+        cls,
+        levels: int | Levels,
+        num_of_states: int = 0,
+        alphabets: alph.AlphabetLevels | None = None,
     ) -> Self:
         """Construct a new explicit NFT with `num_of_states` states, using `levels`."""
         ...
     @classmethod
-    def from_nfa(cls, nfa: mata_nfa.Nfa, num_of_levels: int = 1, default_level: Level = 0) -> Self:
+    def from_nfa(
+        cls, nfa: mata_nfa.Nfa, num_of_levels: int = 1, default_level: Level = 0
+    ) -> Self:
         """Construct a new NFT with `num_of_levels` levels from `nfa`."""
         ...
     @classmethod
@@ -109,43 +110,34 @@ class Nft:
         """Return a deep copy of the NFT."""
         ...
     @property
-    def label(self):
-        ...
+    def label(self): ...
     @label.setter
-    def label(self, value) -> None:
-        ...
+    def label(self, value) -> None: ...
     @property
     def levels(self) -> Levels:
         """A snapshot copy of the per-state levels. Assign back to update the NFT's levels."""
         ...
     @levels.setter
-    def levels(self, value: Levels) -> None:
-        ...
+    def levels(self, value: Levels) -> None: ...
     @property
     def alphabets(self) -> alph.AlphabetLevels | None:
         """The per-level alphabets of the NFT, or `None` if none is set."""
         ...
     @alphabets.setter
-    def alphabets(self, value: alph.AlphabetLevels | None) -> None:
-        ...
+    def alphabets(self, value: alph.AlphabetLevels | None) -> None: ...
     @property
     def alphabet(self) -> alph.Alphabet | None:
         """The alphabet inherited from `Nfa`; always `None` for NFTs (use `alphabets` instead)."""
         ...
     @property
-    def initial_states(self) -> list[State]:
-        ...
+    def initial_states(self) -> list[State]: ...
     @initial_states.setter
-    def initial_states(self, value: list[State]) -> None:
-        ...
+    def initial_states(self, value: list[State]) -> None: ...
     @property
-    def final_states(self) -> list[State]:
-        ...
+    def final_states(self) -> list[State]: ...
     @final_states.setter
-    def final_states(self, value: list[State]) -> None:
-        ...
-    def is_state(self, state: State) -> bool:
-        ...
+    def final_states(self, value: list[State]) -> None: ...
+    def is_state(self, state: State) -> bool: ...
     def add_new_state(self) -> State:
         """Add a new (fresh) state to the automaton."""
         ...
@@ -161,26 +153,16 @@ class Nft:
     def num_of_states_with_level(self, level: Level) -> int:
         """Get the number of states with `level`."""
         ...
-    def make_initial_state(self, state: State) -> None:
-        ...
-    def make_initial_states(self, states: list[State]) -> None:
-        ...
-    def has_initial_state(self, state: State) -> bool:
-        ...
-    def remove_initial_state(self, state: State) -> None:
-        ...
-    def clear_initial(self) -> None:
-        ...
-    def make_final_state(self, state: State) -> None:
-        ...
-    def make_final_states(self, states: list[State]) -> None:
-        ...
-    def has_final_state(self, state: State) -> bool:
-        ...
-    def remove_final_state(self, state: State) -> None:
-        ...
-    def clear_final(self) -> None:
-        ...
+    def make_initial_state(self, state: State) -> None: ...
+    def make_initial_states(self, states: list[State]) -> None: ...
+    def has_initial_state(self, state: State) -> bool: ...
+    def remove_initial_state(self, state: State) -> None: ...
+    def clear_initial(self) -> None: ...
+    def make_final_state(self, state: State) -> None: ...
+    def make_final_states(self, states: list[State]) -> None: ...
+    def has_final_state(self, state: State) -> bool: ...
+    def remove_final_state(self, state: State) -> None: ...
+    def clear_final(self) -> None: ...
     @property
     def delta(self) -> mata_nfa.Delta:
         """The transition relation of the automaton.
@@ -189,38 +171,45 @@ class Nft:
         e.g. `nft.delta.add(source, symbol, target)`, `nft.delta.contains(...)`, or iterating `for t in nft.delta`.
         """
         ...
-    def add_transition_object(self, tr: Transition) -> None:
-        ...
+    def add_transition_object(self, tr: Transition) -> None: ...
     def add_transition(self, source: State, symbols: Symbol | list[Symbol], target: State | None = None) -> State:
         """Add a single NFT transition creating new inner states for all tapes."""
         ...
     def add_transition_with_length(
-        self, source: State, symbol: Symbol, length: int, jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        source: State,
+        symbol: Symbol,
+        length: int,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> State:
         """Add a single NFT transition with `length`, creating a new target state."""
         ...
     def add_transition_with_target(
-        self, source: State, symbol: Symbol, target: State, jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        source: State,
+        symbol: Symbol,
+        target: State,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> None:
         """Add a single NFT transition from `source` to `target`."""
         ...
     def add_transition_with_same_level_targets(
-        self, source: State, symbol: Symbol, targets: Iterable[State], jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        source: State,
+        symbol: Symbol,
+        targets: Iterable[State],
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> None:
         """Add a NFT transition from `source` to a set of `targets`, sharing the common prefix of the transition."""
         ...
-    def remove_trans(self, tr: Transition) -> None:
-        ...
-    def remove_trans_raw(self, source: State, symbol: Symbol, target: State) -> None:
-        ...
-    def has_transition(self, source: State, symbol: Symbol, target: State) -> bool:
-        ...
-    def get_num_of_transitions(self) -> int:
-        ...
-    def clear(self) -> None:
-        ...
-    def num_of_states(self) -> int:
-        ...
+    def remove_trans(self, tr: Transition) -> None: ...
+    def remove_trans_raw(
+        self, source: State, symbol: Symbol, target: State
+    ) -> None: ...
+    def has_transition(self, source: State, symbol: Symbol, target: State) -> bool: ...
+    def get_num_of_transitions(self) -> int: ...
+    def clear(self) -> None: ...
+    def num_of_states(self) -> int: ...
     def iterate(self):
         """Iterates over all transitions."""
         ...
@@ -230,19 +219,20 @@ class Nft:
     def get_used_symbols(self) -> set[Symbol]:
         """Return a set of symbols used on the transitions in NFT."""
         ...
-    def is_identical(self, other: Self) -> bool:
-        ...
-    def is_lang_empty(self, run: Run | None = None) -> bool:
-        ...
-    def is_deterministic(self) -> bool:
-        ...
-    def is_complete(self, alphabet: alph.Alphabet | None = None) -> bool:
-        ...
-    def insert_word(self, source: State, word: list[Symbol], target: State | None = None) -> State:
+    def is_identical(self, other: Self) -> bool: ...
+    def is_lang_empty(self, run: Run | None = None) -> bool: ...
+    def is_deterministic(self) -> bool: ...
+    def is_complete(self, alphabet: alph.Alphabet | None = None) -> bool: ...
+    def insert_word(
+        self, source: State, word: list[Symbol], target: State | None = None
+    ) -> State:
         """Insert `word` into the NFT from `source` to `target`, creating new states along the path."""
         ...
     def insert_word_by_levels(
-        self, source: State, word_parts_on_levels: list[list[Symbol]], target: State | None = None
+        self,
+        source: State,
+        word_parts_on_levels: list[list[Symbol]],
+        target: State | None = None,
     ) -> State:
         """Insert a word interleaved from `word_parts_on_levels` (one part per level) from `source` to `target`."""
         ...
@@ -272,62 +262,92 @@ class Nft:
     def union(self, other: Self) -> Self:
         """Make a non-deterministic union of `self` with `other` in-place."""
         ...
-    def get_one_letter_aut(self, levels_to_keep: Iterable[Level] | None = None, abstract_symbol: Symbol = ...) -> Self:
+    def get_one_letter_aut(
+        self,
+        levels_to_keep: Iterable[Level] | None = None,
+        abstract_symbol: Symbol = ...,
+    ) -> Self:
         """Get an NFT where transitions of `self` are replaced with transitions over one symbol."""
         ...
     def unwind_jumps_inplace(
-        self, dont_care_symbol_replacements: Iterable[Symbol] | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        dont_care_symbol_replacements: Iterable[Symbol] | None = None,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> None:
         """Unwind jump transitions in place."""
         ...
     def unwind_jumps(
-        self, dont_care_symbol_replacements: Iterable[Symbol] | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        dont_care_symbol_replacements: Iterable[Symbol] | None = None,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> Self:
         """Create a transducer with unwound jump transitions from `self`."""
         ...
-    def is_epsilon(self, symbol: Symbol) -> bool:
-        ...
+    def is_epsilon(self, symbol: Symbol) -> bool: ...
     def to_dot_file(
-        self, output_file: str = 'nft.dot', output_format: str = 'pdf', decode_ascii_chars: bool = False,
-        use_intervals: bool = False, max_label_length: int = -1,
-    ) -> None:
-        ...
-    def to_dot_str(
-        self, encoding: str = 'utf-8', decode_ascii_chars: bool = False, use_intervals: bool = False,
+        self,
+        output_file: str = "nft.dot",
+        output_format: str = "pdf",
+        decode_ascii_chars: bool = False,
+        use_intervals: bool = False,
         max_label_length: int = -1,
-    ) -> str:
-        ...
-    def to_mata_str(self, encoding: str = 'utf-8') -> str:
+    ) -> None: ...
+    def to_dot_str(
+        self,
+        encoding: str = "utf-8",
+        decode_ascii_chars: bool = False,
+        use_intervals: bool = False,
+        max_label_length: int = -1,
+    ) -> str: ...
+    def to_mata_str(self, encoding: str = "utf-8") -> str:
         """Transforms the automaton to a mata-format string."""
         ...
-    def to_mata_file(self, output_file: str = 'nft.mata', encoding: str = 'utf-8') -> None:
+    def to_mata_file(
+        self, output_file: str = "nft.mata", encoding: str = "utf-8"
+    ) -> None:
         """Writes the automaton to `output_file` in mata format."""
         ...
-    def post_of(self, states: Iterable[State], symbol: Symbol, symbol_level: Level | None = None) -> set[State]:
+    def post_of(
+        self, states: Iterable[State], symbol: Symbol, symbol_level: Level | None = None
+    ) -> set[State]:
         """Get the set of states reachable from `states` over `symbol` (optionally, on a given `symbol_level`)."""
         ...
-    def is_universal(self, alphabet: alph.Alphabet, params: dict[str, str] | None = None) -> bool:
+    def is_universal(
+        self, alphabet: alph.Alphabet, params: dict[str, str] | None = None
+    ) -> bool:
         """Tests if the NFT is universal with regard to the given alphabet."""
         ...
     def is_in_lang(
-        self, run_or_word: Run | list[Symbol], match_prefix: bool = False, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+        self,
+        run_or_word: Run | list[Symbol],
+        match_prefix: bool = False,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
         has_epsilon_cycles: bool = True,
     ) -> bool:
         """Tests if `run_or_word` (or its prefix, with `match_prefix`) is in the language of the NFT."""
         ...
     def is_in_lang_prefix(
-        self, run_or_word: Run | list[Symbol], jump_mode: JumpMode = JumpMode.RepeatSymbol, has_epsilon_cycles: bool = True
+        self,
+        run_or_word: Run | list[Symbol],
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
+        has_epsilon_cycles: bool = True,
     ) -> bool:
         """Tests if a prefix of `run_or_word` is in the language of the NFT."""
         ...
     def is_in_lang_by_levels(
-        self, level_words: list[list[Symbol]], match_prefix: bool = False, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+        self,
+        level_words: list[list[Symbol]],
+        match_prefix: bool = False,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
         has_epsilon_cycles: bool = True,
     ) -> bool:
         """Tests if the tuple `level_words` (one word per level) is in the regular relation accepted by the NFT."""
         ...
     def is_in_lang_prefix_by_levels(
-        self, level_words: list[list[Symbol]], jump_mode: JumpMode = JumpMode.RepeatSymbol, has_epsilon_cycles: bool = True
+        self,
+        level_words: list[list[Symbol]],
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
+        has_epsilon_cycles: bool = True,
     ) -> bool:
         """Tests if a prefix of the tuple `level_words` is in the regular relation accepted by the NFT."""
         ...
@@ -340,12 +360,17 @@ class Nft:
     def mk_word_from_level_word(self, level_words: list[list[Symbol]]) -> list[Symbol]:
         """Convert `level_words` to a word (interleaved representation) according to the levels of the NFT."""
         ...
-    def get_words(self, max_length: int | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol) -> set[tuple[Symbol, ...]]:
+    def get_words(
+        self, max_length: int | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol
+    ) -> set[tuple[Symbol, ...]]:
         """Get the set of all words in the language of the NFT whose length is <= `max_length`."""
         ...
     def apply(
-        self, nfa_or_word: mata_nfa.Nfa | list[Symbol], level_to_apply_on: Level = 0,
-        project_out_applied_level: bool = True, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+        self,
+        nfa_or_word: mata_nfa.Nfa | list[Symbol],
+        level_to_apply_on: Level = 0,
+        project_out_applied_level: bool = True,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> Self:
         """Apply `nfa_or_word` to `self`, intersecting it with `level_to_apply_on` of `self`."""
         ...
@@ -356,120 +381,188 @@ class Nft:
         """Move the NFT as an NFA. Transitions are not updated to have only one level."""
         ...
     def to_nfa_update_copy(
-        self, dont_care_symbol_replacements: Iterable[Symbol] | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol
+        self,
+        dont_care_symbol_replacements: Iterable[Symbol] | None = None,
+        jump_mode: JumpMode = JumpMode.RepeatSymbol,
     ) -> mata_nfa.Nfa:
         """Copy the NFT as an NFA, updating the transitions to have only one level."""
         ...
     def make_complete(
-        self, alphabet_or_symbols: alph.Alphabet | set[Symbol] | None = None, sink_states: list[State] | None = None
+        self,
+        alphabet_or_symbols: alph.Alphabet | set[Symbol] | None = None,
+        sink_states: list[State] | None = None,
     ) -> bool:
         """Make the NFT complete in place."""
         ...
-    def resolve_alphabet(self, alphabet: alph.Alphabet | None = None, level: Level | None = None) -> alph.Alphabet:
+    def resolve_alphabet(
+        self, alphabet: alph.Alphabet | None = None, level: Level | None = None
+    ) -> alph.Alphabet:
         """Resolve which alphabet to use for the current operation on `level`."""
         ...
-    def get_symbols_to_work_with(self, alphabet: alph.Alphabet | None = None, level: Level | None = None) -> set[Symbol]:
+    def get_symbols_to_work_with(
+        self, alphabet: alph.Alphabet | None = None, level: Level | None = None
+    ) -> set[Symbol]:
         """Get the set of symbols to work with for the current operation on `level`."""
         ...
 
 # Operations
-def determinize(lhs: Nft) -> Nft:
-    ...
-def determinize_with_subset_map(lhs: Nft) -> tuple[Nft, dict]:
-    ...
+def determinize(lhs: Nft) -> Nft: ...
+def determinize_with_subset_map(lhs: Nft) -> tuple[Nft, dict]: ...
 def union_nondet(lhs: Nft, rhs: Nft) -> Nft:
     """Compute a non-deterministic union of `lhs` and `rhs`."""
     ...
+
 def intersection(
-    lhs: Nft, rhs: Nft, jump_mode: JumpMode = JumpMode.RepeatSymbol,
-    lhs_first_aux_state: State = ..., rhs_first_aux_state: State = ...,
+    lhs: Nft,
+    rhs: Nft,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    lhs_first_aux_state: State = ...,
+    rhs_first_aux_state: State = ...,
 ) -> Nft:
     """Compute the intersection of `lhs` and `rhs`."""
     ...
+
 def intersection_with_product_map(
-    lhs: Nft, rhs: Nft, jump_mode: JumpMode = JumpMode.RepeatSymbol,
-    lhs_first_aux_state: State = ..., rhs_first_aux_state: State = ...,
-) -> tuple[Nft, dict[tuple[State, State], State]]:
-    ...
+    lhs: Nft,
+    rhs: Nft,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    lhs_first_aux_state: State = ...,
+    rhs_first_aux_state: State = ...,
+) -> tuple[Nft, dict[tuple[State, State], State]]: ...
 def compose(
-    lhs: Nft, rhs: Nft, lhs_sync_levels: Level | Iterable[Level], rhs_sync_levels: Level | Iterable[Level],
-    project_out_sync_levels: bool = True, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    lhs: Nft,
+    rhs: Nft,
+    lhs_sync_levels: Level | Iterable[Level],
+    rhs_sync_levels: Level | Iterable[Level],
+    project_out_sync_levels: bool = True,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
     composition_mode: CompositionMode = CompositionMode.Auto,
 ) -> Nft:
     """Compose `lhs` and `rhs` by aligning their synchronization levels."""
     ...
+
 def compose_alphabets(
-    lhs: Nft, rhs: Nft, lhs_sync_levels: Level | Iterable[Level], rhs_sync_levels: Level | Iterable[Level],
+    lhs: Nft,
+    rhs: Nft,
+    lhs_sync_levels: Level | Iterable[Level],
+    rhs_sync_levels: Level | Iterable[Level],
     project_out_sync_levels: bool = True,
 ) -> alph.AlphabetLevels | None:
     """Compose the per-level alphabets for NFTs to be composed via `compose`."""
     ...
+
 def concatenate(lhs: Nft, rhs: Nft, use_epsilon: bool = False) -> Nft:
     """Concatenate two NFTs."""
     ...
+
 def concatenate_with_result_state_maps(
     lhs: Nft, rhs: Nft, use_epsilon: bool = False
-) -> tuple[Nft, dict[State, State], dict[State, State]]:
-    ...
+) -> tuple[Nft, dict[State, State], dict[State, State]]: ...
 def concatenate_nth_power(nft: Nft, power: int) -> Nft:
     """Compute the NFT accepting the `power`-th power of the language of `nft`."""
     ...
-def complement(nft: Nft, alphabet: alph.Alphabet, params: dict[str, str] | None = None) -> Nft:
+
+def complement(
+    nft: Nft, alphabet: alph.Alphabet, params: dict[str, str] | None = None
+) -> Nft:
     """Compute the complement of `nft`."""
     ...
+
 def revert(lhs: Nft) -> Nft:
     """Reverse transitions in `lhs`."""
     ...
+
 def invert_levels(aut: Nft, jump_mode: JumpMode = JumpMode.RepeatSymbol) -> Nft:
     """Invert the levels of `aut`."""
     ...
+
 def remove_epsilon(lhs: Nft, epsilon: Symbol = ...) -> Nft:
     """Remove simple epsilon transitions from `lhs`."""
     ...
+
 def reduce(aut: Nft, params: dict[str, str] | None = None) -> Nft:
     """Reduce the size of `aut`."""
     ...
-def reduce_with_state_map(aut: Nft, params: dict[str, str] | None = None) -> tuple[Nft, dict[State, State]]:
-    ...
+
+def reduce_with_state_map(
+    aut: Nft, params: dict[str, str] | None = None
+) -> tuple[Nft, dict[State, State]]: ...
 def compute_relation(lhs: Nft, params: dict[str, str] | None = None) -> BinaryRelation:
     """Compute the relation for the NFT."""
     ...
+
 def is_included_with_cex(
-    smaller: Nft, bigger: Nft, alphabet: alph.Alphabet | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    smaller: Nft,
+    bigger: Nft,
+    alphabet: alph.Alphabet | None = None,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
     params: dict[str, str] | None = None,
 ) -> tuple[bool, Run]:
     """Test inclusion between two NFTs."""
     ...
+
 def is_included(
-    smaller: Nft, bigger: Nft, alphabet: alph.Alphabet | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    smaller: Nft,
+    bigger: Nft,
+    alphabet: alph.Alphabet | None = None,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
     params: dict[str, str] | None = None,
 ) -> bool:
     """Test inclusion between two NFTs: `smaller` <= `bigger`."""
     ...
+
 def are_equivalent(
-    lhs: Nft, rhs: Nft, alphabet: alph.Alphabet | None = None, jump_mode: JumpMode = JumpMode.RepeatSymbol,
+    lhs: Nft,
+    rhs: Nft,
+    alphabet: alph.Alphabet | None = None,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
     params: dict[str, str] | None = None,
 ) -> bool:
     """Test equivalence of two NFTs."""
     ...
-def project_out(nft: Nft, levels_to_project: Level | Iterable[Level], jump_mode: JumpMode = JumpMode.RepeatSymbol) -> Nft:
+
+def project_out(
+    nft: Nft,
+    levels_to_project: Level | Iterable[Level],
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+) -> Nft:
     """Project out `levels_to_project` in `nft`."""
     ...
-def project_to(nft: Nft, levels_to_project: Level | Iterable[Level], jump_mode: JumpMode = JumpMode.RepeatSymbol) -> Nft:
+
+def project_to(
+    nft: Nft,
+    levels_to_project: Level | Iterable[Level],
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+) -> Nft:
     """Project to `levels_to_project` in `nft`."""
     ...
-def insert_levels(nft: Nft, new_levels_mask: Iterable[bool], jump_mode: JumpMode = JumpMode.RepeatSymbol) -> Nft:
+
+def insert_levels(
+    nft: Nft,
+    new_levels_mask: Iterable[bool],
+    new_level_alphabets: list[alph.Alphabet | None] | None = None,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+) -> Nft:
     """Insert new levels, as specified by the boolean mask `new_levels_mask`, into `nft`."""
     ...
-def insert_level(nft: Nft, new_level: Level, jump_mode: JumpMode = JumpMode.RepeatSymbol) -> Nft:
+
+def insert_level(
+    nft: Nft,
+    new_level: Level,
+    new_level_alphabet: alph.Alphabet | None = None,
+    jump_mode: JumpMode = JumpMode.RepeatSymbol,
+) -> Nft:
     """Insert a new level `new_level` into `nft`."""
     ...
+
 def encode_word(alphabet: alph.Alphabet, word: list[str]) -> list[Symbol]:
     """Encode `word` (list of symbol names) based on `alphabet`."""
     ...
+
 def symbols_match(a: Symbol, b: Symbol) -> bool:
     """Check whether `a` and `b` match."""
     ...
+
 def has_epsilon_cycle(nft: Nft) -> bool:
     """Check whether `nft` has a cycle of epsilon transitions."""
     ...
@@ -478,24 +571,32 @@ def has_epsilon_cycle(nft: Nft) -> bool:
 def create_single_word_nft(word: list[Symbol]) -> Nft:
     """Create an NFT accepting only a single `word`."""
     ...
+
 def create_empty_string_nft(num_of_levels: int = DEFAULT_NUM_OF_LEVELS) -> Nft:
     """Create an NFT accepting only the empty string."""
     ...
+
 def create_sigma_star_nft(num_of_levels: int = DEFAULT_NUM_OF_LEVELS) -> Nft:
     """Create an NFT accepting sigma star using the `DONT_CARE` symbol."""
     ...
+
 def parse_from_mata_string(nft_in_mata: str) -> Nft:
     """Parse an NFT from a string in mata format."""
     ...
-def parse_from_mata_file(nft_file: str, encoding: str = 'utf-8') -> Nft:
+
+def parse_from_mata_file(nft_file: str, encoding: str = "utf-8") -> Nft:
     """Parse an NFT from a file in mata format."""
     ...
+
 def from_nfa_with_levels_zero(
-    nfa: mata_nfa.Nfa, num_of_levels: int = DEFAULT_NUM_OF_LEVELS, explicit_transitions: bool = True,
+    nfa: mata_nfa.Nfa,
+    num_of_levels: int = DEFAULT_NUM_OF_LEVELS,
+    explicit_transitions: bool = True,
     next_levels_symbol: Symbol | None = None,
 ) -> Nft:
     """Create an NFT from `nfa` with `num_of_levels` levels, taking `nfa`'s transitions between level 0 and level 1."""
     ...
+
 def from_nfa_with_levels_advancing(nfa: mata_nfa.Nfa, num_of_levels: int) -> Nft:
     """Create an NFT from `nfa` with `num_of_levels` levels, assigning levels by distance from the initial state."""
     ...

--- a/bindings/python/libmata/nft/nft.pyx
+++ b/bindings/python/libmata/nft/nft.pyx
@@ -1145,21 +1145,42 @@ def project_to(Nft nft, levels_to_project, jump_mode = JumpMode.RepeatSymbol) ->
     return result
 
 
-def insert_levels(Nft nft, new_levels_mask, jump_mode = JumpMode.RepeatSymbol) -> Nft:
-    """Insert new levels, as specified by the boolean mask `new_levels_mask`, into `nft`."""
+def insert_levels(
+    Nft nft, new_levels_mask, new_level_alphabets = None, jump_mode = JumpMode.RepeatSymbol
+) -> Nft:
+    """Insert new levels, as specified by the boolean mask `new_levels_mask`, into `nft`.
+
+    :param new_level_alphabets: Alphabets to assign to the newly-inserted levels, in the order the levels appear.
+        When `None` or empty, the newly-inserted levels are left without an alphabet.
+    """
     cdef CBoolVector c_mask = CBoolVector(<vector[uint8_t]>[1 if v else 0 for v in new_levels_mask])
+    cdef vector[shared_ptr[CAlphabet]] c_new_level_alphabets
+    cdef alph.Alphabet a
+    for a in (new_level_alphabets or []):
+        c_new_level_alphabets.push_back(a.as_base() if a is not None else shared_ptr[CAlphabet]())
     cdef Nft result = Nft.__new__(Nft)
     result.thisptr = make_shared[CNft](
-        mata_nft.c_insert_levels(dereference(nft.thisptr.get()), c_mask, _c_jump_mode(jump_mode))
+        mata_nft.c_insert_levels(
+            dereference(nft.thisptr.get()), c_mask, c_new_level_alphabets, _c_jump_mode(jump_mode)
+        )
     )
     return result
 
 
-def insert_level(Nft nft, Level new_level, jump_mode = JumpMode.RepeatSymbol) -> Nft:
-    """Insert a new level `new_level` into `nft`."""
+def insert_level(
+    Nft nft, Level new_level, new_level_alphabet: alph.Alphabet = None, jump_mode = JumpMode.RepeatSymbol
+) -> Nft:
+    """Insert a new level `new_level` into `nft`.
+
+    :param new_level_alphabet: Alphabet to assign to the newly-inserted level. When `None` (the default), the
+        newly-inserted level is left without an alphabet.
+    """
+    cdef shared_ptr[CAlphabet] c_new_level_alphabet = (
+        new_level_alphabet.as_base() if new_level_alphabet is not None else shared_ptr[CAlphabet]()
+    )
     cdef Nft result = Nft.__new__(Nft)
     result.thisptr = make_shared[CNft](
-        mata_nft.c_insert_level(dereference(nft.thisptr.get()), new_level, _c_jump_mode(jump_mode))
+        mata_nft.c_insert_level(dereference(nft.thisptr.get()), new_level, c_new_level_alphabet, _c_jump_mode(jump_mode))
     )
     return result
 

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -1836,11 +1836,23 @@ Nft project_to(const Nft& nft, Level level_to_project, JumpMode jump_mode = Jump
  * @param[in] nft The original transducer.
  * @param[in] new_levels_mask A mask representing the old and new levels. The vector {1, 0, 1, 1, 0} indicates
  *  that one level is inserted before level 0 and two levels are inserted before level 1.
+ * @param[in] new_level_alphabets Alphabets to assign to the newly-inserted levels, in the order the levels appear
+ *  (i.e., aligned with the @c true entries of @p new_levels_mask from left to right). Only meaningful when
+ *  @c nft.alphabets is in @c AlphabetLevels::Mode::MultiLevel (ignored, and may be left empty, in @c Global mode,
+ *  since a single shared alphabet already applies to every level). When empty (the default), the newly-inserted
+ *  levels are left without an alphabet (@c nullptr), matching the previous behaviour.
  * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
+ * @throws std::invalid_argument If @p new_level_alphabets is nonempty and its size does not match the number of
+ *  newly-inserted levels (i.e., the number of @c true entries in @p new_levels_mask).
  */
-Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, JumpMode jump_mode = JumpMode::RepeatSymbol);
+Nft insert_levels(
+	const Nft& nft,
+	const BoolVector& new_levels_mask,
+	const std::vector<std::shared_ptr<Alphabet>>& new_level_alphabets = {},
+	JumpMode jump_mode = JumpMode::RepeatSymbol
+);
 
 /**
  * @brief Inserts a new level @p new_level into the given transducer @p nft.
@@ -1853,11 +1865,20 @@ Nft insert_levels(const Nft& nft, const BoolVector& new_levels_mask, JumpMode ju
  *  If @p new_level is less than @c num_of_levels, then it is inserted before the level @c new_level-1.
  *  If @p new_level is greater than or equal to @c num_of_levels, then all levels from @c num_of_levels through @p
  * new_level are appended after the last level.
+ * @param[in] new_level_alphabet Alphabet to assign to the newly-inserted level @p new_level. Only meaningful when
+ *  @c nft.alphabets is in @c AlphabetLevels::Mode::MultiLevel (ignored in @c Global mode, since a single shared
+ *  alphabet already applies to every level). When @c nullptr (the default), the newly-inserted level is left
+ *  without an alphabet, matching the previous behaviour.
  * @param[in] jump_mode Specifies whether the symbol on a jump transition (a transition with a length greater than 1)
  *  is interpreted as a sequence repeating the same symbol or as a single instance of the symbol followed by a sequence
  *  of @c DONT_CARE symbols.
  */
-Nft insert_level(const Nft& nft, Level new_level, JumpMode jump_mode = JumpMode::RepeatSymbol);
+Nft insert_level(
+	const Nft& nft,
+	Level new_level,
+	std::shared_ptr<Alphabet> new_level_alphabet = nullptr,
+	JumpMode jump_mode = JumpMode::RepeatSymbol
+);
 
 /** Encodes a vector of strings (each corresponding to one symbol) into a
  *  @c Word instance

--- a/src/nft/composition.cc
+++ b/src/nft/composition.cc
@@ -1180,8 +1180,8 @@ Nft algorithms::compose_general(
 	}
 
 	// Insert new levels into lhs and rhs.
-	Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, jump_mode);
-	Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, jump_mode);
+	Nft lhs_synced = insert_levels(lhs, lhs_new_levels_mask, {}, jump_mode);
+	Nft rhs_synced = insert_levels(rhs, rhs_new_levels_mask, {}, jump_mode);
 
 	// Two auxiliary states (states from inserted loops) can not create a product state.
 	const State lhs_first_aux_state = lhs_synced.num_of_states();

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -7,6 +7,7 @@
 #include <format>
 #include <iterator>
 #include <ranges>
+#include <stdexcept>
 
 #include "mata/nft/algorithms.hh"
 #include "mata/nft/delta.hh"
@@ -593,10 +594,24 @@ Nft mata::nft::project_to(const Nft& nft, const Level level_to_project, const Ju
 	return project_to(nft, OrdVector<Level>{level_to_project}, jump_mode);
 }
 
-Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, const JumpMode jump_mode) {
+Nft mata::nft::insert_levels(
+	const Nft& nft,
+	const BoolVector& new_levels_mask,
+	const std::vector<std::shared_ptr<Alphabet>>& new_level_alphabets,
+	const JumpMode jump_mode
+) {
 	assert(0 < nft.levels.num_of_levels);
 	assert(nft.levels.num_of_levels <= new_levels_mask.size());
 	assert(static_cast<size_t>(std::ranges::count(new_levels_mask, false)) == nft.levels.num_of_levels);
+
+	const auto num_of_new_levels = static_cast<size_t>(std::ranges::count(new_levels_mask, true));
+	if (!new_level_alphabets.empty() && new_level_alphabets.size() != num_of_new_levels) {
+		throw std::invalid_argument(
+			"insert_levels(): new_level_alphabets must either be empty or have exactly one alphabet per "
+			"newly-inserted level (expected " +
+			std::to_string(num_of_new_levels) + ", got " + std::to_string(new_level_alphabets.size()) + ")"
+		);
+	}
 
 	if (nft.levels.num_of_levels == new_levels_mask.size()) { return {nft}; }
 
@@ -652,14 +667,20 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 		)
 	);
 
-	// Repare per-level alphabets: insert a null slot for each newly-inserted level, keeping existing entries at
-	//  their shifted indices (matching updated_levels above). In Global mode result.alphabets (== nft.alphabets) is
-	//  already correct as-is.
+	// Repare per-level alphabets: insert a slot for each newly-inserted level (filled from new_level_alphabets, or
+	//  null if none were given), keeping existing entries at their shifted indices (matching updated_levels above).
+	//  In Global mode result.alphabets (== nft.alphabets) is already correct as-is.
 	if (nft.alphabets != nullptr && nft.alphabets->mode() == AlphabetLevels::Mode::MultiLevel) {
 		auto new_alphabets = std::make_shared<AlphabetLevels>(*nft.alphabets);
+		size_t next_new_level_alphabet{0};
 		for (size_t i{0}; i < new_levels_mask.size(); i++) {
 			if (new_levels_mask[i]) {
-				new_alphabets->insert(new_alphabets->begin() + static_cast<std::ptrdiff_t>(i), nullptr);
+				std::shared_ptr<Alphabet> alphabet_for_new_level{
+					new_level_alphabets.empty() ? nullptr : new_level_alphabets[next_new_level_alphabet++]
+				};
+				new_alphabets->insert(
+					new_alphabets->begin() + static_cast<std::ptrdiff_t>(i), std::move(alphabet_for_new_level)
+				);
 			}
 		}
 		result.alphabets = std::move(new_alphabets);
@@ -727,16 +748,24 @@ Nft mata::nft::insert_levels(const Nft& nft, const BoolVector& new_levels_mask, 
 	return result;
 }
 
-Nft mata::nft::insert_level(const Nft& nft, const Level new_level, const JumpMode jump_mode) {
+Nft mata::nft::insert_level(
+	const Nft& nft, const Level new_level, std::shared_ptr<Alphabet> new_level_alphabet, const JumpMode jump_mode
+) {
 	// TODO(nft): Optimize the insertion of just one level by using move.
 	BoolVector new_levels_mask(nft.levels.num_of_levels + 1, false);
 	if (new_level < new_levels_mask.size()) {
 		new_levels_mask[new_level] = true;
-	} else {
-		new_levels_mask[nft.levels.num_of_levels] = true;
-		new_levels_mask.resize(new_level + 1, true);
+		return insert_levels(nft, new_levels_mask, {std::move(new_level_alphabet)}, jump_mode);
 	}
-	return insert_levels(nft, new_levels_mask, jump_mode);
+	// new_level is beyond the current number of levels: pad with levels up to new_level, all of which are new.
+	// Only the last of them (new_level itself) gets new_level_alphabet; the padding levels are left without one.
+	new_levels_mask[nft.levels.num_of_levels] = true;
+	new_levels_mask.resize(new_level + 1, true);
+	std::vector<std::shared_ptr<Alphabet>> new_level_alphabets(
+		static_cast<size_t>(std::ranges::count(new_levels_mask, true))
+	);
+	new_level_alphabets.back() = std::move(new_level_alphabet);
+	return insert_levels(nft, new_levels_mask, new_level_alphabets, jump_mode);
 }
 
 Nft mata::nft::fragile_revert(const Nft& aut) {

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -4592,7 +4592,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels() keep per-lev
     Nft nft(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }, alphabets));
 
     SECTION("insert_level inserts a null slot at the new level, shifting the rest") {
-        Nft output_nft = insert_level(nft, 1, JumpMode::AppendDontCares);
+        Nft output_nft = insert_level(nft, 1, nullptr, JumpMode::AppendDontCares);
         REQUIRE(output_nft.alphabets != nullptr);
         REQUIRE(output_nft.alphabets->size() == 4);
         CHECK(&output_nft.alphabets->for_level(0) == a0.get());
@@ -4608,7 +4608,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels() keep per-lev
     }
 
     SECTION("insert_levels inserts null slots at every new position") {
-        Nft output_nft = insert_levels(nft, { 0, 0, 1, 1, 0, 1 }, JumpMode::AppendDontCares);
+        Nft output_nft = insert_levels(nft, { 0, 0, 1, 1, 0, 1 }, {}, JumpMode::AppendDontCares);
         REQUIRE(output_nft.alphabets != nullptr);
         REQUIRE(output_nft.alphabets->size() == 6);
         CHECK(&output_nft.alphabets->for_level(0) == a0.get());
@@ -4624,7 +4624,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels() keep per-lev
         auto global_alphabets = std::make_shared<AlphabetLevels>(AlphabetLevels{ shared_alphabet });
         Nft global_nft(Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 }, global_alphabets));
 
-        Nft output_nft = insert_level(global_nft, 1, JumpMode::AppendDontCares);
+        Nft output_nft = insert_level(global_nft, 1, nullptr, JumpMode::AppendDontCares);
         REQUIRE(output_nft.alphabets != nullptr);
         CHECK(output_nft.alphabets->mode() == AlphabetLevels::Mode::Global);
         CHECK(&output_nft.alphabets->for_level(0) == shared_alphabet.get());
@@ -4632,6 +4632,74 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels() keep per-lev
         //  is shared with global_nft, not just its underlying alphabet.
         CHECK(output_nft.alphabets == global_nft.alphabets);
     }
+
+    SECTION("insert_level fills the new level's slot with the given alphabet instead of null") {
+        auto a3 = std::make_shared<IntAlphabet>();
+        Nft output_nft = insert_level(nft, 1, a3, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        REQUIRE(output_nft.alphabets->size() == 4);
+        CHECK(&output_nft.alphabets->for_level(0) == a0.get());
+        CHECK(&output_nft.alphabets->for_level(1) == a3.get());
+        CHECK(&output_nft.alphabets->for_level(2) == a1.get());
+        CHECK(&output_nft.alphabets->for_level(3) == a2.get());
+    }
+
+    SECTION("insert_levels fills every new slot with the given alphabets instead of null") {
+        auto a3 = std::make_shared<IntAlphabet>();
+        auto a4 = std::make_shared<IntAlphabet>();
+        auto a5 = std::make_shared<IntAlphabet>();
+        Nft output_nft = insert_levels(
+            nft, { 0, 0, 1, 1, 0, 1 }, { a3, a4, a5 }, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        REQUIRE(output_nft.alphabets->size() == 6);
+        CHECK(&output_nft.alphabets->for_level(0) == a0.get());
+        CHECK(&output_nft.alphabets->for_level(1) == a1.get());
+        CHECK(&output_nft.alphabets->for_level(2) == a3.get());
+        CHECK(&output_nft.alphabets->for_level(3) == a4.get());
+        CHECK(&output_nft.alphabets->for_level(4) == a2.get());
+        CHECK(&output_nft.alphabets->for_level(5) == a5.get());
+    }
+
+    SECTION("insert_levels rejects a mismatched number of new_level_alphabets") {
+        auto a3 = std::make_shared<IntAlphabet>();
+        CHECK_THROWS_AS(
+            insert_levels(nft, { 0, 0, 1, 1, 0, 1 }, { a3 }, JumpMode::AppendDontCares),
+            std::invalid_argument
+        );
+    }
+
+    SECTION("insert_level beyond num_of_levels only assigns the alphabet to the requested level") {
+        auto a3 = std::make_shared<IntAlphabet>();
+        // nft has 3 levels (0, 1, 2); inserting level 4 pads with a new level 3 (no alphabet) before it.
+        Nft output_nft = insert_level(nft, 4, a3, JumpMode::AppendDontCares);
+        REQUIRE(output_nft.alphabets != nullptr);
+        REQUIRE(output_nft.alphabets->size() == 5);
+        CHECK(&output_nft.alphabets->for_level(0) == a0.get());
+        CHECK(&output_nft.alphabets->for_level(1) == a1.get());
+        CHECK(&output_nft.alphabets->for_level(2) == a2.get());
+        CHECK(output_nft.alphabets->at(3) == nullptr);
+        CHECK(&output_nft.alphabets->for_level(4) == a3.get());
+    }
+}
+
+TEST_CASE("mata::nft::insert_level() regression test for #684") {
+    // Reproduces the scenario from https://github.com/VeriFIT/mata/issues/684: inserting a level used to leave its
+    //  alphabet slot null, which made any operation resolving a per-level alphabet (e.g. reverse_translate_symbol,
+    //  used internally by print_to_dot) throw.
+    OnTheFlyAlphabet alph1(std::vector<std::string>{ "aa", "b" });
+    OnTheFlyAlphabet alph2(std::vector<std::string>{ "c", "xy" });
+    auto alph1_ptr = std::shared_ptr<Alphabet>(&alph1, [](Alphabet*) {});
+    auto alph2_ptr = std::shared_ptr<Alphabet>(&alph2, [](Alphabet*) {});
+    auto alphabets = std::make_shared<AlphabetLevels>(
+        std::vector<std::shared_ptr<Alphabet>>{ alph1_ptr, alph2_ptr }, AlphabetLevels::Mode::MultiLevel);
+    Nft aut = Nft::with_levels(2, 1, { 0 }, { 0 }, alphabets);
+    aut.insert_word_by_levels(
+        0, { alph1.translate_word({ "aa", "aa", "b" }), alph2.translate_word({ "c", "xy", "xy" }) });
+
+    Nft inserted = insert_level(aut, 1, alph2_ptr, JumpMode::RepeatSymbol);
+    REQUIRE(inserted.alphabets != nullptr);
+    CHECK_NOTHROW(inserted.alphabets->for_level(1));
+    CHECK(&inserted.alphabets->for_level(1) == alph2_ptr.get());
 }
 
 TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
@@ -4646,7 +4714,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -4656,7 +4724,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, DONT_CARE, 2);
@@ -4666,7 +4734,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -4676,7 +4744,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0 } }, 5, { 0 }, { 4 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -4686,7 +4754,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 4") {
-            output_nft = insert_level(input_nft, 4, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 4, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 5, { 0, 1, 2, 3, 4, 0 } }, 6, { 0 }, { 5 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(1, 1, 2);
@@ -4697,7 +4765,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 100011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 0, 0, 1, 1 }, {}, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 6, { 0, 1, 2, 3, 4, 5, 0 } }, 7, { 0 }, { 6 });
             expected_nft.delta.add(0, DONT_CARE, 1);
             expected_nft.delta.add(1, 0, 2);
@@ -4793,7 +4861,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0, 1, 1 } }, 7, { 0 }, { 4 });
             expected_nft.delta.add(0, DONT_CARE, 5);
             expected_nft.delta.add(5, 4, 0);
@@ -4807,7 +4875,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0, 1, 1, 2, 3, 2, 3 } }, 11, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 7);
@@ -4825,7 +4893,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0, 2, 3, 2, 3 } }, 9, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 7);
             expected_nft.delta.add(7, DONT_CARE, 8);
@@ -4841,7 +4909,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 3, 0, 3, 3 } }, 7, { 0 }, { 4 });
             expected_nft.delta.add(0, 4, 5);
             expected_nft.delta.add(5, DONT_CARE, 0);
@@ -4855,7 +4923,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, {}, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels(
                 { 7, { 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6 } }, 20, { 0 }, { 7 }
             );
@@ -4896,7 +4964,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         input_nft = Nft::with_levels({ 3, { 0, 1, 2, 0 } }, delta, { 0 }, { 3 });
 
         SECTION("add level 0") {
-            output_nft = insert_level(input_nft, 0, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 0, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 2, 3, 0, 1, 1, 1 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, DONT_CARE, 4);
             expected_nft.delta.add(0, DONT_CARE, 5);
@@ -4911,7 +4979,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 1") {
-            output_nft = insert_level(input_nft, 1, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 1, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 3, 0, 2, 2, 2, 2 } }, 8, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 6);
@@ -4927,7 +4995,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 2") {
-            output_nft = insert_level(input_nft, 2, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 2, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 0, 2, 3, 2 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4942,7 +5010,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add level 3") {
-            output_nft = insert_level(input_nft, 3, JumpMode::AppendDontCares);
+            output_nft = insert_level(input_nft, 3, nullptr, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels({ 4, { 0, 1, 2, 0, 3, 3, 3 } }, 7, { 0 }, { 3 });
             expected_nft.delta.add(0, 0, 1);
             expected_nft.delta.add(0, 4, 2);
@@ -4957,7 +5025,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
         }
 
         SECTION("add levels according to the mask 1010011") {
-            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, JumpMode::AppendDontCares);
+            output_nft = insert_levels(input_nft, { 1, 0, 1, 0, 0, 1, 1 }, {}, JumpMode::AppendDontCares);
             expected_nft = Nft::with_levels(
                 { 7, { 0, 2, 4, 0, 1, 1, 3, 3, 3, 5, 5, 6, 6, 1, 5, 6, 3, 2, 4, 2, 4 } }, 21, { 0 }, { 3 }
             );
@@ -4998,7 +5066,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         input_nft = Nft::with_levels({ 4, { 0, 1, 3, 0 } }, delta, { 0 }, { 3 });
 
-        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::RepeatSymbol);
+        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, {}, JumpMode::RepeatSymbol);
         CHECK(output_nft.num_of_states() == 13);
     }
 
@@ -5012,7 +5080,7 @@ TEST_CASE("mata::nft::insert_level() and mata::nft::insert_levels()") {
 
         input_nft = Nft::with_levels({ 4, { 0, 1, 3, 0 } }, delta, { 0 }, { 3 });
 
-        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, JumpMode::AppendDontCares);
+        output_nft = insert_levels(input_nft, { 0, 1, 1, 0, 0, 1, 0 }, {}, JumpMode::AppendDontCares);
         CHECK(output_nft.num_of_states() == 9);
     }
 }


### PR DESCRIPTION
Nft::insert_levels() and Nft::insert_level() left the alphabet slot of each newly-inserted level as null in MultiLevel mode, so any later operation resolving a per-level alphabet (e.g. reverse_translate_symbol, used by print_to_dot) would throw. Adds optional new_level_alphabets / new_level_alphabet parameters so callers can supply the alphabet(s) for the inserted level(s) directly, instead of having to rebuild result.alphabets by hand afterwards.

Resolves #684.