### PR TITLE
`Automaton` uses deducing this from C++23

### DIFF
--- a/.github/workflows/actions/docs/action.yml
+++ b/.github/workflows/actions/docs/action.yml
@@ -12,6 +12,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # It needs the same C++23-capable compiler as the other C++ jobs.
+    - uses: ./.github/workflows/actions/setup
+      with:
+        os: ${{ inputs.os }}
     - name: Setup Python environment
       uses: ./.github/workflows/actions/setup-python
       with:

--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -16,3 +16,25 @@ runs:
       if: ${{ inputs.os == 'ubuntu-latest' }}
       shell: sh
       run: sudo apt install -y build-essential lcov gcovr xdg-utils
+    # Mata uses C++23, which needs GCC >= 14 or Clang >= 18.
+    # The Ubuntu 24.04 runner image ships GCC 12/13/14, but *defaults* to 13.
+    - name: Select a C++23-capable compiler (Linux)
+      if: ${{ inputs.os == 'ubuntu-latest' }}
+      shell: sh
+      run: |
+        command -v g++-14 >/dev/null || sudo apt install -y g++-14 gcc-14
+        echo "CC=gcc-14" >> "$GITHUB_ENV"
+        echo "CXX=g++-14" >> "$GITHUB_ENV"
+        g++-14 --version
+    # AppleClang version numbers do not track upstream LLVM, and the Xcode shipped on macos-latest is not new enough.
+    - name: Select a C++23-capable compiler (macOS)
+      if: ${{ inputs.os == 'macos-latest' }}
+      shell: sh
+      run: |
+        brew install llvm
+        LLVM_PREFIX="$(brew --prefix llvm)"
+        echo "CC=$LLVM_PREFIX/bin/clang" >> "$GITHUB_ENV"
+        echo "CXX=$LLVM_PREFIX/bin/clang++" >> "$GITHUB_ENV"
+        echo "LDFLAGS=-L$LLVM_PREFIX/lib/c++ -L$LLVM_PREFIX/lib -Wl,-rpath,$LLVM_PREFIX/lib/c++" >> "$GITHUB_ENV"
+        echo "CPPFLAGS=-I$LLVM_PREFIX/include" >> "$GITHUB_ENV"
+        "$LLVM_PREFIX/bin/clang++" --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required (VERSION 3.15.0)
-
-
 project (
 	libMATA
 	#VERSION ???? TODO: set the version automatically during merging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,23 @@
 cmake_minimum_required (VERSION 3.15.0)
+
+
 project (
 	libMATA
 	#VERSION ???? TODO: set the version automatically during merging
 	DESCRIPTION "A fast and simple automata library"
 	LANGUAGES C CXX) # C is needed for CUDD
+
+# Mata uses C++23. Setting CMAKE_CXX_STANDARD to 23 is not enough. The compiler has to actually
+# implement the feature. Fail here with a readable message instead of letting it surface during compilation.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+	message (FATAL_ERROR
+		"Mata requires GCC >= 14 (found ${CMAKE_CXX_COMPILER_VERSION}). "
+		"Install a newer compiler and select it, e.g. `CXX=g++-14 cmake ...`.")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 18)
+	message (FATAL_ERROR
+		"Mata requires Clang >= 18 (found ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}) for C++23. "
+		"Note AppleClang version numbers differ from upstream LLVM.")
+endif ()
 
 # 3rd party modules
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -49,7 +49,7 @@ project_includes = [
     os.path.join(src_dir, "3rdparty", "cudd", "include"),
 ]
 
-extra_compile_args = ["-std=c++20", "-DNO_THROW_DISPATCHER"]
+extra_compile_args = ["-std=c++23", "-DNO_THROW_DISPATCHER"]
 if platform.system() == "Darwin":
     extra_compile_args.append("-mmacosx-version-min=10.15")
 

