### PR TITLE
treefmt: +fix Run `ruff check` before `ruff format`

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -65,7 +65,6 @@ includes = [
   "*.yml",
 ]
 options = ["--write"]
-priority = 10
 
 [formatter.ruff-check]
 command = "ruff"
@@ -78,6 +77,7 @@ command = "ruff"
 excludes = []
 includes = ["*.py", "*.pyi"]
 options = ["format", "--line-length", "120"]
+priority = 1
 
 [formatter.taplo]
 command = "taplo"

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -13,21 +13,20 @@
           excludes = [ "3rdparty/*" ];
           allow-missing-formatter = true;
         };
+        programs = {
+          prettier.enable = true;
 
-        programs.clang-format.enable = true;
-        programs.nixfmt.enable = true;
-        programs.yamlfmt.enable = true;
-        programs.taplo.enable = true;
+          clang-format.enable = true;
+          nixfmt.enable = true;
+          yamlfmt.enable = true;
+          taplo.enable = true;
 
-        programs.ruff-check.enable = true;
-        programs.ruff-format = {
-          enable = true;
-          lineLength = 120;
-        };
-
-        programs.prettier = {
-          enable = true;
-          priority = 10;
+          ruff-check.enable = true;
+          ruff-format = {
+            enable = true;
+            lineLength = 120;
+            priority = 1;
+          };
         };
       };
 


### PR DESCRIPTION
This makes linters/checkers run before formatters.