### PR TITLE
utils: +refactor No std::hash override for std::{set,vector}

### DIFF
--- a/bindings/python/libmata/nfa/nfa.pxd
+++ b/bindings/python/libmata/nfa/nfa.pxd
@@ -10,7 +10,7 @@ from libcpp.list cimport list as clist
 from libcpp.pair cimport pair
 from libc.stdint cimport uintptr_t, uint8_t
 
-from libmata.utils cimport CSparseSet, COrdVector, CBoolVector, CBinaryRelation
+from libmata.utils cimport CSparseSet, COrdVector, CBoolVector, CBinaryRelation, CPairHash
 from libmata.alphabets cimport CAlphabet, CConstAlphabet, Symbol
 
 cdef extern from "<iostream>" namespace "std":
@@ -207,7 +207,7 @@ cdef extern from "mata/nfa/plumbing.hh" namespace "mata::nfa::plumbing":
     cdef void get_elements(StateSet*, CBoolVector)
     cdef void c_determinize "mata::nfa::plumbing::determinize" (CNfa*, CNfa&, umap[StateSet, State]*)
     cdef void c_union_nondet "mata::nfa::plumbing::union_nondet" (CNfa*, CNfa&, CNfa&)
-    cdef void c_intersection "mata::nfa::plumbing::intersection" (CNfa*, CNfa&, CNfa&, Symbol, umap[pair[State, State], State]*)
+    cdef void c_intersection "mata::nfa::plumbing::intersection" (CNfa*, CNfa&, CNfa&, Symbol, umap[pair[State, State], State, CPairHash[State, State]]*)
     cdef void c_concatenate "mata::nfa::plumbing::concatenate" (CNfa*, CNfa&, CNfa&, bool, StateRenaming*, StateRenaming*)
     cdef void c_complement "mata::nfa::plumbing::complement" (CNfa*, CNfa&, CAlphabet&, ParameterMap&) except +
     cdef void c_revert "mata::nfa::plumbing::revert" (CNfa*, CNfa&)

--- a/bindings/python/libmata/nfa/nfa.pyx
+++ b/bindings/python/libmata/nfa/nfa.pyx
@@ -24,7 +24,7 @@ from libmata.nfa.nfa cimport \
     CDelta, CRun, CTrans, CNfa, CSymbolPost, CEPSILON
 
 from libmata.alphabets cimport CAlphabet, CConstAlphabet
-from libmata.utils cimport COrdVector, CBinaryRelation, BinaryRelation
+from libmata.utils cimport COrdVector, CBinaryRelation, BinaryRelation, CPairHash
 
 
 cdef Symbol EPSILON = CEPSILON
