### PR TITLE
nfa,nft: +feat Add Nfa::add_transition() using a symbol name

### DIFF
--- a/bindings/python/libmata/nft/nft.pxd
+++ b/bindings/python/libmata/nft/nft.pxd
@@ -97,8 +97,8 @@ cdef extern from "mata/nft/nft.hh" namespace "mata::nft":
         size_t num_of_states_with_level(Level)
         State insert_word(State, vector[Symbol]&, State) except +
         State insert_word(State, vector[Symbol]&) except +
-        State add_transition(State, vector[Symbol]&, State) except +
-        State add_transition(State, vector[Symbol]&) except +
+        State add_transition_by_levels(State, vector[Symbol]&, State) except +
+        State add_transition_by_levels(State, vector[Symbol]&) except +
         State add_transition_with_length(State, Symbol, size_t, CJumpMode) except +
         void add_transition_with_target(State, Symbol, State, CJumpMode) except +
         void add_transition_with_same_level_targets(State, Symbol, StateSet&, CJumpMode) except +

--- a/bindings/python/libmata/nft/nft.pyx
+++ b/bindings/python/libmata/nft/nft.pyx
@@ -441,8 +441,8 @@ cdef class Nft:
         """
         cdef vector[Symbol] c_symbols = symbols
         if target is None:
-            return self.thisptr.get().add_transition(source, c_symbols)
-        return self.thisptr.get().add_transition(source, c_symbols, target)
+            return self.thisptr.get().add_transition_by_levels(source, c_symbols)
+        return self.thisptr.get().add_transition_by_levels(source, c_symbols, target)
 
     def add_transition_with_length(self, State source, Symbol symbol, size_t length, jump_mode = JumpMode.RepeatSymbol):
         """Add a single NFT transition with `length`, creating a new target state.

