### PR TITLE
bindings/python: +feat Expose Delta as a Python object

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -65,24 +65,27 @@ cdef extern from "mata/nfa/nfa.hh" namespace "mata::nfa":
     cdef cppclass CDelta "mata::nfa::Delta":
         vector[CStatePost] state_posts
 
+        bool operator==(CDelta&)
         void reserve(size_t)
         CStatePost& state_post(State)
         CStatePost& operator[](State)
         void clear()
         bool empty()
-        void resize(size_t)
+        bool uses_state(State)
         size_t num_of_states()
-        void defragment()
         void add(CTrans) except +
         void add(State, Symbol, State) except +
+        void add_targets "add" (State, Symbol, StateSet) except +
         void remove(CTrans) except +
         void remove(State, Symbol, State) except +
         bool contains(State, Symbol, State)
+        bool contains(CTrans)
         COrdVector[CSymbolPost].const_iterator epsilon_symbol_posts(State state, Symbol epsilon)
         COrdVector[CSymbolPost].const_iterator epsilon_symbol_posts(CStatePost& post, Symbol epsilon)
         size_t num_of_transitions()
         CTransitions transitions()
         vector[CTrans] get_transitions_to(State)
+        vector[CTrans] get_transitions_between(State, State)
         COrdVector[Symbol] get_used_symbols()
 
     cdef cppclass CRun "mata::nfa::Run":
@@ -230,3 +233,10 @@ cdef class Nfa:
 cdef class Transition:
     cdef CTrans* thisptr
     cdef copy_from(self, CTrans trans)
+
+cdef class Delta:
+    # Holds a shared pointer to the owning automaton (rather than a raw `CDelta*`) so that the `Delta` view stays
+    # valid even if all other Python references to the automaton are dropped.
+    cdef shared_ptr[CNfa] nfa_ptr
+
+cdef object wrap_delta(shared_ptr[CNfa] nfa_ptr)

--- a/bindings/python/libmata/nfa/nfa.pyi
+++ b/bindings/python/libmata/nfa/nfa.pyi
@@ -105,6 +105,83 @@ class SymbolPost:
     def __repr__(self) -> str:
         ...
 
+class Delta:
+    """Wrapper over the transition relation (`Delta`) of an automaton, allowing operations on transitions similar
+    to the C++ interface, e.g. `nfa.delta.add(source, symbol, target)`.
+
+    Obtained through `Nfa.delta`/`Nft.delta`; not meant to be instantiated directly. It holds a shared pointer to
+    the owning automaton, so it stays valid even if the `Nfa`/`Nft` it was obtained from is garbage collected while
+    a reference to its `.delta` is still kept.
+    """
+    @overload
+    def add(self, source: Transition) -> None:
+        ...
+    @overload
+    def add(self, source: State, symbol: Symbol | str, target: State, alphabet: alph.Alphabet = None) -> None:
+        ...
+    @overload
+    def add(self, source: State, symbol: Symbol | str, target: Iterable[State], alphabet: alph.Alphabet = None) -> None:
+        ...
+    @overload
+    def remove(self, source: Transition) -> None:
+        ...
+    @overload
+    def remove(self, source: State, symbol: Symbol, target: State) -> None:
+        ...
+    @overload
+    def contains(self, source: Transition) -> bool:
+        ...
+    @overload
+    def contains(self, source: State, symbol: Symbol, target: State) -> bool:
+        ...
+    def __contains__(self, item: Transition | tuple[State, Symbol, State]) -> bool:
+        ...
+    def clear(self) -> None:
+        """Remove all transitions from Delta."""
+        ...
+    def empty(self) -> bool:
+        """Check whether Delta contains no transitions."""
+        ...
+    def num_of_transitions(self) -> int:
+        """Get the number of transitions in Delta."""
+        ...
+    def __len__(self) -> int:
+        ...
+    def num_of_states(self) -> int:
+        """Get the number of states for which Delta has allocated a state post."""
+        ...
+    def uses_state(self, state: State) -> bool:
+        """Check whether `state` is used in Delta."""
+        ...
+    def state_post(self, state: State) -> list[SymbolPost]:
+        """Get the outgoing transitions from `state`, grouped by symbol."""
+        ...
+    def __getitem__(self, state: State) -> list[SymbolPost]:
+        ...
+    def transitions(self) -> Iterable[Transition]:
+        """Iterate over all transitions in Delta."""
+        ...
+    def __iter__(self) -> Iterable[Transition]:
+        ...
+    def get_transitions_from(self, source: State) -> list[Transition]:
+        """Get the transitions leading from `source`."""
+        ...
+    def get_transitions_to(self, target: State) -> list[Transition]:
+        """Get the transitions leading to `target`."""
+        ...
+    def get_transitions_between(self, source: State, target: State) -> list[Transition]:
+        """Get the transitions leading from `source` to `target`."""
+        ...
+    def get_used_symbols(self) -> set[Symbol]:
+        """Get the set of symbols used on the transitions in Delta."""
+        ...
+    def __eq__(self, other: Self) -> bool:
+        ...
+    def __str__(self) -> str:
+        ...
+    def __repr__(self) -> str:
+        ...
+
 class Nfa:
     """Wrapper over NFA
 
@@ -137,6 +214,14 @@ class Nfa:
         ...
     @final_states.setter
     def final_states(self, value: list[State]) -> None:
+        ...
+    @property
+    def delta(self) -> Delta:
+        """The transition relation of the automaton.
+
+        Returns a live view over the automaton's transitions, allowing operations similar to the C++ interface,
+        e.g. `nfa.delta.add(source, symbol, target)`, `nfa.delta.contains(...)`, or iterating `for t in nfa.delta`.
+        """
         ...
     def is_state(self, state: State) -> bool:
         """Tests if state is in the automaton

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -184,6 +184,206 @@ cdef class SymbolPost:
         return str(self)
 
 
