### PR TITLE
nfa: +feat Add counterexample output param to are_equivalent()

### DIFF
--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -1123,10 +1123,17 @@ inline bool is_included(
  * @param[in] alphabet Alphabet of both NFAs to compute with.
  * @param[in] params[ Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
+ * @param[out] cex If not null and @p lhs and @p rhs are not equivalent, filled with a witness word: a word in the
+ *  language of one of @p lhs/@p rhs but not the other (as also produced by @c is_included() for whichever direction
+ *  of inclusion fails first). Left untouched if @p lhs and @p rhs are equivalent.
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
 bool are_equivalent(
-	const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet, const ParameterMap& params = {{"algorithm", "antichains"}}
+	const Nfa& lhs,
+	const Nfa& rhs,
+	const Alphabet* alphabet,
+	const ParameterMap& params = {{"algorithm", "antichains"}},
+	Run* cex = nullptr
 );
 
 /**
@@ -1144,9 +1151,13 @@ bool are_equivalent(
  * @param[in] rhs Second automaton to concatenate.
  * @param[in] params Optional parameters to control the equivalence check algorithm:
  * - "algorithm": "naive", "antichains" (Default: "antichains")
+ * @param[out] cex If not null and @p lhs and @p rhs are not equivalent, filled with a witness word: a word in the
+ *  language of one of @p lhs/@p rhs but not the other. Left untouched if @p lhs and @p rhs are equivalent.
  * @return True if @p lhs and @p rhs are equivalent, false otherwise.
  */
-bool are_equivalent(const Nfa& lhs, const Nfa& rhs, const ParameterMap& params = {{"algorithm", "antichains"}});
+bool are_equivalent(
+	const Nfa& lhs, const Nfa& rhs, const ParameterMap& params = {{"algorithm", "antichains"}}, Run* cex = nullptr
+);
 
 /// Reverting the automaton by one of the three functions below,
 /// currently simple_revert seems best (however, not tested enough).

--- a/src/nfa/inclusion.cc
+++ b/src/nfa/inclusion.cc
@@ -237,10 +237,12 @@ bool mata::nfa::algorithms::is_included_antichains(
 namespace {
 using AlgoType = decltype(algorithms::is_included_naive)*;
 
-bool compute_equivalence(const Nfa& lhs, const Nfa& rhs, const mata::Alphabet* const alphabet, const AlgoType& algo) {
+bool compute_equivalence(
+	const Nfa& lhs, const Nfa& rhs, const mata::Alphabet* const alphabet, const AlgoType& algo, Run* const cex
+) {
 	// alphabet should not be needed as input parameter
-	if (algo(lhs, rhs, alphabet, nullptr)) {
-		if (algo(rhs, lhs, alphabet, nullptr)) { return true; }
+	if (algo(lhs, rhs, alphabet, cex)) {
+		if (algo(rhs, lhs, alphabet, cex)) { return true; }
 	}
 
 	return false;
@@ -284,20 +286,22 @@ bool mata::nfa::is_included(
 	return algo(smaller, bigger, alphabet, cex);
 } // is_included }}}
 
-bool mata::nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet, const ParameterMap& params) {
+bool mata::nfa::are_equivalent(
+	const Nfa& lhs, const Nfa& rhs, const Alphabet* alphabet, const ParameterMap& params, Run* const cex
+) {
 	// TODO: add comment on what this is doing, what is __func__ ...
 	AlgoType algo{set_algorithm(std::to_string(__func__), params)};
 
 	if (params.at("algorithm") == "naive") {
 		if (alphabet == nullptr) {
 			const auto computed_alphabet{create_alphabet(lhs, rhs)};
-			return compute_equivalence(lhs, rhs, &computed_alphabet, algo);
+			return compute_equivalence(lhs, rhs, &computed_alphabet, algo, cex);
 		}
 	}
 
-	return compute_equivalence(lhs, rhs, alphabet, algo);
+	return compute_equivalence(lhs, rhs, alphabet, algo, cex);
 }
 
-bool mata::nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const ParameterMap& params) {
-	return are_equivalent(lhs, rhs, nullptr, params);
+bool mata::nfa::are_equivalent(const Nfa& lhs, const Nfa& rhs, const ParameterMap& params, Run* const cex) {
+	return are_equivalent(lhs, rhs, nullptr, params, cex);
 }

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -2724,6 +2724,82 @@ TEST_CASE("mata::nfa::are_equivalent")
     }
 }
 
+TEST_CASE("mata::nfa::are_equivalent() counterexample") {
+    OnTheFlyAlphabet alph{ std::vector<std::string>{ "a", "b" } };
+    ParameterMap params;
+
+    const std::unordered_set<std::string> ALGORITHMS = { "naive", "antichains" };
+
+    SECTION("equivalent automata leave cex untouched") {
+        Nfa aut1(1), aut2(2);
+        aut1.initial = {0};
+        aut1.final = {0};
+        aut1.delta.add(0, alph["a"], 0);
+        aut2.initial = {0};
+        aut2.final = {0, 1};
+        aut2.delta.add(0, alph["a"], 1);
+        aut2.delta.add(1, alph["a"], 1);
+
+        for (const auto& algo : ALGORITHMS) {
+            params["algorithm"] = algo;
+            Run cex;
+            CHECK(are_equivalent(aut1, aut2, &alph, params, &cex));
+            CHECK(cex.word.empty());
+        }
+    }
+
+    SECTION("lhs accepts a word rhs does not: cex witnesses the difference") {
+        // lhs: a*, rhs: {epsilon} -- not equivalent, lhs accepts "a" which rhs does not.
+        Nfa lhs(1), rhs(1);
+        lhs.initial = {0};
+        lhs.final = {0};
+        lhs.delta.add(0, alph["a"], 0);
+        rhs.initial = {0};
+        rhs.final = {0};
+
+        for (const auto& algo : ALGORITHMS) {
+            params["algorithm"] = algo;
+            Run cex;
+            CHECK(!are_equivalent(lhs, rhs, &alph, params, &cex));
+            // The witness must be in exactly one of the two languages.
+            CHECK(lhs.is_in_lang(cex) != rhs.is_in_lang(cex));
+        }
+    }
+
+    SECTION("rhs accepts a word lhs does not: cex witnesses the difference") {
+        // lhs: {epsilon}, rhs: a* -- the reverse of the above.
+        Nfa lhs(1), rhs(1);
+        lhs.initial = {0};
+        lhs.final = {0};
+        rhs.initial = {0};
+        rhs.final = {0};
+        rhs.delta.add(0, alph["a"], 0);
+
+        for (const auto& algo : ALGORITHMS) {
+            params["algorithm"] = algo;
+            Run cex;
+            CHECK(!are_equivalent(lhs, rhs, &alph, params, &cex));
+            CHECK(lhs.is_in_lang(cex) != rhs.is_in_lang(cex));
+        }
+    }
+
+    SECTION("alphabet-less overload also fills cex") {
+        Nfa lhs(1), rhs(1);
+        lhs.initial = {0};
+        lhs.final = {0};
+        lhs.delta.add(0, alph["a"], 0);
+        rhs.initial = {0};
+        rhs.final = {0};
+
+        for (const auto& algo : ALGORITHMS) {
+            params["algorithm"] = algo;
+            Run cex;
+            CHECK(!are_equivalent(lhs, rhs, params, &cex));
+            CHECK(lhs.is_in_lang(cex) != rhs.is_in_lang(cex));
+        }
+    }
+}
+
 TEST_CASE("mata::nfa::revert()")
 { // {{{
     Nfa aut(9);


### PR DESCRIPTION
`is_included()` already exposes a `Run* cex` for the failing direction, but `are_equivalent()` discarded the witness the underlying `is_included_naive`/`is_included_antichains` algorithms already compute internally. 

Add a trailing `Run* cex = nullptr` parameter to both `are_equivalent()` overloads (appended after the existing defaulted params, rather than inserted where `is_included()` puts it, to avoid an overload-resolution ambiguity with existing nullptr-literal call sites such as `are_equivalent(lhs, rhs, nullptr, params)`).

Fixes https://github.com/VeriFIT/mata/issues/439.