### PR TITLE
binding,github,docs: +fix Use python3/pip3 instead of python/pip

### DIFF
--- a/.github/workflows/actions/docs/action.yml
+++ b/.github/workflows/actions/docs/action.yml
@@ -20,12 +20,12 @@ runs:
     - name: Install Python Dependencies for documentation build
       shell: bash
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         make -C docs init
     - uses: ssciwr/doxygen-install@v1
     - name: Compile the documentation
       shell: bash
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         make docs
         make -C docs/ html

--- a/.github/workflows/actions/setup-python/action.yml
+++ b/.github/workflows/actions/setup-python/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Install Python Dependencies
       shell: bash
       run: |
-        python -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip
         make -C bindings/python init
     - name: Building MacOS dependencies
       if: ${{ inputs.os == 'macos-latest' }}

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -45,7 +45,7 @@ If you plan to use the existing benchmarking infrastructure in `./tests-integrat
 
 ```sh
 python3 -m venv .venv
-pip install ./tests-integration/
+pip3 install ./tests-integration/
 source .venv/bin/activate
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ uv sync --python 3.13
 Or using `pip`:
 
 ```shell
-python -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 make -C bindings/python init
 
 sudo apt -qq update

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -2,28 +2,28 @@
 jobs=6
 
 build-ext:
-	python setup.py build_ext -i -j$(jobs)
+	python3 setup.py build_ext -i -j$(jobs)
 
 build-ext-force:
-	python setup.py build_ext -fi -j$(jobs)
+	python3 setup.py build_ext -fi -j$(jobs)
 
 build-dist:
-	python setup.py sdist
+	python3 setup.py sdist
 
 install:
-	python setup.py build_ext -fi
-	python setup.py install --force
+	python3 setup.py build_ext -fi
+	python3 setup.py install --force
 
 test:
-	python -m pytest --durations=5 --cov=./ --cov-report term-missing:skip-covered tests/
+	python3 -m pytest --durations=5 --cov=./ --cov-report term-missing:skip-covered tests/
 
 init:
-	pip install ./
+	pip3 install ./
 
 build-install: build-ext install
 
 pypi-release:
-	python setup.py sdist
+	python3 setup.py sdist
 
 clean:
 	find . -type d \( -name "__pycache__" -o -name "*.egg-info" \) -exec rm -rf {} +


### PR DESCRIPTION
A fresh system may not have `python`/`pip` on PATH (only `python3`/`pip3`), so using the unversioned names in the Python binding's build configuration made building from source fail unnecessarily.

Fixes https://github.com/VeriFIT/mata/issues/338.