+cdef object wrap_delta(shared_ptr[CNfa] nfa_ptr):
+    """Wrap the `delta` member of the automaton behind `nfa_ptr` as a Python `Delta` object."""
+    result = Delta.__new__(Delta)
+    (<Delta>result).nfa_ptr = nfa_ptr
+    return result
+
+
+cdef class Delta:
+    """Wrapper over the transition relation (`Delta`) of an automaton, allowing operations on transitions similar
+    to the C++ interface, e.g. `nfa.delta.add(source, symbol, target)`.
+
+    Obtained through `Nfa.delta`/`Nft.delta`; not meant to be instantiated directly. It holds a shared pointer to
+    the owning automaton, so it stays valid even if the `Nfa`/`Nft` it was obtained from is garbage collected while
+    a reference to its `.delta` is still kept.
+    """
+
+    def __cinit__(self):
+        pass
+
+    def add(self, source, symbol=None, target=None, alph.Alphabet alphabet = None):
+        """Add a transition to Delta.
+
+        :param source: Either a `Transition` object to add (in which case `symbol` and `target` are ignored), or
+          the source state of the transition to add.
+        :param symbol: Symbol of the transition. Can be a string, in which case it is translated using `alphabet`.
+        :param target: Target state of the transition, or an iterable of target states to add multiple transitions
+          from `source` over `symbol` at once.
+        :param alph.Alphabet alphabet: Alphabet used to translate a string `symbol`.
+        """
+        cdef StateSet targets
+        if isinstance(source, Transition):
+            self.nfa_ptr.get().delta.add(dereference((<Transition>source).thisptr))
+            return
+        if isinstance(symbol, str):
+            alphabet = alphabet or store().get('alphabet')
+            if not alphabet:
+                raise Exception(f"Cannot translate symbol '{symbol}' without specified alphabet")
+            symbol = alphabet.translate_symbol(symbol)
+        if isinstance(target, (set, frozenset, list, tuple)):
+            targets = StateSet(target)
+            self.nfa_ptr.get().delta.add_targets(<State>source, <Symbol>symbol, targets)
+        else:
+            self.nfa_ptr.get().delta.add(<State>source, <Symbol>symbol, <State>target)
+
+    def remove(self, source, symbol=None, target=None):
+        """Remove a transition from Delta.
+
+        :param source: Either a `Transition` object to remove (in which case `symbol` and `target` are ignored), or
+          the source state of the transition to remove.
+        :param symbol: Symbol of the transition to remove.
+        :param target: Target state of the transition to remove.
+        """
+        if isinstance(source, Transition):
+            self.nfa_ptr.get().delta.remove(dereference((<Transition>source).thisptr))
+            return
+        self.nfa_ptr.get().delta.remove(<State>source, <Symbol>symbol, <State>target)
+
+    def contains(self, source, symbol=None, target=None) -> bool:
+        """Check whether Delta contains the given transition.
+
+        :param source: Either a `Transition` object (in which case `symbol` and `target` are ignored), or the
+          source state of the transition to check.
+        :param symbol: Symbol of the transition to check.
+        :param target: Target state of the transition to check.
+        :return: True if Delta contains the transition, False otherwise.
+        """
+        if isinstance(source, Transition):
+            return self.nfa_ptr.get().delta.contains(dereference((<Transition>source).thisptr))
+        return self.nfa_ptr.get().delta.contains(<State>source, <Symbol>symbol, <State>target)
+
+    def __contains__(self, item) -> bool:
+        if isinstance(item, Transition):
+            return self.contains(item)
+        source, symbol, target = item
+        return self.contains(source, symbol, target)
+
+    def clear(self) -> None:
+        """Remove all transitions from Delta."""
+        self.nfa_ptr.get().delta.clear()
+
+    def empty(self) -> bool:
+        """Check whether Delta contains no transitions.
+
+        :return: True if Delta contains no transitions, False otherwise.
+        """
+        return self.nfa_ptr.get().delta.empty()
+
+    def num_of_transitions(self) -> int:
+        """Get the number of transitions in Delta.
+
+        :return: Number of transitions in Delta.
+        """
+        return self.nfa_ptr.get().delta.num_of_transitions()
+
+    def __len__(self) -> int:
+        return self.num_of_transitions()
+
+    def num_of_states(self) -> int:
+        """Get the number of states for which Delta has allocated a state post.
+
+        :return: Number of states in Delta.
+        """
+        return self.nfa_ptr.get().delta.num_of_states()
+
+    def uses_state(self, State state) -> bool:
+        """Check whether `state` is used in Delta.
+
+        :param State state: State to check.
+        :return: True if `state` is used in Delta, False otherwise.
+        """
+        return self.nfa_ptr.get().delta.uses_state(state)
+
+    def state_post(self, State state) -> list[SymbolPost]:
+        """Get the outgoing transitions from `state`, grouped by symbol.
+
+        :param State state: Source state to get the outgoing transitions of.
+        :return: List of `SymbolPost` for `state`.
+        """
+        cdef CStatePost c_state_post = self.nfa_ptr.get().delta.state_post(state)
+        cdef vector[CSymbolPost] c_symbol_posts = c_state_post.to_vector()
+        return [SymbolPost(symbol_post.symbol, symbol_post.targets.to_vector()) for symbol_post in c_symbol_posts]
+
+    def __getitem__(self, State state) -> list[SymbolPost]:
+        return self.state_post(state)
+
+    def transitions(self):
+        """Iterate over all transitions in Delta.
+
+        :return: Generator of `Transition` instances.
+        """
+        cdef CTransitions c_transitions = self.nfa_ptr.get().delta.transitions()
+        cdef CTransitions.const_iterator iterator = c_transitions.begin()
+        while iterator != c_transitions.end():
+            trans = Transition()
+            (<Transition>trans).copy_from(dereference(iterator))
+            preinc(iterator)
+            yield trans
+
+    def __iter__(self):
+        return self.transitions()
+
+    def get_transitions_from(self, State source) -> list[Transition]:
+        """Get the transitions leading from `source`.
+
+        :param State source: Source state to get the transitions of.
+        :return: List of `Transition` instances leading from `source`.
+        """
+        transitions = []
+        cdef CStatePost c_state_post = self.nfa_ptr.get().delta[source]
+        cdef vector[CSymbolPost] c_symbol_posts = c_state_post.to_vector()
+        cdef vector[State] c_targets
+        for symbol_post in c_symbol_posts:
+            c_targets = symbol_post.targets.to_vector()
+            for target in c_targets:
+                transitions.append(Transition(source, symbol_post.symbol, target))
+        return transitions
+
+    def get_transitions_to(self, State target) -> list[Transition]:
+        """Get the transitions leading to `target`.
+
+        Operation is slow, traverses over all symbol posts.
+
+        :param State target: Target state to get the transitions of.
+        :return: List of `Transition` instances leading to `target`.
+        """
+        cdef vector[CTrans] c_transitions = self.nfa_ptr.get().delta.get_transitions_to(target)
+        return [Transition(t.source, t.symbol, t.target) for t in c_transitions]
+
+    def get_transitions_between(self, State source, State target) -> list[Transition]:
+        """Get the transitions leading from `source` to `target`.
+
+        Operation is slow, traverses over all symbol posts.
+
+        :param State source: Source state to get the transitions of.
+        :param State target: Target state to get the transitions of.
+        :return: List of `Transition` instances leading from `source` to `target`.
+        """
+        cdef vector[CTrans] c_transitions = self.nfa_ptr.get().delta.get_transitions_between(source, target)
+        return [Transition(t.source, t.symbol, t.target) for t in c_transitions]
+
+    def get_used_symbols(self) -> set[Symbol]:
+        """Get the set of symbols used on the transitions in Delta.
+
+        :return: Set of symbols used on the transitions.
+        """
+        cdef COrdVector[Symbol] symbols = self.nfa_ptr.get().delta.get_used_symbols()
+        return {s for s in symbols}
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Delta):
+            return NotImplemented
+        return self.nfa_ptr.get().delta == (<Delta>other).nfa_ptr.get().delta
+
+    def __str__(self):
+        return f"Delta({self.num_of_transitions()} transitions)"
+
+    def __repr__(self):
+        return str(self)
+
+
 cdef class Nfa:
     """Wrapper over NFA
 
@@ -239,6 +439,15 @@ cdef class Nfa:
         self.thisptr.get().final.clear()
         for state in value:
             self.thisptr.get().final.insert(state)
+
+    @property
+    def delta(self) -> Delta:
+        """The transition relation of the automaton.
+
+        Returns a live view over the automaton's transitions, allowing operations similar to the C++ interface,
+        e.g. `nfa.delta.add(source, symbol, target)`, `nfa.delta.contains(...)`, or iterating `for t in nfa.delta`.
+        """
+        return wrap_delta(self.thisptr)
 
     def is_state(self, state):
         """Tests if state is in the automaton

