### PR TITLE
github: +fix Correct invalid GitHub Actions pull_request.base_ref

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
           # fetch-depth: 0
           # If PR, checkout the PR's repo (needed for PRs coming from forks).
           repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.base.sha || github.event.pull_request.base_ref || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.event.pull_request.base.ref || github.sha }}
       - uses: ./.github/workflows/actions/setup
         with:
           os: ${{ matrix.os }}
@@ -109,7 +109,7 @@ jobs:
   #         # fetch-depth: 0
   #         # If PR, checkout the PR's repo (needed for PRs coming from forks).
   #         repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
-  #         ref: ${{ github.event.pull_request.base.sha || github.event.pull_request.base_ref || github.sha }}
+  #         ref: ${{ github.event.pull_request.base.sha || github.event.pull_request.base.ref || github.sha }}
   #     - uses: ./.github/workflows/actions/setup
   #       with:
   #         os: ${{ matrix.os }}


### PR DESCRIPTION
`github.event.pull_request.base_ref` is not a real Actions context field (the correct path is `base.ref`); it was only ever reached as a dead fallback since `base.sha` is always populated for `pull_request` events, but the field name itself was wrong.

Refs #304.