### PR TITLE
github: +fix Run code coverage on pushes to base branches too

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,26 @@
+name: Code Coverage
+on:
+  pull_request:
+  push:
+    # Also run on pushes to the branches PRs are based on, so Codecov has an up-to-date report for the actual
+    #  latest commit on the base branch to compare PRs against (see #323).
+    branches: [master, devel]
+jobs:
+  code-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0
+          # If PR, checkout the PR's repo (needed for PRs coming from forks).
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: ./.github/workflows/actions/setup
+      - name: Build library for coverage
+        run: make coverage
+      - name: Test the library
+        run: make test
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          gcov: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -252,25 +252,6 @@ jobs:
           if [ $number_of_warnings -gt 0 ]; then
             exit 1
           fi
-  code-coverage:
-    runs-on: ubuntu-latest
-    needs: run-tests-cpp
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          # fetch-depth: 0
-          # If PR, checkout the PR's repo (needed for PRs coming from forks).
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: ./.github/workflows/actions/setup
-      - name: Build library for coverage
-        run: make coverage
-      - name: Test the library
-        run: make test
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v5
-        with:
-          gcov: true
   format-check:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Codecov compared a PR's coverage against the wrong base commit (see PR https://github.com/VeriFIT/mata/pull/322): the coverage job only ran on `pull_request`, so Codecov never received a report keyed to the base branch's actual HEAD, only whatever commit happened to be checked out during some earlier PR run.

Move the coverage job into its own workflow, triggered on both `pull_request` and push to master/devel (the two branches PRs target), so every push to a base branch uploads a coverage report tied to its real commit.

Fixes https://github.com/VeriFIT/mata/issues/323.