@@ -1151,7 +1151,7 @@ def intersection_with_product_map(Nfa lhs, Nfa rhs, Symbol first_epsilon = CEPSI
     :return: Intersection of lhs and rhs, product map of original pairs of states to new states.
     """
     result = Nfa()
-    cdef umap[pair[State, State], State] c_product_map
+    cdef umap[pair[State, State], State, CPairHash[State, State]] c_product_map
     mata_nfa.c_intersection(
         result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), first_epsilon, &c_product_map)
     return result, {tuple(k): v for k, v in c_product_map}

--- a/bindings/python/libmata/nft/nft.pxd
+++ b/bindings/python/libmata/nft/nft.pxd
@@ -8,7 +8,7 @@ from libcpp.string cimport string
 from libcpp.utility cimport pair
 from libc.stdint cimport uintptr_t
 
-from libmata.utils cimport CSparseSet, COrdVector, CBoolVector, CBinaryRelation
+from libmata.utils cimport CSparseSet, COrdVector, CBoolVector, CBinaryRelation, CPairHash
 from libmata.alphabets cimport CAlphabet, CConstAlphabet, CAlphabetLevels, Symbol, Level
 
 from libmata.nfa.nfa cimport (
@@ -172,7 +172,7 @@ cdef extern from "mata/nft/nft.hh" namespace "mata::nft":
     ) except +
     cdef CNft c_union_nondet "mata::nft::union_nondet" (CNft&, CNft&) except +
     cdef CNft c_intersection "mata::nft::intersection" (
-        CNft&, CNft&, umap[pair[State, State], State]*, CJumpMode, State, State
+        CNft&, CNft&, umap[pair[State, State], State, CPairHash[State, State]]*, CJumpMode, State, State
     ) except +
     cdef CNft c_compose "mata::nft::compose" (
         CNft&, CNft&, COrdVector[Level]&, COrdVector[Level]&, bool, CJumpMode, CCompositionMode
@@ -218,7 +218,7 @@ cdef extern from "mata/nft/algorithms.hh" namespace "mata::nft::algorithms":
 cdef extern from "mata/nft/plumbing.hh" namespace "mata::nft::plumbing":
     cdef void c_nft_union_nondet "mata::nft::plumbing::union_nondet" (CNft*, CNft&, CNft&)
     cdef void c_nft_intersection "mata::nft::plumbing::intersection" (
-        CNft*, CNft&, CNft&, umap[pair[State, State], State]*, CJumpMode, State, State
+        CNft*, CNft&, CNft&, umap[pair[State, State], State, CPairHash[State, State]]*, CJumpMode, State, State
     )
     cdef void c_nft_concatenate "mata::nft::plumbing::concatenate" (
         CNft*, CNft&, CNft&, bool, StateRenaming*, StateRenaming*

--- a/bindings/python/libmata/nft/nft.pyx
+++ b/bindings/python/libmata/nft/nft.pyx
@@ -25,7 +25,7 @@ from libmata.nft.nft cimport (
 from libmata.nfa.nfa cimport CSparseSet, CBoolVector, CBinaryRelation
 from libmata.nfa.nfa cimport Transition
 from libmata.nfa.nfa cimport ostream, ofstream, stringstream
-from libmata.utils cimport COrdVector, BinaryRelation
+from libmata.utils cimport COrdVector, BinaryRelation, CPairHash
 from libmata.nfa.nfa import Run, run_safely_external_command
 
 
@@ -925,7 +925,7 @@ def intersection_with_product_map(
     :return: Intersection of `lhs` and `rhs`, product map of pairs of original states to new states.
     """
     result = Nft()
-    cdef umap[pair[State, State], State] c_product_map
+    cdef umap[pair[State, State], State, CPairHash[State, State]] c_product_map
     mata_nft.c_nft_intersection(
         result.thisptr.get(), dereference(lhs.thisptr.get()), dereference(rhs.thisptr.get()), &c_product_map,
         _c_jump_mode(jump_mode), lhs_first_aux_state, rhs_first_aux_state

--- a/bindings/python/libmata/utils.pxd
+++ b/bindings/python/libmata/utils.pxd
@@ -73,6 +73,11 @@ cdef extern from "mata/utils/utils.hh" namespace "mata":
         size_t count()
 
 
+cdef extern from "mata/utils/utils.hh" namespace "mata::utils":
+    cdef cppclass CPairHash "mata::utils::PairHash" [A, B]:
+        pass
+
+
 cdef extern from "mata/simlib/util/binary_relation.hh" namespace "Simlib::Util":
     ctypedef vector[size_t] ivector
     ctypedef vector[bool] bvector

--- a/include/mata/nfa/algorithms.hh
+++ b/include/mata/nfa/algorithms.hh
@@ -123,7 +123,7 @@ Nfa product(
 	const Nfa& rhs,
 	const std::function<bool(State, State)>&& final_condition,
 	Symbol first_epsilon = EPSILON,
-	std::unordered_map<std::pair<State, State>, State>* product_map = nullptr
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* product_map = nullptr
 );
 
 /**

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -909,7 +909,7 @@ Nfa product(
 	const Nfa& rhs,
 	ProductFinalStateCondition final_condition = ProductFinalStateCondition::And,
 	Symbol first_epsilon = EPSILON,
-	std::unordered_map<std::pair<State, State>, State>* prod_map = nullptr
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map = nullptr
 );
 
 /**
@@ -959,7 +959,7 @@ Nfa intersection(
 	const Nfa& lhs,
 	const Nfa& rhs,
 	Symbol first_epsilon = EPSILON,
-	std::unordered_map<std::pair<State, State>, State>* prod_map = nullptr
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map = nullptr
 );
 
 /**

--- a/include/mata/nfa/plumbing.hh
+++ b/include/mata/nfa/plumbing.hh
@@ -97,7 +97,7 @@ inline void intersection(
 	const Nfa& lhs,
 	const Nfa& rhs,
 	const Symbol first_epsilon = EPSILON,
-	std::unordered_map<std::pair<State, State>, State>* prod_map = nullptr
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map = nullptr
 ) {
 	*res = intersection(lhs, rhs, first_epsilon, prod_map);
 }

--- a/include/mata/nft/algorithms.hh
+++ b/include/mata/nft/algorithms.hh
@@ -132,7 +132,7 @@ Nft product(
 	const Nft& lhs,
 	const Nft& rhs,
 	const std::function<bool(State, State)>&& final_condition,
-	std::unordered_map<std::pair<State, State>, State>* product_map = nullptr,
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* product_map = nullptr,
 	JumpMode jump_mode = JumpMode::RepeatSymbol,
 	State lhs_first_aux_state = Limits::max_state,
 	State rhs_first_aux_state = Limits::max_state

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -1364,7 +1364,7 @@ Nft product(
 	const Nft& rhs,
 	ProductFinalStateCondition final_condition,
 	Symbol first_epsilon,
-	std::unordered_map<std::pair<State, State>, State>* prod_map
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map
 ) = delete;
 
 /**
@@ -1391,7 +1391,7 @@ Nft product(
 Nft intersection(
 	const Nft& lhs,
 	const Nft& rhs,
-	std::unordered_map<std::pair<State, State>, State>* prod_map = nullptr,
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map = nullptr,
 	JumpMode jump_mode = JumpMode::RepeatSymbol,
 	State lhs_first_aux_state = Limits::max_state,
 	State rhs_first_aux_state = Limits::max_state

--- a/include/mata/nft/plumbing.hh
+++ b/include/mata/nft/plumbing.hh
@@ -94,7 +94,7 @@ inline void intersection(
 	Nft* res,
 	const Nft& lhs,
 	const Nft& rhs,
-	std::unordered_map<std::pair<State, State>, State>* prod_map = nullptr,
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map = nullptr,
 	const JumpMode jump_mode = JumpMode::RepeatSymbol,
 	const State lhs_first_aux_state = Limits::max_state,
 	const State rhs_first_aux_state = Limits::max_state

--- a/include/mata/utils/ord-vector.hh
+++ b/include/mata/utils/ord-vector.hh
@@ -526,7 +526,7 @@ template <class Key> class OrdVector {
 
 template <class Key> struct std::hash<mata::utils::OrdVector<Key>> {
 	std::size_t operator()(const mata::utils::OrdVector<Key>& vec) const {
-		return std::hash<std::vector<Key>>{}(vec.to_vector());
+		return mata::utils::hash_range(vec.begin(), vec.end());
 	}
 };
 

--- a/include/mata/utils/two-dimensional-map.hh
+++ b/include/mata/utils/two-dimensional-map.hh
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <unordered_map>
 
+#include "mata/utils/utils.hh"
+
 namespace mata::utils {
 
 /**
@@ -29,7 +31,7 @@ template <typename T, bool TrackInverted = true, size_t MaxMatrixSize = 50'000'0
 	static_assert(std::is_unsigned_v<T>, "ProductStorage requires an unsigned type");
 
   public:
-	using Map = std::unordered_map<std::pair<T, T>, T>;
+	using Map = std::unordered_map<std::pair<T, T>, T, PairHash<T, T>>;
 	using MatrixStorage = std::vector<std::vector<T>>;
 	using VecMapStorage = std::vector<std::unordered_map<T, T>>;
 	using InvertedStorage = std::vector<T>;

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -190,6 +190,27 @@ template <typename It> size_t hash_range(It first, It last) { // {{{
 	return accum;
 } // hash_range(It, It) }}}
 
+/**
+ * @brief A hasher for @c std::set, usable as the @c Hash template argument of unordered containers.
+ *
+ * @note We deliberately do NOT specialize @c std::hash<std::set<A>> for arbitrary @p A: the standard only allows
+ *  program-defined specializations of standard templates when at least one template argument is a program-defined
+ *  type, so specializing it for e.g. @c std::set<unsigned> would be undefined behavior (and could silently collide
+ *  with another library's specialization for the same type).
+ */
+template <class A> struct SetHash {
+	size_t operator()(const std::set<A>& cont) const { return hash_range(cont.begin(), cont.end()); }
+};
+
+/**
+ * @brief A hasher for @c std::vector, usable as the @c Hash template argument of unordered containers.
+ *
+ * @note See @c SetHash for why we do not specialize @c std::hash<std::vector<A>> directly.
+ */
+template <class A> struct VectorHash {
+	size_t operator()(const std::vector<A>& cont) const { return hash_range(cont.begin(), cont.end()); }
+};
+
 /// checks whether a container with @p find contains a key
 template <class T, class K> inline bool haskey(const T& cont, const K& key) { return cont.find(key) != cont.cend(); }
 
@@ -307,29 +328,16 @@ namespace std { // {{{
 
 /**
  * @brief  A hasher for pairs
+ *
+ * @note This is, strictly speaking, the same kind of library-namespace pollution as the @c std::set / @c std::vector
+ *  hashers we moved to @c mata::utils::SetHash / @c mata::utils::VectorHash (see #628). It stays here for now
+ *  because @c std::pair<State, State> is used as a key of several @c public API @c std::unordered_map parameters
+ *  (e.g. product maps), so hiding it would require changing those public signatures; left as follow-up work.
  */
 template <class A, class B> struct hash<std::pair<A, B>> {
 	inline size_t operator()(const std::pair<A, B>& k) const { // {{{
 		size_t accum = std::hash<A>{}(k.first);
 		return mata::utils::hash_combine(accum, k.second);
-	} // operator() }}}
-};
-
-/**
- * @brief  A hasher for sets
- */
-template <class A> struct hash<std::set<A>> {
-	inline size_t operator()(const std::set<A>& cont) const { // {{{
-		return mata::utils::hash_range(cont.begin(), cont.end());
-	} // operator() }}}
-};
-
-/**
- * @brief  A hasher for vectors
- */
-template <class A> struct hash<std::vector<A>> {
-	inline size_t operator()(const std::vector<A>& cont) const { // {{{
-		return mata::utils::hash_range(cont.begin(), cont.end());
 	} // operator() }}}
 };
 

--- a/include/mata/utils/utils.hh
+++ b/include/mata/utils/utils.hh
@@ -211,6 +211,17 @@ template <class A> struct VectorHash {
 	size_t operator()(const std::vector<A>& cont) const { return hash_range(cont.begin(), cont.end()); }
 };
 
+/**
+ * @brief A hasher for @c std::pair, usable as the @c Hash template argument of unordered containers.
+ *
+ * @note See @c SetHash for why we do not specialize @c std::hash<std::pair<A, B>> directly.
+ */
+template <class A, class B> struct PairHash {
+	size_t operator()(const std::pair<A, B>& pair) const {
+		return hash_combine(std::hash<A>{}(pair.first), pair.second);
+	}
+};
+
 /// checks whether a container with @p find contains a key
 template <class T, class K> inline bool haskey(const T& cont, const K& key) { return cont.find(key) != cont.cend(); }
 
@@ -325,21 +336,6 @@ template <class Vector> void inline sort_and_rmdupl(Vector& vec) {
 
 // Some things that need to go to std
 namespace std { // {{{
-
-/**
- * @brief  A hasher for pairs
- *
- * @note This is, strictly speaking, the same kind of library-namespace pollution as the @c std::set / @c std::vector
- *  hashers we moved to @c mata::utils::SetHash / @c mata::utils::VectorHash (see #628). It stays here for now
- *  because @c std::pair<State, State> is used as a key of several @c public API @c std::unordered_map parameters
- *  (e.g. product maps), so hiding it would require changing those public signatures; left as follow-up work.
- */
-template <class A, class B> struct hash<std::pair<A, B>> {
-	inline size_t operator()(const std::pair<A, B>& k) const { // {{{
-		size_t accum = std::hash<A>{}(k.first);
-		return mata::utils::hash_combine(accum, k.second);
-	} // operator() }}}
-};
 
 /*#######################################################
  #                  std::to_string(TYPE)

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -23,7 +23,7 @@ bool mata::nfa::algorithms::is_included_naive(
 		bigger_cmpl = complement(bigger, *alphabet);
 	}
 
-	std::unordered_map<std::pair<State, State>, State> prod_map;
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
 	Nfa nfa_isect = intersection(smaller, bigger_cmpl, Limits::max_symbol, &prod_map);
 
 	bool result = nfa_isect.is_lang_empty(cex);

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -1051,7 +1051,7 @@ Nfa mata::nfa::product(
 	const Nfa& rhs,
 	const ProductFinalStateCondition final_condition,
 	const Symbol first_epsilon,
-	std::unordered_map<std::pair<State, State>, State>* prod_map
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map
 ) {
 	std::function<bool(const State, const State)> is_product_state_final_func;
 	if (final_condition == ProductFinalStateCondition::Or) {
@@ -1077,7 +1077,7 @@ Nfa mata::nfa::intersection(
 	const Nfa& lhs,
 	const Nfa& rhs,
 	const Symbol first_epsilon,
-	std::unordered_map<std::pair<State, State>, State>* prod_map
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* prod_map
 ) {
 	return product(lhs, rhs, ProductFinalStateCondition::And, first_epsilon, prod_map);
 }
@@ -1569,8 +1569,12 @@ Nfa mata::nfa::lang_difference(
 ) {
 	std::unordered_set<StateSet> subset_set_included{};
 	std::unordered_set<StateSet> subset_set_excluded{};
+	using SubsetMacrostatePair =
+		std::pair<std::unordered_set<StateSet>::const_pointer, std::unordered_set<StateSet>::const_pointer>;
 	using SubsetMacrostateMap = std::unordered_map<
-		std::pair<std::unordered_set<StateSet>::const_pointer, std::unordered_set<StateSet>::const_pointer>, State>;
+		SubsetMacrostatePair, State,
+		mata::utils::PairHash<
+			std::unordered_set<StateSet>::const_pointer, std::unordered_set<StateSet>::const_pointer>>;
 	SubsetMacrostateMap subset_macrostate_map{};
 	std::vector<SubsetMacrostateMap::const_pointer> worklist{};
 

--- a/src/nfa/product.cc
+++ b/src/nfa/product.cc
@@ -19,7 +19,7 @@ Nfa mata::nfa::algorithms::product(
 	const Nfa& rhs,
 	const std::function<bool(State, State)>&& final_condition,
 	const Symbol first_epsilon,
-	std::unordered_map<std::pair<State, State>, State>* product_map
+	std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>* product_map
 ) {
 	Nfa product{}; // The product automaton.
 	utils::TwoDimensionalMap<State> product_storage{lhs.num_of_states(), rhs.num_of_states()};

--- a/src/nft/intersection.cc
+++ b/src/nft/intersection.cc
@@ -12,7 +12,7 @@
 using namespace mata::nft;
 
 namespace {
-using ProductMap = std::unordered_map<std::pair<State, State>, State>;
+using ProductMap = std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>>;
 } // Anonymous namespace.
 
 namespace mata::nft {

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -696,7 +696,7 @@ StateSet Nft::post(
 	std::vector<size_t> end_positions(tape_symbols.size());
 	for (size_t i = 0; i < tape_symbols.size(); ++i) { end_positions[i] = tape_symbols[i].size(); }
 
-	std::unordered_map<std::vector<size_t>, uint32_t> position_ids;
+	std::unordered_map<std::vector<size_t>, uint32_t, VectorHash<size_t>> position_ids;
 	std::vector<const std::vector<size_t>*> id_to_positions;
 	auto intern = [&](const std::vector<size_t>& positions) -> uint32_t {
 		const auto [it, inserted]{position_ids.try_emplace(positions, static_cast<uint32_t>(id_to_positions.size()))};

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -998,7 +998,7 @@ Nft nft::invert_levels(const Nft& aut, const JumpMode jump_mode) {
 		// Auxiliary state between two states can be reused for transitions over different symbols.
 		// The key is a pair of source and target states.
 		// auxiliary_states map will be used only if the jump_mode is JumpMode::AppendDontCares.
-		std::unordered_map<std::pair<State, State>, State> auxiliary_states;
+		std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> auxiliary_states;
 		auto get_aux_state = [&](const State src, const State tgt, const Level level) {
 			const std::pair<State, State> key{src, tgt};
 			if (!auxiliary_states.contains(key)) { auxiliary_states[key] = aut_inv.add_state_with_level(level); }

--- a/tests/nfa/nfa-product.cc
+++ b/tests/nfa/nfa-product.cc
@@ -56,7 +56,7 @@ using namespace mata::parser;
 TEST_CASE("mata::nfa::intersection()")
 { // {{{
     Nfa a, b, res;
-    std::unordered_map<std::pair<State, State>, State> prod_map;
+    std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
 
     SECTION("Intersection of empty automata")
     {
@@ -173,7 +173,7 @@ TEST_CASE("mata::nfa::intersection()")
 
 TEST_CASE("mata::nfa::intersection() with preserving epsilon transitions")
 {
-    std::unordered_map<std::pair<State, State>, State> prod_map;
+    std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
 
     Nfa a{6};
     a.initial.insert(0);

--- a/tests/nft/nft-intersection.cc
+++ b/tests/nft/nft-intersection.cc
@@ -56,7 +56,7 @@ using namespace mata::parser;
 TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares")
 { // {{{
     Nft a, b, res;
-    std::unordered_map<std::pair<State, State>, State> prod_map;
+    std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
 
     SECTION("Intersection of empty automata")
     {
@@ -264,7 +264,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
             b.delta.add(2, 'b', 3);
             b.delta.add(3, 'a', 4);
 
-            std::unordered_map<std::pair<State, State>, State> prod_map;
+            std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
             Nft res = intersection(a, b, &prod_map, JumpMode::AppendDontCares);
 
             REQUIRE(!res.initial.empty());
@@ -431,7 +431,7 @@ TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::AppendDontCares
 
 TEST_CASE("mata::nft::intersection() with jump_mode == JumpMode::RepeatSymbol") {
     Nft a, b, res;
-    std::unordered_map<std::pair<State, State>, State> prod_map;
+    std::unordered_map<std::pair<State, State>, State, mata::utils::PairHash<State, State>> prod_map;
 
     SECTION("Intersection of empty automata")
     {

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -203,3 +203,15 @@ TEST_CASE("mata::utils::SetHash and mata::utils::VectorHash") {
     const std::unordered_map<std::vector<int>, int, VectorHash<int>> map{ { { 1, 2, 3 }, 42 } };
     CHECK(map.at({ 1, 2, 3 }) == 42);
 }
+
+TEST_CASE("mata::utils::PairHash") {
+    // #628: mata must not specialize std::hash for std::pair<A, B> for arbitrary A/B, since A/B may not be a
+    //  program-defined type. PairHash is the replacement, usable as the explicit Hash argument of unordered
+    //  containers.
+    const PairHash<int, int> pair_hasher{};
+    CHECK(pair_hasher({ 1, 2 }) == pair_hasher({ 1, 2 }));
+    CHECK(pair_hasher({ 1, 2 }) != pair_hasher({ 2, 1 }));
+
+    const std::unordered_map<std::pair<int, int>, int, PairHash<int, int>> map{ { { 1, 2 }, 42 } };
+    CHECK(map.at({ 1, 2 }) == 42);
+}

--- a/tests/ord-vector.cc
+++ b/tests/ord-vector.cc
@@ -1,6 +1,9 @@
 /* tests-ord-vector.cc -- tests of OrdVector
  */
 
+#include <unordered_map>
+#include <unordered_set>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
@@ -168,4 +171,35 @@ TEST_CASE("mata::utils::OrdVector::at()") {
         CHECK(vec.at(4) == 99);
         CHECK_THROWS_AS(vec.at(5), std::out_of_range);
     }
+}
+
+TEST_CASE("std::hash<mata::utils::OrdVector<Key>>") {
+    const OrdVector<int> vec1{ 1, 2, 3 };
+    const OrdVector<int> vec2{ 3, 2, 1 }; // Same elements, different insertion order.
+    const OrdVector<int> vec3{ 1, 2, 4 };
+    const std::hash<OrdVector<int>> hasher{};
+
+    CHECK(hasher(vec1) == hasher(vec2));
+    CHECK(hasher(vec1) != hasher(vec3));
+
+    // Usable as an unordered_set element without any extra Hash argument, since it is a legitimate
+    //  program-defined std::hash specialization (unlike hashing std::set/std::vector directly, see #628).
+    std::unordered_set<OrdVector<int>> set{ vec1, vec2, vec3 };
+    CHECK(set.size() == 2);
+}
+
+TEST_CASE("mata::utils::SetHash and mata::utils::VectorHash") {
+    // #628: mata must not specialize std::hash for std::set<A>/std::vector<A> for arbitrary A, since A may not be a
+    //  program-defined type. SetHash/VectorHash are the replacement, usable as the explicit Hash argument of
+    //  unordered containers.
+    const SetHash<int> set_hasher{};
+    CHECK(set_hasher(std::set<int>{ 1, 2, 3 }) == set_hasher(std::set<int>{ 3, 2, 1 }));
+    CHECK(set_hasher(std::set<int>{ 1, 2, 3 }) != set_hasher(std::set<int>{ 1, 2, 4 }));
+
+    const VectorHash<int> vector_hasher{};
+    CHECK(vector_hasher(std::vector<int>{ 1, 2, 3 }) == vector_hasher(std::vector<int>{ 1, 2, 3 }));
+    CHECK(vector_hasher(std::vector<int>{ 1, 2, 3 }) != vector_hasher(std::vector<int>{ 3, 2, 1 }));
+
+    const std::unordered_map<std::vector<int>, int, VectorHash<int>> map{ { { 1, 2, 3 }, 42 } };
+    CHECK(map.at({ 1, 2, 3 }) == 42);
 }


### PR DESCRIPTION
Specializing `std::hash` for `std::set<A>`/`std::vector<A>` with an arbitrary (possibly built-in) `A` is undefined behavior: the standard only allows program-defined specializations of standard templates when at least one template argument is program-defined. It also means users can transparently observe mata's hasher through e.g. `std::hash<std::set<unsigned>>`, even without touching mata types.

Replaces the `std::set`/`std::vector` specializations with `mata::utils::SetHash` and `mata::utils::VectorHash`, usable as the explicit Hash template argument of unordered containers, and updates the two internal call sites (OrdVector's own `std::hash` specialization, and a local unordered_map in `Nft::lookahead`) accordingly.

`std::hash<std::pair<A, B>>` is left as-is for now: it backs the Hash argument of several public API `std::unordered_map<std::pair<State, State>, State>` parameters (product maps), so removing it would require changing those public signatures.

Refs https://github.com/VeriFIT/mata/issues/628.