--- a/bindings/python/libmata/nft/nft.pyi
+++ b/bindings/python/libmata/nft/nft.pyi
@@ -181,6 +181,14 @@ class Nft:
         ...
     def clear_final(self) -> None:
         ...
+    @property
+    def delta(self) -> mata_nfa.Delta:
+        """The transition relation of the automaton.
+
+        Returns a live view over the automaton's transitions, allowing operations similar to the C++ interface,
+        e.g. `nft.delta.add(source, symbol, target)`, `nft.delta.contains(...)`, or iterating `for t in nft.delta`.
+        """
+        ...
     def add_transition_object(self, tr: Transition) -> None:
         ...
     def add_transition(self, source: State, symbols: Symbol | list[Symbol], target: State | None = None) -> State:

--- a/bindings/python/libmata/nft/nft.pyx
+++ b/bindings/python/libmata/nft/nft.pyx
@@ -418,6 +418,15 @@ cdef class Nft:
     def clear_final(self):
         self.thisptr.get().final.clear()
 
+    @property
+    def delta(self) -> mata_nfa.Delta:
+        """The transition relation of the automaton.
+
+        Returns a live view over the automaton's transitions, allowing operations similar to the C++ interface,
+        e.g. `nft.delta.add(source, symbol, target)`, `nft.delta.contains(...)`, or iterating `for t in nft.delta`.
+        """
+        return mata_nfa.wrap_delta(static_pointer_cast[CNfa, CNft](self.thisptr))
+
     def add_transition_object(self, Transition tr):
         self.thisptr.get().delta.add(dereference((<mata_nfa.Transition>tr).thisptr))
 