--- a/include/mata/automaton.hh
+++ b/include/mata/automaton.hh
@@ -182,6 +182,42 @@ class Automaton {
 	 */
 	bool is_acyclic() const;
 
+	/**
+	 * @brief Check if @c this is structuralry identical to @p other.
+	 *
+	 * Compares only @c delta, @c initial and @c final. This is exact structural
+	 *  equality, including state numbering (so even stronger than isomorphism),
+	 *  essentially only useful for testing purposes.
+	 *
+	 * @note Templated on @p Self (`deducing this`) so that only same-type comparisons compile.
+	 * @param[in] other The other automaton to compare with.
+	 * @return true iff the structural parts of @c this and @p other are identical.
+	 */
+	template <typename Self>
+	bool is_identical(this const Self& self, const Self& other);
+
+	/**
+	 * @brief Remove unreachable and non-terminating states in-place.
+	 *  Remaining states are renumbered densely in ascending order.
+	 *
+	 * @note A state is reachable when the state is the endpoint of a path starting from an initial state.
+	 *  A state is terminating when the state is the starting point of a path ending in a final state.
+	 * @param[out] state_renaming Mapping of trimmed states to new states.
+	 * @return @c this after trimming.
+	 */
+	template <typename Self>
+	Self& trim(this Self&& self, nfa::StateRenaming* state_renaming = nullptr);
+
+	/**
+	 * Check whether no accepting path exists, recording a witness in @p cex when one does.
+	 *
+	 * @param[out] cex Counter-example path (and, via the leaf's @c get_word_for_path(), word) for a case an
+	 *  accepting path exists.
+	 * @return true if no accepting path exists, false otherwise.
+	 */
+	template <typename Self>
+	bool is_lang_empty(this const Self& self, nfa::Run* cex = nullptr);
+
   protected:
 	/**
 	 * Add a new (fresh) state to the automaton.
@@ -218,58 +254,31 @@ class Automaton {
 	Automaton reverted() const;
 
 	/**
-	 * @brief Structural part of `is_identical()`. See @c mata::nfa::Nfa::is_identical().
-	 *
-	 * TODO(c++23): fold into a public `is_identical(this const Self&, const Self&)`.
-	 *
-	 * Compares only @c delta, @c initial and @c final.
-	 * @note Kept protected so that comparing an NFA against an NFT (or either against a bare @c Automaton) never
-	 * compiles. The leaves have to expose their own same-type overloads.
-	 * @return true iff the structural parts of the two automata are identical.
-	 */
-	bool is_identical_impl(const Automaton& aut) const;
-
-	/**
-	 * @brief Structural part of `trim()`. See @c mata::nfa::Nfa::trim().
-	 *
-	 * TODO(c++23): fold into a public `Self& trim(this Self&, ...)`, dropping the Nfa/Nft forwarders.
-	 *
-	 * @param state_renaming Optional pointer to a @c StateRenaming map to fill with the renaming of states after
-	 * trimming. If provided, the map will be filled with the mapping from old state numbers to new state numbers after
-	 * trimming.
-	 */
-	void trim_impl(nfa::StateRenaming* state_renaming = nullptr);
-
-	/**
 	 * @brief Structural part of `trim()` for a precomputed @p useful_states.
-	 *
-	 * TODO(c++23): fold into a public `Self& trim(this Self&, ...)`, dropping the Nfa/Nft forwarders.
 	 *
 	 * Lets a leaf class compute the useful states once, adjust its own per-state data (such as
 	 *  @c mata::nft::Nft::levels) and then hand the same bool vector over, instead of running Tarjan twice.
 	 *  Any renaming that happens after the trim follows ascending order of the original state numbers.
+	 *
+	 * @note Kept protected: it assumes @p useful_states was computed for @c self and gives no guarantee about a
+	 *  mismatched one. Templated on @p Self (`deducing this`) purely so it can return @p Self& for @c trim() to
+	 *  return directly; a leaf that redeclares its own @c trim() (hiding this by name, since both share the name
+	 *  `trim`) still reaches it unqualified as `trim_impl(...)`, since only `trim` is redeclared, not `trim_impl`.
 	 * @param useful_states A @c BoolVector indicating which states are useful (true) and which are not (false).
 	 * @param state_renaming Optional pointer to a @c StateRenaming map to fill with the renaming of states
 	 *  after trimming. If provided, the map will be filled with the mapping from old state numbers to
 	 *  new state numbers after trimming.
+	 * @return @c self after trimming.
 	 */
-	void trim_impl(const BoolVector& useful_states, nfa::StateRenaming* state_renaming);
-
-	/**
-	 * @brief As @c has_no_accepting_path(), but records a witness when an accepting path exists.
-	 *
-	 * TODO(c++23): with `deducing this` this can be the public `is_lang_empty()` itself.
-	 *
-	 * Fills only @c cex->path; reconstructing @c cex->word from the path is word semantics and therefore the
-	 *  responsibility of the leaf class, which knows how to read a path as a word. Delegates to
-	 *  @c has_no_accepting_path() when @p cex is @c nullptr.
-	 * @param[out] cex Pointer to a @c nfa::Run structure to fill with a witness path if an accepting path exists.
-	 *  If @c nullptr, no witness is recorded.
-	 * @return true iff no accepting path exists.
-	 */
-	bool has_no_accepting_path(nfa::Run* cex) const;
+	template <typename Self>
+	Self& trim_impl(this Self& self, const BoolVector& useful_states, nfa::StateRenaming* state_renaming);
 }; // class Automaton.
 
 } // namespace mata.
