### PR TITLE
Delta as a Black Box

### DIFF
--- a/include/mata/automaton.tpp
+++ b/include/mata/automaton.tpp
@@ -16,15 +16,13 @@
 
 namespace mata {
 
-template <typename Self>
-bool Automaton::is_identical(this const Self& self, const Self& other) {
+template <typename Self> bool Automaton::is_identical(this const Self& self, const Self& other) {
 	if (utils::OrdVector<nfa::State>(self.initial) != utils::OrdVector<nfa::State>(other.initial)) { return false; }
 	if (utils::OrdVector<nfa::State>(self.final) != utils::OrdVector<nfa::State>(other.final)) { return false; }
 	return self.delta == other.delta;
 }
 
-template <typename Self>
-Self& Automaton::trim(this Self& self, nfa::StateRenaming* state_renaming) {
+template <typename Self> Self& Automaton::trim(this Self& self, nfa::StateRenaming* state_renaming) {
 #ifdef _STATIC_STRUCTURES_
 	BoolVector useful_states{self.get_useful_states()};
 	useful_states.clear();
@@ -35,8 +33,7 @@ Self& Automaton::trim(this Self& self, nfa::StateRenaming* state_renaming) {
 	return self.trim_impl(useful_states, state_renaming);
 }
 
-template <typename Self>
-bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
+template <typename Self> bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
 	// TODO: hot fix for performance reasons for TACAS.
 	//  Perhaps make the get_useful_states return a witness on demand somehow.
 	if (!cex) { return self.has_no_accepting_path(); }
@@ -71,19 +68,17 @@ bool Automaton::is_lang_empty(this const Self& self, nfa::Run* const cex) {
 
 		if (self.delta.empty()) { continue; }
 
-		for (const nfa::SymbolPost& symbol_post : self.delta[state]) {
-			for (const nfa::State& target : symbol_post.targets) {
-				bool inserted;
-				std::tie(std::ignore, inserted) = processed.insert(target);
-				if (inserted) {
-					worklist.push_back(target);
-					// Also set that tgt_state was accessed from state.
-					paths[target] = state;
-				} else {
-					MATA_ASSERT(utils::haskey(paths, target)); /* Invariant. */
-				}
+		self.delta.for_each_successor(state, [&](const nfa::State target) {
+			bool inserted;
+			std::tie(std::ignore, inserted) = processed.insert(target);
+			if (inserted) {
+				worklist.push_back(target);
+				// Also set that tgt_state was accessed from state.
+				paths[target] = state;
+			} else {
+				MATA_ASSERT(utils::haskey(paths, target)); /* Invariant. */
 			}
-		}
+		});
 	} // while (!worklist.empty()).
 	return true;
 } // is_lang_empty().

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -13,6 +13,7 @@
 #include "mata/utils/synchronized-iterator.hh"
 
 #include <iterator>
+#include <span>
 
 namespace mata::nfa {
 
@@ -97,6 +98,33 @@ class SymbolPost {
 
 	std::vector<State>::const_iterator find(const State s) const { return targets.find(s); }
 	std::vector<State>::iterator find(const State s) { return targets.find(s); }
+
+	/**
+	 * @brief Apply @p fn to every target state of this symbol post.
+	 *
+	 * The innermost level of the traversal that @c mata::Automaton is written against.
+	 *  Callers above this level never need to know how the targets are stored.
+	 */
+	template <typename Fn> void for_each_target(Fn&& fn) const {
+		for (const State target : targets) { fn(target); }
+	}
+
+	/**
+	 * @brief Is @p target among the targets of this symbol post?
+	 *
+	 * @param[in] target Target state to check.
+	 * @return True if @p target is among the targets of this symbol post, false otherwise.
+	 */
+	bool has_target(const State target) const { return targets.find(target) != targets.end(); }
+
+	/**
+	 * The targets as a contiguous range.
+	 * Used to build a flat successor cursor without exposing storage.
+	 */
+	std::span<const State> target_span() const {
+		const std::vector<State>& v{targets.to_vector()};
+		return {v.data(), v.size()};
+	}
 }; // class mata::nfa::SymbolPost.
 
 /**
@@ -229,7 +257,96 @@ class StatePost : utils::OrdVector<SymbolPost> {
 	 * Count the number of all moves in @c StatePost.
 	 */
 	size_t num_of_moves() const;
+
+	/**
+	 * @brief Apply @p fn to every target state reachable from this state post, over any symbol.
+	 */
+	template <typename Fn> void for_each_target(Fn&& fn) const {
+		for (const SymbolPost& symbol_post : *this) { symbol_post.for_each_target(fn); }
+	}
+
+	/**
+	 * @brief Apply @p fn to every @c Move of this state post, as a (symbol, target) pair.
+	 */
+	template <typename Fn> void for_each_move(Fn&& fn) const {
+		for (const SymbolPost& symbol_post : *this) {
+			symbol_post.for_each_target([&](const State target) { fn(symbol_post.symbol, target); });
+		}
+	}
+
+	/**
+	 * @brief Is @p target reachable from this state post over any symbol?
+	 *
+	 * @param[in] target Target state to check.
+	 * @return True if @p target is reachable from this state post over any symbol, false otherwise.
+	 */
+	bool has_target(const State target) const {
+		for (const SymbolPost& symbol_post : *this) {
+			if (symbol_post.has_target(target)) { return true; }
+		}
+		return false;
+	}
 }; // class StatePost.
+
+/**
+ * @brief A resumable cursor over every target reachable from one state post.
+ *
+ * Flattens the (symbol post -> targets) walk into a single pointer walk,
+ *  so a traversal position can be stored and continued later
+ *
+ * @note Header-defined so it inlines. The inner range is loaded without a branch.
+ *
+ * @note Unlike @c for_each_target(), this deliberately knows the nesting depth.
+ *  Composing a cursor out of per-level cursors is measurably slower,
+ *  and @c Delta is the one place entitled to know its own representation.
+ */
+class SuccessorCursor {
+  public:
+	class const_iterator {
+	  public:
+		StatePost::const_iterator symbol_post_it_{}, symbol_post_end_{};
+		const State *target_it_{nullptr}, *target_end_{nullptr};
+
+		void load_targets() {
+			const std::span<const State> targets{symbol_post_it_->target_span()};
+			target_it_ = targets.data();
+			target_end_ = target_it_ + targets.size();
+		}
+		/// Restore the invariant "positioned on a target, or exhausted".
+		void seek() {
+			while (target_it_ == target_end_) {
+				if (++symbol_post_it_ == symbol_post_end_) {
+					target_it_ = target_end_ = nullptr;
+					return;
+				}
+				load_targets();
+			}
+		}
+		const State& operator*() const { return *target_it_; }
+		const_iterator& operator++() {
+			if (++target_it_ == target_end_) { seek(); }
+			return *this;
+		}
+		/// Compares against @c std::default_sentinel: the end is stateless, so no end iterator is stored.
+		bool operator==(std::default_sentinel_t) const { return symbol_post_it_ == symbol_post_end_; }
+	};
+
+	explicit SuccessorCursor(const StatePost& state_post) : state_post_{&state_post} {}
+
+	const_iterator begin() const {
+		const_iterator it;
+		it.symbol_post_it_ = state_post_->begin();
+		it.symbol_post_end_ = state_post_->end();
+		if (it.symbol_post_it_ == it.symbol_post_end_) { return it; }
+		it.load_targets();
+		it.seek();
+		return it;
+	}
+	std::default_sentinel_t end() const { return std::default_sentinel; }
+
+  private:
+	const StatePost* state_post_;
+};
 
 /**
  * Iterator over moves.
@@ -474,6 +591,44 @@ class Delta {
 	 * @param targets Set of states to
 	 */
 	void add(State source, Symbol symbol, const StateSet& targets);
+
+	/**
+	 * @brief Apply @p fn to every target state reachable from @p source, over any symbol.
+	 */
+	template <typename Fn> void for_each_successor(const State source, Fn&& fn) const {
+		state_post(source).for_each_target(fn);
+	}
+
+	/**
+	 * @brief Apply @p fn to every @c Move leaving @p source, as a (symbol, target) pair.
+	 */
+	template <typename Fn> void for_each_move(const State source, Fn&& fn) const {
+		state_post(source).for_each_move(fn);
+	}
+
+	/**
+	 * @brief Does @p source have @p target among its successors, over any symbol?
+	 *
+	 * @param[in] source Source state to look from.
+	 * @param[in] target Target state to look for.
+	 */
+	bool is_successor(const State source, const State target) const { return state_post(source).has_target(target); }
+
+	/**
+	 * @brief Does @p state have a transition back to itself over any symbol?
+	 *
+	 * @param[in] state State to check for self-loop.
+	 * @return True if @p state has a transition back to itself over any symbol, false otherwise.
+	 */
+	bool has_self_loop(const State state) const { return is_successor(state, state); }
+
+	/**
+	 * @brief A resumable cursor over the successors of @p source. See @c SuccessorCursor.
+	 *
+	 * @param source Source state to get the successors of.
+	 * @return A resumable cursor over the successors of @p source.
+	 */
+	SuccessorCursor successor_cursor(const State source) const { return SuccessorCursor{state_post(source)}; }
 
 	using const_iterator = std::vector<StatePost>::const_iterator;
 	const_iterator cbegin() const { return state_posts_.cbegin(); }

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -118,7 +118,8 @@ class SymbolPost {
 	bool has_target(const State target) const { return targets.find(target) != targets.end(); }
 
 	/**
-	 * The targets as a contiguous range.
+	 * @brief The targets as a contiguous range.
+	 * 
 	 * Used to build a flat successor cursor without exposing storage.
 	 */
 	std::span<const State> target_span() const {

--- a/include/mata/nfa/delta.hh
+++ b/include/mata/nfa/delta.hh
@@ -119,7 +119,7 @@ class SymbolPost {
 
 	/**
 	 * @brief The targets as a contiguous range.
-	 * 
+	 *
 	 * Used to build a flat successor cursor without exposing storage.
 	 */
 	std::span<const State> target_span() const {

--- a/src/automaton.cc
+++ b/src/automaton.cc
@@ -70,12 +70,11 @@ struct TarjanNodeData {
 	TarjanNodeData() = default;
 
 	TarjanNodeData(const State q, const Delta& delta, const unsigned long index)
-		: index(index),
+		: current_successor_it(delta.successor_cursor(q).begin()),
+		  index(index),
 		  lowlink(index),
 		  initilized(true),
-		  on_stack(true) {
-		current_successor_it = delta.successor_cursor(q).begin();
-	};
+		  on_stack(true) {}
 };
 } // anonymous namespace
 

--- a/src/automaton.cc
+++ b/src/automaton.cc
@@ -13,9 +13,8 @@ using namespace mata::utils;
 
 using mata::nfa::Delta;
 using mata::nfa::State;
-using mata::nfa::StatePost;
 using mata::nfa::StateSet;
-using mata::nfa::SymbolPost;
+using mata::nfa::SuccessorCursor;
 
 using StateBoolArray = std::vector<bool>; ///< Bool array for states in the automaton.
 
@@ -43,15 +42,13 @@ StateBoolArray reachable_states(
 	while (!worklist.empty()) {
 		const State state{worklist.back()};
 		worklist.pop_back();
-		for (const SymbolPost& move : aut.delta[state]) {
-			for (const State target_state : move.targets) {
-				if (!reachable[target_state] &&
-					(!states_to_consider.has_value() || states_to_consider.value()[target_state])) {
-					worklist.push_back(target_state);
-					reachable[target_state] = true;
-				}
+		aut.delta.for_each_successor(state, [&](const State target_state) {
+			if (!reachable[target_state] &&
+				(!states_to_consider.has_value() || states_to_consider.value()[target_state])) {
+				worklist.push_back(target_state);
+				reachable[target_state] = true;
 			}
-		}
+		});
 	}
 	return reachable;
 }
@@ -60,8 +57,7 @@ StateBoolArray reachable_states(
 // of useful states. It contains Tarjan's metadata and the state of the
 // iteration through the successors.
 struct TarjanNodeData {
-	StatePost::Moves::const_iterator current_move{};
-	StatePost::Moves::const_iterator end_move{};
+	SuccessorCursor::const_iterator current_successor_it{};
 	// index of a node (corresponds to the time of discovery)
 	unsigned long index{0};
 	// index of a lower node in the same SCC
@@ -78,9 +74,7 @@ struct TarjanNodeData {
 		  lowlink(index),
 		  initilized(true),
 		  on_stack(true) {
-		const StatePost::Moves moves{delta[q].moves()};
-		current_move = moves.begin();
-		end_move = moves.end();
+		current_successor_it = delta.successor_cursor(q).begin();
 	};
 };
 } // anonymous namespace
@@ -122,11 +116,9 @@ Automaton Automaton::reverted() const {
 	result.delta.allocate(num_of_states);
 
 	for (State source_state{0}; source_state < num_of_states; ++source_state) {
-		for (const SymbolPost& transition : delta[source_state]) {
-			for (const State target_state : transition.targets) {
-				result.delta.add(target_state, transition.symbol, source_state);
-			}
-		}
+		delta.for_each_move(source_state, [&](const Symbol symbol, const State target_state) {
+			result.delta.add(target_state, symbol, source_state);
+		});
 	}
 
 	result.initial = final;
@@ -162,13 +154,13 @@ std::vector<State> Automaton::distances_from_initial() const {
 	while (!que.empty()) {
 		const State src = que.front();
 		que.pop_front();
-		for (auto [_, target] : delta[src].moves()) {
+		delta.for_each_successor(src, [&](const State target) {
 			if (!visited[target]) {
 				visited[target] = true;
 				distances[target] = distances[src] + 1;
 				que.push_back(target);
 			}
-		}
+		});
 	}
 
 	return distances;
@@ -241,10 +233,10 @@ void Automaton::tarjan_scc_discover(
 
 			if (callback.state_discover && callback.state_discover(act_state)) { return; }
 		} else { // return from the recursive call
-			const State act_succ = act_state_data.current_move->target;
+			const State act_succ = *act_state_data.current_successor_it;
 			act_state_data.lowlink = std::min(act_state_data.lowlink, node_info[act_succ].lowlink);
-			// act_succ is the state that cased the recursive call. Move to another successor.
-			++act_state_data.current_move;
+			// act_succ is the state that caused the recursive call. Move on to the next successor.
+			++act_state_data.current_successor_it;
 		}
 
 		// iterate through outgoing edges
@@ -252,8 +244,8 @@ void Automaton::tarjan_scc_discover(
 		// rec_call simulates call of the strongconnect. Since c++ cannot do continue over
 		// multiple loops, we use rec_call to jump to the main loop
 		bool rec_call = false;
-		for (; act_state_data.current_move != act_state_data.end_move; ++act_state_data.current_move) {
-			next_state = act_state_data.current_move->target;
+		for (; act_state_data.current_successor_it != std::default_sentinel; ++act_state_data.current_successor_it) {
+			next_state = *act_state_data.current_successor_it;
 			if (callback.succ_state_discover) { callback.succ_state_discover(act_state, next_state); }
 			if (!node_info[next_state].initilized) { // recursive call
 				program_stack.push_back(next_state);
@@ -350,11 +342,9 @@ bool Automaton::is_acyclic() const {
 			acyclic = false;
 			return true;
 		} else { // check for self-loops
-			for (const State st = scc[0]; const auto& sp : this->delta[st]) {
-				if (sp.targets.find(st) != sp.targets.end()) {
-					acyclic = false;
-					return true;
-				}
+			if (delta.has_self_loop(scc[0])) {
+				acyclic = false;
+				return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
In this PR:
- `Automaton` no longer inspects `Delta`'s internal shape.
- New level-delegating primitives were added:
  - `for_each_target`/`for_each_move` -  header-defined member templates so they always inline
  - `SuccessorCursor` - a resumable, flattened cursor for `tarjan_scc_discover`.
  - `Delta::for_each_successor`/`for_each_move`/`is_successor`/`has_self_loop`/`successor_cursor` are the only points of `Delta` that `Automaton` uses for iteration or checks.
- There are no API changes to `Nfa` or `Nft`.
- It appears that this change sped up `is_lang_empty_scc`, `idstance_from_initial`, `is_acyclic`, `get_useful_states`, and `trim` by replacing `StatePost::Moves::operator++` with header-inlined primitives.

This is prep work for templating `Delta` later. Once Automaton only calls these primitives and never names `Delta`'s internal types, `Delta` (and `StatePost`/`SymbolPost`) can be templated without `Automaton` knowing or caring.