--- a/bindings/python/tests/test_nft.py
+++ b/bindings/python/tests/test_nft.py
@@ -22,6 +22,17 @@ def test_nft_construction_and_states():
     assert nft.is_state(new_state)
 
 
+def test_nft_delta():
+    nft = mata_nft.Nft(3)
+    assert isinstance(nft.delta, mata_nfa.Delta)
+    assert nft.delta.empty()
+
+    nft.delta.add(0, 1, 1)
+    assert nft.delta.contains(0, 1, 1)
+    assert len(nft.delta) == 1
+    assert nft.get_num_of_transitions() == 1
+
+
 def test_nft_insert_word_and_is_in_lang():
     nft = mata_nft.Nft(1, num_of_levels=2)
     nft.make_initial_state(0)

--- a/bindings/python/tests/test_trans.py
+++ b/bindings/python/tests/test_trans.py
@@ -119,3 +119,66 @@ def test_transitions():
     # Test that transitions are not duplicated.
     lhs.add_transition_object(t3)
     assert [t for t in lhs.iterate()] == [t1, t2, t3, t4]
+
+
+def test_delta_add_remove_contains():
+    """Tests basic Delta operations mirroring the C++ interface, e.g. nfa.delta.add()."""
+    nfa = mata_nfa.Nfa(5)
+    assert isinstance(nfa.delta, mata_nfa.Delta)
+    assert nfa.delta.empty()
+    assert len(nfa.delta) == 0
+
+    nfa.delta.add(0, ord('a'), 1)
+    assert not nfa.delta.empty()
+    assert len(nfa.delta) == 1
+    assert nfa.delta.contains(0, ord('a'), 1)
+    assert (0, ord('a'), 1) in nfa.delta
+
+    tr = mata_nfa.Transition(1, ord('b'), 2)
+    nfa.delta.add(tr)
+    assert nfa.delta.contains(tr)
+    assert tr in nfa.delta
+
+    # Adding a transition to multiple targets at once.
+    nfa.delta.add(2, ord('c'), {3, 4})
+    assert nfa.delta.contains(2, ord('c'), 3)
+    assert nfa.delta.contains(2, ord('c'), 4)
+    assert len(nfa.delta) == 4
+
+    nfa.delta.remove(0, ord('a'), 1)
+    assert not nfa.delta.contains(0, ord('a'), 1)
+    nfa.delta.remove(tr)
+    assert not nfa.delta.contains(tr)
+
+
+def test_delta_views(prepare_automaton_a):
+    """Tests that Delta exposes the transitions similarly to the corresponding Nfa methods."""
+    nfa = prepare_automaton_a()
+
+    assert nfa.delta.num_of_transitions() == nfa.get_num_of_transitions()
+    assert list(nfa.delta) == nfa.get_trans_as_sequence()
+    assert nfa.delta.get_transitions_from(1) == nfa.get_trans_from_state_as_sequence(1)
+    assert nfa.delta.get_transitions_to(9) == nfa.get_transitions_to_state(9)
+    assert nfa.delta.get_used_symbols() == nfa.get_symbols()
+    assert nfa.delta[1] == nfa.get_transitions_from_state(1)
+
+
+def test_delta_survives_nfa_deletion():
+    """Tests that a kept Delta reference stays valid after the owning Nfa is garbage collected."""
+    nfa = mata_nfa.Nfa(2)
+    nfa.delta.add(0, 0, 1)
+    delta = nfa.delta
+    del nfa
+    assert len(delta) == 1
+    assert delta.contains(0, 0, 1)
+
+
+def test_delta_equality():
+    lhs = mata_nfa.Nfa(2)
+    lhs.add_transition(0, 0, 1)
+    rhs = mata_nfa.Nfa(2)
+    rhs.add_transition(0, 0, 1)
+
+    assert lhs.delta == rhs.delta
+    rhs.delta.add(1, 1, 1)
+    assert lhs.delta != rhs.delta


### PR DESCRIPTION
Add `nfa.delta`/`nft.delta` returning a Delta wrapper supporting add(), remove(), contains(), state_post(), transitions(), etc., mirroring `mata::nfa::Delta` instead of only offering flat methods on Nfa/Nft.