+
+// Template member definitions. Kept out of this file so that automaton.hh reads like an ordinary class declaration;
+//  see automaton.tpp itself for why these have to live somewhere textually included by every translation unit that
+//  instantiates them, rather than in automaton.cc.
+#include "mata/automaton.tpp"
 
 #endif // MATA_AUTOMATON_HH_

--- a/include/mata/automaton.hh
+++ b/include/mata/automaton.hh
@@ -193,8 +193,7 @@ class Automaton {
 	 * @param[in] other The other automaton to compare with.
 	 * @return true iff the structural parts of @c this and @p other are identical.
 	 */
-	template <typename Self>
-	bool is_identical(this const Self& self, const Self& other);
+	template <typename Self> bool is_identical(this const Self& self, const Self& other);
 
 	/**
 	 * @brief Remove unreachable and non-terminating states in-place.
@@ -202,11 +201,11 @@ class Automaton {
 	 *
 	 * @note A state is reachable when the state is the endpoint of a path starting from an initial state.
 	 *  A state is terminating when the state is the starting point of a path ending in a final state.
+	 * @note Reached only through a leaf's own one-line @c trim(), on @c *this, so an lvalue @p Self suffices here.
 	 * @param[out] state_renaming Mapping of trimmed states to new states.
 	 * @return @c this after trimming.
 	 */
-	template <typename Self>
-	Self& trim(this Self&& self, nfa::StateRenaming* state_renaming = nullptr);
+	template <typename Self> Self& trim(this Self& self, nfa::StateRenaming* state_renaming = nullptr);
 
 	/**
 	 * Check whether no accepting path exists, recording a witness in @p cex when one does.
@@ -215,8 +214,7 @@ class Automaton {
 	 *  accepting path exists.
 	 * @return true if no accepting path exists, false otherwise.
 	 */
-	template <typename Self>
-	bool is_lang_empty(this const Self& self, nfa::Run* cex = nullptr);
+	template <typename Self> bool is_lang_empty(this const Self& self, nfa::Run* cex = nullptr);
 
   protected:
 	/**

--- a/include/mata/automaton.hh
+++ b/include/mata/automaton.hh
@@ -274,9 +274,6 @@ class Automaton {
 
 } // namespace mata.
 
-// Template member definitions. Kept out of this file so that automaton.hh reads like an ordinary class declaration;
-//  see automaton.tpp itself for why these have to live somewhere textually included by every translation unit that
-//  instantiates them, rather than in automaton.cc.
 #include "mata/automaton.tpp"
 
 #endif // MATA_AUTOMATON_HH_

--- a/include/mata/automaton.tpp
+++ b/include/mata/automaton.tpp
@@ -1,0 +1,137 @@
+/** @file
+ * @brief Template member definitions for @c mata::Automaton.
+ */
+
+#ifndef MATA_AUTOMATON_TPP_
+#define MATA_AUTOMATON_TPP_
+
+#include <algorithm>
+#include <list>
+#include <map>
+#include <tuple>
+#include <unordered_set>
+
+#include "mata/utils/assert.hh"
+#include "mata/utils/ord-vector.hh"
+
+namespace mata {
+
+template <typename Self> bool Automaton::is_identical(this const Self& self, const Self& other) {
+	if (utils::OrdVector<nfa::State>(self.initial) != utils::OrdVector<nfa::State>(other.initial)) { return false; }
+	if (utils::OrdVector<nfa::State>(self.final) != utils::OrdVector<nfa::State>(other.final)) { return false; }
+	return self.delta == other.delta;
+}
+
+template <typename Self> Self& Automaton::trim(this Self&& self, nfa::StateRenaming* state_renaming) {
+#ifdef _STATIC_STRUCTURES_
+	BoolVector useful_states{self.get_useful_states()};
+	useful_states.clear();
+	useful_states = self.get_useful_states();
+#else
+	const BoolVector useful_states{self.get_useful_states()};
+#endif
+	return self.trim_impl(useful_states, state_renaming);
+}
+
+template <typename Self> bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
+	// TODO: hot fix for performance reasons for TACAS.
+	//  Perhaps make the get_useful_states return a witness on demand somehow.
+	if (!cex) { return self.has_no_accepting_path(); }
+
+	std::list<nfa::State> worklist(self.initial.begin(), self.initial.end());
+	std::unordered_set<nfa::State> processed(self.initial.begin(), self.initial.end());
+
+	// 'paths[s] == t' denotes that state 's' was accessed from state 't',
+	// 'paths[s] == s' means that 's' is an initial state
+	std::map<nfa::State, nfa::State> paths;
+	// Initialize paths.
+	for (const nfa::State s : worklist) { paths[s] = s; }
+
+	while (!worklist.empty()) {
+		nfa::State state{worklist.front()};
+		worklist.pop_front();
+
+		if (self.final[state]) {
+			cex->path.clear();
+			cex->path.push_back(state);
+			while (paths[state] != state) {
+				state = paths[state];
+				cex->path.push_back(state);
+			}
+			std::ranges::reverse(cex->path);
+			// The structural search above only finds the path; reading it as a word is leaf-specific (flat for an
+			//  NFA, level-aware for an NFT). `self.get_word_for_path()` is not declared on `Automaton` at all --
+			//  it resolves once `Self` is known, at instantiation, so this always calls the leaf's own version.
+			cex->word = self.get_word_for_path(*cex).first.word;
+			return false;
+		}
+
+		if (self.delta.empty()) { continue; }
+
+		for (const nfa::SymbolPost& symbol_post : self.delta[state]) {
+			for (const nfa::State& target : symbol_post.targets) {
+				bool inserted;
+				std::tie(std::ignore, inserted) = processed.insert(target);
+				if (inserted) {
+					worklist.push_back(target);
+					// Also set that tgt_state was accessed from state.
+					paths[target] = state;
+				} else {
+					MATA_ASSERT(utils::haskey(paths, target)); /* Invariant. */
+				}
+			}
+		}
+	} // while (!worklist.empty()).
+	return true;
+} // is_lang_empty().
+
+template <typename Self>
+Self& Automaton::trim_impl(this Self& self, const BoolVector& useful_states, nfa::StateRenaming* state_renaming) {
+	const size_t useful_states_size{useful_states.size()};
+	std::vector<nfa::State> renaming(useful_states_size);
+	for (nfa::State new_state{0}, orig_state{0}; orig_state < useful_states_size; ++orig_state) {
+		if (useful_states[orig_state]) {
+			renaming[orig_state] = new_state;
+			++new_state;
+		}
+	}
+
+	self.delta.defragment(useful_states, renaming);
+	// Only useful states have a meaningful entry in `renaming`.
+	// Removed states keep the default zero.
+	// Check that the useful-state projection is the expected dense, ascending sequence.
+	MATA_ASSERT(
+		[&] {
+			nfa::State expected_new_state{0};
+			for (nfa::State orig_state{0}; orig_state < useful_states_size; ++orig_state) {
+				if (useful_states[orig_state]) {
+					if (renaming[orig_state] != expected_new_state) { return false; }
+					++expected_new_state;
+				}
+			}
+			return true;
+		}(),
+		"Automaton::trim_impl: useful states must be renamed densely in ascending order."
+	);
+
+	auto is_state_useful = [&](const nfa::State q) { return q < useful_states_size && useful_states[q]; };
+	self.initial.filter(is_state_useful);
+	self.final.filter(is_state_useful);
+	auto rename_state = [&](const nfa::State q) { return renaming[q]; };
+	self.initial.rename(rename_state);
+	self.final.rename(rename_state);
+	self.initial.truncate();
+	self.final.truncate();
+	if (state_renaming != nullptr) {
+		state_renaming->clear();
+		state_renaming->reserve(useful_states_size);
+		for (nfa::State q{0}; q < useful_states_size; ++q) {
+			if (useful_states[q]) { (*state_renaming)[q] = renaming[q]; }
+		}
+	}
+	return self;
+}
+
+} // namespace mata.
+
+#endif // MATA_AUTOMATON_TPP_

