### PR TITLE
nft: +fix Stop leaking local containers on malformed exceptions

### DIFF
--- a/src/nft/builder.cc
+++ b/src/nft/builder.cc
@@ -19,11 +19,8 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
 		throw std::runtime_error(std::string(__FUNCTION__) + ": expecting type \"" + TYPE_NFT + "\"");
 	}
 
-	bool remove_state_map = false;
-	if (nullptr == state_map) {
-		state_map = new NameStateMap();
-		remove_state_map = true;
-	}
+	NameStateMap tmp_state_map;
+	if (nullptr == state_map) { state_map = &tmp_state_map; }
 
 	// a lambda for translating state names to identifiers
 	auto get_state_name = [&](const std::string& str) {
@@ -34,11 +31,6 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
 		} else {
 			return (*state_map)[str];
 		}
-	};
-
-	// a lambda for cleanup
-	auto clean_up = [&]() {
-		if (remove_state_map) { delete state_map; }
 	};
 
 	auto it = parsec.dict.find("Initial");
@@ -102,9 +94,6 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
 
 	for (const auto& body_line : parsec.body) {
 		if (body_line.size() != 3) {
-			// clean up
-			clean_up();
-
 			if (body_line.size() == 2) {
 				throw std::runtime_error("Epsilon transitions not supported: " + std::to_string(body_line));
 			} else {
@@ -117,9 +106,6 @@ Nft builder::construct(const mata::parser::ParsedSection& parsec, mata::Alphabet
 		const State target = get_state_name(body_line[2]);
 		aut.delta.add(source, symbol, target);
 	}
-
-	// do the dishes and take out garbage
-	clean_up();
 
 	return aut;
 } // construct().

--- a/src/nft/operations.cc
+++ b/src/nft/operations.cc
@@ -1342,11 +1342,8 @@ Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset
 
 	// Assuming all sets targets are non-empty.
 	std::vector<std::pair<State, StateSet>> worklist{};
-	bool deallocate_subset_map = false;
-	if (subset_map == nullptr) {
-		subset_map = new std::unordered_map<StateSet, State>{};
-		deallocate_subset_map = true;
-	}
+	std::unordered_map<StateSet, State> subset_map_local{};
+	if (subset_map == nullptr) { subset_map = &subset_map_local; }
 
 	const StateSet sources_init{nft.initial};
 	const State source_init_res{result.add_state()};
@@ -1355,10 +1352,7 @@ Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset
 	if (nft.final.intersects_with(sources_init)) { result.final.insert(source_init_res); }
 	worklist.emplace_back(source_init_res, sources_init);
 
-	if (nft.delta.empty()) {
-		if (deallocate_subset_map) { delete subset_map; }
-		return result;
-	}
+	if (nft.delta.empty()) { return result; }
 
 	(*subset_map)[sources_init] = source_init_res;
 
@@ -1434,7 +1428,6 @@ Nft nft::determinize(const Nft& nft, std::unordered_map<StateSet, State>* subset
 		}
 	}
 
-	if (deallocate_subset_map) { delete subset_map; }
 	return result;
 }
 


### PR DESCRIPTION
builder::construct(const ParsedSection&, ...) heap-allocated a NameStateMap when the caller didn't supply one, freeing it only via a clean_up() lambda called at the two normal exit points. Several throws inside the "Levels"/"LevelsNum" parsing (bad colon count, negative or unparsable level) happen before clean_up() is ever reached, leaking the map on any malformed .mata input.

Switch to the same stack-allocated tmp_state_map pattern already used by the other construct() overloads in this file, which needs no cleanup on any exit path.

determinize() used raw new/delete for an optional caller-supplied subset_map, only deleted on normal fall-through. Anything thrown inside the main worklist loop (e.g. bad_alloc) would leak it.

Mirror nfa::determinize()'s existing safe pattern: a stack-allocated local map that subset_map points to when the caller passes nullptr, so there is nothing to clean up on any exit path.