### PR TITLE
tests-integration: +fix Correct post-mintermization alphabet type

### DIFF
--- a/tests-integration/src/utils/utils.cc
+++ b/tests-integration/src/utils/utils.cc
@@ -58,7 +58,8 @@ int load_automata(
 			std::vector<mata::IntermediateAut> mintermized = mintermization.mintermize(inter_auts);
 			TIME_END(mintermization);
 			for (mata::IntermediateAut& inter_aut : mintermized) {
-				assert(inter_aut.alphabet_type == mata::IntermediateAut::AlphabetType::Bitvector);
+				// Mintermization always rewrites the alphabet to Explicit (see Mintermization::mintermize()).
+				assert(inter_aut.alphabet_type == mata::IntermediateAut::AlphabetType::Explicit);
 				auts.push_back(mata::nfa::builder::construct(inter_aut, &alphabet));
 			}
 		}


### PR DESCRIPTION
`load_automata()` asserted `alphabet_type == Bitvector` on the result of `Mintermization::mintermize()`, but `mintermize()` always rewrites `alphabet_type` to `Explicit`. The assertion, therefore, failed on essentially any batch of bitvector automata, e.g.:
```shell
bench-bool-comb-cox-inter automata/b-param-easy/aut0.mata automata/b-param-easy/aut1.mata
```

Fixes https://github.com/VeriFIT/mata/issues/350.