--- a/include/mata/automaton.tpp
+++ b/include/mata/automaton.tpp
@@ -16,13 +16,15 @@
 
 namespace mata {
 
-template <typename Self> bool Automaton::is_identical(this const Self& self, const Self& other) {
+template <typename Self>
+bool Automaton::is_identical(this const Self& self, const Self& other) {
 	if (utils::OrdVector<nfa::State>(self.initial) != utils::OrdVector<nfa::State>(other.initial)) { return false; }
 	if (utils::OrdVector<nfa::State>(self.final) != utils::OrdVector<nfa::State>(other.final)) { return false; }
 	return self.delta == other.delta;
 }
 
-template <typename Self> Self& Automaton::trim(this Self&& self, nfa::StateRenaming* state_renaming) {
+template <typename Self>
+Self& Automaton::trim(this Self& self, nfa::StateRenaming* state_renaming) {
 #ifdef _STATIC_STRUCTURES_
 	BoolVector useful_states{self.get_useful_states()};
 	useful_states.clear();
@@ -33,7 +35,8 @@ template <typename Self> Self& Automaton::trim(this Self&& self, nfa::StateRenam
 	return self.trim_impl(useful_states, state_renaming);
 }
 
-template <typename Self> bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
+template <typename Self>
+bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
 	// TODO: hot fix for performance reasons for TACAS.
 	//  Perhaps make the get_useful_states return a witness on demand somehow.
 	if (!cex) { return self.has_no_accepting_path(); }

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -232,33 +232,6 @@ class Nfa : public Automaton {
 	}
 
 	/**
-	 * @brief Check if @c this is exactly identical to @p aut.
-	 *
-	 * This is exact equality of automata, including state numbering (so even stronger than isomorphism),
-	 *  essentially only useful for testing purposes.
-	 * @return True if automata are exactly identical, false otherwise.
-	 */
-	bool is_identical(const Nfa& aut) const;
-
-	/**
-	 * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.
-	 *
-	 * Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
-	 * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
-	 * the starting point of a path ending in a final state).
-	 *
-	 * @note The states are renumbered after trimming.
-	 *
-	 * @param[out] state_renaming Mapping of trimmed states to new states.
-	 * @return @c this after trimming.
-	 */
-	Nfa& trim(StateRenaming* state_renaming = nullptr) {
-		// TODO(c++23): drop this forwarder.
-		trim_impl(state_renaming);
-		return *this;
-	}
-
-	/**
 	 * @brief Decodes automaton from UTF-8 encoding. Method removes unreachable states from delta.
 	 *
 	 * @return Decoded automaton.
@@ -442,14 +415,6 @@ class Nfa : public Automaton {
 	 * @return Set of states reachable from the given state over the given symbol.
 	 */
 	const StateSet& post(const State state, const Symbol symbol) const { return delta.get_successors(state, symbol); }
-
-	/**
-	 * Check whether the language of NFA is empty.
-	 * Currently, calls is_lang_empty_scc if cex is null
-	 * @param[out] cex Counter-example path for a case the language is not empty.
-	 * @return True if the language is empty, false otherwise.
-	 */
-	bool is_lang_empty(Run* cex = nullptr) const;
 
 	/**
 	 * @brief Check if the language is empty using Tarjan's SCC discover algorithm.

--- a/include/mata/nfa/nfa.hh
+++ b/include/mata/nfa/nfa.hh
@@ -232,6 +232,29 @@ class Nfa : public Automaton {
 	}
 
 	/**
+	 * @brief Check if @c this is exactly identical to @p aut.
+	 *
+	 * This is exact equality of automata, including state numbering (so even stronger than isomorphism),
+	 *  essentially only useful for testing purposes.
+	 * @return True if automata are exactly identical, false otherwise.
+	 */
+	bool is_identical(const Nfa& aut) const { return Automaton::is_identical(aut); }
+
+	/**
+	 * @brief Remove inaccessible (unreachable) and not co-accessible (non-terminating) states in-place.
+	 *
+	 * Remove states which are not accessible (unreachable; state is accessible when the state is the endpoint of a path
+	 * starting from an initial state) or not co-accessible (non-terminating; state is co-accessible when the state is
+	 * the starting point of a path ending in a final state).
+	 *
+	 * @note The states are renumbered after trimming.
+	 *
+	 * @param[out] state_renaming Mapping of trimmed states to new states.
+	 * @return @c this after trimming.
+	 */
+	Nfa& trim(StateRenaming* state_renaming = nullptr) { return Automaton::trim(state_renaming); }
+
+	/**
 	 * @brief Decodes automaton from UTF-8 encoding. Method removes unreachable states from delta.
 	 *
 	 * @return Decoded automaton.
@@ -415,6 +438,14 @@ class Nfa : public Automaton {
 	 * @return Set of states reachable from the given state over the given symbol.
 	 */
 	const StateSet& post(const State state, const Symbol symbol) const { return delta.get_successors(state, symbol); }
+
+	/**
+	 * Check whether the language of NFA is empty.
+	 * Currently, calls is_lang_empty_scc if cex is null
+	 * @param[out] cex Counter-example path for a case the language is not empty.
+	 * @return True if the language is empty, false otherwise.
+	 */
+	bool is_lang_empty(Run* cex = nullptr) const { return Automaton::is_lang_empty(cex); }
 
 	/**
 	 * @brief Check if the language is empty using Tarjan's SCC discover algorithm.

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -602,6 +602,14 @@ class Nft : public mata::Automaton {
 	Nft& unify_final(bool force_new_state = false);
 
 	/**
+	 * Check whether the relation of the NFT is empty.
+	 * Currently, calls is_lang_empty_scc if cex is null.
+	 * @param[out] cex Counter-example path for a case the relation is not empty.
+	 * @return True if the relation is empty, false otherwise.
+	 */
+	bool is_lang_empty(Run* cex = nullptr) const { return Automaton::is_lang_empty(cex); }
+
+	/**
 	 * @brief Check if the relation is empty using Tarjan's SCC discover algorithm.
 	 *
 	 * @return Relation empty <-> True

--- a/include/mata/nft/nft.hh
+++ b/include/mata/nft/nft.hh
@@ -602,14 +602,6 @@ class Nft : public mata::Automaton {
 	Nft& unify_final(bool force_new_state = false);
 
 	/**
-	 * Check whether the relation of the NFT is empty.
-	 * Currently, calls is_lang_empty_scc if cex is null.
-	 * @param[out] cex Counter-example path for a case the relation is not empty.
-	 * @return True if the relation is empty, false otherwise.
-	 */
-	bool is_lang_empty(Run* cex = nullptr) const;
-
-	/**
 	 * @brief Check if the relation is empty using Tarjan's SCC discover algorithm.
 	 *
 	 * @return Relation empty <-> True

--- a/src/automaton.cc
+++ b/src/automaton.cc
@@ -4,22 +4,16 @@
 
 #include <algorithm>
 #include <deque>
-#include <list>
-#include <map>
-#include <unordered_set>
 
 #include "mata/automaton.hh"
-#include "mata/utils/assert.hh"
 #include "mata/utils/sparse-set.hh"
 
 using namespace mata;
 using namespace mata::utils;
 
 using mata::nfa::Delta;
-using mata::nfa::Run;
 using mata::nfa::State;
 using mata::nfa::StatePost;
-using mata::nfa::StateRenaming;
 using mata::nfa::StateSet;
 using mata::nfa::SymbolPost;
 
@@ -121,12 +115,6 @@ void Automaton::clear() {
 	final.clear();
 }
 
-bool Automaton::is_identical_impl(const Automaton& aut) const {
-	if (utils::OrdVector<State>(initial) != utils::OrdVector<State>(aut.initial)) { return false; }
-	if (utils::OrdVector<State>(final) != utils::OrdVector<State>(aut.final)) { return false; }
-	return delta == aut.delta;
-}
-
 Automaton Automaton::reverted() const {
 	Automaton result{};
 
@@ -187,62 +175,6 @@ std::vector<State> Automaton::distances_from_initial() const {
 }
 
 std::vector<State> Automaton::distances_to_final() const { return reverted().distances_from_initial(); }
-
-void Automaton::trim_impl(StateRenaming* state_renaming) {
-#ifdef _STATIC_STRUCTURES_
-	BoolVector useful_states{get_useful_states()};
-	useful_states.clear();
-	useful_states = get_useful_states();
-#else
-	const BoolVector useful_states{get_useful_states()};
-#endif
-	trim_impl(useful_states, state_renaming);
-}
-
-void Automaton::trim_impl(const BoolVector& useful_states, StateRenaming* state_renaming) {
-	const size_t useful_states_size{useful_states.size()};
-	std::vector<State> renaming(useful_states_size);
-	for (State new_state{0}, orig_state{0}; orig_state < useful_states_size; ++orig_state) {
-		if (useful_states[orig_state]) {
-			renaming[orig_state] = new_state;
-			++new_state;
-		}
-	}
-
-	delta.defragment(useful_states, renaming);
-	// Only useful states have a meaningful entry in `renaming`.
-	// Removed states keep the default zero.
-	// Check that the useful-state projection is the expected dense, ascending sequence.
-	MATA_ASSERT(
-		[&] {
-			State expected_new_state{0};
-			for (State orig_state{0}; orig_state < useful_states_size; ++orig_state) {
-				if (useful_states[orig_state]) {
-					if (renaming[orig_state] != expected_new_state) { return false; }
-					++expected_new_state;
-				}
-			}
-			return true;
-		}(),
-		"Automaton::trim_impl: useful states must be renamed densely in ascending order."
-	);
-
-	auto is_state_useful = [&](const State q) { return q < useful_states_size && useful_states[q]; };
-	initial.filter(is_state_useful);
-	final.filter(is_state_useful);
-	auto rename_state = [&](const State q) { return renaming[q]; };
-	initial.rename(rename_state);
-	final.rename(rename_state);
-	initial.truncate();
-	final.truncate();
-	if (state_renaming != nullptr) {
-		state_renaming->clear();
-		state_renaming->reserve(useful_states_size);
-		for (State q{0}; q < useful_states_size; ++q) {
-			if (useful_states[q]) { (*state_renaming)[q] = renaming[q]; }
-		}
-	}
-}
 
 /**
  * @brief This function employs non-recursive version of Tarjan's algorithm for finding SCCs
@@ -431,51 +363,3 @@ bool Automaton::is_acyclic() const {
 	tarjan_scc_discover(callback);
 	return acyclic;
 }
-
-bool Automaton::has_no_accepting_path(Run* cex) const {
-	// TODO: hot fix for performance reasons for TACAS.
-	//  Perhaps make the get_useful_states return a witness on demand somehow.
-	if (!cex) { return has_no_accepting_path(); }
-
-	std::list<State> worklist(initial.begin(), initial.end());
-	std::unordered_set<State> processed(initial.begin(), initial.end());
-
-	// 'paths[s] == t' denotes that state 's' was accessed from state 't',
-	// 'paths[s] == s' means that 's' is an initial state
-	std::map<State, State> paths;
-	// Initialize paths.
-	for (const State s : worklist) { paths[s] = s; }
-
-	while (!worklist.empty()) {
-		State state{worklist.front()};
-		worklist.pop_front();
-
-		if (final[state]) {
-			cex->path.clear();
-			cex->path.push_back(state);
-			while (paths[state] != state) {
-				state = paths[state];
-				cex->path.push_back(state);
-			}
-			std::ranges::reverse(cex->path);
-			return false;
-		}
-
-		if (delta.empty()) { continue; }
-
-		for (const SymbolPost& symbol_post : delta[state]) {
-			for (const State& target : symbol_post.targets) {
-				bool inserted;
-				tie(std::ignore, inserted) = processed.insert(target);
-				if (inserted) {
-					worklist.push_back(target);
-					// Also set that tgt_state was accessed from state.
-					paths[target] = state;
-				} else {
-					MATA_ASSERT(haskey(paths, target)); /* Invariant. */
-				}
-			}
-		}
-	} // while (!worklist.empty()).
-	return true;
-} // has_no_accepting_path(Run*).