--- a/examples/nft.cc
+++ b/examples/nft.cc
@@ -23,7 +23,7 @@ int main() {
 	// nft.final.insert(nft.add_state_with_level(1));
 
 	// Transduce one symbol on each tape.
-	State next_state{nft.add_transition(initial, {'a', 'A'})};
+	State next_state{nft.add_transition_by_levels(initial, {'a', 'A'})};
 	// Then transduce a sequence of 'bc' to 'BC'.
 	next_state = nft.insert_word(next_state, {'b', 'B', 'c', 'C'});
 	// Then transduce a sequence 'd' to 'DEF' (non-length-preserving operation).
@@ -54,7 +54,7 @@ int main() {
 	nft2.initial.insert(initial2);
 	State final2{nft2.add_state()};
 	nft2.final.insert(final2);
-	State next2{nft2.add_transition(initial2, {'A', '1'})};
+	State next2{nft2.add_transition_by_levels(initial2, {'A', '1'})};
 	next2 = nft2.insert_word(next2, {'B', '2', 'C', '3'});
 	nft2.insert_word_by_levels(next2, {{'D'}, {'4', '5', '6'}}, final2);
 	nft2.insert_identity(final2, &alphabet);

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -175,6 +175,23 @@ class Nfa {
 	State add_state(State state);
 
 	/**
+	 * @brief Add a new transition from @p source to @p target labeled by the symbol named @p symbol_name.
+	 *
+	 * Convenience wrapper around @c delta.add(), translating @p symbol_name to a @c Symbol via the resolved
+	 *  alphabet instead of requiring the caller to call @c alphabet->translate_symb() themselves, i.e.,
+	 *  @c aut.add_transition(source, "my_symbol", target) instead of
+	 *  @c aut.delta.add(source, aut.alphabet->translate_symb("my_symbol"), target).
+	 *
+	 * @param[in] source Source state of the new transition.
+	 * @param[in] symbol_name Name of the symbol labeling the new transition, translated via the resolved alphabet.
+	 * @param[in] target Target state of the new transition.
+	 * @param[in] alphabet Alphabet to translate @p symbol_name with, taking precedence over @c this->alphabet when
+	 *  non-null.
+	 * @throws std::runtime_error If neither @p alphabet nor @c this->alphabet is set.
+	 */
+	void add_transition(State source, const std::string& symbol_name, State target, Alphabet* alphabet = nullptr);
+
+	/**
 	 * Inserts a @p word into the NFA from a source state @p source to a target state @p target.
 	 * Creates new states along the path of the @p word.
 	 *

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -359,7 +359,7 @@ class Nft : public nfa::Nfa {
 	 * @param target The target state where the NFT transition ends. @p target must already exist.
 	 * @return The target state @p target.
 	 */
-	State add_transition(State source, const std::vector<Symbol>& symbols, State target);
+	State add_transition_by_levels(State source, const std::vector<Symbol>& symbols, State target);
 
 	/**
 	 * @brief Add a single NFT transition to the NFT from a source state @p source to a newly created target state,
@@ -372,7 +372,7 @@ class Nft : public nfa::Nfa {
 	 * @param symbols The nonempty set of symbols, one for each tape to be inserted into the NFT.
 	 * @return The target state @p target.
 	 */
-	State add_transition(State source, const std::vector<Symbol>& symbols);
+	State add_transition_by_levels(State source, const std::vector<Symbol>& symbols);
 
 	/**
 	 * @brief Add a single NFT transition with a length @p length from a source state @p source
@@ -418,6 +418,34 @@ class Nft : public nfa::Nfa {
 	void add_transition_with_same_level_targets(
 		State source, Symbol symbol, const StateSet& targets, JumpMode jump_mode = JumpMode::RepeatSymbol
 	);
+
+	/**
+	 * @brief Add a new transition from @p source to @p target labeled by the symbol named @p symbol_name.
+	 *
+	 * Convenience wrapper mirroring @c Nfa::add_transition(), translating @p symbol_name to a @c Symbol via the
+	 *  resolved alphabet instead of requiring the caller to translate it themselves.
+	 *
+	 * Unlike the plain-@c Symbol overloads above, @p symbol_name is translated separately for each level the
+	 *  transition spans (i.e., @c levels[source], @c levels[next_level_after(levels[source])], ..., up to but
+	 *  excluding @c levels[target]), each via the alphabet resolved for that level (see @c resolve_alphabet):
+	 *  @p alphabet, when non-null, takes precedence over @c this->alphabets (used in @c AlphabetLevels::Mode
+	 *  ::MultiLevel via the level being translated for; ignored in @c Global mode) over @c this->alphabet.
+	 *
+	 * If every affected level translates @p symbol_name to the same @c Symbol, a single jump transition from
+	 *  @p source directly to @p target is added (no new states). Otherwise, since a single jump transition cannot
+	 *  carry a different symbol per level, the jump is unwound into a sequence of ordinary, single-level
+	 *  transitions, each carrying its own level's translation of @p symbol_name, through freshly created inner
+	 *  states.
+	 *
+	 * @param[in] source Source state of the new transition. Must already exist.
+	 * @param[in] symbol_name Name of the symbol labeling the new transition, translated separately for each level
+	 *  the transition spans.
+	 * @param[in] target Target state of the new transition. Must already exist.
+	 * @param[in] alphabet Alphabet to translate @p symbol_name with on every affected level, taking precedence over
+	 *  @c this->alphabets/@c this->alphabet when non-null.
+	 * @throws std::runtime_error If no alphabet is available to translate @p symbol_name for some affected level.
+	 */
+	void add_transition(State source, const std::string& symbol_name, State target, Alphabet* alphabet = nullptr);
 
 	/**
 	 * @brief Inserts a word, which is created by interleaving parts from @p word_parts_on_levels, into the NFT

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -747,6 +747,18 @@ State Nfa::add_state(const State state) {
 	return state;
 }
 
+void Nfa::add_transition(
+	const State source, const std::string& symbol_name, const State target, Alphabet* const alphabet
+) {
+	Alphabet* const resolved_alphabet{alphabet != nullptr ? alphabet : this->alphabet.get()};
+	if (resolved_alphabet == nullptr) {
+		throw std::runtime_error(
+			"Nfa::add_transition(): no alphabet available to translate symbol '" + symbol_name + "'"
+		);
+	}
+	delta.add(source, resolved_alphabet->translate_symb(symbol_name), target);
+}
+
 State Nfa::insert_word(const State source, const Word& word, const State target) {
 	assert(!word.empty());
 	assert(source < num_of_states());

--- a/src/nft/concatenation.cc
+++ b/src/nft/concatenation.cc
@@ -107,7 +107,7 @@ Nft algorithms::concatenate_eps(
 	const std::vector<Symbol> nft_epsilon(result.levels.num_of_levels, epsilon);
 	for (const auto& lhs_final_state : lhs.final) {
 		for (const auto& rhs_initial_state : rhs.initial) {
-			result.add_transition(lhs_final_state, nft_epsilon, rhs_states_renaming[rhs_initial_state]);
+			result.add_transition_by_levels(lhs_final_state, nft_epsilon, rhs_states_renaming[rhs_initial_state]);
 		}
 	}
 

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -1012,11 +1012,11 @@ State Nft::insert_word_by_levels(const State source, const std::vector<Word>& wo
 	return insert_word_by_levels(source, word_parts_on_levels, add_state_with_level(levels[source]));
 }
 
-State Nft::add_transition(const State source, const std::vector<Symbol>& symbols, const State target) {
+State Nft::add_transition_by_levels(const State source, const std::vector<Symbol>& symbols, const State target) {
 	return insert_word(source, symbols, target);
 }
 
-State Nft::add_transition(const State source, const std::vector<Symbol>& symbols) {
+State Nft::add_transition_by_levels(const State source, const std::vector<Symbol>& symbols) {
 	return insert_word(source, symbols);
 }
 
@@ -1092,6 +1092,56 @@ void Nft::add_transition_with_same_level_targets(
 	StatePost& mutable_inner_state_post = delta.mutable_state_post(inner_src);
 	assert(mutable_inner_state_post.find(symbol) == mutable_inner_state_post.end());
 	mutable_inner_state_post.insert(std::move(SymbolPost(symbol, targets)));
+}
+
+void Nft::add_transition(
+	const State source, const std::string& symbol_name, const State target, Alphabet* const alphabet
+) {
+	assert(source < num_of_states());
+	assert(target < num_of_states());
+
+	const Level source_level{levels[source]};
+	const Level target_level{levels[target]};
+	const size_t trans_len{(target_level == 0 ? levels.num_of_levels : target_level) - source_level};
+	assert(target_level == 0 || target_level > source_level);
+	assert(trans_len > 0);
+
+	// Resolve the alphabet for each level the transition spans (source_level, next_level_after(source_level), ...)
+	//  and translate symbol_name separately for each of them, since per-level alphabets (this->alphabets in
+	//  AlphabetLevels::Mode::MultiLevel) may translate the same name to a different Symbol on different levels.
+	auto resolve_level_alphabet{[&](const Level level) -> Alphabet& {
+		if (alphabet != nullptr) { return *alphabet; }
+		if (this->alphabets != nullptr) { return this->alphabets->for_level(level); }
+		if (this->alphabet != nullptr) { return *this->alphabet; }
+		throw std::runtime_error(
+			"Nft::add_transition(): no alphabet available to translate symbol '" + symbol_name + "' for level " +
+			std::to_string(level)
+		);
+	}};
+
+	std::vector<Symbol> level_symbols;
+	level_symbols.reserve(trans_len);
+	Level lvl{source_level};
+	for (size_t i{0}; i < trans_len; ++i, lvl = levels.next_level_after(lvl)) {
+		level_symbols.push_back(resolve_level_alphabet(lvl).translate_symb(symbol_name));
+	}
+
+	if (std::ranges::all_of(level_symbols, [&](const Symbol symb) { return symb == level_symbols.front(); })) {
+		// The affected levels agree on the translation of symbol_name: a single jump transition suffices.
+		delta.add(source, level_symbols.front(), target);
+		return;
+	}
+
+	// The affected levels disagree: unwind the jump into a sequence of ordinary, single-level transitions, each
+	//  carrying its own level's translation of symbol_name.
+	State inner_src{source};
+	lvl = levels.next_level_after(source_level);
+	for (size_t i{0}; i < trans_len - 1; ++i, lvl = levels.next_level_after(lvl)) {
+		const State inner_target{add_state_with_level(lvl)};
+		delta.add(inner_src, level_symbols[i], inner_target);
+		inner_src = inner_target;
+	}
+	delta.add(inner_src, level_symbols.back(), target);
 }
 
 Nft& Nft::insert_identity(const State state, const std::vector<Symbol>& symbols, const JumpMode jump_mode) {

--- a/tests/applications/strings/noodlification.cc
+++ b/tests/applications/strings/noodlification.cc
@@ -575,8 +575,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         x = create_from_regex("(a|b)*");
         y = create_from_regex("(a|b)*");
         t = Nft::with_levels(2, 1, { 0 }, { 0 });
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'b'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'b'}, 0);
         Nft copy = t;
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x)}, {std::make_shared<Nfa>(y)});
         REQUIRE(noodles.size() == 1);
@@ -594,8 +594,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
         t = Nft::with_levels(2, 1, {0}, {0});
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'b'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'b'}, 0);
         Nft copy = t;
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x)}, {std::make_shared<Nfa>(y), std::make_shared<Nfa>(z)});
         REQUIRE(noodles.size() == 1);
@@ -619,8 +619,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         y = create_from_regex("(a|b)*");
         z = create_from_regex("(a|b)*");
         t = Nft::with_levels(2, 1, { 0 }, { 0 });
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'b'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'b'}, 0);
         Nft copy = t;
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x), std::make_shared<Nfa>(z)}, {std::make_shared<Nfa>(y)});
         REQUIRE(noodles.size() == 1);
@@ -645,8 +645,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         z = create_from_regex("(a|b)*");
         w = create_from_regex("(a|b)*");
         t = Nft::with_levels(2, 1, {0}, {0});
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'b'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'b'}, 0);
         Nft copy = t;
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x), std::make_shared<Nfa>(z)}, {std::make_shared<Nfa>(y), std::make_shared<Nfa>(w)});
         REQUIRE(noodles.size() == 2);
@@ -712,8 +712,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         z = create_from_regex("(a|b)*");
         w = create_from_regex("a*");
         t = Nft::with_levels(2, 1, {0}, {0});
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'a'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'a'}, 0);
         Nft copy = t;
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x), std::make_shared<Nfa>(z)}, {std::make_shared<Nfa>(y)});
         REQUIRE(noodles.size() == 1);
@@ -737,8 +737,8 @@ TEST_CASE("mata::nfa::SegNfa::noodlify_for_transducer()") {
         y = create_from_regex("b+");
         z = create_from_regex("(a|b)*");
         t = Nft::with_levels(2, 1, { 0 }, { 0 });
-        t.add_transition(0, {'a', 'a'}, 0);
-        t.add_transition(0, {'b', 'a'}, 0);
+        t.add_transition_by_levels(0, {'a', 'a'}, 0);
+        t.add_transition_by_levels(0, {'b', 'a'}, 0);
         auto noodles = seg_nfa::noodlify_for_transducer(std::make_shared<Nft>(t), {std::make_shared<Nfa>(x), std::make_shared<Nfa>(z)}, {std::make_shared<Nfa>(y)});
         CHECK(noodles.empty());
     }

--- a/tests/nfa/nfa.cc
+++ b/tests/nfa/nfa.cc
@@ -4729,6 +4729,38 @@ TEST_CASE("mata::nfa::Nfa::get_word()") {
     }
 }
 
+TEST_CASE("mata::nfa::Nfa::add_transition()") {
+    SECTION("uses the automaton's own alphabet") {
+        Nfa aut(2);
+        aut.alphabet = std::make_shared<OnTheFlyAlphabet>(std::vector<std::string>{ "a", "b" });
+        aut.add_transition(0, "a", 1);
+        CHECK(aut.delta.contains(0, aut.alphabet->translate_symb("a"), 1));
+    }
+
+    SECTION("an explicit alphabet takes precedence over the automaton's own alphabet") {
+        Nfa aut(2);
+        OnTheFlyAlphabet own_alph{ std::vector<std::string>{ "a" } };
+        aut.alphabet = std::make_shared<OnTheFlyAlphabet>(own_alph);
+        OnTheFlyAlphabet override_alph{ std::vector<std::string>{ "z", "a" } };
+        aut.add_transition(0, "a", 1, &override_alph);
+        CHECK(aut.delta.contains(0, override_alph.translate_symb("a"), 1));
+        // The automaton's own alphabet must be untouched.
+        CHECK(!own_alph.get_alphabet_symbols().contains(override_alph.translate_symb("a")));
+    }
+
+    SECTION("an explicit alphabet works even without the automaton having one of its own") {
+        Nfa aut(2);
+        OnTheFlyAlphabet alph{ std::vector<std::string>{ "a" } };
+        aut.add_transition(0, "a", 1, &alph);
+        CHECK(aut.delta.contains(0, alph.translate_symb("a"), 1));
+    }
+
+    SECTION("throws when no alphabet is available at all") {
+        Nfa aut(2);
+        CHECK_THROWS_AS(aut.add_transition(0, "a", 1), std::runtime_error);
+    }
+}
+
 TEST_CASE("mata::nfa::Nfa::insert_word()") {
     Delta delta;
     delta.add(0, 0, 1);

--- a/tests/nft/nft.cc
+++ b/tests/nft/nft.cc
@@ -2896,9 +2896,9 @@ TEST_CASE("mata::nft::reduce_size_by_simulation()") {
         aut.add_state_with_level(1, 0);
         aut.initial = { 0 };
         aut.final = { 1 };
-        aut.add_transition(0, { 'a', 'a' }, 1);
-        aut.add_transition(0, { 'a', 'a' }, 1);
-        aut.add_transition(0, { 'a', 'a' }, 1);
+        aut.add_transition_by_levels(0, { 'a', 'a' }, 1);
+        aut.add_transition_by_levels(0, { 'a', 'a' }, 1);
+        aut.add_transition_by_levels(0, { 'a', 'a' }, 1);
         REQUIRE(aut.num_of_states() == 5);
         Nft result = reduce(aut, &state_renaming);
         CHECK(are_equivalent(result, aut));
@@ -3117,11 +3117,11 @@ TEST_CASE("mata::nft::remove_epsilon()") {
     SECTION("3 tapes") {
         Nft aut{ 4, { 0 }, { 2 } };
         aut.levels.num_of_levels = 3;
-        aut.add_transition(0, { 'a', 'a', 'a' }, 1);
-        aut.add_transition(0, { 'b', 'a', 'a' }, 3);
-        aut.add_transition(3, { 'a', 'a', 'a' }, 2);
-        aut.add_transition(1, { 'a', 'a', 'a' }, 2);
-        aut.add_transition(2, { 'c', 'b', 'd' }, 2);
+        aut.add_transition_by_levels(0, { 'a', 'a', 'a' }, 1);
+        aut.add_transition_by_levels(0, { 'b', 'a', 'a' }, 3);
+        aut.add_transition_by_levels(3, { 'a', 'a', 'a' }, 2);
+        aut.add_transition_by_levels(1, { 'a', 'a', 'a' }, 2);
+        aut.add_transition_by_levels(2, { 'c', 'b', 'd' }, 2);
         aut.remove_epsilon('a');
         REQUIRE(aut.delta[0].size() == 2);
         CHECK(aut.delta[0].to_vector()[0].symbol == 'b');
@@ -5318,10 +5318,10 @@ TEST_CASE("mata::nft::Nft::insert_word()") {
         }
     }
 
-    SECTION("add_transition()") {
+    SECTION("add_transition_by_levels()") {
         nft = Nft::with_levels(3);
-        nft.add_transition(0, { 'a', 'b', 'c' }, 1);
-        nft.add_transition(1, { 'd', 'e', 'f' }, 2);
+        nft.add_transition_by_levels(0, { 'a', 'b', 'c' }, 1);
+        nft.add_transition_by_levels(1, { 'd', 'e', 'f' }, 2);
 
         expected = Nft::with_levels({ 3, { 0, 0, 0, 1, 2, 1, 2 } }, {});
         expected.delta.add(0, 'a', 3);
@@ -5503,6 +5503,75 @@ TEST_CASE("mata::nft::Nft::insert_identity()") {
 
             CHECK(are_equivalent(nft, expected, JumpMode::RepeatSymbol));
         }
+    }
+}
+
+TEST_CASE("mata::nft::Nft::add_transition() using a symbol name") {
+    // 3-level NFT, source at level 0 and a pre-existing target at level 2: a jump spanning levels 0 and 1.
+    Nft nft{ Nft::with_levels({ 3, { 0, 0, 2 } }, 3) };
+    nft.initial.insert(0);
+    nft.final.insert(2);
+
+    SECTION("per-level alphabets translating to the same symbol on every affected level create a jump transition") {
+        auto a0 = std::make_shared<OnTheFlyAlphabet>();
+        auto a1 = std::make_shared<OnTheFlyAlphabet>();
+        auto a2 = std::make_shared<OnTheFlyAlphabet>();
+        // Both a0 and a1 assign "x" the same (first, default-initial) symbol value.
+        nft.alphabets = std::make_shared<AlphabetLevels>(
+            AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2 } });
+
+        nft.add_transition(0, "x", 2);
+
+        CHECK(nft.num_of_states() == 3);
+        CHECK(nft.delta.contains(0, a0->translate_symb("x"), 2));
+        CHECK(a0->translate_symb("x") == a1->translate_symb("x"));
+    }
+
+    SECTION("per-level alphabets translating to different symbols unwind the jump into a sequence of transitions") {
+        auto a0 = std::make_shared<OnTheFlyAlphabet>();
+        auto a1 = std::make_shared<OnTheFlyAlphabet>(std::vector<std::string>{ "y" });
+        auto a2 = std::make_shared<OnTheFlyAlphabet>();
+        // "x" is the first symbol on a0 (-> 0), but the second symbol on a1 (-> 1): they disagree.
+        nft.alphabets = std::make_shared<AlphabetLevels>(
+            AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a2 } });
+
+        nft.add_transition(0, "x", 2);
+
+        REQUIRE(nft.num_of_states() == 4);
+        const State inner{ 3 };
+        CHECK(nft.levels[inner] == 1);
+        CHECK(nft.delta.contains(0, a0->translate_symb("x"), inner));
+        CHECK(nft.delta.contains(inner, a1->translate_symb("x"), 2));
+        CHECK(a0->translate_symb("x") != a1->translate_symb("x"));
+    }
+
+    SECTION("an explicit alphabet takes precedence over this->alphabets on every affected level") {
+        auto a0 = std::make_shared<OnTheFlyAlphabet>();
+        auto a1 = std::make_shared<OnTheFlyAlphabet>(std::vector<std::string>{ "y" });
+        nft.alphabets = std::make_shared<AlphabetLevels>(
+            AlphabetLevels{ std::vector<std::shared_ptr<Alphabet>>{ a0, a1, a0 } });
+        OnTheFlyAlphabet override_alphabet{ std::vector<std::string>{ "x" } };
+
+        nft.add_transition(0, "x", 2, &override_alphabet);
+
+        // Using the same override_alphabet object for both affected levels always agrees, so a single jump
+        //  transition is created, ignoring this->alphabets entirely.
+        CHECK(nft.num_of_states() == 3);
+        CHECK(nft.delta.contains(0, override_alphabet.translate_symb("x"), 2));
+    }
+
+    SECTION("adjacent levels (no jump) add a single ordinary transition") {
+        OnTheFlyAlphabet alphabet{ std::vector<std::string>{ "x" } };
+        Nft adjacent{ Nft::with_levels({ 3, { 0, 1 } }, 2) };
+
+        adjacent.add_transition(0, "x", 1, &alphabet);
+
+        CHECK(adjacent.num_of_states() == 2);
+        CHECK(adjacent.delta.contains(0, alphabet.translate_symb("x"), 1));
+    }
+
+    SECTION("throws when no alphabet is available for some affected level") {
+        CHECK_THROWS_AS(nft.add_transition(0, "x", 2), std::runtime_error);
     }
 }
 


### PR DESCRIPTION
Per the design agreed upon in https://github.com/VeriFIT/mata/issues/587 (option 3: a plain std::string overload, no template), this PR adds an add_transition() overload that accepts symbol names instead of symbols for transitions.

Fixes https://github.com/VeriFIT/mata/issues/587.