--- a/src/nfa/nfa.cc
+++ b/src/nfa/nfa.cc
@@ -444,9 +444,6 @@ State Nfa::insert_word(const State source, const Word& word, const State target)
 
 State Nfa::insert_word(const State source, const Word& word) { return insert_word(source, word, add_state()); }
 
-// TODO(c++23): drop this forwarder.
-bool Nfa::is_identical(const Nfa& aut) const { return is_identical_impl(aut); }
-
 Nfa& Nfa::complement_deterministic(const OrdVector<Symbol>& symbols, const std::optional<State> sink_state) {
 	const State sink{sink_state.value_or(num_of_states())};
 	if (initial.empty()) { // The automaton has no reachable states (accepting an empty language).

--- a/src/nfa/operations.cc
+++ b/src/nfa/operations.cc
@@ -604,14 +604,6 @@ bool Nfa::is_in_lang(const Run& run, const bool use_epsilon, const bool match_pr
 	return this->final.intersects_with(read_word(run, use_epsilon));
 }
 
-bool mata::nfa::Nfa::is_lang_empty(Run* cex) const {
-	// TODO(c++23): drop this split. `deducing this` Automaton can call the leaf's get_word_for_path() itself.
-	if (has_no_accepting_path(cex)) { return true; }
-	// The structural search filled only the path; reading the path as a word is NFA-specific.
-	if (cex != nullptr) { cex->word = get_word_for_path(*cex).first.word; }
-	return false;
-} // is_lang_empty().
-
 Nfa mata::nfa::algorithms::minimize_brzozowski(const Nfa& aut) {
 	// compute the minimal deterministic automaton, Brzozovski algorithm
 	return determinize(revert(determinize(revert(aut))));

--- a/src/nft/nft.cc
+++ b/src/nft/nft.cc
@@ -158,9 +158,7 @@ Nft& Nft::trim(StateRenaming* state_renaming) {
 		levels.end()
 	);
 
-	// TODO(c++23): drop this forwarder.
-	trim_impl(useful_states, state_renaming);
-	return *this;
+	return trim_impl(useful_states, state_renaming);
 }
 
 void Nft::remove_epsilon(const Symbol epsilon) { *this = nft::remove_epsilon(*this, epsilon); }
@@ -1228,14 +1226,6 @@ Nft& Nft::unify_final(const bool force_new_state) {
 	return *this;
 }
 
-bool Nft::is_lang_empty(Run* cex) const {
-	// TODO(c++23): drop this split; with `deducing this` Automaton can call the leaf's get_word_for_path() itself.
-	if (has_no_accepting_path(cex)) { return true; }
-	// The structural search filled only the path; reading the path as a word is level-aware for NFTs.
-	if (cex != nullptr) { cex->word = get_word_for_path(*cex).first.word; }
-	return false;
-}
-
 bool Nft::is_deterministic() const {
 	if (initial.size() != 1) { return false; }
 	if (delta.empty()) { return true; }
@@ -1339,9 +1329,10 @@ void Nft::fill_alphabet(OnTheFlyAlphabet& alphabet_to_fill) const {
 	}
 }
 
-// TODO(c++23): drop this forwarder. `deducing this` lets Automaton take a same-type parameter directly.
 bool Nft::is_identical(const Nft& aut) const {
-	return levels.num_of_levels == aut.levels.num_of_levels && levels == aut.levels && is_identical_impl(aut);
+	// Nft's own is_identical() hides Automaton::is_identical() by name, so an unqualified call here
+	//  would recurse into this very function instead of reaching the structural comparison.
+	return levels.num_of_levels == aut.levels.num_of_levels && levels == aut.levels && Automaton::is_identical(aut);
 }
 
 mata::nfa::Nfa


### PR DESCRIPTION
In this PR:
- Replaces the `_impl` helper pattern in `Automaton` by deducing this.
- `is_identical`, `trim` and `is_lang_empty` are now single templated members on Automaton.
- Template definitions are in the new `automaton.tpp`.
- `Nfa` and `Nft` keep thin forwarders for these methods so the users don't see the cryptic signatures in the tooltip. They inline away entirely at `-O2`.
- Fixes CMake, Python bindings `setup.py`, and GitHub Actions to correctly use C++23.